### PR TITLE
feat: add long-range disadvantage for ranged weapon attacks

### DIFF
--- a/apps/control-server/app/integrations/limiar_map_client.py
+++ b/apps/control-server/app/integrations/limiar_map_client.py
@@ -57,6 +57,7 @@ class LimiarMapTargetingResponse:
     version: int
     source_token_id: str | None
     target_token_id: str | None
+    distance_cells: int | None = None
     cover: str | None = None
 
 
@@ -305,6 +306,7 @@ class LimiarMapClient:
         version = payload.get("version")
         source_token_id = payload.get("sourceTokenId")
         target_token_id = payload.get("targetTokenId")
+        distance_cells = payload.get("distanceCells")
 
         if not isinstance(is_valid, bool):
             raise LimiarMapClientError(
@@ -341,6 +343,11 @@ class LimiarMapClient:
                 "LimiarMap targeting response has an invalid targetTokenId",
                 kind="payload",
             )
+        if distance_cells is not None and not isinstance(distance_cells, int):
+            raise LimiarMapClientError(
+                "LimiarMap targeting response has an invalid distanceCells",
+                kind="payload",
+            )
 
         return LimiarMapTargetingResponse(
             is_valid=is_valid,
@@ -350,6 +357,7 @@ class LimiarMapClient:
             version=version,
             source_token_id=source_token_id,
             target_token_id=target_token_id,
+            distance_cells=distance_cells,
             cover=payload.get("cover") if isinstance(payload.get("cover"), str) else None,
         )
 

--- a/apps/control-server/app/schemas/campaign_entity_actions.py
+++ b/apps/control-server/app/schemas/campaign_entity_actions.py
@@ -22,6 +22,9 @@ class CombatAction(BaseModel):
     damageBonus: int | None = None
     damageType: DamageType | None = None
     rangeMeters: int | None = Field(default=None, ge=0)
+    rangeLongMeters: int | None = Field(default=None, ge=0)
+    rangeType: str | None = None
+    hasReach: bool | None = None
     isMelee: bool | None = None
     saveAbility: AbilityName | None = None
     saveDc: int | None = Field(default=None, ge=1)
@@ -59,6 +62,14 @@ class CombatAction(BaseModel):
         normalized = value.strip().lower()
         return normalized or None
 
+    @field_validator("rangeType", mode="before")
+    @classmethod
+    def normalize_range_type(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip().lower()
+        return normalized or None
+
     @field_validator("description", mode="before")
     @classmethod
     def normalize_description(cls, value: str | None) -> str | None:
@@ -91,6 +102,9 @@ class CombatAction(BaseModel):
             self.damageBonus,
             self.damageType,
             self.rangeMeters,
+            self.rangeLongMeters,
+            self.rangeType,
+            self.hasReach,
             self.isMelee,
             self.saveAbility,
             self.saveDc,

--- a/apps/control-server/app/services/combat_service/actions/weapon_attacks.py
+++ b/apps/control-server/app/services/combat_service/actions/weapon_attacks.py
@@ -81,6 +81,7 @@ from ..targeting_requirements import (
     resolve_weapon_targeting_requirements,
 )
 from ..targeting_intent import AreaTargetingIntent, SpellCastIntent, WeaponAttackIntent
+from ..reach import resolve_weapon_attack_kind
 from ..unit_conversion import meters_to_cells
 
 
@@ -147,6 +148,7 @@ class WeaponAttacksMixin:
             weapon_item_id=req.weapon_item_id,
             weapon_canonical_key=attack_context.get("weapon_canonical_key"),
             range_meters=attack_context.get("range_meters"),
+            range_long_meters=attack_context.get("range_long_meters"),
             weapon_range_type=attack_context.get("weapon_range_type"),
             has_reach=bool(attack_context.get("has_reach")),
             requires_sight=weapon_targeting.requires_target_sight,
@@ -196,10 +198,12 @@ class WeaponAttacksMixin:
             attacker, "attack_bonus"
         )
         # Condition-based advantage/disadvantage (Phase F1)
