### PR TITLE
fix: centralize spell authority precedence across creation and combat flows

### DIFF
--- a/apps/control-web/src/entities/dnd-base/index.ts
+++ b/apps/control-web/src/entities/dnd-base/index.ts
@@ -9,6 +9,17 @@ export {
   normalizeDndItemKey
 } from "./itemCanonicalization";
 export type { BaseSpell } from "./spellCatalogApi";
+export type {
+  SpellAuthorityCandidate,
+  SpellAuthorityReference
+} from "./spellAuthority";
+export {
+  getSpellAuthorityKey,
+  getSpellAuthorityReference,
+  isSameSpellAuthority,
+  normalizeSpellAuthorityName,
+  resolveSpellByAuthority,
+} from "./spellAuthority";
 export {
   getBaseSpells,
   findBaseSpell,

--- a/apps/control-web/src/entities/dnd-base/spellAuthority.test.ts
+++ b/apps/control-web/src/entities/dnd-base/spellAuthority.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getSpellAuthorityReference,
+  normalizeSpellAuthorityName,
+  resolveSpellByAuthority
+} from "./spellAuthority";
+
+describe("spellAuthority", () => {
+  it("prefers campaignSpellId over canonicalKey and name", () => {
+    expect(
+      getSpellAuthorityReference({
+        campaignSpellId: "camp-spell-1",
+        canonicalKey: "magic_missile",
+        name: "Magic Missile"
+      })
+    ).toEqual({
+      kind: "campaign",
+      key: "campaign:camp-spell-1",
+      value: "camp-spell-1"
+    });
+  });
+
+  it("falls back to canonicalKey when campaignSpellId is absent", () => {
+    expect(
+      getSpellAuthorityReference({
+        canonicalKey: "magic_missile",
+        name: "Magic Missile"
+      })
+    ).toEqual({
+      kind: "canonical",
+      key: "canonical:magic_missile",
+      value: "magic_missile"
+    });
+  });
+
+  it("falls back to normalized name when only name exists", () => {
+    expect(
+      getSpellAuthorityReference({
+        name: "  Magic   Missile  "
+      })
+    ).toEqual({
+      kind: "name",
+      key: "name:magic missile",
+      value: "magic missile"
+    });
+  });
+
+  it("normalizes fallback names deterministically", () => {
+    expect(normalizeSpellAuthorityName("  Hunter's   Mark ")).toBe(
+      "hunter's mark"
+    );
+  });
+
+  it("does not degrade to weaker identifiers when campaignSpellId is present", () => {
+    const catalog = [
+      {
+        campaignSpellId: "camp-spell-2",
+        canonicalKey: "magic_missile",
+        name: "Magic Missile"
+      },
+      {
+        campaignSpellId: null,
+        canonicalKey: "magic_missile",
+        name: "Magic Missile"
+      }
+    ];
+
+    expect(
+      resolveSpellByAuthority(catalog, {
+        campaignSpellId: "camp-spell-1",
+        canonicalKey: "magic_missile",
+        name: "Magic Missile"
+      })
+    ).toBeUndefined();
+  });
+});

