### PR TITLE
Align production/lab env examples and compose realtime networking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,10 @@ POSTGRES_DB=limiarcontrol
 DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/limiarcontrol
 PORT=8000
 API_PORT=8002
+# Browser origins allowed to call the API (comma-separated).
+# Local development defaults below are safe for host-based Vite + dockerized API.
 CORS_ORIGIN=http://localhost:5173,http://127.0.0.1:5173,http://localhost:8002,http://127.0.0.1:8002
+# Browser origins allowed to open the Centrifugo websocket (space-separated).
 CENTRIFUGO_ALLOWED_ORIGINS=http://localhost:5173 http://127.0.0.1:5173 http://localhost:5174 http://127.0.0.1:5174 http://localhost:8002 http://127.0.0.1:8002
 APP_ENV=development
 AUTO_MIGRATE=true
@@ -13,7 +16,11 @@ CENTRIFUGO_API_URL=http://localhost:8001/api
 CENTRIFUGO_API_KEY=dev-api-key
 CENTRIFUGO_TOKEN_SECRET=dev-secret-change-me
 CENTRIFUGO_TOKEN_HMAC_SECRET_KEY=dev-secret-change-me
+# Public websocket URL exposed to browsers.
 CENTRIFUGO_PUBLIC_URL=ws://localhost:8001/connection/websocket
+# Internal websocket URL used by backend/container-to-container consumers.
+# Keep the localhost value for host-based development.
+CENTRIFUGO_INTERNAL_WS_URL=ws://localhost:8001/connection/websocket
 LIMIAR_MAP_ENABLED=true
 LIMIAR_MAP_BASE_URL=http://localhost:3000
 LIMIAR_MAP_TIMEOUT_SECONDS=2.0
@@ -25,12 +32,15 @@ MINIO_SECRET_KEY=minioadmin
 MINIO_BUCKET=limiarcontrol-media
 MINIO_SECURE=false
 MEDIA_LEGACY_ALLOWED_ORIGINS=res.cloudinary.com
+# Local Vite defaults. The production compose file always builds with Vite in production mode.
 VITE_APP_ENV=development
 VITE_API_BASE_URL=/api
 VITE_CENTRIFUGO_URL=ws://localhost:8001/connection/websocket
 VITE_ENABLE_MUSIC=true
 VITE_ENABLE_MAPS=true
 DOCKER_VITE_API_BASE_URL=/api
+# Baked into the production frontend build: must be the public websocket URL
+# served to the browser (usually wss://your-domain/centrifugo/connection/websocket).
 DOCKER_VITE_CENTRIFUGO_URL=ws://localhost:8001/connection/websocket
 DOCKER_VITE_ENABLE_MUSIC=true
 DOCKER_VITE_ENABLE_MAPS=true

--- a/.env.lab.example
+++ b/.env.lab.example
@@ -8,22 +8,23 @@ LAB_POSTGRES_DB=limiarcontrol_lab
 
 LAB_API_PORT=8002
 
-LAB_APP_ENV=production
 LAB_AUTO_MIGRATE=true
 LAB_JWT_SECRET=change-me-lab-jwt-secret
 
-LAB_CORS_ORIGIN=http://localhost:8002,http://127.0.0.1:8002
+# Set to the public HTTPS origin(s) used by the browser (e.g. https://lab-limiar.example.com)
+LAB_CORS_ORIGIN=https://lab-limiar.example.com
 
 LAB_CENTRIFUGO_API_KEY=change-me-lab-centrifugo-api-key
 LAB_CENTRIFUGO_TOKEN_SECRET=change-me-lab-centrifugo-token-secret
-LAB_CENTRIFUGO_ALLOWED_ORIGINS=http://localhost:8002 http://127.0.0.1:8002
-LAB_CENTRIFUGO_PUBLIC_URL=ws://127.0.0.1:8003/connection/websocket
+# Space-separated list of public origins allowed to open the Centrifugo WebSocket.
+# Must include the browser origin serving the SPA (HTTPS in production).
+LAB_CENTRIFUGO_ALLOWED_ORIGINS=https://lab-limiar.example.com
 LAB_LIMIAR_MAP_INTERNAL_KEY=change-me-lab-limiar-map-internal-key
-LAB_CONTROL_SERVER_BASE_URL=http://127.0.0.1:8002
 
-LAB_VITE_APP_ENV=production
 LAB_DOCKER_VITE_API_BASE_URL=/api