-        _attack_kind = (
-            "ranged"
-            if str(attack_context.get("weapon_range_type") or "").lower() == "ranged"
-            else "melee"
+        _attack_kind = resolve_weapon_attack_kind(
+            weapon_range_type=attack_context.get("weapon_range_type"),
+            range_meters=attack_context.get("range_meters"),
+            range_long_meters=attack_context.get("range_long_meters"),
+            has_reach=bool(attack_context.get("has_reach")),
+            distance_meters=targeting_result.spatial_metadata.distance_meters,
         )
         _adv_ctx = resolve_attack_advantage(attacker, target_p, _attack_kind)
         _vis_ctx = resolve_target_visibility(
@@ -219,6 +223,7 @@ class WeaponAttacksMixin:
             or cls._has_effect_kind(attacker, "disadvantage_on_attacks")
             or cls._has_effect_kind(target_p, "dodging")
             or bool(_adv_ctx.disadvantage_sources)
+            or bool(targeting_result.spatial_metadata.is_in_long_range)
             or not _vis_ctx.is_directly_visible
         )
         # Consume advantage_on_attacks (Help) after first use

--- a/apps/control-server/app/services/combat_service/combat_targeting.py
+++ b/apps/control-server/app/services/combat_service/combat_targeting.py
@@ -39,6 +39,7 @@ mechanical resolution code are needed.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import replace
 import logging
 
 from app.core.config import settings
@@ -58,7 +59,11 @@ from .targeting_requirements import (
     resolve_spell_targeting_requirements,
     resolve_weapon_targeting_requirements,
 )
-from .reach import resolve_melee_reach_cells, derive_max_range_meters
+from .reach import derive_max_range_meters
+from .reach import (
+    classify_weapon_attack_distance,
+    resolve_weapon_attack_range_profile,
+)
 from .targeting_diagnostics import (
     TARGET_NOT_FOUND,
     INVALID_TARGET_TYPE,
@@ -80,7 +85,7 @@ from .targeting_diagnostics import (
     TargetingDiagnostics,
 )
 from .targeting_result import SpatialMetadata, TargetingResult
-from .unit_conversion import meters_to_cells
+from .unit_conversion import METERS_PER_CELL, meters_to_cells
 from .visibility import can_target_in_combat
 
 logger = logging.getLogger(__name__)
@@ -290,12 +295,25 @@ class LocalCombatTargetingService(CombatTargetingService):
             diag.set_check(CHECK_HAS_LINE_OF_SIGHT, True)
             diag.set_check(CHECK_IS_VISIBLE, True)
 
-        max_range, range_failure = derive_max_range_meters(
-            range_meters=getattr(intent, "range_meters", None),
-            weapon_range_type=getattr(intent, "weapon_range_type", None),
-            has_reach=getattr(intent, "has_reach", False),
-            target_mode=getattr(intent, "target_mode", None),
-        )
+        weapon_profile = None
+        if isinstance(intent, WeaponAttackIntent):
+            weapon_profile = resolve_weapon_attack_range_profile(
+                range_meters=getattr(intent, "range_meters", None),
+                range_long_meters=getattr(intent, "range_long_meters", None),
+                weapon_range_type=getattr(intent, "weapon_range_type", None),
+                has_reach=getattr(intent, "has_reach", False),
+            )
+            max_range = weapon_profile.max_range
+            range_failure = weapon_profile.failure_reason
+        else:
+            max_range, range_failure = derive_max_range_meters(
+                range_meters=getattr(intent, "range_meters", None),
+                weapon_range_type=getattr(intent, "weapon_range_type", None),
+                has_reach=getattr(intent, "has_reach", False),
+                target_mode=getattr(intent, "target_mode", None),
+            )
+
+        spatial_metadata = SpatialMetadata(targeting_authority="local")
 
         if not self._skip_range_validation:
             if range_failure is not None:
@@ -324,7 +342,31 @@ class LocalCombatTargetingService(CombatTargetingService):
                     return result
                 diag.set_meta("distance_meters", distance_meters)
                 diag.set_meta("max_range_meters", max_range)
-                if distance_meters > max_range:
+                if weapon_profile is not None and weapon_profile.normal_range is not None:
+                    diag.set_meta("normal_range_meters", weapon_profile.normal_range)
+                    if weapon_profile.long_range is not None:
+                        diag.set_meta("long_range_meters", weapon_profile.long_range)
+                    range_classification = classify_weapon_attack_distance(
+                        distance_meters,
+                        normal_range=weapon_profile.normal_range,
+                        long_range=weapon_profile.long_range,
+                    )
+                    spatial_metadata = SpatialMetadata(
+                        distance_meters=distance_meters,
+                        is_in_normal_range=range_classification.is_in_normal_range,
+                        is_in_long_range=range_classification.is_in_long_range,
+                        targeting_authority="local",
+                    )
+                    if not range_classification.is_in_range:
+                        diag.set_check(CHECK_IN_RANGE, False)
+                        diag.fail(TARGET_OUT_OF_REACH)
+                        result = TargetingResult.invalid(
+                            f"Target out of range ({distance_meters:.1f}m > {max_range:.1f}m).",
+                            diagnostics=diag,
+                        )
+                        _log_diagnostics_debug(logger, intent, result)
+                        return result
+                elif distance_meters > max_range:
                     diag.set_check(CHECK_IN_RANGE, False)
                     diag.fail(TARGET_OUT_OF_REACH)
                     result = TargetingResult.invalid(
@@ -333,6 +375,11 @@ class LocalCombatTargetingService(CombatTargetingService):
                     )
                     _log_diagnostics_debug(logger, intent, result)
                     return result
+                else:
+                    spatial_metadata = SpatialMetadata(
+                        distance_meters=distance_meters,
+                        targeting_authority="local",
+                    )
             diag.set_check(CHECK_IN_RANGE, True)
 
         result = TargetingResult(
@@ -340,7 +387,7 @@ class LocalCombatTargetingService(CombatTargetingService):
             validated_primary_target_ref_id=requested_ref_id,
             affected_target_ref_ids=[requested_ref_id],
             target_kind=target_kind,
-            spatial_metadata=SpatialMetadata(targeting_authority="local"),
+            spatial_metadata=spatial_metadata,
             diagnostics=diag,
         )
         _log_diagnostics_debug(logger, intent, result)
@@ -424,6 +471,11 @@ class LimiarMapTargetingService(CombatTargetingService):
             return result
 
         if not response.is_valid:
+            if isinstance(response.distance_cells, int):
+                diag.set_meta("distance_cells", response.distance_cells)
+                diag.set_meta(
+                    "distance_meters", response.distance_cells * METERS_PER_CELL
+                )
             canonical = self._map_reason_to_canonical(response.reason)
             diag.fail(canonical)
             self._populate_checks_from_map_failure(diag, response.reason)
@@ -447,8 +499,51 @@ class LimiarMapTargetingService(CombatTargetingService):
         diag.set_check(CHECK_IN_RANGE, True)
         diag.set_check(CHECK_HAS_LINE_OF_SIGHT, True)
         diag.set_check(CHECK_HAS_LINE_OF_EFFECT, True)
+        spatial_metadata = SpatialMetadata(
+            source_token_id=response.source_token_id,
+            target_token_id=response.target_token_id,
+            map_version=response.version,
+            targeting_authority="limiar_map",
+            cover=response.cover,
+        )
         if getattr(response, "cover", None):
             diag.set_meta("cover", response.cover)
+        if isinstance(response.distance_cells, int):
+            diag.set_meta("distance_cells", response.distance_cells)
+            diag.set_meta(
+                "distance_meters", response.distance_cells * METERS_PER_CELL
+            )
+            spatial_metadata = replace(
+                spatial_metadata,
+                distance_meters=response.distance_cells * METERS_PER_CELL,
+            )
+            if isinstance(intent, WeaponAttackIntent):
+                weapon_profile = resolve_weapon_attack_range_profile(
+                    range_meters=intent.range_meters,
+                    range_long_meters=intent.range_long_meters,
+                    weapon_range_type=intent.weapon_range_type,
+                    has_reach=intent.has_reach,
+                )
+                if weapon_profile.normal_range is not None:
+                    normal_range_cells = meters_to_cells(weapon_profile.normal_range)
+                    long_range_cells = (
+                        meters_to_cells(weapon_profile.long_range)
+                        if weapon_profile.long_range is not None
+                        else None
+                    )
+                    range_classification = classify_weapon_attack_distance(
+                        response.distance_cells,
+                        normal_range=normal_range_cells,
+                        long_range=long_range_cells,
+                    )
+                    diag.set_meta("normal_range_cells", normal_range_cells)
+                    if long_range_cells is not None:
+                        diag.set_meta("long_range_cells", long_range_cells)
+                    spatial_metadata = replace(
+                        spatial_metadata,
+                        is_in_normal_range=range_classification.is_in_normal_range,
+                        is_in_long_range=range_classification.is_in_long_range,
+                    )
 
         actor_participant = next(
             (p for p in state.participants if p.get("ref_id") == intent.actor_ref_id),
@@ -490,13 +585,7 @@ class LimiarMapTargetingService(CombatTargetingService):
             validated_primary_target_ref_id=local_result.validated_primary_target_ref_id,
             affected_target_ref_ids=local_result.affected_target_ref_ids,
             target_kind=local_result.target_kind,
-            spatial_metadata=SpatialMetadata(
-                source_token_id=response.source_token_id,
-                target_token_id=response.target_token_id,
-                map_version=response.version,
-                targeting_authority="limiar_map",
-                cover=response.cover,
-            ),
+            spatial_metadata=spatial_metadata,
             diagnostics=diag,
         )
         _log_diagnostics_debug(logger, intent, result)
@@ -721,17 +810,18 @@ class LimiarMapTargetingService(CombatTargetingService):
         Returns None when no range constraint applies.
         """
         if isinstance(intent, SpellCastIntent):
-            if isinstance(intent.range_meters, int) and intent.range_meters > 0:
+            if isinstance(intent.range_meters, (int, float)) and intent.range_meters > 0:
                 return meters_to_cells(intent.range_meters)
             return None
 
-        if isinstance(intent.range_meters, int) and intent.range_meters > 0:
-            return meters_to_cells(intent.range_meters)
-
-        weapon_range_type = (intent.weapon_range_type or "").strip().lower()
-        if weapon_range_type == "melee":
-            return resolve_melee_reach_cells(has_reach=intent.has_reach)
-
+        profile = resolve_weapon_attack_range_profile(
+            range_meters=intent.range_meters,
+            range_long_meters=intent.range_long_meters,
+            weapon_range_type=intent.weapon_range_type,
+            has_reach=intent.has_reach,
+        )
+        if profile.max_range is not None:
+            return meters_to_cells(profile.max_range)
         return None
 
     @staticmethod

--- a/apps/control-server/app/services/combat_service/entity_actions.py
+++ b/apps/control-server/app/services/combat_service/entity_actions.py
@@ -7,7 +7,7 @@ from math import floor
 from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import Session, select
 
-from app.models.base_item import BaseItemKind, BaseItemWeaponRangeType
+from app.models.base_item import BaseItemKind, BaseItemProperty, BaseItemWeaponRangeType
 from app.models.campaign import Campaign, SystemType
 from app.models.combat import CombatPhase, CombatState
 from app.models.session import Session as CampaignSession
@@ -42,6 +42,23 @@ from .exceptions import CombatServiceError, _roll_dice_expression
 
 
 class CombatEntityActionMixin:
+
+    @staticmethod
+    def _has_reach_property(properties: list[str] | None) -> bool:
+        return BaseItemProperty.REACH.value in {
+            str(value).strip().lower()
+            for value in (properties or [])
+            if isinstance(value, str)
+        }
+
+    @staticmethod
+    def _normalize_weapon_range_type_value(value: object) -> str | None:
+        if isinstance(value, BaseItemWeaponRangeType):
+            return value.value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            return normalized or None
+        return None
 
     @classmethod
     def _resolve_weapon_combat_action(
@@ -85,6 +102,41 @@ class CombatEntityActionMixin:
                 else (catalog_weapon.range_normal_meters if catalog_weapon else None)
             )
         )
+        range_long_meters = (
+            action.rangeLongMeters
+            if action.rangeLongMeters is not None
+            else (
+                int(campaign_weapon.range_long_meters)
+                if campaign_weapon and campaign_weapon.range_long_meters is not None
+                else (catalog_weapon.range_long_meters if catalog_weapon else None)
+            )
+        )
+        range_type = (
+            action.rangeType.strip().lower()
+            if isinstance(action.rangeType, str) and action.rangeType.strip()
+            else (
+                cls._normalize_weapon_range_type_value(campaign_weapon.weapon_range_type)
+                if campaign_weapon and campaign_weapon.weapon_range_type is not None
+                else (
+                    cls._normalize_weapon_range_type_value(catalog_weapon.weapon_range_type)
+                    if catalog_weapon and catalog_weapon.weapon_range_type is not None
+                    else ("melee" if action.isMelee else None)
+                )
+            )
+        )
+        has_reach = (
+            action.hasReach
+            if isinstance(action.hasReach, bool)
+            else (
+                cls._has_reach_property(campaign_weapon.properties)
+                if campaign_weapon
+                else (
+                    cls._has_reach_property(catalog_weapon.weapon_properties_json)
+                    if catalog_weapon
+                    else False
+                )
+            )
+        )
         is_melee = (
             action.isMelee
             if action.isMelee is not None
@@ -116,6 +168,9 @@ class CombatEntityActionMixin:
             "damageBonus": action.damageBonus or 0,
             "damageType": damage_type,
             "rangeMeters": range_meters,
+            "rangeLongMeters": range_long_meters,
+            "rangeType": range_type,
+            "hasReach": has_reach,
             "isMelee": is_melee,
         }
 

--- a/apps/control-server/app/services/combat_service/npc_actions.py
+++ b/apps/control-server/app/services/combat_service/npc_actions.py
@@ -68,6 +68,7 @@ from .cover_modifiers import (
 from .exceptions import CombatServiceError, _roll_dice_expression
 from .targeting_intent import SpellCastIntent, WeaponAttackIntent
 from .targeting_requirements import resolve_spell_targeting_requirements
+from .reach import resolve_weapon_attack_kind
 
 
 class CombatNpcActionMixin:
@@ -85,10 +86,6 @@ class CombatNpcActionMixin:
         # Read explicit targeting requirements from action definition
         requires_sight = resolved_action.get("requiresTargetSight")
         requires_effect = resolved_action.get("requiresTargetEffect")
-
-        # Determine weapon range type
-        range_type = resolved_action.get("rangeType") or ""
-        is_ranged = range_type.lower() == "ranged"
 
         return TargetingRequirements(
             requires_target_sight=True if requires_sight is None else requires_sight,
@@ -216,6 +213,9 @@ class CombatNpcActionMixin:
                     range_meters=cls._safe_int(
                         resolved_action.get("rangeMeters"), None
                     ),
+                    range_long_meters=cls._safe_int(
+                        resolved_action.get("rangeLongMeters"), None
+                    ),
                     weapon_range_type=resolved_action.get("rangeType"),
                     has_reach=bool(resolved_action.get("hasReach")),
                     requires_sight=weapon_targeting.requires_target_sight,
@@ -311,10 +311,12 @@ class CombatNpcActionMixin:
             damage_bonus = cls._safe_int(resolved_action.get("damageBonus"), 0)
             # Condition-based advantage/disadvantage (Phase F1)
             if action_kind == "weapon_attack":
-                _attack_kind = (
-                    "ranged"
-                    if str(resolved_action.get("rangeType") or "").lower() == "ranged"
-                    else "melee"
+                _attack_kind = resolve_weapon_attack_kind(
+                    weapon_range_type=resolved_action.get("rangeType"),
+                    range_meters=resolved_action.get("rangeMeters"),
+                    range_long_meters=resolved_action.get("rangeLongMeters"),
+                    has_reach=bool(resolved_action.get("hasReach")),
+                    distance_meters=targeting_result.spatial_metadata.distance_meters,
                 )
             else:  # spell_attack — kind resolved centrally
                 _attack_kind = resolve_spell_attack_kind(resolved_action)
@@ -338,6 +340,7 @@ class CombatNpcActionMixin:
                 or cls._has_effect_kind(attacker, "disadvantage_on_attacks")
                 or cls._has_effect_kind(target_p, "dodging")
                 or bool(_adv_ctx.disadvantage_sources)
+                or bool(targeting_result.spatial_metadata.is_in_long_range)
                 or not _vis_ctx.is_directly_visible
             )
             # Consume advantage_on_attacks (Help) after first use

--- a/apps/control-server/app/services/combat_service/reach.py
+++ b/apps/control-server/app/services/combat_service/reach.py
@@ -20,6 +20,9 @@ For 1×1 entities the two functions are equivalent.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Literal
+
 from .unit_conversion import METERS_PER_CELL
 
 DEFAULT_MELEE_REACH_CELLS: int = 1
@@ -28,6 +31,24 @@ TOUCH_RANGE_METERS: float = METERS_PER_CELL
 
 WEAPON_RANGE_NOT_CONFIGURED = "weapon_range_not_configured"
 SPELL_RANGE_NOT_CONFIGURED = "spell_range_not_configured"
+
+WeaponRangeBand = Literal["normal", "long", "out_of_range"]
+
+
+@dataclass(frozen=True)
+class WeaponAttackRangeProfile:
+    normal_range: float | None
+    long_range: float | None
+    max_range: float | None
+    failure_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class WeaponAttackRangeClassification:
+    band: WeaponRangeBand
+    is_in_range: bool
+    is_in_normal_range: bool
+    is_in_long_range: bool
 
 
 def get_effective_reach(base_reach_cells: int) -> int:
@@ -56,6 +77,149 @@ def resolve_melee_reach_cells(*, has_reach: bool = False) -> int:
     """
     base = EXTENDED_REACH_CELLS if has_reach else DEFAULT_MELEE_REACH_CELLS
     return get_effective_reach(base)
+
+
+def normalize_weapon_long_range(
+    *,
+    range_meters: int | float | None = None,
+    range_long_meters: int | float | None = None,
+) -> tuple[float | None, float | None]:
+    """Normalize a weapon's normal/long range bounds.
+
+    Long range is only considered valid when it is numeric and strictly
+    greater than the normal range.
+    """
+    if not isinstance(range_meters, (int, float)):
+        return (None, None)
+
+    normal_range = float(range_meters)
+    if normal_range <= 0:
+        normal_range = TOUCH_RANGE_METERS
+
+    long_range = None
+    if isinstance(range_long_meters, (int, float)):
+        maybe_long = float(range_long_meters)
+        if maybe_long > normal_range:
+            long_range = maybe_long
+
+    return (normal_range, long_range)
+
+
+def resolve_weapon_attack_range_profile(
+    *,
+    range_meters: int | float | None = None,
+    range_long_meters: int | float | None = None,
+    weapon_range_type: str | None = None,
+    has_reach: bool = False,
+) -> WeaponAttackRangeProfile:
+    """Resolve the authoritative weapon range profile for a targeting intent."""
+    normal_range, long_range = normalize_weapon_long_range(
+        range_meters=range_meters,
+        range_long_meters=range_long_meters,
+    )
+    if normal_range is not None:
+        return WeaponAttackRangeProfile(
+            normal_range=normal_range,
+            long_range=long_range,
+            max_range=long_range if long_range is not None else normal_range,
+        )
+
+    rng_type = (weapon_range_type or "").strip().lower()
+    if rng_type == "melee":
+        melee_reach = resolve_melee_reach_cells(has_reach=has_reach) * METERS_PER_CELL
+        return WeaponAttackRangeProfile(
+            normal_range=melee_reach,
+            long_range=None,
+            max_range=melee_reach,
+        )
+
+    if rng_type == "ranged":
+        return WeaponAttackRangeProfile(
+            normal_range=None,
+            long_range=None,
+            max_range=None,
+            failure_reason=WEAPON_RANGE_NOT_CONFIGURED,
+        )
+
+    return WeaponAttackRangeProfile(
+        normal_range=None,
+        long_range=None,
+        max_range=None,
+    )
+
+
+def classify_weapon_attack_distance(
+    distance: int | float,
+    *,
+    normal_range: int | float | None,
+    long_range: int | float | None = None,
+) -> WeaponAttackRangeClassification:
+    """Classify a resolved distance using the normal/long range profile."""
+    normalized_normal, normalized_long = normalize_weapon_long_range(
+        range_meters=normal_range,
+        range_long_meters=long_range,
+    )
+    if normalized_normal is None:
+        raise ValueError("normal_range must be numeric to classify weapon distance.")
+
+    resolved_distance = float(distance)
+    max_range = (
+        normalized_long if normalized_long is not None else normalized_normal
+    )
+    if resolved_distance <= normalized_normal:
+        return WeaponAttackRangeClassification(
+            band="normal",
+            is_in_range=True,
+            is_in_normal_range=True,
+            is_in_long_range=False,
+        )
+    if resolved_distance <= max_range:
+        return WeaponAttackRangeClassification(
+            band="long",
+            is_in_range=True,
+            is_in_normal_range=False,
+            is_in_long_range=True,
+        )
+    return WeaponAttackRangeClassification(
+        band="out_of_range",
+        is_in_range=False,
+        is_in_normal_range=False,
+        is_in_long_range=False,
+    )
+
+
+def resolve_weapon_attack_kind(
+    *,
+    weapon_range_type: str | None = None,
+    range_meters: int | float | None = None,
+    range_long_meters: int | float | None = None,
+    has_reach: bool = False,
+    distance_meters: int | float | None = None,
+) -> Literal["melee", "ranged"]:
+    """Resolve the effective attack kind for a weapon strike.
+
+    This keeps thrown/melee weapons coherent:
+    - true ranged weapons are always ranged
+    - melee weapons with a valid ranged profile become ranged only when the
+      resolved attack distance exceeds melee reach
+    - otherwise the attack remains melee
+    """
+    normalized_range_type = (weapon_range_type or "").strip().lower()
+    if normalized_range_type == "ranged":
+        return "ranged"
+
+    if isinstance(distance_meters, (int, float)):
+        profile = resolve_weapon_attack_range_profile(
+            range_meters=range_meters,
+            range_long_meters=range_long_meters,
+            weapon_range_type=weapon_range_type,
+            has_reach=has_reach,
+        )
+        melee_reach = resolve_melee_reach_cells(has_reach=has_reach) * METERS_PER_CELL
+        if profile.normal_range is not None and float(distance_meters) > melee_reach:
+            return "ranged"
+
+    return "melee"
 
 
 def is_within_melee_reach(
@@ -125,6 +289,7 @@ def is_within_melee_reach_multi(
 def derive_max_range_meters(
     *,
     range_meters: int | float | None = None,
+    range_long_meters: int | float | None = None,
     weapon_range_type: str | None = None,
     has_reach: bool = False,
     target_mode: str | None = None,
@@ -141,23 +306,25 @@ def derive_max_range_meters(
     if target_mode == "self":
         return (None, None)
 
-    if isinstance(range_meters, (int, float)):
-        if range_meters > 0:
-            return (float(range_meters), None)
-        return (TOUCH_RANGE_METERS, None)
-
     if target_mode == "touch":
         return (TOUCH_RANGE_METERS, None)
 
     normalized_target_mode = (target_mode or "").strip().lower()
     if normalized_target_mode == "ranged":
+        if isinstance(range_meters, (int, float)):
+            if range_meters > 0:
+                return (float(range_meters), None)
+            return (TOUCH_RANGE_METERS, None)
         return (None, SPELL_RANGE_NOT_CONFIGURED)
 
-    rng_type = (weapon_range_type or "").strip().lower()
-    if rng_type == "melee":
-        return (resolve_melee_reach_cells(has_reach=has_reach) * METERS_PER_CELL, None)
-
-    if rng_type == "ranged":
-        return (None, WEAPON_RANGE_NOT_CONFIGURED)
-
+    profile = resolve_weapon_attack_range_profile(
+        range_meters=range_meters,
+        range_long_meters=range_long_meters,
+        weapon_range_type=weapon_range_type,
+        has_reach=has_reach,
+    )
+    if profile.failure_reason is not None:
+        return (None, profile.failure_reason)
+    if profile.max_range is not None:
+        return (profile.max_range, None)
     return (None, None)

--- a/apps/control-server/app/services/combat_service/targeting_intent.py
+++ b/apps/control-server/app/services/combat_service/targeting_intent.py
@@ -38,7 +38,8 @@ class WeaponAttackIntent:
     weapon_item_id: str | None = None
     weapon_canonical_key: str | None = None
     is_wild_shape: bool = False
-    range_meters: int | None = None
+    range_meters: int | float | None = None
+    range_long_meters: int | float | None = None
     weapon_range_type: str | None = None
     has_reach: bool = False
     # Final target-facing requirements resolved before validation.

--- a/apps/control-server/app/services/combat_service/weapon_resolution.py
+++ b/apps/control-server/app/services/combat_service/weapon_resolution.py
@@ -250,6 +250,7 @@ class CombatWeaponResolutionMixin:
                 "inventory_item_id": "unarmed",
                 "weapon_canonical_key": None,
                 "range_meters": 1,
+                "range_long_meters": None,
                 "weapon_range_type": BaseItemWeaponRangeType.MELEE.value,
                 "has_reach": False,
             }
@@ -269,6 +270,7 @@ class CombatWeaponResolutionMixin:
                 "inventory_item_id": "unarmed",
                 "weapon_canonical_key": None,
                 "range_meters": 1,
+                "range_long_meters": None,
                 "weapon_range_type": BaseItemWeaponRangeType.MELEE.value,
                 "has_reach": False,
             }
@@ -294,6 +296,7 @@ class CombatWeaponResolutionMixin:
                 "inventory_item_id": "unarmed",
                 "weapon_canonical_key": None,
                 "range_meters": 1,
+                "range_long_meters": None,
                 "weapon_range_type": BaseItemWeaponRangeType.MELEE.value,
                 "has_reach": False,
             }
@@ -359,6 +362,11 @@ class CombatWeaponResolutionMixin:
             "range_meters": (
                 int(item.range_meters)
                 if getattr(item, "range_meters", None) is not None
+                else None
+            ),
+            "range_long_meters": (
+                int(item.range_long_meters)
+                if getattr(item, "range_long_meters", None) is not None
                 else None
             ),
             "weapon_range_type": (

--- a/apps/control-server/tests/_combat_test_entity_stats.py
+++ b/apps/control-server/tests/_combat_test_entity_stats.py
@@ -245,7 +245,9 @@ class CombatEntityStatsTestsMixin:
             damage_dice="1d6",
             damage_type="piercing",
             range_normal_meters=24,
+            range_long_meters=96,
             weapon_range_type="ranged",
+            weapon_properties_json=[],
         )
 
         resolved = CombatService._resolve_weapon_combat_action(
@@ -264,6 +266,9 @@ class CombatEntityStatsTestsMixin:
         self.assertEqual(resolved["damageDice"], "1d6")
         self.assertEqual(resolved["damageType"], "piercing")
         self.assertEqual(resolved["rangeMeters"], 24)
+        self.assertEqual(resolved["rangeLongMeters"], 96)
+        self.assertEqual(resolved["rangeType"], "ranged")
+        self.assertFalse(resolved["hasReach"])
         self.assertEqual(resolved["isMelee"], False)
 
     def test_resolve_weapon_action_prefers_campaign_item_profile(self):
@@ -279,8 +284,10 @@ class CombatEntityStatsTestsMixin:
             damage_dice="1d6",
             damage_type="piercing",
             range_meters=6,
+            range_long_meters=18,
             weapon_range_type="melee",
             item_kind="weapon",
+            properties=["reach"],
         )
         self.db.exec.side_effect = [session_entry_result, item_result]
 
@@ -300,6 +307,9 @@ class CombatEntityStatsTestsMixin:
         self.assertEqual(resolved["damageDice"], "1d6")
         self.assertEqual(resolved["damageType"], "piercing")
         self.assertEqual(resolved["rangeMeters"], 6)
+        self.assertEqual(resolved["rangeLongMeters"], 18)
+        self.assertEqual(resolved["rangeType"], "melee")
+        self.assertTrue(resolved["hasReach"])
         self.assertEqual(resolved["isMelee"], True)
 
     @patch("app.services.combat.CombatService._get_spell_catalog_entry_for_session")

--- a/apps/control-server/tests/_combat_test_flow.py
+++ b/apps/control-server/tests/_combat_test_flow.py
@@ -33,6 +33,7 @@ from app.services.combat import (
     _parse_dice,
     _roll_dice_expression,
 )
+from app.services.combat_service.targeting_result import SpatialMetadata, TargetingResult
 from app.schemas.roll import RollActorStats
 from app.schemas.roll import RollResult
 
@@ -458,6 +459,95 @@ class CombatFlowTestsMixin:
         self.assertEqual(res["roll_result"].roll_source, "manual")
         self.assertEqual(res["roll_result"].selected_roll, 17)
         self.assertEqual(res["target_ac"], 14)
+
+    @patch("app.services.combat.CombatService._emit_entity_hp_update")
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_log")
+    async def test_attack_applies_disadvantage_when_target_is_in_long_range(
+        self,
+        mock_emit_log,
+        mock_emit_state,
+        mock_emit_entity_hp_update,
+    ):
+        self.state.phase = CombatPhase.active
+        self.state.current_turn_index = 0
+        attacker_state = MagicMock()
+        attacker_state.state_json = {"currentWeaponId": "inv-1"}
+        long_range_roll = RollResult(
+            event_id="roll-long-1",
+            roll_type="attack",
+            actor_kind="player",
+            actor_ref_id="player-123",
+            actor_display_name="Hero",
+            rolls=[7, 15],
+            selected_roll=7,
+            advantage_mode="disadvantage",
+            modifier_used=5,
+            override_used=True,
+            formula="2d20kh1 + 5",
+            total=12,
+            target_ac=14,
+            success=False,
+            timestamp=datetime.now(timezone.utc),
+        )
+        mock_targeting_service = MagicMock()
+        mock_targeting_service.validate.return_value = TargetingResult(
+            is_valid=True,
+            validated_primary_target_ref_id="enemy-123",
+            affected_target_ref_ids=["enemy-123"],
+            target_kind="session_entity",
+            spatial_metadata=SpatialMetadata(
+                targeting_authority="local",
+                distance_meters=24.0,
+                is_in_normal_range=False,
+                is_in_long_range=True,
+            ),
+        )
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch(
+                "app.services.combat_service.actions.weapon_attacks.get_combat_targeting_service",
+                return_value=mock_targeting_service,
+            ),
+            patch(
+                "app.services.combat.CombatService._get_stats",
+                side_effect=[
+                    (attacker_state, 12, 16, 14, 2, 0),
+                    (MagicMock(), 14, 10, 10, 2, 0),
+                ],
+            ),
+            patch(
+                "app.services.combat.CombatService._build_player_attack_context",
+                return_value={
+                    "name": "Longbow",
+                    "damage_dice": "1d8",
+                    "damage_bonus": 3,
+                    "attack_bonus": 5,
+                    "damage_type": "piercing",
+                    "range_meters": 18,
+                    "range_long_meters": 36,
+                    "weapon_range_type": "ranged",
+                    "has_reach": False,
+                },
+            ),
+            patch(
+                "app.services.combat_service.actions.weapon_attacks.resolve_attack_base",
+                return_value=long_range_roll,
+            ) as mock_resolve_attack,
+        ):
+            res = await CombatService.attack(
+                self.db,
+                "session-123",
+                CombatAttackRequest(target_ref_id="enemy-123"),
+                "user-xyz",
+                True,
+            )
+
+        self.assertEqual(
+            mock_resolve_attack.call_args.kwargs["advantage_mode"], "disadvantage"
+        )
+        self.assertEqual(res["roll_result"].advantage_mode, "disadvantage")
 
     @patch("app.services.combat.CombatService._emit_entity_hp_update")
     @patch("app.services.combat.CombatService._emit_state")

--- a/apps/control-server/tests/_combat_test_npc_turns.py
+++ b/apps/control-server/tests/_combat_test_npc_turns.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 from app.models.campaign_entity import CampaignEntity
@@ -24,6 +25,7 @@ from app.services.combat import (
     _roll_dice_expression,
 )
 from app.services.combat_service.combat_targeting import TargetingResult, SpatialMetadata
+from app.schemas.roll import RollResult
 
 
 
@@ -271,6 +273,105 @@ class CombatNpcTurnTestsMixin:
         log_args = mock_emit_log.call_args.args
         log_message = log_args[1]["message"] if len(log_args) > 1 else mock_emit_log.call_args.kwargs.get("message", "")
         self.assertIn("Half Cover", log_message)
+
+    @patch("app.services.combat.CombatService._emit_entity_hp_update")
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_log")
+    async def test_npc_attack_applies_disadvantage_in_long_range(self, mock_emit_log, mock_emit_state, mock_emit_entity_hp_update):
+        self.state.phase = CombatPhase.active
+        self.state.current_turn_index = 1
+        self.state.participants.append({
+            "id": "e2",
+            "ref_id": "enemy-456",
+            "kind": "session_entity",
+            "display_name": "Wolf",
+            "initiative": 8,
+            "status": "active",
+            "team": "enemies",
+            "visible": True,
+            "actor_user_id": None,
+        })
+
+        mock_targeting_service = MagicMock()
+        mock_targeting_service.validate.return_value = TargetingResult(
+            is_valid=True,
+            validated_primary_target_ref_id="enemy-456",
+            affected_target_ref_ids=["enemy-456"],
+            target_kind="session_entity",
+            spatial_metadata=SpatialMetadata(
+                targeting_authority="local",
+                distance_meters=24.0,
+                is_in_normal_range=False,
+                is_in_long_range=True,
+            ),
+        )
+        long_range_roll = RollResult(
+            event_id="roll-npc-long-1",
+            roll_type="attack",
+            actor_kind="session_entity",
+            actor_ref_id="enemy-123",
+            actor_display_name="Goblin Archer",
+            rolls=[5, 16],
+            selected_roll=5,
+            advantage_mode="disadvantage",
+            modifier_used=5,
+            override_used=True,
+            formula="2d20kl1 + 5",
+            total=10,
+            target_ac=10,
+            success=True,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat_service.npc_actions.get_combat_targeting_service", return_value=mock_targeting_service),
+            patch(
+                "app.services.combat.CombatService._get_combat_action_for_entity",
+                return_value=(
+                    SessionEntity(id="enemy-123", session_id="session-123", campaign_entity_id="ce-1", current_hp=7),
+                    MagicMock(),
+                    CombatAction(
+                        id="ranged_attack",
+                        name="Ranged Attack",
+                        kind="weapon_attack",
+                        toHitBonus=5,
+                        damageDice="1d8",
+                        damageBonus=2,
+                        damageType="piercing",
+                        isMelee=False,
+                        rangeType="ranged",
+                        rangeMeters=18,
+                        rangeLongMeters=36,
+                    ),
+                ),
+            ),
+            patch(
+                "app.services.combat.CombatService._get_stats",
+                return_value=(SessionEntity(id="enemy-456", session_id="session-123", campaign_entity_id="ce-2", current_hp=5), 10, 10, 10, 2, 0),
+            ),
+            patch(
+                "app.services.combat_service.npc_actions.resolve_attack_base",
+                return_value=long_range_roll,
+            ) as mock_resolve_attack,
+        ):
+            await CombatService.entity_action(
+                self.db,
+                "session-123",
+                CombatEntityActionRequest(
+                    actor_participant_id="e1",
+                    target_ref_id="enemy-456",
+                    combat_action_id="ranged_attack",
+                    roll_source="manual",
+                    manual_roll=17,
+                ),
+                "gm-user",
+                True,
+            )
+
+        self.assertEqual(
+            mock_resolve_attack.call_args.kwargs["advantage_mode"], "disadvantage"
+        )
 
     @patch("app.services.combat.CombatService._emit_entity_hp_update")
     @patch("app.services.combat.CombatService._emit_state")

--- a/apps/control-server/tests/test_combat_targeting_integration.py
+++ b/apps/control-server/tests/test_combat_targeting_integration.py
@@ -209,6 +209,7 @@ class CombatTargetingIntegrationServiceTests(unittest.TestCase):
                 version=7,
                 source_token_id="token-source",
                 target_token_id="token-target",
+                distance_cells=4,
             )
         )
         service = LimiarMapTargetingService(
@@ -234,6 +235,9 @@ class CombatTargetingIntegrationServiceTests(unittest.TestCase):
         self.assertEqual(result.spatial_metadata.target_token_id, "token-target")
         self.assertEqual(result.spatial_metadata.map_version, 7)
         self.assertEqual(result.spatial_metadata.targeting_authority, "limiar_map")
+        self.assertEqual(result.spatial_metadata.distance_meters, 6.0)
+        self.assertTrue(result.spatial_metadata.is_in_normal_range)
+        self.assertFalse(result.spatial_metadata.is_in_long_range)
         # 6 m / 1.5 m/cell = 4 cells (round)
         self.assertEqual(client.calls[0]["range_cells"], 4)
         self.assertTrue(client.calls[0]["requires_sight"])
@@ -412,6 +416,42 @@ class CombatTargetingIntegrationServiceTests(unittest.TestCase):
 
         # 9 m / 1.5 m/cell = 6 cells
         self.assertEqual(client.calls[0]["range_cells"], 6)
+
+    def test_weapon_attack_long_range_uses_long_range_cells(self) -> None:
+        state = build_combat_state()
+        client = StubLimiarMapClient(
+            response=LimiarMapTargetingResponse(
+                is_valid=True,
+                reason=None,
+                session_id="session-123",
+                action_id="action-long",
+                version=3,
+                source_token_id="token-source",
+                target_token_id="token-target",
+                distance_cells=10,
+            )
+        )
+        service = LimiarMapTargetingService(
+            client, fallback_service=LocalCombatTargetingService()
+        )
+
+        result = service.validate(
+            WeaponAttackIntent(
+                session_id="session-123",
+                action_id="action-long",
+                actor_ref_id="player-123",
+                actor_kind="player",
+                requested_target_ref_id="enemy-123",
+                range_meters=9,
+                range_long_meters=18,
+                weapon_range_type="ranged",
+            ),
+            state,
+        )
+
+        self.assertEqual(client.calls[0]["range_cells"], 12)
+        self.assertTrue(result.spatial_metadata.is_in_long_range)
+        self.assertFalse(result.spatial_metadata.is_in_normal_range)
 
     def test_spell_range_is_derived_from_range_meters(self) -> None:
         state = build_combat_state()

--- a/apps/control-server/tests/test_local_targeting_range.py
+++ b/apps/control-server/tests/test_local_targeting_range.py
@@ -11,8 +11,11 @@ import unittest
 
 from app.models.combat import CombatState, CombatPhase
 from app.services.combat_service.reach import (
+    classify_weapon_attack_distance,
     derive_max_range_meters,
+    normalize_weapon_long_range,
     WEAPON_RANGE_NOT_CONFIGURED,
+    WeaponAttackRangeClassification,
     SPELL_RANGE_NOT_CONFIGURED,
     TOUCH_RANGE_METERS,
 )
@@ -57,6 +60,7 @@ def _weapon_intent(
     target_ref_id: str = "enemy-1",
     *,
     range_meters: int | None = None,
+    range_long_meters: int | None = None,
     weapon_range_type: str | None = "melee",
     has_reach: bool = False,
     requires_sight: bool = False,
@@ -68,6 +72,7 @@ def _weapon_intent(
         actor_kind="player",
         requested_target_ref_id=target_ref_id,
         range_meters=range_meters,
+        range_long_meters=range_long_meters,
         weapon_range_type=weapon_range_type,
         has_reach=has_reach,
         requires_sight=requires_sight,
@@ -106,6 +111,28 @@ svc = LocalCombatTargetingService()
 
 
 class TestDeriveMaxRangeMeters(unittest.TestCase):
+    def test_normalize_weapon_long_range_requires_long_to_exceed_normal(self):
+        self.assertEqual(
+            normalize_weapon_long_range(range_meters=18, range_long_meters=18),
+            (18.0, None),
+        )
+
+    def test_classify_weapon_attack_distance_marks_long_range(self):
+        classification = classify_weapon_attack_distance(
+            24,
+            normal_range=18,
+            long_range=36,
+        )
+        self.assertEqual(
+            classification,
+            WeaponAttackRangeClassification(
+                band="long",
+                is_in_range=True,
+                is_in_normal_range=False,
+                is_in_long_range=True,
+            ),
+        )
+
     def test_self_target_mode_returns_none(self):
         r, fail = derive_max_range_meters(target_mode="self")
         self.assertIsNone(r)
@@ -119,6 +146,15 @@ class TestDeriveMaxRangeMeters(unittest.TestCase):
     def test_ranged_with_range_meters(self):
         r, fail = derive_max_range_meters(range_meters=18, weapon_range_type="ranged")
         self.assertEqual(r, 18.0)
+        self.assertIsNone(fail)
+
+    def test_ranged_with_long_range_uses_long_range_as_max(self):
+        r, fail = derive_max_range_meters(
+            range_meters=18,
+            range_long_meters=36,
+            weapon_range_type="ranged",
+        )
+        self.assertEqual(r, 36.0)
         self.assertIsNone(fail)
 
     def test_ranged_without_range_meters_fails(self):
@@ -213,6 +249,27 @@ class TestLocalRangedRangeValidation(unittest.TestCase):
         result = svc.validate(intent, state)
         self.assertTrue(result.is_valid)
         self.assertTrue(result.diagnostics.checks.get(CHECK_IN_RANGE))
+        self.assertEqual(result.spatial_metadata.distance_meters, 9.0)
+        self.assertTrue(result.spatial_metadata.is_in_normal_range)
+        self.assertFalse(result.spatial_metadata.is_in_long_range)
+
+    def test_ranged_weapon_in_long_range_is_valid_with_long_range_metadata(self):
+        state = _make_state(
+            _make_participant("player-1", "player"),
+            _make_participant("enemy-1", "session_entity"),
+            local_distances={"player-1": {"enemy-1": 24.0}},
+        )
+        intent = _weapon_intent(
+            range_meters=18,
+            range_long_meters=36,
+            weapon_range_type="ranged",
+        )
+        result = svc.validate(intent, state)
+        self.assertTrue(result.is_valid)
+        self.assertTrue(result.diagnostics.checks.get(CHECK_IN_RANGE))
+        self.assertEqual(result.spatial_metadata.distance_meters, 24.0)
+        self.assertFalse(result.spatial_metadata.is_in_normal_range)
+        self.assertTrue(result.spatial_metadata.is_in_long_range)
 
     def test_ranged_weapon_out_of_range(self):
         state = _make_state(
@@ -229,6 +286,24 @@ class TestLocalRangedRangeValidation(unittest.TestCase):
         self.assertIn("18.0m", result.failure_reason)
         self.assertEqual(result.diagnostics.metadata.get("distance_meters"), 20.0)
         self.assertEqual(result.diagnostics.metadata.get("max_range_meters"), 18.0)
+
+    def test_ranged_weapon_beyond_long_range_is_invalid(self):
+        state = _make_state(
+            _make_participant("player-1", "player"),
+            _make_participant("enemy-1", "session_entity"),
+            local_distances={"player-1": {"enemy-1": 40.0}},
+        )
+        intent = _weapon_intent(
+            range_meters=18,
+            range_long_meters=36,
+            weapon_range_type="ranged",
+        )
+        result = svc.validate(intent, state)
+        self.assertFalse(result.is_valid)
+        self.assertIn(TARGET_OUT_OF_REACH, result.diagnostics.failure_reasons)
+        self.assertIn("40.0m", result.failure_reason)
+        self.assertIn("36.0m", result.failure_reason)
+        self.assertEqual(result.diagnostics.metadata.get("max_range_meters"), 36.0)
 
     def test_ranged_weapon_without_range_meters_fails(self):
         state = _make_state(

--- a/apps/control-server/tests/test_reach.py
+++ b/apps/control-server/tests/test_reach.py
@@ -14,6 +14,7 @@ from app.services.combat_service.reach import (
     get_effective_reach,
     is_within_melee_reach,
     is_within_melee_reach_multi,
+    resolve_weapon_attack_kind,
     resolve_melee_reach_cells,
 )
 
@@ -73,6 +74,41 @@ class TestResolveMeleeReachCells(unittest.TestCase):
         # Ensures the clamp in get_effective_reach is respected via this path
         self.assertGreaterEqual(resolve_melee_reach_cells(), 1)
         self.assertGreaterEqual(resolve_melee_reach_cells(has_reach=True), 1)
+
+
+class TestResolveWeaponAttackKind(unittest.TestCase):
+    def test_true_ranged_weapon_is_always_ranged(self):
+        self.assertEqual(
+            resolve_weapon_attack_kind(
+                weapon_range_type="ranged",
+                range_meters=18,
+                range_long_meters=36,
+                distance_meters=1.5,
+            ),
+            "ranged",
+        )
+
+    def test_thrown_profile_stays_melee_inside_reach(self):
+        self.assertEqual(
+            resolve_weapon_attack_kind(
+                weapon_range_type="melee",
+                range_meters=6,
+                range_long_meters=18,
+                distance_meters=1.5,
+            ),
+            "melee",
+        )
+
+    def test_thrown_profile_becomes_ranged_beyond_melee_reach(self):
+        self.assertEqual(
+            resolve_weapon_attack_kind(
+                weapon_range_type="melee",
+                range_meters=6,
+                range_long_meters=18,
+                distance_meters=6,
+            ),
+            "ranged",
+        )
 
 
 # ─── is_within_melee_reach ───────────────────────────────────────────────────

--- a/apps/map-server/src/routes/integration/targeting.routes.ts
+++ b/apps/map-server/src/routes/integration/targeting.routes.ts
@@ -118,7 +118,8 @@ export function registerTargetingRoutes(app: FastifyInstance, repository: InMemo
         actionId,
         version: encounter.combatState.version,
         sourceTokenId: null,
-        targetTokenId: null
+        targetTokenId: null,
+        distanceCells: null
       });
     }
 
@@ -140,7 +141,8 @@ export function registerTargetingRoutes(app: FastifyInstance, repository: InMemo
         actionId,
         version: encounter.combatState.version,
         sourceTokenId: null,
-        targetTokenId: null
+        targetTokenId: null,
+        distanceCells: null
       });
     }
 
@@ -165,13 +167,15 @@ export function registerTargetingRoutes(app: FastifyInstance, repository: InMemo
         actionId,
         version: encounter.combatState.version,
         sourceTokenId: sourceToken.id,
-        targetTokenId: null
+        targetTokenId: null,
+        distanceCells: null
       });
     }
 
