### PR TITLE
feat: GM opt-out of tactical map when opening combat

### DIFF
--- a/apps/control-server/alembic/versions/0055_combat_state_use_map.py
+++ b/apps/control-server/alembic/versions/0055_combat_state_use_map.py
@@ -1,0 +1,38 @@
+"""Add use_map flag to combat_state.
+
+Allows the GM to opt out of tactical map integration when opening combat.
+When use_map=False, all LimiarMap-dependent flows (projection, targeting,
+area preview) are skipped for that combat session.
+
+Revision ID: 0055_combat_state_use_map
+Revises: 0054_spell_area_size_meters
+Create Date: 2026-04-13 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0055_combat_state_use_map"
+down_revision: Union[str, None] = "0054_spell_area_size_meters"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "combat_state",
+        sa.Column(
+            "use_map",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("combat_state", "use_map")

--- a/apps/control-server/app/api/routes/combat.py
+++ b/apps/control-server/app/api/routes/combat.py
@@ -184,12 +184,12 @@ def ensure_combat_map(
             reason="combat_not_active",
         )
 
-    if not settings.limiar_map_enabled:
+    if not state.use_map:
         return CombatMapEnsureResponse(
             session_id=session_id,
             combat_phase=phase,
             map_available=False,
-            reason="limiar_map_disabled",
+            reason="map_disabled_for_combat",
         )
 
     result = get_limiar_map_projection_service().project_combat_start(

--- a/apps/control-server/app/api/routes/sessions/combat_preview.py
+++ b/apps/control-server/app/api/routes/sessions/combat_preview.py
@@ -163,7 +163,7 @@ def combat_preview(
             requires_effect=True,
         )
 
-    targeting_service = get_combat_targeting_service()
+    targeting_service = get_combat_targeting_service(combat_state.use_map)
     result = targeting_service.validate(intent, combat_state)
 
     diag: TargetingDiagnostics = result.diagnostics or TargetingDiagnostics()
@@ -215,8 +215,8 @@ def _handle_aoe_preview(
     assert payload.source_position is not None
     assert payload.target_position is not None
 
-    if not settings.limiar_map_enabled:
-        logger.debug("[preview] AoE preview skipped — LimiarMap disabled session=%s", session_id)
+    if not combat_state.use_map:
+        logger.debug("[preview] AoE preview skipped — combat opened without map session=%s", session_id)
         return CombatPreviewResponse(effectiveReachCells=reach)
 
     try:

--- a/apps/control-server/app/core/config.py
+++ b/apps/control-server/app/core/config.py
@@ -152,9 +152,6 @@ class Settings:
         "CENTRIFUGO_PUBLIC_URL",
         "ws://localhost:8001/connection/websocket",
     )
-    limiar_map_enabled: bool = parse_bool(
-        os.getenv("LIMIAR_MAP_ENABLED"), default=False
-    )
     limiar_map_base_url: str = os.getenv(
         "LIMIAR_MAP_BASE_URL",
         "http://localhost:3000",

--- a/apps/control-server/app/integrations/limiar_map_realtime_client.py
+++ b/apps/control-server/app/integrations/limiar_map_realtime_client.py
@@ -575,7 +575,6 @@ def reset_limiar_map_realtime_sync_service() -> None:
 def get_limiar_map_realtime_sync_service() -> LimiarMapRealtimeSyncService:
     global _realtime_sync_service, _realtime_sync_service_signature
     signature = (
-        settings.limiar_map_enabled,
         settings.limiar_map_base_url,
         settings.limiar_map_timeout_seconds,
         settings.centrifugo_public_url,
@@ -594,8 +593,6 @@ def get_limiar_map_realtime_sync_service() -> LimiarMapRealtimeSyncService:
 
 
 def start_limiar_map_realtime_sync() -> None:
-    if not settings.limiar_map_enabled:
-        return
     get_limiar_map_realtime_sync_service().start()
 
 
@@ -608,8 +605,6 @@ def stop_limiar_map_realtime_sync() -> None:
 def resync_limiar_map_session(
     session_id: str,
 ) -> LimiarMapSessionSyncState | None:
-    if not settings.limiar_map_enabled:
-        return None
     return get_limiar_map_realtime_sync_service().resync_session(session_id)
 
 
@@ -619,8 +614,6 @@ def trigger_limiar_map_resync_if_needed(
     reason: str,
     version: int | None = None,
 ) -> LimiarMapSessionSyncState | None:
-    if not settings.limiar_map_enabled:
-        return None
     return get_limiar_map_realtime_sync_service().trigger_resync_if_needed(
         session_id,
         reason=reason,

--- a/apps/control-server/app/models/combat.py
+++ b/apps/control-server/app/models/combat.py
@@ -4,7 +4,7 @@ import enum
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Column, DateTime, Enum, func
+from sqlalchemy import Boolean, Column, DateTime, Enum, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel
 
@@ -33,6 +33,10 @@ class CombatState(SQLModel, table=True):
     map_selection: dict | None = Field(
         default=None,
         sa_column=Column(JSONB, nullable=True),
+    )
+    use_map: bool = Field(
+        default=True,
+        sa_column=Column(Boolean, nullable=False, server_default="true"),
     )
     created_at: datetime = Field(
         sa_column=Column(DateTime(timezone=True), server_default=func.now())

--- a/apps/control-server/app/schemas/combat.py
+++ b/apps/control-server/app/schemas/combat.py
@@ -52,6 +52,7 @@ class CombatMapSelection(BaseModel):
 class CombatStartRequest(BaseModel):
     participants: list[CombatParticipant]
     selectedMap: CombatMapChoice | None = None
+    useMap: bool = True
 
     @model_validator(mode="after")
     def validate_selected_map(self):

--- a/apps/control-server/app/services/combat_service/actions/weapon_attacks.py
+++ b/apps/control-server/app/services/combat_service/actions/weapon_attacks.py
@@ -152,7 +152,7 @@ class WeaponAttacksMixin:
             requires_sight=weapon_targeting.requires_target_sight,
             requires_effect=weapon_targeting.requires_target_effect,
         )
-        targeting_result = get_combat_targeting_service().validate(
+        targeting_result = get_combat_targeting_service(state.use_map).validate(
             targeting_intent, state
         )
         if not targeting_result.is_valid:

--- a/apps/control-server/app/services/combat_service/actions/wild_shape.py
+++ b/apps/control-server/app/services/combat_service/actions/wild_shape.py
@@ -138,7 +138,7 @@ class WildShapeMixin:
             requires_sight=weapon_targeting.requires_target_sight,
             requires_effect=weapon_targeting.requires_target_effect,
         )
-        targeting_result = get_combat_targeting_service().validate(targeting_intent, state)
+        targeting_result = get_combat_targeting_service(state.use_map).validate(targeting_intent, state)
         if not targeting_result.is_valid:
             _diag = targeting_result.diagnostics
             logger.info(

--- a/apps/control-server/app/services/combat_service/combat_targeting.py
+++ b/apps/control-server/app/services/combat_service/combat_targeting.py
@@ -701,50 +701,54 @@ class LimiarMapTargetingService(CombatTargetingService):
 # Module-level singleton — swap this to change the active implementation.
 # ---------------------------------------------------------------------------
 
-_targeting_service: CombatTargetingService | None = None
-_targeting_service_signature: tuple[bool, str, float] | None = None
+_map_targeting_service: CombatTargetingService | None = None
+_map_targeting_service_signature: tuple[str, float] | None = None
+_local_targeting_service: LocalCombatTargetingService | None = None
 
 
 def reset_combat_targeting_service() -> None:
-    global _targeting_service, _targeting_service_signature
-    _targeting_service = None
-    _targeting_service_signature = None
+    global _map_targeting_service, _map_targeting_service_signature, _local_targeting_service
+    _map_targeting_service = None
+    _map_targeting_service_signature = None
+    _local_targeting_service = None
 
 
-def _build_targeting_service() -> CombatTargetingService:
-    if not settings.limiar_map_enabled:
-        logger.info(
-            "Combat targeting service using LocalCombatTargetingService (LIMIAR_MAP_ENABLED=false)"
-        )
-        return LocalCombatTargetingService()
-
-    logger.info(
-        "Combat targeting service using LimiarMapTargetingService base_url=%s timeout_seconds=%s",
-        settings.limiar_map_base_url,
-        settings.limiar_map_timeout_seconds,
-    )
-    return LimiarMapTargetingService(
-        LimiarMapClient(
-            base_url=settings.limiar_map_base_url,
-            timeout_seconds=settings.limiar_map_timeout_seconds,
-        ),
-        fallback_service=LocalCombatTargetingService(),
-    )
+def _get_local_targeting_service() -> LocalCombatTargetingService:
+    global _local_targeting_service
+    if _local_targeting_service is None:
+        _local_targeting_service = LocalCombatTargetingService()
+    return _local_targeting_service
 
 
-def get_combat_targeting_service() -> CombatTargetingService:
-    """Return the active CombatTargetingService implementation.
-
-    Replace the module-level _targeting_service instance (or override this
-    function) to plug in the LimiarMap adapter without touching any caller.
-    """
-    global _targeting_service, _targeting_service_signature
+def _get_map_targeting_service() -> CombatTargetingService:
+    global _map_targeting_service, _map_targeting_service_signature
     signature = (
-        settings.limiar_map_enabled,
         settings.limiar_map_base_url,
         settings.limiar_map_timeout_seconds,
     )
-    if _targeting_service is None or _targeting_service_signature != signature:
-        _targeting_service = _build_targeting_service()
-        _targeting_service_signature = signature
-    return _targeting_service
+    if _map_targeting_service is None or _map_targeting_service_signature != signature:
+        logger.info(
+            "Combat targeting service using LimiarMapTargetingService base_url=%s timeout_seconds=%s",
+            settings.limiar_map_base_url,
+            settings.limiar_map_timeout_seconds,
+        )
+        _map_targeting_service = LimiarMapTargetingService(
+            LimiarMapClient(
+                base_url=settings.limiar_map_base_url,
+                timeout_seconds=settings.limiar_map_timeout_seconds,
+            ),
+            fallback_service=_get_local_targeting_service(),
+        )
+        _map_targeting_service_signature = signature
+    return _map_targeting_service
+
+
+def get_combat_targeting_service(use_map: bool = True) -> CombatTargetingService:
+    """Return the active CombatTargetingService for this combat.
+
+    Pass ``use_map=state.use_map`` so that combats opened without a tactical
+    map fall back to the local targeting service, skipping all LimiarMap calls.
+    """
+    if not use_map:
+        return _get_local_targeting_service()
+    return _get_map_targeting_service()

--- a/apps/control-server/app/services/combat_service/lifecycle.py
+++ b/apps/control-server/app/services/combat_service/lifecycle.py
@@ -149,6 +149,7 @@ class CombatLifecycleMixin:
                 for p in req.participants
             ],
             map_selection=map_selection,
+            use_map=req.useMap,
         )
         db.add(new_state)
         cls._sync_all_participant_statuses(db, new_state)

--- a/apps/control-server/app/services/combat_service/limiar_map_projection.py
+++ b/apps/control-server/app/services/combat_service/limiar_map_projection.py
@@ -614,7 +614,6 @@ def _build_projection_service() -> LimiarMapCombatProjectionService:
 def get_limiar_map_projection_service() -> LimiarMapCombatProjectionService:
     global _projection_service, _projection_service_signature
     signature = (
-        settings.limiar_map_enabled,
         settings.limiar_map_base_url,
         settings.limiar_map_timeout_seconds,
     )
@@ -629,7 +628,7 @@ def maybe_project_combat_start_to_limiar_map(
     session_id: str,
     state: CombatState,
 ) -> None:
-    if not settings.limiar_map_enabled:
+    if not state.use_map:
         return
 
     get_limiar_map_projection_service().project_combat_start(
@@ -643,7 +642,7 @@ def maybe_project_combat_advance_to_limiar_map(
     session_id: str,
     state: CombatState,
 ) -> None:
-    if not settings.limiar_map_enabled:
+    if not state.use_map:
         return
 
     get_limiar_map_projection_service().project_combat_advance(
@@ -656,7 +655,7 @@ def maybe_project_combat_end_to_limiar_map(
     session_id: str,
     state: CombatState,
 ) -> None:
-    if not settings.limiar_map_enabled:
+    if not state.use_map:
         return
 
     get_limiar_map_projection_service().project_combat_end(
@@ -675,7 +674,7 @@ def maybe_sync_conditions_to_limiar_map(
     Errors are logged and swallowed inside the projection service — condition
     display degradation must never block the combat flow.
     """
