### PR TITLE
fix: resolve control-server base seed paths in Docker lab

### DIFF
--- a/apps/control-server/app/services/base_item_seeds.py
+++ b/apps/control-server/app/services/base_item_seeds.py
@@ -10,11 +10,13 @@ from app.api.serializers.base_item import to_base_item_seed_entry
 from app.models.base_item import BaseItem
 from app.schemas.base_item import BaseItemCreate, BaseItemSeedDocument
 from app.services.base_items import create_base_item, update_base_item
+from app.services.seed_paths import resolve_base_seed_path
 
 logger = logging.getLogger(__name__)
 
-REPO_ROOT = Path(__file__).resolve().parents[4]
-DEFAULT_BASE_ITEMS_SEED_PATH = REPO_ROOT / "Base" / "base_items.seed.json"
+DEFAULT_BASE_ITEMS_SEED_PATH = resolve_base_seed_path(
+    __file__, "base_items.seed.json"
+)
 
 
 def read_base_item_seed_document(

--- a/apps/control-server/app/services/base_spell_seeds.py
+++ b/apps/control-server/app/services/base_spell_seeds.py
@@ -10,11 +10,13 @@ from app.api.serializers.base_spell import to_base_spell_seed_entry
 from app.models.base_spell import BaseSpell
 from app.schemas.base_spell import BaseSpellCreate, BaseSpellSeedDocument
 from app.services.base_spells import create_base_spell, update_base_spell
+from app.services.seed_paths import resolve_base_seed_path
 
 logger = logging.getLogger(__name__)
 
-REPO_ROOT = Path(__file__).resolve().parents[4]
-DEFAULT_BASE_SPELLS_SEED_PATH = REPO_ROOT / "Base" / "base_spells.seed.json"
+DEFAULT_BASE_SPELLS_SEED_PATH = resolve_base_seed_path(
+    __file__, "base_spells.seed.json"
+)
 
 
 def read_base_spell_seed_document(

--- a/apps/control-server/app/services/seed_paths.py
+++ b/apps/control-server/app/services/seed_paths.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_base_seed_path(source_file: str | Path, filename: str) -> Path:
+    source_path = Path(source_file).resolve()
+    candidate_with_base_dir: Path | None = None
+    last_candidate: Path | None = None
+
+    for ancestor in (source_path.parent, *source_path.parents):
+        candidate = ancestor / "Base" / filename
+        if candidate.is_file():
+            return candidate
+        if candidate_with_base_dir is None and candidate.parent.is_dir():
+            candidate_with_base_dir = candidate
+        last_candidate = candidate
+
+    return candidate_with_base_dir or last_candidate or Path("Base") / filename

--- a/apps/control-server/tests/test_base_item_admin.py
+++ b/apps/control-server/tests/test_base_item_admin.py
@@ -41,6 +41,7 @@ from app.services.base_item_seeds import (
     write_base_item_seed_document,
 )
 from app.services.base_items import create_base_item
+from app.services.seed_paths import resolve_base_seed_path
 
 
 def make_base_item(**overrides):
@@ -348,6 +349,36 @@ class BaseItemServiceTests(unittest.TestCase):
 
 
 class BaseItemSeedTests(unittest.TestCase):
+    def test_resolve_base_seed_path_prefers_repo_base_directory(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            service_path = repo_root / "apps" / "control-server" / "app" / "services" / "base_item_seeds.py"
+            service_path.parent.mkdir(parents=True, exist_ok=True)
+            service_path.write_text("# test\n", encoding="utf-8")
+
+            expected_path = repo_root / "Base" / "base_items.seed.json"
+            expected_path.parent.mkdir(parents=True, exist_ok=True)
+            expected_path.write_text('{"version": 1, "items": []}\n', encoding="utf-8")
+
+            resolved_path = resolve_base_seed_path(service_path, "base_items.seed.json")
+
+        self.assertEqual(resolved_path, expected_path)
+
+    def test_resolve_base_seed_path_supports_docker_base_directory(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            container_root = Path(tmp_dir)
+            service_path = container_root / "app" / "app" / "services" / "base_item_seeds.py"
+            service_path.parent.mkdir(parents=True, exist_ok=True)
+            service_path.write_text("# test\n", encoding="utf-8")
+
+            expected_path = container_root / "Base" / "base_items.seed.json"
+            expected_path.parent.mkdir(parents=True, exist_ok=True)
+            expected_path.write_text('{"version": 1, "items": []}\n', encoding="utf-8")
+
+            resolved_path = resolve_base_seed_path(service_path, "base_items.seed.json")
+
+        self.assertEqual(resolved_path, expected_path)
+
     def test_write_and_read_seed_document_roundtrip(self):
         item_a = BaseItemCreate(
             canonicalKey="club",

--- a/apps/control-server/tests/test_base_spell_admin.py
+++ b/apps/control-server/tests/test_base_spell_admin.py
@@ -39,6 +39,7 @@ from app.services.base_spell_seeds import (
     write_base_spell_seed_document,
 )
 from app.services.base_spells import create_base_spell, delete_base_spell
+from app.services.seed_paths import resolve_base_seed_path
 
 
 def make_base_spell(**overrides):
@@ -456,6 +457,36 @@ class BaseSpellSerializerTests(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class BaseSpellSeedTests(unittest.TestCase):
+    def test_resolve_base_seed_path_prefers_repo_base_directory(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            service_path = repo_root / "apps" / "control-server" / "app" / "services" / "base_spell_seeds.py"
+            service_path.parent.mkdir(parents=True, exist_ok=True)
+            service_path.write_text("# test\n", encoding="utf-8")
+
+            expected_path = repo_root / "Base" / "base_spells.seed.json"
+            expected_path.parent.mkdir(parents=True, exist_ok=True)
+            expected_path.write_text('{"version": 1, "spells": []}\n', encoding="utf-8")
+
+            resolved_path = resolve_base_seed_path(service_path, "base_spells.seed.json")
+
+        self.assertEqual(resolved_path, expected_path)
+
+    def test_resolve_base_seed_path_supports_docker_base_directory(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            container_root = Path(tmp_dir)
+            service_path = container_root / "app" / "app" / "services" / "base_spell_seeds.py"
+            service_path.parent.mkdir(parents=True, exist_ok=True)
+            service_path.write_text("# test\n", encoding="utf-8")
+
+            expected_path = container_root / "Base" / "base_spells.seed.json"
+            expected_path.parent.mkdir(parents=True, exist_ok=True)
+            expected_path.write_text('{"version": 1, "spells": []}\n', encoding="utf-8")
+
+            resolved_path = resolve_base_seed_path(service_path, "base_spells.seed.json")
+
+        self.assertEqual(resolved_path, expected_path)
+
     def test_write_and_read_seed_document_roundtrip(self):
         spell_a = BaseSpellCreate(
             canonicalKey="acid_splash",


### PR DESCRIPTION
## Summary

Fixes the control-server boot failure in the lab Docker environment by resolving base seed file paths without assuming a fixed monorepo depth.

## Root cause

`base_item_seeds.py` and `base_spell_seeds.py` used `Path(__file__).resolve().parents[4]` to derive the repository root.

That works in the local monorepo layout, but it breaks in the Docker image because the control-server code is copied to `/app` and the seed files are copied to `/Base`. In that layout, `parents[4]` raises `IndexError` during import time, preventing the API from starting.

## What changed

- added a shared `resolve_base_seed_path()` helper
- updated base item seed loading to use the new resolver
- updated base spell seed loading to use the same resolver
- added regression tests for both:
  - local monorepo-style layout
  - Docker-style `/Base` layout

## Impact

- fixes homologation/lab API boot in Docker
- keeps the existing local development behavior intact
- prevents the same path bug from remaining latent in base spell seed loading

## Validation

- `apps/control-server/.venv/bin/python -m pytest apps/control-server/tests/test_base_item_admin.py -q`
- `apps/control-server/.venv/bin/python -m pytest apps/control-server/tests/test_base_spell_admin.py -q`
- `.venv/bin/python -c "import app.main; print('app-import-ok')"` in `apps/control-server`
- lab environment validated manually on the server after checking out this branch and rebuilding with Docker

Closes #33