+    const distance = chebyshevDistance(sourceToken.position, targetToken.position);
+
     // Range validation (rangeCells is in grid cells, Chebyshev distance)
     if (rangeCells !== null) {
-      const distance = chebyshevDistance(sourceToken.position, targetToken.position);
       if (distance > rangeCells) {
         request.log.info(
           { sessionId, combatantId, targetCombatantId, distance, rangeCells },
@@ -184,7 +188,8 @@ export function registerTargetingRoutes(app: FastifyInstance, repository: InMemo
           actionId,
           version: encounter.combatState.version,
           sourceTokenId: sourceToken.id,
-          targetTokenId: targetToken.id
+          targetTokenId: targetToken.id,
+          distanceCells: distance
         });
       }
     }
@@ -202,7 +207,8 @@ export function registerTargetingRoutes(app: FastifyInstance, repository: InMemo
         actionId,
         version: encounter.combatState.version,
         sourceTokenId: sourceToken.id,
-        targetTokenId: targetToken.id
+        targetTokenId: targetToken.id,
+        distanceCells: distance
       });
     }
 
@@ -219,7 +225,8 @@ export function registerTargetingRoutes(app: FastifyInstance, repository: InMemo
         actionId,
         version: encounter.combatState.version,
         sourceTokenId: sourceToken.id,
-        targetTokenId: targetToken.id
+        targetTokenId: targetToken.id,
+        distanceCells: distance
       });
     }
 