-    if not settings.limiar_map_enabled:
+    if not state.use_map:
         return
 
     get_limiar_map_projection_service().sync_conditions_to_map(

--- a/apps/control-server/app/services/combat_service/npc_actions.py
+++ b/apps/control-server/app/services/combat_service/npc_actions.py
@@ -253,7 +253,7 @@ class CombatNpcActionMixin:
                 )
 
             # Validate targeting
-            targeting_result = get_combat_targeting_service().validate(
+            targeting_result = get_combat_targeting_service(state.use_map).validate(
                 targeting_intent, state
             )
             if not targeting_result.is_valid:

--- a/apps/control-server/app/services/combat_service/spells/area_targeting.py
+++ b/apps/control-server/app/services/combat_service/spells/area_targeting.py
@@ -101,11 +101,6 @@ class AreaTargetingMixin:
 
     @classmethod
     def _build_limiar_map_client(cls) -> LimiarMapClient:
-        if not settings.limiar_map_enabled:
-            raise CombatServiceError(
-                "Area targeting map integration is disabled.",
-                503,
-            )
         return LimiarMapClient(
             base_url=settings.limiar_map_base_url,
             timeout_seconds=settings.limiar_map_timeout_seconds,
@@ -150,6 +145,8 @@ class AreaTargetingMixin:
     ) -> CombatMapPreviewState:
         state = cls.get_state(db, session_id)
         cls._require_active(state)
+        if not state.use_map:
+            raise CombatServiceError("This combat was opened without a tactical map.", 400)
         actor = cls._resolve_actor_participant(
             state,
             actor_user_id,
@@ -215,6 +212,8 @@ class AreaTargetingMixin:
     ) -> dict[str, Any]:
         state = cls.get_state(db, session_id)
         cls._require_active(state)
+        if not state.use_map:
+            raise CombatServiceError("This combat was opened without a tactical map.", 400)
         attacker = cls._resolve_actor_participant(
             state,
             actor_user_id,

--- a/apps/control-server/app/services/combat_service/spells/cast_area.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_area.py
@@ -101,7 +101,7 @@ class CastAreaMixin:
             requires_sight=bool(spell_context.get("requires_point_sight")),
             requires_effect=bool(spell_context.get("requires_point_effect")),
         )
-        targeting_result = get_combat_targeting_service().validate(targeting_intent, state)
+        targeting_result = get_combat_targeting_service(state.use_map).validate(targeting_intent, state)
         if not targeting_result.is_valid:
             raise CombatServiceError(
                 targeting_result.failure_reason or "Area targeting could not be resolved.",

--- a/apps/control-server/app/services/combat_service/spells/cast_target.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target.py
@@ -740,7 +740,7 @@ class CastTargetMixin:
             requires_sight=bool(spell_context.get("requires_target_sight")),
             requires_effect=bool(spell_context.get("requires_target_effect")),
         )
-        targeting_result = get_combat_targeting_service().validate(
+        targeting_result = get_combat_targeting_service(state.use_map).validate(
             targeting_intent, state
         )
         if not targeting_result.is_valid:

--- a/apps/control-server/tests/test_campaign_spell_creation.py
+++ b/apps/control-server/tests/test_campaign_spell_creation.py
@@ -103,6 +103,7 @@ class CampaignSpellCreateRouteTests(unittest.TestCase):
             range_meters=18,
             range_text="18 m",
             target_mode=None,
+            area_size_meters=None,
             duration="Instantaneous",
             components_json=["V", "S"],
             material_component_text=None,


### PR DESCRIPTION
## Summary

- Removes `LIMIAR_MAP_ENABLED` environment variable as a feature gate — LimiarMap integration is now always available at the infrastructure level
- Adds `useMap: bool = True` to `CombatStartRequest` so GMs choose at combat-start whether to use the tactical map
- Persists `use_map` on `CombatState` (migration 0055) so all subsequent actions in the session respect the GM's original choice
- Replaces all `settings.limiar_map_enabled` checks with `state.use_map` across: projection, targeting service, area preview, AoE targeting, realtime sync startup
- `get_combat_targeting_service(use_map)` now receives the per-combat flag instead of reading from env; callers pass `state.use_map`
- Realtime sync service always starts on app startup — no env gate needed

## Test plan

- [x] Start combat with `useMap: true` → map integration works as before
- [x] Start combat with `useMap: false` → all map-dependent endpoints return early with `map_disabled_for_combat`; attacks and spells resolve via local targeting without errors
- [x] `use_map` persists across turns — set once at combat start, respected for the full session
- [x] `alembic upgrade head` applies migration 0055 cleanly
- [x] 15 Python unit tests pass

Closes #20
