### PR TITLE
Stabilize GM dashboard active-session loading and redirect timing

### DIFF
--- a/apps/control-web/src/features/sessions/hooks/useActiveSession.state.test.ts
+++ b/apps/control-web/src/features/sessions/hooks/useActiveSession.state.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import type { ActiveSession } from "../../../shared/api/sessionsRepo";
+import {
+  beginActiveSessionRefresh,
+  createInitialActiveSessionQueryState,
+  resolveActiveSessionView,
+} from "./useActiveSession.state";
+
+const session = (id: string): ActiveSession =>
+  ({
+    id,
+    campaignId: "camp-1",
+    title: "Session",
+    status: "ACTIVE",
+    createdAt: "2026-04-19T00:00:00.000Z",
+    activatedAt: "2026-04-19T00:00:00.000Z",
+    partyId: "party-1",
+  }) as ActiveSession;
+
+describe("useActiveSession.state", () => {
+  it("starts in loading state when a campaign is already known", () => {
+    expect(createInitialActiveSessionQueryState("camp-1").loading).toBe(true);
+    expect(createInitialActiveSessionQueryState(null).loading).toBe(false);
+  });
+
+  it("marks a new campaign as pending immediately and hides stale session data", () => {
+    const current = {
+      campaignId: "camp-1",
+      activeSession: session("session-1"),
+      loading: false,
+      error: "stale error",
+    };
+
+    const nextView = resolveActiveSessionView(current, "camp-2");
+
+    expect(nextView.loading).toBe(true);
+    expect(nextView.activeSession).toBeNull();
+    expect(nextView.error).toBeNull();
+  });
+
+  it("preserves the current session while refreshing the same campaign", () => {
+    const current = {
+      campaignId: "camp-1",
+      activeSession: session("session-1"),
+      loading: false,
+      error: "old error",
+    };
+
+    const pending = beginActiveSessionRefresh(current, "camp-1");
+    const pendingView = resolveActiveSessionView(pending, "camp-1");
+
+    expect(pending.loading).toBe(true);
+    expect(pending.error).toBeNull();
+    expect(pendingView.activeSession?.id).toBe("session-1");
+    expect(pendingView.loading).toBe(true);
+  });
+});

--- a/apps/control-web/src/features/sessions/hooks/useActiveSession.state.ts
+++ b/apps/control-web/src/features/sessions/hooks/useActiveSession.state.ts
@@ -1,0 +1,36 @@
+import type { ActiveSession } from "../../../shared/api/sessionsRepo";
+
+export type ActiveSessionQueryState = {
+  campaignId: string | null;
+  activeSession: ActiveSession | null;
+  loading: boolean;
+  error: string | null;
+};
+
+export const createInitialActiveSessionQueryState = (
+  campaignId: string | null,
+): ActiveSessionQueryState => ({
+  campaignId,
+  activeSession: null,
+  loading: Boolean(campaignId),
+  error: null,
+});
+
+export const beginActiveSessionRefresh = (
+  current: ActiveSessionQueryState,
+  campaignId: string,
+): ActiveSessionQueryState => ({
+  campaignId,
+  activeSession: current.campaignId === campaignId ? current.activeSession : null,
+  loading: true,
+  error: null,
+});
+
+export const resolveActiveSessionView = (
+  current: ActiveSessionQueryState,
+  campaignId: string | null,
+) => ({
+  activeSession: current.campaignId === campaignId ? current.activeSession : null,
+  loading: current.loading || (Boolean(campaignId) && current.campaignId !== campaignId),
+  error: current.campaignId === campaignId ? current.error : null,
+});

--- a/apps/control-web/src/features/sessions/hooks/useActiveSession.tsx
+++ b/apps/control-web/src/features/sessions/hooks/useActiveSession.tsx
@@ -1,39 +1,66 @@
-import { useCallback, useEffect, useState } from "react";
-import { sessionsRepo, type ActiveSession } from "../../../shared/api/sessionsRepo";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { sessionsRepo } from "../../../shared/api/sessionsRepo";
 import { useCampaigns } from "../../campaign-select";