@@ -240,6 +247,7 @@ export function registerTargetingRoutes(app: FastifyInstance, repository: InMemo
         version: encounter.combatState.version,
         sourceTokenId: sourceToken.id,
         targetTokenId: targetToken.id,
+        distanceCells: distance,
         cover
       });
     }
@@ -292,6 +300,7 @@ export function registerTargetingRoutes(app: FastifyInstance, repository: InMemo
       version: newVersion,
       sourceTokenId: sourceToken.id,
       targetTokenId: targetToken.id,
+      distanceCells: distance,
       cover
     });
   });

--- a/apps/map-server/tests/contract/targeting.contract.test.ts
+++ b/apps/map-server/tests/contract/targeting.contract.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   areaTargetRequestSchema,
   areaTargetResponseSchema,
+  singleTargetResponseSchema,
   targetingSubmitSchema,
   targetingResolvedEventSchema
 } from "@limiarmap/shared-contracts";
@@ -71,6 +72,22 @@ describe("targeting contract", () => {
         affectedCells: [{ x: 10, y: 10 }],
         affectedTokenIds: ["tok_enemy"],
         affectedCombatantIds: ["cmb_2"]
+      })
+    ).not.toThrow();
+  });
+
+  it("accepts single-target integration responses with distanceCells", () => {
+    expect(() =>
+      singleTargetResponseSchema.parse({
+        isValid: false,
+        reason: "out_of_range",
+        sessionId: "demo-session",
+        actionId: "target-1",
+        version: 3,
+        sourceTokenId: "tok_player",
+        targetTokenId: "tok_enemy",
+        distanceCells: 7,
+        cover: "none"
       })
     ).not.toThrow();
   });

