### PR TITLE
Use internal Centrifugo websocket URL for map realtime sync

### DIFF
--- a/apps/control-server/app/core/config.py
+++ b/apps/control-server/app/core/config.py
@@ -152,6 +152,13 @@ class Settings:
         "CENTRIFUGO_PUBLIC_URL",
         "ws://localhost:8001/connection/websocket",
     )
+    centrifugo_internal_ws_url: str = os.getenv(
+        "CENTRIFUGO_INTERNAL_WS_URL",
+        os.getenv(
+            "CENTRIFUGO_PUBLIC_URL",
+            "ws://localhost:8001/connection/websocket",
+        ),
+    )
     limiar_map_base_url: str = os.getenv(
         "LIMIAR_MAP_BASE_URL",
         "http://localhost:3000",

--- a/apps/control-server/app/integrations/limiar_map_realtime_client.py
+++ b/apps/control-server/app/integrations/limiar_map_realtime_client.py
@@ -92,7 +92,7 @@ class LimiarMapRealtimeSyncService:
                 self._realtime_client = _NoopSpatialEventStream()
             else:
                 self._realtime_client = LimiarMapCentrifugoClient(
-                    ws_url=settings.centrifugo_public_url,
+                    ws_url=settings.centrifugo_internal_ws_url,
                     event_handler=self.handle_event,
                     channels=(MAP_SYSTEM_EVENTS_CHANNEL,),
                 )
@@ -578,7 +578,7 @@ def get_limiar_map_realtime_sync_service() -> LimiarMapRealtimeSyncService:
         settings.limiar_map_enabled,
         settings.limiar_map_base_url,
         settings.limiar_map_timeout_seconds,
-        settings.centrifugo_public_url,
+        settings.centrifugo_internal_ws_url,
     )
     if _realtime_sync_service is None or _realtime_sync_service_signature != signature:
         if _realtime_sync_service is not None:

--- a/apps/control-server/tests/test_limiar_map_realtime_sync.py
+++ b/apps/control-server/tests/test_limiar_map_realtime_sync.py
@@ -131,7 +131,7 @@ class LimiarMapRealtimeSyncServiceTests(unittest.TestCase):
             ),
             patch.object(
                 realtime_module.settings,
-                "centrifugo_public_url",
+                "centrifugo_internal_ws_url",
                 "ws://centrifugo.local/connection/websocket",
             ),
         ):


### PR DESCRIPTION
## Summary

Makes the control-server LimiarMap realtime sync use the backend-internal Centrifugo websocket URL instead of the public/browser-facing URL.

## Root Cause

The env/compose work already separated browser-facing realtime configuration from backend-internal realtime configuration, but the LimiarMap realtime sync service was still wired to `centrifugo_public_url` in local code.

That left lab and production-like containerized setups vulnerable to using the wrong websocket endpoint at runtime.

## What Changed

- added `centrifugo_internal_ws_url` to control-server settings with fallback to the public URL for host-based development
- updated `LimiarMapRealtimeSyncService` to construct the realtime client with `centrifugo_internal_ws_url`
- updated the realtime sync service signature to reinitialize based on the internal websocket URL
- updated the focused unit test to assert the internal websocket URL is the one passed to the realtime client

## Impact

- backend-to-backend realtime sync now aligns with the merged env/compose separation
- Dockerized lab and production-like deployments are less likely to fail by trying to connect through the public/default websocket URL
- host-based development still keeps a safe fallback to the public localhost websocket URL

## Validation

- `PYTHONPATH=apps/control-server /usr/bin/python3 apps/control-server/tests/test_limiar_map_realtime_sync.py`
- `PYTHONPATH=apps/control-server /usr/bin/python3 apps/control-server/tests/test_config_env_loading.py`

## Related

- Closes #40
- Related follow-up tracked separately in #39