-LAB_DOCKER_VITE_CENTRIFUGO_URL=ws://127.0.0.1:8003/connection/websocket
+# Baked into the SPA bundle at build time: must be the public wss:// URL reverse-proxied by nginx.
+# nginx vhost should expose `location /centrifugo/` forwarding to 127.0.0.1:8003 with Upgrade headers.
+LAB_DOCKER_VITE_CENTRIFUGO_URL=wss://lab-limiar.example.com/centrifugo/connection/websocket
 LAB_DOCKER_VITE_ENABLE_MUSIC=true
 LAB_DOCKER_VITE_ENABLE_MAPS=true
 

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,31 @@
+POSTGRES_USER=app_user
+POSTGRES_PASSWORD=change-me-strong-postgres-password
+POSTGRES_DB=limiarcontrol
+
+# Host-local bind used by nginx/upstream checks.
+API_PORT=8000
+
+AUTO_MIGRATE=false
+JWT_SECRET=change-me-strong-jwt-secret
+
+# Browser origins allowed to call the API (comma-separated).
+CORS_ORIGIN=https://seu-dominio.com
+
+CENTRIFUGO_API_KEY=change-me-strong-centrifugo-api-key
+CENTRIFUGO_TOKEN_SECRET=change-me-strong-centrifugo-token-secret
+# Browser origins allowed to open the Centrifugo websocket (space-separated).
+CENTRIFUGO_ALLOWED_ORIGINS=https://seu-dominio.com
+
+LIMIAR_MAP_INTERNAL_KEY=change-me-strong-map-internal-key
+
+MINIO_ACCESS_KEY=change-me-minio-access-key
+MINIO_SECRET_KEY=change-me-minio-secret-key
+MINIO_BUCKET=limiarcontrol-media
+MINIO_SECURE=false
+MEDIA_LEGACY_ALLOWED_ORIGINS=res.cloudinary.com
+
+DOCKER_VITE_API_BASE_URL=/api
+# Public websocket URL baked into the SPA bundle.
+DOCKER_VITE_CENTRIFUGO_URL=wss://seu-dominio.com/centrifugo/connection/websocket
+DOCKER_VITE_ENABLE_MUSIC=true
+DOCKER_VITE_ENABLE_MAPS=true

--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ Recommended for day-to-day work. Run infrastructure in Docker and keep frontend/
 
 Recommended for pre-merge validation and homologation. This stack is isolated from production and uses its own ports, containers, network, and database volume.
 
-- App + API: `http://127.0.0.1:8002`
-- Centrifugo: `ws://127.0.0.1:8003/connection/websocket`
+- Host-local app + API bind: `http://127.0.0.1:8002`
+- Host-local Centrifugo bind: `ws://127.0.0.1:8003/connection/websocket`
+- Public browser origin should come from `LAB_CORS_ORIGIN` and `LAB_DOCKER_VITE_CENTRIFUGO_URL`
 - Compose file: [docker-compose.lab.yml](/home/caue/LimiarControl/docker-compose.lab.yml)
 - Env example: [.env.lab.example](/home/caue/LimiarControl/.env.lab.example)
 
@@ -84,8 +85,9 @@ Recommended for pre-merge validation and homologation. This stack is isolated fr
 
 Production now uses the single-container app stack for frontend + backend, with Centrifugo and Postgres alongside it.
 
-- App + API: `http://127.0.0.1:8000`
-- Centrifugo: `ws://127.0.0.1:8001/connection/websocket`
+- Host-local app + API bind: `http://127.0.0.1:8000`
+- Host-local Centrifugo bind: `ws://127.0.0.1:8001/connection/websocket`
+- Public browser origin should be reverse-proxied and must match `CORS_ORIGIN`, `CENTRIFUGO_ALLOWED_ORIGINS`, and `DOCKER_VITE_CENTRIFUGO_URL`
 - Compose file: [docker-compose.prod.yml](/home/caue/LimiarControl/docker-compose.prod.yml)
 
 ## Local development
@@ -172,6 +174,7 @@ Expected endpoints in this mode:
 - App + API: `http://127.0.0.1:8000/`
 - API health: `http://127.0.0.1:8000/health`
 - Centrifugo websocket: `ws://localhost:8001/connection/websocket`
+- Internal backend-to-Centrifugo websocket: `ws://centrifugo:8000/connection/websocket`
 
 ### 8. Validate the lab stack locally
 
@@ -185,6 +188,7 @@ Expected endpoints in this mode:
 - App + API: `http://127.0.0.1:8002/`
 - API health: `http://127.0.0.1:8002/health`
 - Centrifugo websocket: `ws://127.0.0.1:8003/connection/websocket`
