### PR TITLE
feat: improve missing-distance error recovery in no-map combat

### DIFF
--- a/apps/control-web/src/features/combat-ui/combatErrors.test.ts
+++ b/apps/control-web/src/features/combat-ui/combatErrors.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isMissingDistanceError, toPlayerFriendlyError } from "./combatErrors";
+
+describe("isMissingDistanceError", () => {
+  it("detects the exact backend phrase", () => {
+    expect(
+      isMissingDistanceError(
+        "Target distance not configured for non-map combat. GM must set combat distances first.",
+      ),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isMissingDistanceError("DISTANCE NOT CONFIGURED")).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isMissingDistanceError("Resource limit exceeded")).toBe(false);
+    expect(isMissingDistanceError("Target is out of range")).toBe(false);
+    expect(isMissingDistanceError("")).toBe(false);
+  });
+});
+
+describe("toPlayerFriendlyError", () => {
+  it("returns a human-readable message for missing-distance errors", () => {
+    const result = toPlayerFriendlyError(
+      "Target distance not configured for non-map combat. GM must set combat distances first.",
+    );
+    expect(result).toBe(
+      "Distância não configurada — aguarde o GM definir as distâncias antes de agir.",
+    );
+  });
+
+  it("passes through unrelated error messages unchanged", () => {
+    const msg = "Resource limit exceeded for this action.";
+    expect(toPlayerFriendlyError(msg)).toBe(msg);
+  });
+
+  it("passes through empty string unchanged", () => {
+    expect(toPlayerFriendlyError("")).toBe("");
+  });
+});

--- a/apps/control-web/src/features/combat-ui/combatErrors.ts
+++ b/apps/control-web/src/features/combat-ui/combatErrors.ts
@@ -1,0 +1,12 @@
+export const MISSING_DISTANCE_MARKER = "distance not configured";
+
+export function isMissingDistanceError(msg: string): boolean {
+  return msg.toLowerCase().includes(MISSING_DISTANCE_MARKER);
+}
+
+export function toPlayerFriendlyError(rawMsg: string): string {
+  if (isMissingDistanceError(rawMsg)) {
+    return "Distância não configurada — aguarde o GM definir as distâncias antes de agir.";
+  }
+  return rawMsg;
+}