--- a/apps/control-web/src/entities/dnd-base/spellAuthority.ts
+++ b/apps/control-web/src/entities/dnd-base/spellAuthority.ts
@@ -1,0 +1,100 @@
+export type SpellAuthorityCandidate = {
+  campaignSpellId?: string | null;
+  canonicalKey?: string | null;
+  name?: string | null;
+};
+
+const normalizeSpellAuthorityValue = (value?: string | null) => {
+  const normalized = value?.trim().toLowerCase();
+  return normalized ? normalized : null;
+};
+
+export const normalizeSpellAuthorityName = (name?: string | null) => {
+  const normalized = normalizeSpellAuthorityValue(name);
+  return normalized ? normalized.replace(/\s+/g, " ") : null;
+};
+
+export type SpellAuthorityReference =
+  | {
+      kind: "campaign";
+      key: string;
+      value: string;
+    }
+  | {
+      kind: "canonical";
+      key: string;
+      value: string;
+    }
+  | {
+      kind: "name";
+      key: string;
+      value: string;
+    };
+
+/**
+ * Returns the authoritative spell identity using explicit precedence:
+ * campaignSpellId > canonicalKey > name.
+ */
+export const getSpellAuthorityReference = (
+  spell: SpellAuthorityCandidate
+): SpellAuthorityReference | null => {
+  const campaignSpellId = normalizeSpellAuthorityValue(spell.campaignSpellId);
+  if (campaignSpellId) {
+    return {
+      kind: "campaign",
+      key: `campaign:${campaignSpellId}`,
+      value: campaignSpellId
+    };
+  }
+
+  const canonicalKey = normalizeSpellAuthorityValue(spell.canonicalKey);
+  if (canonicalKey) {
+    return {
+      kind: "canonical",
+      key: `canonical:${canonicalKey}`,
+      value: canonicalKey
+    };
+  }
+
+  const name = normalizeSpellAuthorityName(spell.name);
+  if (name) {
+    return {
+      kind: "name",
+      key: `name:${name}`,
+      value: name
+    };
+  }
+
+  return null;
+};
+
+export const getSpellAuthorityKey = (spell: SpellAuthorityCandidate) =>
+  getSpellAuthorityReference(spell)?.key ?? null;
+
+export const isSameSpellAuthority = (
+  left: SpellAuthorityCandidate,
+  right: SpellAuthorityCandidate
+) => {
+  const leftKey = getSpellAuthorityKey(left);
+  return leftKey !== null && leftKey === getSpellAuthorityKey(right);
+};
+
+/**
+ * Resolves a spell entry from a catalog/collection using the explicit
+ * authority precedence. If a stronger identifier exists and fails to match,
+ * this function does not silently fall back to weaker identifiers.
+ */
+export const resolveSpellByAuthority = <T extends SpellAuthorityCandidate>(
+  spells: readonly T[],
+  spell: SpellAuthorityCandidate
+): T | undefined => {
+  const authority = getSpellAuthorityReference(spell);
+  if (!authority) {
+    return undefined;
+  }
+
+  return spells.find((entry) => {
+    const entryAuthority = getSpellAuthorityReference(entry);
+    return entryAuthority?.key === authority.key;
+  });
+};

--- a/apps/control-web/src/features/character-sheet/utils/creationSpells.test.ts
+++ b/apps/control-web/src/features/character-sheet/utils/creationSpells.test.ts
@@ -178,4 +178,84 @@ describe("toSheetSpell / selectCatalogSpellForSheet", () => {
       }),
     ]);
   });
+
+  it("keeps campaign-authoritative fixed spells even when weaker identifiers drift", () => {
+    seedSpellCatalogCache(
+      [
+        {
+          campaignSpellId: "camp-animal-friendship",
+          canonicalKey: "animal_friendship",
+          name: "Animal Friendship",
+          level: 1,
+          school: "Enchantment",
+          castingTime: "1 action",
+          range: "9 m",
+          components: "V, S, M",
+          duration: "24 hours",
+          concentration: false,
+          ritual: false,
+          description: "",
+          damageType: null,
+          savingThrow: "WIS",
+          classes: ["Bard", "Druid", "Ranger"],
+        },
+        {
+          campaignSpellId: "camp-hunters-mark",
+          canonicalKey: "hunters_mark",
+          name: "Hunter's Mark",
+          level: 1,
+          school: "Divination",
+          castingTime: "1 bonus action",
+          range: "27 m",
+          components: "V",
+          duration: "1 hour",
+          concentration: true,
+          ritual: false,
+          description: "",
+          damageType: null,
+          savingThrow: null,
+          classes: ["Ranger"],
+        },
+      ],
+      "camp-2",
+    );
+
+    const normalized = normalizeCreationSpellSelection(
+      {
+        ability: "wisdom",
+        mode: "known",
+        slots: { 1: { max: 2, used: 0 } },
+        spells: [
+          {
+            id: "spell-1",
+            name: "Outdated Spell Name",
+            canonicalKey: "outdated_key",
+            campaignSpellId: "camp-animal-friendship",
+            level: 1,
+            school: "Enchantment",
+            prepared: true,
+            notes: "",
+          },
+        ],
+      },
+      "guardian",
+      INITIAL_SHEET.abilities,
+      2,
+      "camp-2",
+    );
+
+    expect(normalized?.spells).toHaveLength(2);
+    expect(normalized?.spells).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          canonicalKey: "animal_friendship",
+          campaignSpellId: "camp-animal-friendship",
+        }),
+        expect.objectContaining({
+          canonicalKey: "hunters_mark",
+          campaignSpellId: "camp-hunters-mark",
+        }),
+      ]),
+    );
+  });
 });