--- a/apps/map-server/tests/integration/single-target-targeting.integration.test.ts
+++ b/apps/map-server/tests/integration/single-target-targeting.integration.test.ts
@@ -58,7 +58,8 @@ describe("single-target targeting integration", () => {
       isValid: false,
       reason: "no_line_of_sight",
       sourceTokenId: "tok_player",
-      targetTokenId: "tok_enemy"
+      targetTokenId: "tok_enemy",
+      distanceCells: 3
     });
 
     await app.close();
@@ -98,7 +99,8 @@ describe("single-target targeting integration", () => {
       isValid: false,
       reason: "no_line_of_effect",
       sourceTokenId: "tok_player",
-      targetTokenId: "tok_enemy"
+      targetTokenId: "tok_enemy",
+      distanceCells: 3
     });
 
     await app.close();
@@ -139,7 +141,45 @@ describe("single-target targeting integration", () => {
       isValid: true,
       reason: null,
       sourceTokenId: "tok_player",
-      targetTokenId: "tok_enemy"
+      targetTokenId: "tok_enemy",
+      distanceCells: 3
+    });
+
+    await app.close();
+  });
+
+  it("returns distanceCells for out_of_range rejections", async () => {
+    const { app, repository } = createApp();
+    registerIntegrationRoutes(app, repository, { emit: vi.fn() });
+
+    const encounter = repository.createEncounter("session-out-of-range");
+    encounter.tokens = encounter.tokens.map((token) =>
+      token.combatantId === "cmb_1"
+        ? { ...token, position: { x: 0, y: 0 } }
+        : token.combatantId === "cmb_2"
+          ? { ...token, position: { x: 4, y: 0 } }
+          : token
+    );
+    repository.saveEncounter(encounter);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/integration/sessions/session-out-of-range/targeting",
+      payload: {
+        actionId: "target-out-of-range-1",
+        combatantId: "cmb_1",
+        targetCombatantId: "cmb_2",
+        rangeCells: 3
+      }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      isValid: false,
+      reason: "out_of_range",
+      sourceTokenId: "tok_player",
+      targetTokenId: "tok_enemy",
+      distanceCells: 4
     });
 
     await app.close();