--- a/apps/control-web/src/features/combat-ui/gm/GmCombatModeShell.tsx
+++ b/apps/control-web/src/features/combat-ui/gm/GmCombatModeShell.tsx
@@ -62,10 +62,14 @@ export const GmCombatModeShell = ({
       <div className="space-y-6">
         {shell.combat.state?.use_map === false ? (
           <GmDistancesPanel
+            highlightPair={shell.missingDistancePair}
             participants={shell.combat.state.participants}
             localDistances={shell.combat.state.local_distances}
             sessionId={sessionId}
-            onDistancesUpdated={shell.combat.applyState}
+            onDistancesUpdated={(updatedState) => {
+              shell.combat.applyState(updatedState);
+              shell.setMissingDistancePair(null);
+            }}
           />
         ) : (
           <CombatMapFrame
@@ -198,6 +202,12 @@ export const GmCombatModeShell = ({
           actionDescription={shell.selectedCombatAction?.description}
           target={shell.selectedTarget as any}
           onClose={() => shell.setEntityActionDialogOpen(false)}
+          onMissingDistance={() =>
+            shell.setMissingDistancePair({
+              fromRefId: shell.currentParticipant?.ref_id ?? "",
+              toRefId: shell.selectedTarget?.ref_id ?? "",
+            })
+          }
           onResolved={shell.handleEntityActionResolved}
         />
       ) : null}

--- a/apps/control-web/src/features/combat-ui/gm/GmDistancesPanel.tsx
+++ b/apps/control-web/src/features/combat-ui/gm/GmDistancesPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type {
   CombatParticipant,
   CombatState,
@@ -7,6 +7,7 @@ import type {
 import { combatRepo } from "../../../shared/api/combatRepo";
 
 type Props = {
+  highlightPair?: { fromRefId: string; toRefId: string } | null;
   participants: CombatParticipant[];
   localDistances: Record<string, Record<string, number>>;
   sessionId: string;
@@ -37,6 +38,7 @@ function formatMeters(meters: number): string {
 }
 
 export const GmDistancesPanel = ({
+  highlightPair,
   participants,
   localDistances,
   sessionId,
@@ -48,6 +50,12 @@ export const GmDistancesPanel = ({
 
   const [fromRefId, setFromRefId] = useState(activeParticipants[0]?.ref_id ?? "");
   const [toRefId, setToRefId] = useState(activeParticipants[1]?.ref_id ?? "");
+
+  useEffect(() => {
+    if (!highlightPair) return;
+    if (highlightPair.fromRefId) setFromRefId(highlightPair.fromRefId);
+    if (highlightPair.toRefId) setToRefId(highlightPair.toRefId);
+  }, [highlightPair]);
   const [selectedPreset, setSelectedPreset] = useState<PresetKey>("engaged");
   const [customValue, setCustomValue] = useState("5");
   const [submitting, setSubmitting] = useState(false);

--- a/apps/control-web/src/features/combat-ui/gm/useGmCombatHandlers.ts
+++ b/apps/control-web/src/features/combat-ui/gm/useGmCombatHandlers.ts
@@ -9,6 +9,7 @@ import type {
 import { combatRepo } from "../../../shared/api/combatRepo";
 import type { CombatAction } from "../../../entities/campaign-entity/campaignEntity.types";
 import { useLocale } from "../../../shared/hooks/useLocale";
+import { isMissingDistanceError } from "../combatErrors";
 
 const NUMERIC_KINDS = new Set<ActiveEffectKind>(["temp_ac_bonus", "attack_bonus", "damage_bonus"]);
 
@@ -29,6 +30,8 @@ type UseCombatHandlersOptions = {
   numericValue: string;
   durationType: ActiveEffectDurationType;
   remainingRounds: string;
+  availableParticipants: CombatParticipant[];
+  setMissingDistancePair: (pair: { fromRefId: string; toRefId: string } | null) => void;
   refreshCombat: () => Promise<void>;
   setSubmitting: (v: boolean) => void;
   setActionError: (v: string | null) => void;
@@ -58,6 +61,8 @@ export const useGmCombatHandlers = ({
   numericValue,
   durationType,
   remainingRounds,
+  availableParticipants,
+  setMissingDistancePair,
   refreshCombat,
   setSubmitting,
   setActionError,
@@ -70,6 +75,21 @@ export const useGmCombatHandlers = ({
   setPendingOverrideAction,
 }: UseCombatHandlersOptions) => {
   const { t } = useLocale();
+
+  const handleMissingDistanceError = (rawMsg: string): string => {
+    if (!isMissingDistanceError(rawMsg) || !currentParticipant || !selectedTargetRefId) {
+      return rawMsg;
+    }
+    const targetName =
+      availableParticipants.find((p) => p.ref_id === selectedTargetRefId)?.display_name ??
+      selectedTargetRefId;
+    setMissingDistancePair({
+      fromRefId: currentParticipant.ref_id,
+      toRefId: selectedTargetRefId,
+    });
+    return `Distância não configurada entre ${currentParticipant.display_name} e ${targetName}. Defina o par no painel abaixo.`;
+  };
+
   const formatEntityActionResult = (result: CombatEntityActionResult) => {
     const actionName = result.action_name || selectedCombatAction?.name || selectedUtilityAction?.name || "Action";
     if (result.action_kind === "weapon_attack" || result.action_kind === "spell_attack") {
@@ -108,7 +128,8 @@ export const useGmCombatHandlers = ({
             const overrideResult = await apiCall(true);
             await onSuccess(overrideResult);
           } catch (overrideErr: any) {
-            setActionError(overrideErr?.data?.detail || overrideErr?.message || fallbackMsg);
+            const overrideMsg = overrideErr?.data?.detail || overrideErr?.message || fallbackMsg;
+            setActionError(handleMissingDistanceError(overrideMsg));
           } finally {
             setSubmitting(false);
             setOverrideDialogOpen(false);
@@ -118,7 +139,8 @@ export const useGmCombatHandlers = ({
         setOverrideDialogOpen(true);
         setSubmitting(false);
       } else {
-        setActionError(err?.data?.detail || err?.message || fallbackMsg);
+        const errMsg = err?.data?.detail || err?.message || fallbackMsg;
+        setActionError(handleMissingDistanceError(errMsg));
       }
     } finally {
       if (!is409) setSubmitting(false);

--- a/apps/control-web/src/features/combat-ui/gm/useGmCombatShell.ts
+++ b/apps/control-web/src/features/combat-ui/gm/useGmCombatShell.ts
@@ -4,6 +4,7 @@ import type {
   ActiveEffectDurationType,
   ActiveEffectKind,
   CombatEntityActionResult,
+  CombatParticipant,
   StandardActionType,
 } from "../../../shared/api/combatRepo";
 import type { CharacterSheet } from "../../../features/character-sheet/model/characterSheet.types";
@@ -45,6 +46,7 @@ export const useGmCombatShell = ({ sessionId, playerSheetByUserId }: UseGmCombat
   const [overrideDialogOpen, setOverrideDialogOpen] = useState(false);
   const [overrideResourceName, setOverrideResourceName] = useState("");
   const [pendingOverrideAction, setPendingOverrideAction] = useState<(() => Promise<void>) | null>(null);
+  const [missingDistancePair, setMissingDistancePair] = useState<{ fromRefId: string; toRefId: string } | null>(null);
 
   const playerVitalsByUserId = useMemo(
     () =>
@@ -154,6 +156,8 @@ export const useGmCombatShell = ({ sessionId, playerSheetByUserId }: UseGmCombat
     numericValue,
     durationType,
     remainingRounds,
+    availableParticipants: availableTargets as CombatParticipant[],
+    setMissingDistancePair,
     refreshCombat: combat.refreshState,
     setSubmitting,
     setActionError,
@@ -324,6 +328,9 @@ export const useGmCombatShell = ({ sessionId, playerSheetByUserId }: UseGmCombat
     reviveHp,
     setReviveHp,
     selectedTarget,
+    // Missing distance pair (for GmDistancesPanel preselection)
+    missingDistancePair,
+    setMissingDistancePair,
     // Handlers (from useGmCombatHandlers)
     ...handlers,
   };

--- a/apps/control-web/src/pages/GmDashboardPage/GmEntityActionRollDialog.tsx
+++ b/apps/control-web/src/pages/GmDashboardPage/GmEntityActionRollDialog.tsx
@@ -15,6 +15,7 @@ import {
 import { GmActionOverrideDialog } from "../../features/combat-ui/gm/GmActionOverrideDialog";
 import { D20_VALUES, formatSigned, formatDamageBreakdown } from "./gmEntityActionRollHelpers";
 import { GmDamageRollSection } from "./GmDamageRollSection";
+import { isMissingDistanceError } from "../../features/combat-ui/combatErrors";
 
 type Props = {
   actionDescription?: string | null;
@@ -23,6 +24,7 @@ type Props = {
   actionName: string;
   actorParticipantId: string;
   onClose: () => void;
+  onMissingDistance?: () => void;
   onResolved?: (result: CombatEntityActionResult) => void | Promise<void>;
   sessionId: string;
   target: CombatParticipant;
@@ -35,6 +37,7 @@ export const GmEntityActionRollDialog = ({
   actionName,
   actorParticipantId,
   onClose,
+  onMissingDistance,
   onResolved,
   sessionId,
   target,
@@ -99,7 +102,9 @@ export const GmEntityActionRollDialog = ({
         setPendingOverridePayload(payload);
         setOverrideDialogOpen(true);
       } else {
-        setError(err?.data?.detail || err?.message || "Falha ao resolver a acao");
+        const errMsg = err?.data?.detail || err?.message || "Falha ao resolver a acao";
+        if (isMissingDistanceError(errMsg)) onMissingDistance?.();
+        setError(errMsg);
       }
     } finally {
       if (!overrideDialogOpen) setLoading(false);
@@ -129,7 +134,9 @@ export const GmEntityActionRollDialog = ({
       setResult(resolved);
       await onResolved?.(resolved);
     } catch (err: any) {
-      setError(err?.data?.detail || err?.message || "Falha ao rolar dano");
+      const errMsg = err?.data?.detail || err?.message || "Falha ao rolar dano";
+      if (isMissingDistanceError(errMsg)) onMissingDistance?.();
+      setError(errMsg);
     } finally {
       setLoading(false);
     }

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerAttackRollDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerAttackRollDialog.tsx
@@ -8,6 +8,7 @@ import type {
   CombatParticipant,
 } from "../../../shared/api/combatRepo";
 import { combatRepo } from "../../../shared/api/combatRepo";
+import { toPlayerFriendlyError } from "../../../features/combat-ui/combatErrors";
 import {
   formatDamageDiceExpression,
   getDamageRollCount,
@@ -91,7 +92,7 @@ export const PlayerAttackRollDialog = ({
         await onResolved?.(resolved);
       }
     } catch (err: any) {
-      setError(err?.data?.detail || err?.message || "Falha ao resolver ataque");
+      setError(toPlayerFriendlyError(err?.data?.detail || err?.message || "Falha ao resolver ataque"));
     } finally {
       setLoading(false);
     }
@@ -120,7 +121,7 @@ export const PlayerAttackRollDialog = ({
       setResult(resolved);
       await onResolved?.(resolved);
     } catch (err: any) {
-      setError(err?.data?.detail || err?.message || "Falha ao rolar dano");
+      setError(toPlayerFriendlyError(err?.data?.detail || err?.message || "Falha ao rolar dano"));
     } finally {
       setLoading(false);
     }

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
@@ -11,6 +11,7 @@ import type {
   CombatSpellResult,
 } from "../../../shared/api/combatRepo";
 import { combatRepo } from "../../../shared/api/combatRepo";
+import { toPlayerFriendlyError } from "../../../features/combat-ui/combatErrors";
 import {
   getDamageRollCount,
   getDamageRollSides,
@@ -297,7 +298,7 @@ export const PlayerSpellCastDialog = ({
         await onResolved?.(resolved);
       }
     } catch (err: any) {
-      setError(err?.data?.detail || err?.message || "Falha ao conjurar magia");
+      setError(toPlayerFriendlyError(err?.data?.detail || err?.message || "Falha ao conjurar magia"));
       setTargetingMode(isAreaSpell ? "area_target_select" : "single_target_select");
     } finally {
       setLoading(false);


### PR DESCRIPTION
Closes #28

## Summary

- Add `combatErrors.ts` utility with `isMissingDistanceError()` and `toPlayerFriendlyError()` — detects the backend phrase `"distance not configured"` and provides a human-readable substitute
- When a GM action (saving throw, heal) fails with a missing-distance error, enrich the error in `useGmCombatHandlers` with actor and target names: `"Distância não configurada entre X e Y. Defina o par no painel abaixo."`
- Call `setMissingDistancePair({ fromRefId, toRefId })` so the distances panel preselects the right pair automatically
- Add `onMissingDistance?: () => void` to `GmEntityActionRollDialog` (covers weapon_attack / spell_attack NPC actions) and call it from `GmCombatModeShell` with the current actor/target ref_ids
- Add `highlightPair` prop to `GmDistancesPanel`; a `useEffect` preselects the form when `highlightPair` changes
- Clear `missingDistancePair` after a successful distance update in `GmCombatModeShell`
- Apply `toPlayerFriendlyError()` in `PlayerAttackRollDialog` and `PlayerSpellCastDialog` so players see a clear message instead of the raw backend string

No backend changes. No changes to range validation rules. Map-backed combat unaffected.

## Validation

- No-map combat → GM executes NPC action against player without configured distance → error shows actor and target names → distances panel preselects the pair
- GM updates distance → pair cleared from highlight → action succeeds on retry
- Player attacks without configured distance → dialog shows `"Distância não configurada — aguarde o GM definir as distâncias antes de agir."` instead of raw backend message
- `npx vitest run apps/control-web/src/features/combat-ui/combatErrors.test.ts` → 6 passed
- `npx tsc --noEmit` → no errors in modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)