+- Public browser websocket should usually be exposed by nginx as `wss://<lab-domain>/centrifugo/connection/websocket`
 
 ## Environment files
 
@@ -206,6 +210,14 @@ Use [.env.lab.example](.env.lab.example) as the starting point for homologation:
 cp .env.lab.example .env.lab
 ```
 
+### Production `.env`
+
+Use [.env.prod.example](.env.prod.example) as the starting point for the production-like stack:
+
+```bash
+cp .env.prod.example .env
+```
+
 ## Useful commands
 
 ### Frontend
@@ -222,20 +234,27 @@ npx tsc --noEmit
 The main `Dockerfile` already packages frontend + backend in the same container. In production,
 FastAPI serves the Vite `dist/` directly.
 
-Before bringing the production stack up, set the root `.env` with real values:
+Before bringing the production stack up, start from [.env.prod.example](.env.prod.example):
+
+```bash
+cp .env.prod.example .env
+```
+
+`docker-compose.prod.yml` forces `APP_ENV=production` and builds the SPA with `VITE_APP_ENV=production`:
 
 ```env
-APP_ENV=production
 POSTGRES_USER=app_user
 POSTGRES_PASSWORD=use-uma-senha-forte
 POSTGRES_DB=limiarcontrol
 JWT_SECRET=use-um-segredo-forte
 CENTRIFUGO_API_KEY=use-uma-chave-forte
 CENTRIFUGO_TOKEN_SECRET=use-um-segredo-forte
+# Comma-separated list of browser origins allowed by FastAPI.
 CORS_ORIGIN=https://seu-dominio.com
+# Space-separated list of browser origins allowed by Centrifugo.
 CENTRIFUGO_ALLOWED_ORIGINS=https://seu-dominio.com
 DOCKER_VITE_API_BASE_URL=/api
-DOCKER_VITE_CENTRIFUGO_URL=wss://rt.seu-dominio.com/connection/websocket
+DOCKER_VITE_CENTRIFUGO_URL=wss://seu-dominio.com/centrifugo/connection/websocket
 ```
 
 Suba com:
@@ -243,6 +262,9 @@ Suba com:
 ```bash
 docker compose -f docker-compose.prod.yml up -d --build
 ```
+
+The compose stack already pins the backend-internal Centrifugo websocket to
+`ws://centrifugo:8000/connection/websocket`.
 
 If `POSTGRES_USER=postgres` and `POSTGRES_PASSWORD=postgres` remain in `.env`, the backend
 will abort in production with `DATABASE_URL must use strong credentials in production`.
@@ -261,6 +283,14 @@ Start it with:
 
 ```bash
 docker compose --env-file .env.lab -f docker-compose.lab.yml up -d --build
+```
+
+Recommended public settings in `.env.lab`:
+
+```env
+LAB_CORS_ORIGIN=https://lab-limiar.example.com
+LAB_CENTRIFUGO_ALLOWED_ORIGINS=https://lab-limiar.example.com
+LAB_DOCKER_VITE_CENTRIFUGO_URL=wss://lab-limiar.example.com/centrifugo/connection/websocket
 ```
 
 ### Backend

--- a/apps/control-server/README.md
+++ b/apps/control-server/README.md
@@ -49,10 +49,14 @@ JWT_SECRET=dev-secret-change-me
 CENTRIFUGO_API_URL=http://localhost:8001/api
 CENTRIFUGO_API_KEY=dev-api-key
 CENTRIFUGO_PUBLIC_URL=ws://localhost:8001/connection/websocket
+CENTRIFUGO_INTERNAL_WS_URL=ws://localhost:8001/connection/websocket
 CENTRIFUGO_TOKEN_SECRET=dev-secret-change-me
 CENTRIFUGO_TOKEN_HMAC_SECRET_KEY=dev-secret-change-me
 LIMIAR_MAP_INTERNAL_KEY=dev-map-internal-key
 ```
+
+When the API itself runs inside Docker, use `CENTRIFUGO_INTERNAL_WS_URL=ws://centrifugo:8000/connection/websocket`
+so backend-to-backend realtime sync does not try to connect back to `localhost`.
 
 ## Run migrations
 ```bash
@@ -119,6 +123,10 @@ Endpoints:
 - App + API: `http://127.0.0.1:8002`
 - API health: `http://127.0.0.1:8002/health`
 - Centrifugo: `ws://127.0.0.1:8003/connection/websocket`
+
+For browser access in homologation, prefer a reverse-proxied public URL such as
+`wss://lab-limiar.example.com/centrifugo/connection/websocket` and keep
+`LAB_CORS_ORIGIN` plus `LAB_CENTRIFUGO_ALLOWED_ORIGINS` aligned with that origin.
 
 ## Combat docs
 