@@ -343,4 +383,3 @@ describe("single-target targeting integration", () => {
     await app.close();
   });
 });
-

--- a/packages/shared-contracts/src/integration.js
+++ b/packages/shared-contracts/src/integration.js
@@ -81,7 +81,8 @@ export const singleTargetResponseSchema = z.object({
     actionId: z.string(),
     version: z.number().int().nonnegative(),
     sourceTokenId: z.string().nullable(),
-    targetTokenId: z.string().nullable()
+    targetTokenId: z.string().nullable(),
+    distanceCells: z.number().int().nonnegative().nullable().optional()
 });
 export const areaTargetResponseSchema = z.object({
     isValid: z.boolean(),

--- a/packages/shared-contracts/src/integration.ts
+++ b/packages/shared-contracts/src/integration.ts
@@ -218,6 +218,8 @@ export const singleTargetResponseSchema = z.object({
   sourceTokenId: z.string().nullable(),
   /** Present when isValid is true. Null otherwise. */
   targetTokenId: z.string().nullable(),
+  /** Chebyshev distance between source and target, in cells, when resolved. */
+  distanceCells: z.number().int().nonnegative().nullable().optional(),
   /**
    * Cover level evaluated along the line between source and target.
    * Evaluated independently of LoS/LoE. Defaults to "none".


### PR DESCRIPTION
## Summary
- centralize weapon range-band resolution for normal, long, and out-of-range attacks
- propagate `range_long_meters` through player/NPC weapon targeting and entity combat actions
- return `distanceCells` from LimiarMap targeting so Control can classify long-range attacks after a single authoritative map check
- apply disadvantage for long-range weapon attacks without changing combat request payloads
- keep thrown weapon profiles coherent by resolving ranged attack kind when a melee/thrown weapon is used beyond melee reach

## Validation
- `apps/control-server/.venv/bin/python -m pytest apps/control-server/tests`
- `npm test`
- `npm run lint`

Closes #24
