### PR TITLE
fix: preserve campaignSpellId in character sheet schema round-trip

### DIFF
--- a/apps/control-web/src/features/character-sheet/model/characterSheet.schema.test.ts
+++ b/apps/control-web/src/features/character-sheet/model/characterSheet.schema.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { INITIAL_SHEET } from "./initialSheet";
+import { parseCharacterSheet } from "./characterSheet.schema";
+
+describe("characterSheet schema spell parsing", () => {
+  it("preserves campaignSpellId when present on parsed sheets", () => {
+    const parsed = parseCharacterSheet({
+      ...INITIAL_SHEET,
+      spellcasting: {
+        ability: "intelligence",
+        mode: "spellbook",
+        slots: { 1: { max: 2, used: 0 } },
+        spells: [
+          {
+            id: "spell-1",
+            name: "Magic Missile",
+            canonicalKey: "magic_missile",
+            campaignSpellId: "camp-spell-1",
+            level: 1,
+            school: "Evocation",
+            prepared: false,
+            notes: "",
+          },
+        ],
+      },
+    });
+
+    expect(parsed.spellcasting?.spells[0]?.campaignSpellId).toBe("camp-spell-1");
+  });
+
+  it("accepts legacy sheets without campaignSpellId", () => {
+    const parsed = parseCharacterSheet({
+      ...INITIAL_SHEET,
+      spellcasting: {
+        ability: "wisdom",
+        mode: "prepared",
+        slots: { 1: { max: 2, used: 0 } },
+        spells: [
+          {
+            id: "spell-1",
+            name: "Bless",
+            canonicalKey: "bless",
+            level: 1,
+            school: "Enchantment",
+            prepared: true,
+            notes: "",
+          },
+        ],
+      },
+    });
+
+    expect(parsed.spellcasting?.spells[0]?.canonicalKey).toBe("bless");
+    expect(parsed.spellcasting?.spells[0]?.campaignSpellId).toBeUndefined();
+  });
+});

--- a/apps/control-web/src/features/character-sheet/model/characterSheet.schema.ts
+++ b/apps/control-web/src/features/character-sheet/model/characterSheet.schema.ts
@@ -122,6 +122,7 @@ const spellSchema = z.object({
   id: z.string(),
   name: z.string(),
   canonicalKey: z.string().nullable().optional(),
+  campaignSpellId: z.string().nullable().optional(),
   level: z.number().min(0).max(9),
   school: z.string(),
   prepared: z.boolean(),

--- a/apps/control-web/src/features/character-sheet/services/characterSheet.service.test.ts
+++ b/apps/control-web/src/features/character-sheet/services/characterSheet.service.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { INITIAL_SHEET } from "../model/initialSheet";
 import { prepareCharacterSheetForSave } from "./characterSheet.service";
+import { parseCharacterSheet } from "../model/characterSheet.schema";
 import { applyCreationLoadoutToSheet } from "../utils/creationEquipment";
 import {
   resetCreationItemCatalogForTests,
@@ -85,5 +86,36 @@ describe("prepareCharacterSheetForSave", () => {
   it("does not rebuild play sheets", () => {
     const prepared = prepareCharacterSheetForSave(INITIAL_SHEET, "play");
     expect(prepared).toStrictEqual(INITIAL_SHEET);
+  });
+
+  it("preserves campaignSpellId through save and parse round-trip", () => {
+    const prepared = prepareCharacterSheetForSave(
+      {
+        ...INITIAL_SHEET,
+        spellcasting: {
+          ability: "intelligence",
+          mode: "spellbook",
+          slots: { 1: { max: 2, used: 0 } },
+          spells: [
+            {
+              id: "spell-1",
+              name: "Magic Missile",
+              canonicalKey: "magic_missile",
+              campaignSpellId: "camp-spell-1",
+              level: 1,
+              school: "Evocation",
+              prepared: false,
+              notes: "",
+            },
+          ],
+        },
+      },
+      "play",
+    );
+
+    const parsed = parseCharacterSheet(prepared);
+
+    expect(prepared.spellcasting?.spells[0]?.campaignSpellId).toBe("camp-spell-1");
+    expect(parsed.spellcasting?.spells[0]?.campaignSpellId).toBe("camp-spell-1");
   });
 });


### PR DESCRIPTION
## Summary

This fixes an issue where `campaignSpellId` was being lost during the character sheet parse/load round-trip.

## Root cause

- `campaignSpellId` existed in the CharacterSheet types
- but was missing from the runtime Zod schema
- causing it to be stripped during parsing/validation

## Fix

- Added `campaignSpellId: z.string().nullable().optional()` to the runtime spell schema

## Why this is correct

- Aligns runtime schema with the existing `Spell` type
- Preserves campaign-based spell references without affecting base spells
- Maintains backward compatibility (legacy sheets without the field still parse correctly)
- Keeps the fix localized to the validation boundary

## Behavior after fix

- Campaign spells retain their `campaignSpellId` after save/load
- Base spells remain unaffected
- No changes to spellcasting flows or class configurations

## Tests

- Parsing a sheet preserves `campaignSpellId`
- Legacy sheets without the field still parse correctly
- Save → parse round-trip keeps `campaignSpellId`

## Notes

- This PR does not modify spellcasting logic or class configs
- Pre-existing test failure in `apps/map-web` is unrelated and not addressed here