### PR TITLE
feat: enhance magic item handling with campaignSpellId support and re…

### DIFF
--- a/apps/control-web/src/entities/base-item/baseItem.types.ts
+++ b/apps/control-web/src/entities/base-item/baseItem.types.ts
@@ -125,6 +125,8 @@ export type MagicItemRechargeType =
 
 export type MagicItemCastSpellEffect = {
   type: "cast_spell";
+  /** Authority id for campaign-backed spell entries. Null/absent for base or legacy item spells. */
+  campaignSpellId?: string | null;
   spellCanonicalKey: string;
   castLevel: number;
   ignoreComponents: boolean;

--- a/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.test.ts
+++ b/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.test.ts
@@ -264,6 +264,7 @@ describe("buildSpellOptions", () => {
     expect(options).toEqual([
       expect.objectContaining({
         id: "magic-item:inv-1",
+        campaignSpellId: null,
         canonicalKey: "magic_missile",
         sourceType: "magic_item",
         sourceItemName: "Bracelete de Phantyr: Mísseis Mágicos",
@@ -275,6 +276,149 @@ describe("buildSpellOptions", () => {
         noFreeHandRequired: true,
       }),
     ]);
+  });
+
+  it("resolves campaign-backed magic item spells by campaignSpellId", () => {
+    seedSpellCatalogCache(
+      [
+        {
+          campaignSpellId: "camp-spell-1",
+          canonicalKey: "spike_growth",
+          name: "Spike Growth",
+          level: 2,
+          school: "transmutation",
+          castingTimeType: "action",
+          castingTime: "1 action",
+          range: "45 m",
+          components: "V, S, M",
+          duration: "Up to 10 minutes",
+          concentration: true,
+          ritual: false,
+          description: "Test spell.",
+          resolutionType: "control",
+          targetMode: "sphere",
+          damageType: null,
+          savingThrow: "DEX",
+          saveSuccessOutcome: "none",
+          healDice: null,
+          upcast: null,
+          classes: ["Druid", "Ranger"],
+        },
+      ],
+      "camp-magic-item",
+    );
+
+    const options = buildSpellOptions(
+      null,
+      "camp-magic-item",
+      [
+        {
+          id: "inv-1",
+          itemId: "item-1",
+          memberId: "member-1",
+          quantity: 1,
+          chargesCurrent: 1,
+          isEquipped: false,
+        },
+      ],
+      {
+        "item-1": {
+          id: "item-1",
+          name: "Cajado de Espinhos",
+          type: ITEM_TYPES.MAGIC,
+          description: "Canaliza Spike Growth.",
+          chargesMax: 3,
+          rechargeType: "dawn",
+          magicEffect: {
+            type: "cast_spell",
+            campaignSpellId: "camp-spell-1",
+            spellCanonicalKey: "outdated_key",
+            castLevel: 2,
+            ignoreComponents: true,
+            noFreeHandRequired: false,
+          },
+        },
+      },
+    );
+
+    expect(options).toEqual([
+      expect.objectContaining({
+        id: "magic-item:inv-1",
+        campaignSpellId: "camp-spell-1",
+        canonicalKey: "spike_growth",
+        name: "Spike Growth",
+        sourceType: "magic_item",
+        actionCost: "action",
+        targetMode: "sphere",
+        savingThrow: "DEX",
+        availableSlotLevels: [2],
+      }),
+    ]);
+  });
+
+  it("does not fall back to canonicalKey when a magic item campaignSpellId is present but invalid", () => {
+    seedSpellCatalogCache(
+      [
+        {
+          campaignSpellId: "camp-spell-2",
+          canonicalKey: "magic_missile",
+          name: "Magic Missile",
+          level: 1,
+          school: "evocation",
+          castingTimeType: "action",
+          castingTime: "1 action",
+          range: "36 m",
+          components: "V, S",
+          duration: "Instantaneous",
+          concentration: false,
+          ritual: false,
+          description: "Test spell.",
+          resolutionType: "damage",
+          damageType: "Force",
+          savingThrow: null,
+          saveSuccessOutcome: null,
+          healDice: null,
+          upcast: null,
+          classes: ["Wizard"],
+        },
+      ],
+      "camp-magic-item-mismatch",
+    );
+
+    const options = buildSpellOptions(
+      null,
+      "camp-magic-item-mismatch",
+      [
+        {
+          id: "inv-1",
+          itemId: "item-1",
+          memberId: "member-1",
+          quantity: 1,
+          chargesCurrent: 1,
+          isEquipped: false,
+        },
+      ],
+      {
+        "item-1": {
+          id: "item-1",
+          name: "Bracelete Quebrado",
+          type: ITEM_TYPES.MAGIC,
+          description: "Tem uma referencia de spell quebrada.",
+          chargesMax: 1,
+          rechargeType: "none",
+          magicEffect: {
+            type: "cast_spell",
+            campaignSpellId: "camp-spell-1",
+            spellCanonicalKey: "magic_missile",
+            castLevel: 1,
+            ignoreComponents: true,
+            noFreeHandRequired: true,
+          },
+        },
+      },
+    );
+
+    expect(options).toEqual([]);
   });
 
   it("hides exhausted magic items from combat spell options", () => {

--- a/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.ts
+++ b/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.ts
@@ -49,9 +49,6 @@ export const buildSpellOptions = (
   itemsById?: Record<string, Item>
 ): CombatSpellOption[] => {
   const catalog = getBaseSpells(campaignId);
-  const byCanonicalKey = new Map(
-    catalog.map((spell) => [spell.canonicalKey.toLowerCase(), spell] as const)
-  );
   const spellcasting = playerSheet?.spellcasting;
   const availableSlotLevels = Object.entries(spellcasting?.slots ?? {})
     .map(([level, slot]) => ({ level: Number(level), slot }))
@@ -134,15 +131,18 @@ export const buildSpellOptions = (
     if (typeof chargesCurrent === "number" && chargesCurrent <= 0) {
       return [];
     }
-    const catalogSpell = byCanonicalKey.get(
-      magicEffect.spellCanonicalKey.toLowerCase()
-    );
+    const catalogSpell = resolveSpellByAuthority(catalog, {
+      campaignSpellId: magicEffect.campaignSpellId,
+      canonicalKey: magicEffect.spellCanonicalKey,
+    });
     if (!catalogSpell) {
       return [];
     }
     return [
       {
         canonicalKey: catalogSpell.canonicalKey,
+        campaignSpellId:
+          magicEffect.campaignSpellId ?? catalogSpell.campaignSpellId ?? null,
         actionCost: resolveCombatSpellActionCost(
           catalogSpell.castingTimeType ?? null
         ),

--- a/apps/control-web/src/features/shop/hooks/useShop.test.ts
+++ b/apps/control-web/src/features/shop/hooks/useShop.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import type { ItemInput } from "../../../entities/item";
+import { toItemRepoPayload } from "./useShop";
+
+describe("toItemRepoPayload", () => {
+  it("preserves campaignSpellId for campaign-backed magic item spell effects", () => {
+    const payload: ItemInput = {
+      name: "  Wand of Thorns  ",
+      type: "MAGIC",
+      description: "  Casts Spike Growth.  ",
+      price: 250,
+      magicEffect: {
+        type: "cast_spell",
+        campaignSpellId: "camp-spell-1",
+        spellCanonicalKey: "spike_growth",
+        castLevel: 2,
+        ignoreComponents: true,
+        noFreeHandRequired: false,
+      },
+    };
+
+    expect(toItemRepoPayload(payload)).toEqual(
+      expect.objectContaining({
+        name: "Wand of Thorns",
+        description: "Casts Spike Growth.",
+        magicEffect: {
+          type: "cast_spell",
+          campaignSpellId: "camp-spell-1",
+          spellCanonicalKey: "spike_growth",
+          castLevel: 2,
+          ignoreComponents: true,
+          noFreeHandRequired: false,
+        },
+      }),
+    );
+  });
+
+  it("keeps legacy canonical-only magic item spell effects valid", () => {
+    const payload: ItemInput = {
+      name: "Wand of Missiles",
+      type: "MAGIC",
+      description: "Casts Magic Missile.",
+      price: 100,
+      magicEffect: {
+        type: "cast_spell",
+        spellCanonicalKey: "magic_missile",
+        castLevel: 1,
+        ignoreComponents: true,
+        noFreeHandRequired: true,
+      },
+    };
+
+    expect(toItemRepoPayload(payload)).toEqual(
+      expect.objectContaining({
+        magicEffect: {
+          type: "cast_spell",
+          spellCanonicalKey: "magic_missile",
+          castLevel: 1,
+          ignoreComponents: true,
+          noFreeHandRequired: true,
+        },
+      }),
+    );
+  });
+});

--- a/apps/control-web/src/features/shop/hooks/useShop.ts
+++ b/apps/control-web/src/features/shop/hooks/useShop.ts
@@ -17,6 +17,29 @@ type UseShopOptions = {
   auto?: boolean;
 };
 
+export const toItemRepoPayload = (payload: ItemInput): ItemInput => ({
+  name: payload.name.trim(),
+  type: payload.type,
+  description: payload.description.trim(),
+  price: payload.price,
+  weight: payload.weight,
+  damageDice: payload.damageDice,
+  damageType: payload.damageType,
+  magicEffect: payload.magicEffect,
+  rangeMeters: payload.rangeMeters,
+  rangeLongMeters: payload.rangeLongMeters,
+  versatileDamage: payload.versatileDamage,
+  weaponCategory: payload.weaponCategory || undefined,
+  weaponRangeType: payload.weaponRangeType || undefined,
+  armorCategory: payload.armorCategory || undefined,
+  armorClassBase: payload.armorClassBase,
+  dexBonusRule: payload.dexBonusRule || undefined,
+  strengthRequirement: payload.strengthRequirement,
+  stealthDisadvantage: payload.stealthDisadvantage,
+  isShield: payload.isShield,
+  properties: payload.properties,
+});
+
 export const useShop = (options?: UseShopOptions) => {
   const { campaigns, selectedCampaignId } = useCampaigns();
   const campaignId = options?.campaignId ?? selectedCampaignId ?? null;
@@ -75,27 +98,10 @@ export const useShop = (options?: UseShopOptions) => {
     }
 
     try {
-      const item = await itemsRepo.create(campaignId, {
-        name: validation.value.name.trim(),
-        type: validation.value.type,
-        description: validation.value.description.trim(),
-        price: validation.value.price,
-        weight: validation.value.weight,
-        damageDice: validation.value.damageDice,
-        damageType: validation.value.damageType,
-        rangeMeters: validation.value.rangeMeters,
-        rangeLongMeters: validation.value.rangeLongMeters,
-        versatileDamage: validation.value.versatileDamage,
-        weaponCategory: validation.value.weaponCategory || undefined,
-        weaponRangeType: validation.value.weaponRangeType || undefined,
-        armorCategory: validation.value.armorCategory || undefined,
-        armorClassBase: validation.value.armorClassBase,
-        dexBonusRule: validation.value.dexBonusRule || undefined,
-        strengthRequirement: validation.value.strengthRequirement,
-        stealthDisadvantage: validation.value.stealthDisadvantage,
-        isShield: validation.value.isShield,
-        properties: validation.value.properties,
-      });
+      const item = await itemsRepo.create(
+        campaignId,
+        toItemRepoPayload(validation.value),
+      );
       if (item) {
         setItems((current) => [item, ...current]);
       }
@@ -119,27 +125,11 @@ export const useShop = (options?: UseShopOptions) => {
     }
 
     try {
-      const item = await itemsRepo.update(campaignId, itemId, {
-        name: validation.value.name.trim(),
-        type: validation.value.type,
-        description: validation.value.description.trim(),
-        price: validation.value.price,
-        weight: validation.value.weight,
-        damageDice: validation.value.damageDice,
-        damageType: validation.value.damageType,
-        rangeMeters: validation.value.rangeMeters,
-        rangeLongMeters: validation.value.rangeLongMeters,
-        versatileDamage: validation.value.versatileDamage,
-        weaponCategory: validation.value.weaponCategory || undefined,
-        weaponRangeType: validation.value.weaponRangeType || undefined,
-        armorCategory: validation.value.armorCategory || undefined,
-        armorClassBase: validation.value.armorClassBase,
-        dexBonusRule: validation.value.dexBonusRule || undefined,
-        strengthRequirement: validation.value.strengthRequirement,
-        stealthDisadvantage: validation.value.stealthDisadvantage,
-        isShield: validation.value.isShield,
-        properties: validation.value.properties,
-      });
+      const item = await itemsRepo.update(
+        campaignId,
+        itemId,
+        toItemRepoPayload(validation.value),
+      );
       if (item) {
         setItems((current) =>
           current.map((entry) => (entry.id === itemId ? item : entry)),


### PR DESCRIPTION
## Summary

This PR adds campaign spell authority support to magic-item cast actions.

Previously, magic-item spell effects were modeled and resolved using `spellCanonicalKey` only, which meant campaign-backed item spells could not carry or preserve `campaignSpellId`.

## Root cause

Magic-item spell effects only stored `spellCanonicalKey`.

As a result:
- campaign-backed item spells had no place to store `campaignSpellId`
- combat resolution for item spells could only match by canonical key
- item-based spell flows degraded to a weaker identifier even when stronger campaign authority existed elsewhere

## Fix

### Model
- Extended `MagicItemCastSpellEffect` to support optional `campaignSpellId`
- Kept `spellCanonicalKey` unchanged for backward compatibility

### Runtime resolution
- Updated magic-item combat spell resolution to use the centralized spell authority resolver
- Resolution now prefers:
  1. `campaignSpellId`
  2. `spellCanonicalKey`

### Write path
- Updated the shop write mapper so `magicEffect` is preserved on create/update payloads instead of being dropped when provided by callers

## Why this is correct

- Preserves backward compatibility for canonical-only magic items
- Allows campaign-backed magic items to resolve from the stronger identifier first
- Reuses the existing centralized spell authority rule instead of introducing a separate item-specific system
- Keeps downstream combat/casting payload behavior stable by resolving authoritative catalog data first and then deriving canonical data from it

## Behavior after fix

- Canonical-only magic-item spells continue to work as before
- Campaign-backed magic-item spells now preserve and use `campaignSpellId`
- If `campaignSpellId` is present but invalid, resolution does not silently fall back to `spellCanonicalKey`
- Combat spell options for magic items now also carry `campaignSpellId`

## Tests

Added/updated coverage for:
- campaign-backed magic item spell resolution by `campaignSpellId`
- canonical-only magic item spell resolution
- strict no-fallback behavior when `campaignSpellId` is present but invalid
- write-path preservation of `magicEffect.campaignSpellId`

## Results

- Focused tests: `8` passing
- `apps/control-web`: `203` passing
- Root `npm test`: `535` passing
- `npm run lint`: passing

## Notes

- Inventory display/search paths that use `spellCanonicalKey` remain unchanged, since they are descriptive UI behavior rather than authority-sensitive combat resolution
- `campaign-entity` combat actions were not changed, because they belong to a separate spell-action system and are outside the scope of this PR