+import {
+  beginActiveSessionRefresh,
+  createInitialActiveSessionQueryState,
+  resolveActiveSessionView,
+} from "./useActiveSession.state";
 
 export const useActiveSession = (campaignId?: string | null) => {
   const { selectedCampaignId } = useCampaigns();
   const effectiveCampaignId = campaignId ?? selectedCampaignId ?? null;
-  const [activeSession, setActiveSession] = useState<ActiveSession | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [state, setState] = useState(() =>
+    createInitialActiveSessionQueryState(effectiveCampaignId),
+  );
+  const requestIdRef = useRef(0);
+
+  const view = resolveActiveSessionView(state, effectiveCampaignId);
 
   const refresh = useCallback(() => {
     if (!effectiveCampaignId) {
-      setActiveSession(null);
-      setError(null);
+      requestIdRef.current += 1;
+      setState(createInitialActiveSessionQueryState(null));
       return Promise.resolve(null);
     }
-    setLoading(true);
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    setState((current) => beginActiveSessionRefresh(current, effectiveCampaignId));
     return sessionsRepo
       .getActive(effectiveCampaignId)
       .then((data) => {
-        setActiveSession(data);
-        setError(null);
+        if (requestIdRef.current !== requestId) {
+          return null;
+        }
+        setState({
+          campaignId: effectiveCampaignId,
+          activeSession: data,
+          loading: false,
+          error: null,
+        });
         return data;
       })
       .catch((err: { status?: number; message?: string }) => {
-        if (err?.status === 404) {
-          setActiveSession(null);
-          setError(null);
+        if (requestIdRef.current !== requestId) {
           return null;
         }
-        setActiveSession(null);
-        setError(err?.message ?? "Failed to load active session");
+        if (err?.status === 404) {
+          setState({
+            campaignId: effectiveCampaignId,
+            activeSession: null,
+            loading: false,
+            error: null,
+          });
+          return null;
+        }
+        setState({
+          campaignId: effectiveCampaignId,
+          activeSession: null,
+          loading: false,
+          error: err?.message ?? "Failed to load active session",
+        });
         return null;
-      })
-      .finally(() => setLoading(false));
+      });
   }, [effectiveCampaignId]);
 
   useEffect(() => {
@@ -48,12 +75,19 @@ export const useActiveSession = (campaignId?: string | null) => {
       return sessionsRepo
         .activate(effectiveCampaignId, { title })
         .then((data) => {
-          setActiveSession(data);
-          setError(null);
+          setState({
+            campaignId: effectiveCampaignId,
+            activeSession: data,
+            loading: false,
+            error: null,
+          });
           return data;
         })
         .catch((err: { message?: string }) => {
-          setError(err?.message ?? "Failed to activate session");
+          setState((current) => ({
+            ...current,
+            error: err?.message ?? "Failed to activate session",
+          }));
           throw err; // re-throw so callers can inspect the full error
         });
     },
@@ -61,24 +95,30 @@ export const useActiveSession = (campaignId?: string | null) => {
   );
 
   const endSession = useCallback(() => {
-    if (!activeSession?.id) return Promise.resolve(null);
+    if (!view.activeSession?.id) return Promise.resolve(null);
     return sessionsRepo
-      .end(activeSession.id)
+      .end(view.activeSession.id)
       .then(() => {
-        setActiveSession(null);
-        setError(null);
+        setState((current) => ({
+          ...current,
+          activeSession: null,
+          error: null,
+        }));
         return true;
       })
       .catch((err: { message?: string }) => {
-        setError(err?.message ?? "Failed to end session");
+        setState((current) => ({
+          ...current,
+          error: err?.message ?? "Failed to end session",
+        }));
         return false;
       });
-  }, [activeSession?.id]);
+  }, [view.activeSession?.id]);
 
   return {
-    activeSession,
-    loading,
-    error,
+    activeSession: view.activeSession,
+    loading: view.loading,
+    error: view.error,
     refresh,
     activate,
     endSession,


### PR DESCRIPTION
## Summary

Stabilizes GM dashboard active-session loading so the page does not redirect before the current campaign lookup has actually settled.

## Root Cause

`useActiveSession()` kept `loading` in local state, but that state was only initialized from the first render. When the effective campaign changed later, the hook could briefly expose:

- no active session
- `loading = false`
- resolved legacy party fallback

before the new request finished.

That let the GM dashboard redirect too early based on stale state.

## What Changed

- made `useActiveSession()` track the campaign associated with its current query state
- derived the exposed view so a new campaign is treated as pending immediately
- clear stale session/error data when switching campaigns
- ignore late responses from older requests with a request id guard
- preserve the current session while refreshing the same campaign
- added focused unit coverage for the new state transitions

## Impact

- GM dashboard redirect timing is now tied to the current campaign lookup instead of stale hook state
- campaign changes after mount no longer reuse the previous campaign's settled state
- the hook is more resilient to async races without changing unrelated session flows

## Validation

- `npm test -w apps/control-web -- --run src/features/sessions/hooks/useActiveSession.state.test.ts`
- `npm run build -w apps/control-web`

Closes #39