--- a/apps/control-web/src/features/character-sheet/utils/creationSpells.ts
+++ b/apps/control-web/src/features/character-sheet/utils/creationSpells.ts
@@ -3,6 +3,8 @@ import {
   findBaseSpell,
   getBaseSpells,
   getBaseSpellsForClass,
+  isSameSpellAuthority,
+  resolveSpellByAuthority,
   resolveSpellSourceClassId
 } from "../../../entities/dnd-base";
 import { getModifier } from "./calculations";
@@ -50,14 +52,6 @@ const getFixedSpellKeys = (
       : (levelConfig?.fixedLeveledSpellCanonicalKeys ?? []))
   ]);
 };
-
-const spellMatchesBaseSpell = (
-  spell: Spell,
-  baseSpellName: string,
-  baseSpellKey: string
-) =>
-  spell.canonicalKey?.toLowerCase() === baseSpellKey.toLowerCase() ||
-  spell.name.toLowerCase() === baseSpellName.toLowerCase();
 
 const toSheetSpell = (
   spellIdentifier: string,
@@ -125,17 +119,10 @@ export const hasUnresolvedCreationSpellSelections = (
   campaignId?: string | null
 ) => {
   if (!spellcasting) return false;
-
-  const availableSpellKeys = new Set(
-    getCatalogSpellOptions(className, campaignId).map((spell) =>
-      spell.canonicalKey.toLowerCase()
-    )
+  const availableSpells = getCatalogSpellOptions(className, campaignId);
+  return spellcasting.spells.some(
+    (spell) => !resolveSpellByAuthority(availableSpells, spell)
   );
-
-  return spellcasting.spells.some((spell) => {
-    const lookup = spell.canonicalKey?.trim().toLowerCase();
-    return !lookup || !availableSpellKeys.has(lookup);
-  });
 };
 
 const ensureFixedStartingSpells = (
@@ -155,11 +142,7 @@ const ensureFixedStartingSpells = (
   const merged = [...spells];
   for (const fixedSpell of fixedSpells) {
     const existingIndex = merged.findIndex((spell) =>
-      spellMatchesBaseSpell(
-        spell,
-        fixedSpell.name,
-        fixedSpell.canonicalKey ?? ""
-      )
+      isSameSpellAuthority(spell, fixedSpell)
     );
     if (existingIndex >= 0) {
       merged[existingIndex] = {
@@ -285,18 +268,9 @@ export const normalizeCreationSpellSelection = (
 
   const mode = spellcasting.mode;
   const allowedSpells = getBaseSpellsForClass(className, 1, campaignId);
-  const allowedSpellKeys = new Set(
-    allowedSpells.map((spell) => spell.canonicalKey.toLowerCase())
-  );
-  const allowedSpellNames = new Set(
-    allowedSpells.map((spell) => spell.name.toLowerCase())
-  );
   const selected = ensureFixedStartingSpells(
-    spellcasting.spells.filter(
-      (spell) =>
-        (spell.canonicalKey &&
-          allowedSpellKeys.has(spell.canonicalKey.toLowerCase())) ||
-        allowedSpellNames.has(spell.name.toLowerCase())
+    spellcasting.spells.filter((spell) =>
+      Boolean(resolveSpellByAuthority(allowedSpells, spell))
     ),
     className,
     level,
@@ -352,7 +326,7 @@ export const toggleStartingSpell = (
   }
 
   const existing = spellcasting.spells.find((entry) =>
-    spellMatchesBaseSpell(entry, spell.name, spell.canonicalKey)
+    isSameSpellAuthority(entry, spell)
   );
   if (existing) {
     return normalizeCreationSpellSelection(

--- a/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.test.ts
+++ b/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.test.ts
@@ -4,12 +4,211 @@ import { seedSpellCatalogCache } from "../../../entities/dnd-base";
 import { ITEM_TYPES } from "../../../entities/item";
 import type { InventoryItem } from "../../../entities/inventory";
 import type { Item } from "../../../entities/item";
+import type { CharacterSheet } from "../../../features/character-sheet/model/characterSheet.types";
 import { buildSpellOptions } from "./usePlayerCombatModeHelpers";
 
 describe("buildSpellOptions", () => {
+  it("prefers campaignSpellId over stale canonicalKey and name for sheet spell resolution", () => {
+    seedSpellCatalogCache(
+      [
+        {
+          campaignSpellId: "camp-spell-1",
+          canonicalKey: "spike_growth",
+          name: "Spike Growth",
+          level: 2,
+          school: "transmutation",
+          castingTimeType: "action",
+          castingTime: "1 action",
+          range: "45 m",
+          components: "V, S, M",
+          duration: "Up to 10 minutes",
+          concentration: true,
+          ritual: false,
+          description: "Test spell.",
+          resolutionType: "control",
+          targetMode: "sphere",
+          damageType: null,
+          savingThrow: "DEX",
+          saveSuccessOutcome: "none",
+          healDice: null,
+          upcast: null,
+          classes: ["Druid", "Ranger"],
+        },
+      ],
+      "camp-authority",
+    );
+
+    const playerSheet = {
+      abilities: {
+        strength: 10,
+        dexterity: 10,
+        constitution: 10,
+        intelligence: 10,
+        wisdom: 16,
+        charisma: 10,
+      },
+      alignment: "neutral",
+      background: "outlander",
+      class: "ranger",
+      classEquipmentSelections: {},
+      classFeatures: [],
+      classSkillChoices: [],
+      classToolProficiencyChoices: [],
+      conditions: {},
+      currentHP: 10,
+      currentWeaponId: null,
+      deathSaves: { failures: 0, successes: 0 },
+      equippedArmor: { armorType: "none", baseAC: 10, dexCap: null, name: "None" },
+      equippedArmorItemId: null,
+      equippedShield: null,
+      experiencePoints: 0,
+      expertiseChoices: [],
+      fightingStyle: null,
+      hitDiceRemaining: 2,
+      hitDiceTotal: 2,
+      inspiration: false,
+      inventory: [],
+      languageChoices: [],
+      level: 2,
+      maxHP: 10,
+      name: "Ranger",
+      pendingLevelUp: false,
+      playerName: "Player",
+      race: "human",
+      raceConfig: {},
+      raceToolProficiencyChoices: [],
+      restState: "exploration",
+      savingThrowProficiencies: {
+        strength: false,
+        dexterity: true,
+        constitution: false,
+        intelligence: false,
+        wisdom: true,
+        charisma: false,
+      },
+      schemaVersion: 1,
+      skillProficiencies: {
+        acrobatics: 0,
+        animalHandling: 0,
+        arcana: 0,
+        athletics: 0,
+        deception: 0,
+        history: 0,
+        insight: 0,
+        intimidation: 0,
+        investigation: 0,
+        medicine: 0,
+        nature: 0,
+        perception: 0,
+        performance: 0,
+        persuasion: 0,
+        religion: 0,
+        sleightOfHand: 0,
+        stealth: 0,
+        survival: 1,
+      },
+      spellcasting: {
+        ability: "wisdom",
+        mode: "known",
+        slots: {
+          1: { max: 0, used: 0 },
+          2: { max: 2, used: 0 },
+        },
+        spells: [
+          {
+            id: "spell-1",
+            name: "Outdated Spell Name",
+            canonicalKey: "outdated_key",
+            campaignSpellId: "camp-spell-1",
+            level: 2,
+            school: "illusion",
+            prepared: true,
+            notes: "",
+          },
+        ],
+      },
+      subclass: null,
+      subclassConfig: {},
+      temporaryHP: 0,
+      weapons: [],
+      currency: { copperValue: 0 },
+    } as CharacterSheet;
+
+    expect(buildSpellOptions(playerSheet, "camp-authority")).toEqual([
+      expect.objectContaining({
+        id: "spell-1",
+        campaignSpellId: "camp-spell-1",
+        canonicalKey: "spike_growth",
+        actionCost: "action",
+        targetMode: "sphere",
+        savingThrow: "DEX",
+        availableSlotLevels: [2],
+      }),
+    ]);
+  });
+
+  it("still resolves base sheet spells by canonicalKey when campaignSpellId is absent", () => {
+    seedSpellCatalogCache([
+      {
+        campaignSpellId: null,
+        canonicalKey: "magic_missile",
+        name: "Magic Missile",
+        level: 1,
+        school: "evocation",
+        castingTimeType: "action",
+        castingTime: "1 action",
+        range: "36 m",
+        components: "V, S",
+        duration: "Instantaneous",
+        concentration: false,
+        ritual: false,
+        description: "Test spell.",
+        resolutionType: "damage",
+        damageType: "Force",
+        savingThrow: null,
+        saveSuccessOutcome: null,
+        healDice: null,
+        upcast: null,
+        classes: ["Wizard"],
+      },
+    ]);
+
+    const playerSheet = {
+      spellcasting: {
+        ability: "intelligence",
+        mode: "known",
+        slots: { 1: { max: 2, used: 0 } },
+        spells: [
+          {
+            id: "spell-1",
+            name: "Outdated Name",
+            canonicalKey: "magic_missile",
+            campaignSpellId: null,
+            level: 1,
+            school: "evocation",
+            prepared: true,
+            notes: "",
+          },
+        ],
+      },
+    } as CharacterSheet;
+
+    expect(buildSpellOptions(playerSheet)).toEqual([
+      expect.objectContaining({
+        id: "spell-1",
+        campaignSpellId: null,
+        canonicalKey: "magic_missile",
+        actionCost: "action",
+        damageType: "Force",
+        availableSlotLevels: [1],
+      }),
+    ]);
+  });
+
   it("includes cast_spell magic items from inventory without requiring spellcasting", () => {
     seedSpellCatalogCache([
       {
+        campaignSpellId: null,
         canonicalKey: "magic_missile",
         name: "Magic Missile",
         level: 1,
@@ -81,6 +280,7 @@ describe("buildSpellOptions", () => {
   it("hides exhausted magic items from combat spell options", () => {
     seedSpellCatalogCache([
       {
+        campaignSpellId: null,
         canonicalKey: "detect_magic",
         name: "Detect Magic",
         level: 1,

--- a/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.ts
+++ b/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.ts
@@ -1,5 +1,9 @@
 import type { AbilityName } from "../../../entities/roll/rollResolution.types";
-import { getBaseSpells, loadSpellCatalog } from "../../../entities/dnd-base";
+import {
+  getBaseSpells,
+  loadSpellCatalog,
+  resolveSpellByAuthority
+} from "../../../entities/dnd-base";
 import type { InventoryItem } from "../../../entities/inventory";
 import type { Item } from "../../../entities/item";
 import type { CharacterSheet } from "../../../features/character-sheet/model/characterSheet.types";
@@ -48,9 +52,6 @@ export const buildSpellOptions = (
   const byCanonicalKey = new Map(
     catalog.map((spell) => [spell.canonicalKey.toLowerCase(), spell] as const)
   );
-  const byName = new Map(
-    catalog.map((spell) => [spell.name.toLowerCase(), spell] as const)
-  );
   const spellcasting = playerSheet?.spellcasting;
   const availableSlotLevels = Object.entries(spellcasting?.slots ?? {})
     .map(([level, slot]) => ({ level: Number(level), slot }))
@@ -89,12 +90,11 @@ export const buildSpellOptions = (
             spell.level === 0 || spell.prepared || spellcasting.mode === "known"
         )
         .map((spell) => {
-          const catalogSpell = spell.canonicalKey
-            ? (byCanonicalKey.get(spell.canonicalKey.toLowerCase()) ??
-              byName.get(spell.name.toLowerCase()))
-            : byName.get(spell.name.toLowerCase());
+          const catalogSpell = resolveSpellByAuthority(catalog, spell);
           const canonicalKey =
-            spell.canonicalKey ?? catalogSpell?.canonicalKey ?? null;
+            spell.campaignSpellId
+              ? (catalogSpell?.canonicalKey ?? spell.canonicalKey ?? null)
+              : (spell.canonicalKey ?? catalogSpell?.canonicalKey ?? null);
           return {
             canonicalKey,
             campaignSpellId: spell.campaignSpellId ?? null,

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/types.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/types.ts
@@ -25,6 +25,7 @@ export type CombatSpellOption = {
   id: string;
   name: string;
   canonicalKey: string | null;
+  campaignSpellId?: string | null;
   sourceType?: "sheet" | "magic_item";
   sourceItemName?: string | null;
   inventoryItemId?: string | null;

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/usePlayerCombatDebugState.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/usePlayerCombatDebugState.ts
@@ -9,7 +9,11 @@ import {
 } from "../../../shared/api/combatRepo";
 import { subscribe } from "../../../shared/realtime/centrifugoClient";
 import type { AbilityName } from "../../../entities/roll/rollResolution.types";
-import { getBaseSpells, loadSpellCatalog } from "../../../entities/dnd-base";
+import {
+  getBaseSpells,
+  loadSpellCatalog,
+  resolveSpellByAuthority
+} from "../../../entities/dnd-base";
 import type { CharacterSheet } from "../../../features/character-sheet/model/characterSheet.types";
 import {
   getCombatSpellAutomation,
@@ -61,12 +65,6 @@ const buildSpellOptions = (
   if (!spellcasting) return [];
 
   const catalog = getBaseSpells(campaignId);
-  const byCanonicalKey = new Map(
-    catalog.map((spell) => [spell.canonicalKey.toLowerCase(), spell] as const)
-  );
-  const byName = new Map(
-    catalog.map((spell) => [spell.name.toLowerCase(), spell] as const)
-  );
   const availableSlotLevels = Object.entries(spellcasting.slots ?? {})
     .map(([level, slot]) => ({ level: Number(level), slot }))
     .filter(
@@ -82,12 +80,11 @@ const buildSpellOptions = (
         spell.level === 0 || spell.prepared || spellcasting.mode === "known"
     )
     .map((spell) => {
-      const catalogSpell = spell.canonicalKey
-        ? (byCanonicalKey.get(spell.canonicalKey.toLowerCase()) ??
-          byName.get(spell.name.toLowerCase()))
-        : byName.get(spell.name.toLowerCase());
+      const catalogSpell = resolveSpellByAuthority(catalog, spell);
       const automation = getCombatSpellAutomation(
-        spell.canonicalKey ?? catalogSpell?.canonicalKey ?? null
+        spell.campaignSpellId
+          ? (catalogSpell?.canonicalKey ?? spell.canonicalKey ?? null)
+          : (spell.canonicalKey ?? catalogSpell?.canonicalKey ?? null)
       );
       const suggestedMode: CombatSpellMode | null =
         (catalogSpell?.defaultSpellMode as
@@ -103,7 +100,10 @@ const buildSpellOptions = (
       return {
         id: spell.id,
         name: spell.name,
-        canonicalKey: spell.canonicalKey ?? catalogSpell?.canonicalKey ?? null,
+        canonicalKey: spell.campaignSpellId
+          ? (catalogSpell?.canonicalKey ?? spell.canonicalKey ?? null)
+          : (spell.canonicalKey ?? catalogSpell?.canonicalKey ?? null),
+        campaignSpellId: spell.campaignSpellId ?? null,
         level: spell.level,
         prepared: spell.prepared,
         actionCost: resolveCombatSpellActionCost(


### PR DESCRIPTION
## Summary

This PR centralizes and enforces spell authority precedence across character creation and combat-sensitive flows.

It introduces a single spell authority resolver and updates relevant matching/resolution paths to consistently use:

- `campaignSpellId`
- `canonicalKey`
- `name`

in that exact order.

## Root cause

Spell identity precedence existed only implicitly and inconsistently across a few code paths.

The main gaps were:

- character creation normalization and matching
- combat spell option building
- tactical/debug combat spell option building

Those paths could resolve spells by `canonicalKey` or `name` without a single enforced rule, which meant campaign-backed spells could degrade to weaker identifiers even when `campaignSpellId` was present.

## Fix

Added a centralized spell authority helper in `spellAuthority.ts` with:

- `getSpellAuthorityReference(spell)`
- `getSpellAuthorityKey(spell)`
- `isSameSpellAuthority(left, right)`
- `resolveSpellByAuthority(catalog, spell)`
- `normalizeSpellAuthorityName(name)`

This helper enforces:

1. `campaignSpellId`
2. `canonicalKey`
3. `name`

and does not silently fall back to weaker identifiers when a stronger identifier exists but does not match.

## Code paths updated

- Character creation matching, dedup, and normalization now use the centralized resolver
- Combat sheet spell resolution now uses the centralized resolver
- Tactical/debug combat spell resolution now uses the same resolver
- Debug combat spell option types now carry `campaignSpellId`

## Why this is safe

The change was kept narrow and focused.

- No schema changes
- No persistence changes
- No class rule changes
- No combat engine behavior changes

Only spell-to-catalog matching was updated before automation and payload building.

This makes campaign spell resolution stronger and more consistent while preserving the existing payload shapes and downstream behavior.

## Behavior after fix

- Campaign spells resolve by `campaignSpellId` when available
- Base spells continue to resolve by `canonicalKey`
- Name fallback is only used when stronger identifiers are absent
- Character creation, combat, and tactical/debug spell option building now share the same authority rule

## Tests

- Focused authority / creation / combat tests: `26` passing
- `apps/control-web` suite: `199` passing
- Root `npm test`: `531` passing
- `npm run lint`: passing

## Notes

- `CreationSpellPicker` still uses display names only for UI chip state and does not resolve spell authority
- Magic-item spell actions remain canonical-only because their model only carries `spellCanonicalKey`
- `findBaseSpell()` remains a direct canonical/name lookup by design, since it handles catalog selection input rather than authority-bearing sheet spell objects