### PR TITLE
feat: normalize campaignSpellId during creation spell selection

### DIFF
--- a/apps/control-web/src/features/character-sheet/utils/creationSpells.test.ts
+++ b/apps/control-web/src/features/character-sheet/utils/creationSpells.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, afterEach } from "vitest";
 import { seedSpellCatalogCache } from "../../../entities/dnd-base";
-import { selectCatalogSpellForSheet } from "./creationSpells";
+import { INITIAL_SHEET } from "../model/initialSheet";
+import {
+  normalizeCreationSpellSelection,
+  selectCatalogSpellForSheet
+} from "./creationSpells";
 
 const BASE_SPELL = {
   campaignSpellId: null as string | null,
@@ -86,5 +90,92 @@ describe("toSheetSpell / selectCatalogSpellForSheet", () => {
     expect(result?.id).toBe("existing-id");
     expect(result?.notes).toBe("My note");
     expect(result?.campaignSpellId).toBe("cs-fireball");
+  });
+
+  it("preserves campaignSpellId during creation normalization for fixed spells", () => {
+    seedSpellCatalogCache(
+      [
+        {
+          campaignSpellId: "camp-animal-friendship",
+          canonicalKey: "animal_friendship",
+          name: "Animal Friendship",
+          level: 1,
+          school: "Enchantment",
+          castingTime: "1 action",
+          range: "9 m",
+          components: "V, S, M",
+          duration: "24 hours",
+          concentration: false,
+          ritual: false,
+          description: "",
+          damageType: null,
+          savingThrow: "WIS",
+          classes: ["Bard", "Druid", "Ranger"],
+        },
+        {
+          campaignSpellId: "camp-hunters-mark",
+          canonicalKey: "hunters_mark",
+          name: "Hunter's Mark",
+          level: 1,
+          school: "Divination",
+          castingTime: "1 bonus action",
+          range: "27 m",
+          components: "V",
+          duration: "1 hour",
+          concentration: true,
+          ritual: false,
+          description: "",
+          damageType: null,
+          savingThrow: null,
+          classes: ["Ranger"],
+        },
+      ],
+      "camp-1",
+    );
+
+    const normalized = normalizeCreationSpellSelection(
+      {
+        ability: "wisdom",
+        mode: "known",
+        slots: { 1: { max: 2, used: 0 } },
+        spells: [
+          {
+            id: "spell-1",
+            name: "Animal Friendship",
+            canonicalKey: "animal_friendship",
+            campaignSpellId: "camp-animal-friendship",
+            level: 1,
+            school: "Enchantment",
+            prepared: true,
+            notes: "",
+          },
+          {
+            id: "spell-2",
+            name: "Hunter's Mark",
+            canonicalKey: "hunters_mark",
+            campaignSpellId: "camp-hunters-mark",
+            level: 1,
+            school: "Divination",
+            prepared: true,
+            notes: "",
+          },
+        ],
+      },
+      "guardian",
+      INITIAL_SHEET.abilities,
+      2,
+      "camp-1",
+    );
+
+    expect(normalized?.spells).toEqual([
+      expect.objectContaining({
+        canonicalKey: "animal_friendship",
+        campaignSpellId: "camp-animal-friendship",
+      }),
+      expect.objectContaining({
+        canonicalKey: "hunters_mark",
+        campaignSpellId: "camp-hunters-mark",
+      }),
+    ]);
   });
 });

--- a/apps/control-web/src/features/character-sheet/utils/creationSpells.ts
+++ b/apps/control-web/src/features/character-sheet/utils/creationSpells.ts
@@ -166,6 +166,10 @@ const ensureFixedStartingSpells = (
         ...fixedSpell,
         ...merged[existingIndex],
         canonicalKey: fixedSpell.canonicalKey,
+        campaignSpellId:
+          merged[existingIndex]?.campaignSpellId ??
+          fixedSpell.campaignSpellId ??
+          null,
         name: merged[existingIndex]?.name || fixedSpell.name,
         level: merged[existingIndex]?.level ?? fixedSpell.level,
         school: merged[existingIndex]?.school || fixedSpell.school,


### PR DESCRIPTION
## Summary

Ensures `campaignSpellId` is consistently preserved during spell normalization, especially for fixed spells in character creation.

## Root cause

Although the schema and main write paths already supported `campaignSpellId`, the normalization logic for fixed spells relied on implicit object spreading.

This made the preservation of `campaignSpellId` work in many cases, but not explicitly or reliably at the most critical recomposition point.

## Fix

- Updated normalization logic in `creationSpells.ts`
- Made `campaignSpellId` handling explicit during fixed spell merging:
  - Preserve existing `campaignSpellId` if present
  - Otherwise, use the value from the resolved catalog spell
  - Base spells continue to work with `null`

## Why this is correct

- Aligns normalization behavior with existing authority rules:
  - campaign spell → `campaignSpellId`
  - base spell → no `campaignSpellId`
- Removes reliance on implicit object spread behavior
- Ensures consistent data integrity across:
  - creation
  - updates
  - normalization
- Keeps the fix localized without modifying schema or core spell logic

## Behavior after fix

- `campaignSpellId` is preserved across:
  - creation from catalog
  - spell updates
  - normalization of fixed spells
- No accidental overwrites or drops during recomposition
- Base spells remain unaffected

## Tests

- Existing tests continue to pass:
  - catalog creation sets `campaignSpellId`
  - update preserves `campaignSpellId`
- Added:
  - normalization preserves `campaignSpellId` for fixed spells in campaign scope

## Notes

- No changes to schema or persistence layer
- No changes to class configurations or spellcasting flow
- Focused strictly on data integrity in normalization