--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -44,7 +44,7 @@ services:
     environment:
       CENTRIFUGO_TOKEN_HMAC_SECRET_KEY: ${LAB_CENTRIFUGO_TOKEN_SECRET:-dev-secret-change-me}
       CENTRIFUGO_API_KEY: ${LAB_CENTRIFUGO_API_KEY:-dev-api-key}
-      CENTRIFUGO_ALLOWED_ORIGINS: ${LAB_CENTRIFUGO_ALLOWED_ORIGINS:-http://localhost:${LAB_API_PORT:-8002} http://127.0.0.1:${LAB_API_PORT:-8002}}
+      CENTRIFUGO_ALLOWED_ORIGINS: ${LAB_CENTRIFUGO_ALLOWED_ORIGINS:?LAB_CENTRIFUGO_ALLOWED_ORIGINS is required (public browser origin(s))}
     ports:
       - "127.0.0.1:8003:8000"
     networks:
@@ -56,24 +56,24 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        VITE_APP_ENV: ${LAB_VITE_APP_ENV:-production}
+        VITE_APP_ENV: production
         VITE_API_BASE_URL: ${LAB_DOCKER_VITE_API_BASE_URL:-/api}
-        VITE_CENTRIFUGO_URL: ${LAB_DOCKER_VITE_CENTRIFUGO_URL:-ws://127.0.0.1:8003/connection/websocket}
+        VITE_CENTRIFUGO_URL: ${LAB_DOCKER_VITE_CENTRIFUGO_URL:?LAB_DOCKER_VITE_CENTRIFUGO_URL is required (public wss:// URL served by nginx)}
         VITE_ENABLE_MUSIC: ${LAB_DOCKER_VITE_ENABLE_MUSIC:-true}
         VITE_ENABLE_MAPS: ${LAB_DOCKER_VITE_ENABLE_MAPS:-true}
     container_name: limiar-lab-api
     ports:
       - "127.0.0.1:${LAB_API_PORT:-8002}:8000"
     environment:
-      APP_ENV: ${LAB_APP_ENV:-production}
+      APP_ENV: production
       DATABASE_URL: postgresql+psycopg://${LAB_POSTGRES_USER:-postgres}:${LAB_POSTGRES_PASSWORD:-postgres}@db:5432/${LAB_POSTGRES_DB:-limiarcontrol_lab}
       JWT_SECRET: ${LAB_JWT_SECRET:?LAB_JWT_SECRET is required}
       CENTRIFUGO_API_URL: http://centrifugo:8000/api
       CENTRIFUGO_API_KEY: ${LAB_CENTRIFUGO_API_KEY:-dev-api-key}
       CENTRIFUGO_TOKEN_SECRET: ${LAB_CENTRIFUGO_TOKEN_SECRET:-dev-secret-change-me}
-      CENTRIFUGO_PUBLIC_URL: ${LAB_CENTRIFUGO_PUBLIC_URL:-ws://127.0.0.1:8003/connection/websocket}
+      CENTRIFUGO_INTERNAL_WS_URL: ws://centrifugo:8000/connection/websocket
       LIMIAR_MAP_INTERNAL_KEY: ${LAB_LIMIAR_MAP_INTERNAL_KEY:-dev-map-internal-key}
-      CORS_ORIGIN: ${LAB_CORS_ORIGIN:-http://localhost:${LAB_API_PORT:-8002},http://127.0.0.1:${LAB_API_PORT:-8002}}
+      CORS_ORIGIN: ${LAB_CORS_ORIGIN:?LAB_CORS_ORIGIN is required (public HTTPS origin(s) used by the SPA)}
       AUTO_MIGRATE: ${LAB_AUTO_MIGRATE:-true}
       MINIO_ENDPOINT: minio:9000
       MINIO_ACCESS_KEY: ${LAB_MINIO_ACCESS_KEY:-minioadmin}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -54,22 +54,22 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        VITE_APP_ENV: ${VITE_APP_ENV:-production}
+        VITE_APP_ENV: production
         VITE_API_BASE_URL: ${DOCKER_VITE_API_BASE_URL:-/api}
-        VITE_CENTRIFUGO_URL: ${DOCKER_VITE_CENTRIFUGO_URL:-ws://localhost:8001/connection/websocket}
+        VITE_CENTRIFUGO_URL: ${DOCKER_VITE_CENTRIFUGO_URL:?DOCKER_VITE_CENTRIFUGO_URL is required (public wss:// URL served to the browser)}
         VITE_ENABLE_MUSIC: ${DOCKER_VITE_ENABLE_MUSIC:-true}
         VITE_ENABLE_MAPS: ${DOCKER_VITE_ENABLE_MAPS:-true}
     container_name: limiarcontrol-api
     ports:
       - "127.0.0.1:${API_PORT:-8002}:8000"
     environment:
-      APP_ENV: ${APP_ENV:-production}
+      APP_ENV: production
       DATABASE_URL: postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-limiarcontrol}
       JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
       CENTRIFUGO_API_URL: http://centrifugo:8000/api
       CENTRIFUGO_API_KEY: ${CENTRIFUGO_API_KEY:?CENTRIFUGO_API_KEY is required}
       CENTRIFUGO_TOKEN_SECRET: ${CENTRIFUGO_TOKEN_SECRET:?CENTRIFUGO_TOKEN_SECRET is required}
-      CENTRIFUGO_PUBLIC_URL: ${CENTRIFUGO_PUBLIC_URL:?CENTRIFUGO_PUBLIC_URL is required}
+      CENTRIFUGO_INTERNAL_WS_URL: ws://centrifugo:8000/connection/websocket
       LIMIAR_MAP_INTERNAL_KEY: ${LIMIAR_MAP_INTERNAL_KEY:?LIMIAR_MAP_INTERNAL_KEY is required}
       CORS_ORIGIN: ${CORS_ORIGIN:?CORS_ORIGIN is required}
       AUTO_MIGRATE: ${AUTO_MIGRATE:-false}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       CENTRIFUGO_API_KEY: ${CENTRIFUGO_API_KEY:-dev-api-key}
       CENTRIFUGO_TOKEN_SECRET: ${CENTRIFUGO_TOKEN_SECRET:-dev-secret-change-me}
       CENTRIFUGO_PUBLIC_URL: ${CENTRIFUGO_PUBLIC_URL:-ws://localhost:8001/connection/websocket}
+      CENTRIFUGO_INTERNAL_WS_URL: ws://centrifugo:8000/connection/websocket
       LIMIAR_MAP_INTERNAL_KEY: ${LIMIAR_MAP_INTERNAL_KEY:-dev-map-internal-key}
       CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:5173,http://127.0.0.1:5173,http://localhost:${API_PORT:-8002},http://127.0.0.1:${API_PORT:-8002}}
       AUTO_MIGRATE: ${AUTO_MIGRATE:-true}


### PR DESCRIPTION
## Summary

Aligns the repository env examples, compose files, and operational docs so dev, lab, and production-like environments use the correct public origins and internal realtime endpoints.

## Root Cause

The repo was mixing dev-local defaults with deployment-oriented guidance in a few key places:

- lab examples still suggested localhost-style browser origins and websocket URLs
- production-like guidance did not have a dedicated env example
- backend-internal realtime connectivity could drift toward `localhost` instead of the Docker-network Centrifugo service
- docs did not clearly distinguish public browser websocket URLs from backend-internal websocket URLs

That made lab/prod-like setup more error-prone and increased the risk of CORS failures or refused realtime connections.

## What Changed

- kept `.env.example` focused on local development and documented each realtime/CORS variable more clearly
- added `.env.prod.example` with production-oriented placeholders and safer defaults
- updated `.env.lab.example` to reflect a public HTTPS origin and reverse-proxied `wss://.../centrifugo/connection/websocket` browser URL
- pinned backend-internal realtime connectivity to `ws://centrifugo:8000/connection/websocket` in:
  - `docker-compose.yml`
  - `docker-compose.prod.yml`
  - `docker-compose.lab.yml`
- made lab and production-like compose builds run in production mode explicitly
- made lab and production-like compose files require the public browser-facing origin/websocket values needed for correct CORS and realtime setup
- updated the root README and control-server README to explain the separation between:
  - browser-facing origin settings
  - public websocket URL baked into the SPA bundle
  - backend-internal websocket URL used between containers

## Impact

- dev keeps working with localhost-friendly defaults
- lab configuration now matches the real public reverse-proxied setup more closely
- production-like validation has a dedicated env example instead of reusing the dev example
- backend realtime consumers inside Docker no longer risk connecting to `localhost` by mistake
- the compose/docs path should be much less likely to produce CORS or websocket connection errors

## Validation

- `docker compose --env-file .env.example config`
- `docker compose --env-file .env.prod.example -f docker-compose.prod.yml config`
- `docker compose --env-file .env.lab.example -f docker-compose.lab.yml config`

Closes #37
