### PR TITLE
feat: add semantic cell obstacles to campaign map config

### DIFF
--- a/apps/control-server/alembic/versions/0057_campaign_map_obstacles.py
+++ b/apps/control-server/alembic/versions/0057_campaign_map_obstacles.py
@@ -1,0 +1,35 @@
+"""Add obstacles_json to campaign_tactical_map.
+
+Canonical semantic obstacle storage for campaign maps. Each row in
+obstacles_json encodes a per-cell obstacle with full tactical semantics
+(blocksMovement, blocksEffect, blocksVision, cover, clipsDiagonalMovement,
+movementCostMultiplier). When present, this column is the authoritative
+source; blocked_cells_json becomes a legacy fallback for old maps.
+
+Revision ID: 0057_campaign_map_obstacles
+Revises: 0056_combat_state_local_distances
+Create Date: 2026-04-19 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0057_campaign_map_obstacles"
+down_revision: Union[str, None] = "0056_combat_state_local_distances"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "campaign_tactical_map",
+        sa.Column("obstacles_json", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("campaign_tactical_map", "obstacles_json")

--- a/apps/control-server/app/api/routes/campaigns.py
+++ b/apps/control-server/app/api/routes/campaigns.py
@@ -20,7 +20,9 @@ from app.schemas.campaign import (
     CampaignRead,
     CampaignUpdate,
     decode_blocked_cells,
+    decode_obstacles,
     encode_blocked_cells,
+    encode_obstacles,
 )
 from app.services.campaign_catalog import snapshot_campaign_catalog
 from app.services.campaign_cleanup import delete_campaign_tree
@@ -110,8 +112,14 @@ def _apply_campaign_map_payload(
         entry.calibration_width = payload.calibration.width
         entry.calibration_height = payload.calibration.height
 
-    # blockedCells: None = leave unchanged; [] = clear all; [...] = replace
-    if payload.blockedCells is not None:
+    # obstacles (canonical): None = leave unchanged; [] = clear; [...] = replace
+    if payload.obstacles is not None:
+        entry.obstacles_json = encode_obstacles(payload.obstacles)
+        # When canonical obstacles are written, clear the legacy column so the
+        # read path always returns a consistent view.
+        entry.blocked_cells_json = None
+    elif payload.blockedCells is not None:
+        # Legacy path: only write blockedCells when no canonical obstacles supplied.
         entry.blocked_cells_json = encode_blocked_cells(payload.blockedCells)
 
     return previous_image_url, entry.image_url
@@ -152,6 +160,7 @@ def _serialize_campaign_map_config(campaign: CampaignTacticalMap) -> CampaignMap
             "height": campaign.calibration_height,
         }
 
+    obstacles = decode_obstacles(campaign.obstacles_json)
     return CampaignMapConfigRead(
         id=campaign.id,
         mapName=campaign.name,
@@ -159,7 +168,9 @@ def _serialize_campaign_map_config(campaign: CampaignTacticalMap) -> CampaignMap
         gridWidth=campaign.grid_width,
         gridHeight=campaign.grid_height,
         calibration=calibration,
-        blockedCells=decode_blocked_cells(campaign.blocked_cells_json),
+        obstacles=obstacles,
+        # Emit legacy blockedCells only when the canonical obstacles_json is absent.
+        blockedCells=decode_blocked_cells(campaign.blocked_cells_json) if obstacles is None else [],
         createdAt=campaign.created_at,
         updatedAt=campaign.updated_at,
     )

--- a/apps/control-server/app/models/campaign_tactical_map.py
+++ b/apps/control-server/app/models/campaign_tactical_map.py
@@ -20,8 +20,12 @@ class CampaignTacticalMap(SQLModel, table=True):
     calibration_width: float | None = Field(default=None, sa_column=Column(Float, nullable=True))
     calibration_height: float | None = Field(default=None, sa_column=Column(Float, nullable=True))
     # JSON-encoded list of blocked cell coordinates: [{"x": int, "y": int}, ...]
-    # Used by Phase 1 of tactical obstacle handling (movement blocking only).
+    # Legacy Phase 1 storage — superseded by obstacles_json for new maps.
     blocked_cells_json: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    # JSON-encoded semantic obstacles: [{x, y, blocksMovement, blocksEffect, blocksVision,
+    # cover, clipsDiagonalMovement, movementCostMultiplier}, ...]
+    # Authoritative when present; blocked_cells_json is ignored.
+    obstacles_json: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
     created_at: datetime = Field(
         sa_column=Column(DateTime(timezone=True), server_default=func.now())
     )

--- a/apps/control-server/app/schemas/campaign.py
+++ b/apps/control-server/app/schemas/campaign.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -9,10 +9,23 @@ from app.services.media_storage_service import is_managed_url
 
 MAX_GRID_DIMENSION = 150
 
+ObstacleCover = Literal["none", "half", "threeQuarters", "full"]
+
 
 class BlockedCell(BaseModel):
     x: int = Field(ge=0)
     y: int = Field(ge=0)
+
+
+class CampaignObstacle(BaseModel):
+    x: int = Field(ge=0)
+    y: int = Field(ge=0)
+    blocksMovement: bool
+    blocksEffect: bool = False
+    blocksVision: bool = False
+    cover: ObstacleCover = "none"
+    clipsDiagonalMovement: bool = False
+    movementCostMultiplier: int = Field(default=1, ge=1)
 
 
 def decode_blocked_cells(raw_json: str | None) -> list[BlockedCell]:
@@ -33,6 +46,40 @@ def encode_blocked_cells(cells: list[BlockedCell] | None) -> str | None:
     if not cells:
         return None
     return json.dumps([{"x": c.x, "y": c.y} for c in cells])
+
+
+def decode_obstacles(raw_json: str | None) -> list[CampaignObstacle] | None:
+    """Parse obstacles_json from DB. Returns None when column is absent (legacy map)."""
+    if raw_json is None:
+        return None
+    try:
+        items = json.loads(raw_json)
+        if not isinstance(items, list):
+            return []
+        return [CampaignObstacle(**item) for item in items if isinstance(item, dict)]
+    except Exception:
+        return []
+
+
+def encode_obstacles(obstacles: list[CampaignObstacle] | None) -> str | None:
+    """Serialize obstacles to JSON for DB storage. Empty list clears; None leaves unchanged."""
+    if obstacles is None:
+        return None
+    return json.dumps(
+        [
+            {
+                "x": o.x,
+                "y": o.y,
+                "blocksMovement": o.blocksMovement,
+                "blocksEffect": o.blocksEffect,
+                "blocksVision": o.blocksVision,
+                "cover": o.cover,
+                "clipsDiagonalMovement": o.clipsDiagonalMovement,
+                "movementCostMultiplier": o.movementCostMultiplier,
+            }
+            for o in obstacles
+        ]
+    )
 
 
 class CampaignCreate(BaseModel):
@@ -72,7 +119,9 @@ class CampaignMapConfigRead(BaseModel):
     gridWidth: Optional[int] = Field(default=None, ge=1, le=MAX_GRID_DIMENSION)
     gridHeight: Optional[int] = Field(default=None, ge=1, le=MAX_GRID_DIMENSION)
     calibration: Optional[CampaignMapCalibration] = None
-    # Movement-blocking cells defined at the campaign map level (Phase 1 obstacles).
+    # Canonical semantic obstacles (None = legacy map without obstacles_json).
+    obstacles: Optional[list[CampaignObstacle]] = None
+    # Legacy movement-blocking cells — present only when obstacles is None.
     blockedCells: list[BlockedCell] = Field(default_factory=list)
     createdAt: datetime
     updatedAt: Optional[datetime] = None
@@ -101,8 +150,11 @@ class CampaignMapConfigWrite(BaseModel):
     gridWidth: Optional[int] = Field(default=None, ge=1, le=MAX_GRID_DIMENSION)
     gridHeight: Optional[int] = Field(default=None, ge=1, le=MAX_GRID_DIMENSION)
     calibration: Optional[CampaignMapCalibration] = None
-    # Movement-blocking cells for Phase 1 obstacle handling.
-    # None means "leave existing cells unchanged"; [] means "clear all blocked cells".
+    # Canonical semantic obstacles.
+    # None = leave existing unchanged; [] = clear all; [...] = replace all.
+    obstacles: Optional[list[CampaignObstacle]] = None
+    # Legacy movement-only cells — still accepted for backward compat.
+    # Ignored when obstacles is provided.
     blockedCells: Optional[list[BlockedCell]] = None
 
     @field_validator("mapName", "imageUrl", mode="before")
@@ -136,6 +188,7 @@ class CampaignMapConfigWrite(BaseModel):
                 self.gridWidth,
                 self.gridHeight,
                 self.calibration,
+                self.obstacles,
                 self.blockedCells,
             )
         )

--- a/apps/control-server/app/schemas/combat.py
+++ b/apps/control-server/app/schemas/combat.py
@@ -2,7 +2,7 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, Field, model_validator
 from app.schemas.campaign_entity_shared import AbilityName
-from app.schemas.campaign import BlockedCell, CampaignMapCalibration, MAX_GRID_DIMENSION
+from app.schemas.campaign import BlockedCell, CampaignMapCalibration, CampaignObstacle, MAX_GRID_DIMENSION
 from app.schemas.roll import RollResult, RollSource
 
 CombatActionCost = Literal["action", "bonus_action", "reaction", "free"]
@@ -51,7 +51,10 @@ class CombatMapSelection(BaseModel):
     gridWidth: int = Field(ge=1, le=MAX_GRID_DIMENSION)
     gridHeight: int = Field(ge=1, le=MAX_GRID_DIMENSION)
     calibration: CampaignMapCalibration
-    # Movement-blocking cells loaded from CampaignTacticalMap at combat start.
+    # Canonical semantic obstacles loaded from CampaignTacticalMap at combat start.
+    # None = legacy map without obstacles_json.
+    obstacles: list[CampaignObstacle] | None = None
+    # Legacy movement-only cells — present only when obstacles is None.
     blockedCells: list[BlockedCell] = Field(default_factory=list)
 
     @model_validator(mode="after")

--- a/apps/control-server/app/services/combat_service/lifecycle.py
+++ b/apps/control-server/app/services/combat_service/lifecycle.py
@@ -17,7 +17,7 @@ from app.models.session_state import SessionState
 from app.models.campaign_entity import CampaignEntity
 from app.models.inventory import InventoryItem
 from app.models.item import Item, ItemType
-from app.schemas.campaign import decode_blocked_cells
+from app.schemas.campaign import decode_blocked_cells, decode_obstacles
 from app.schemas.combat import (
     CombatApplyDamageRequest,
     CombatApplyHealingRequest,
@@ -242,6 +242,7 @@ class CombatLifecycleMixin:
             else 1,
         }
 
+        obstacles = decode_obstacles(campaign_map.obstacles_json)
         selection = CombatMapSelection(
             kind="campaign_map",
             mapId=campaign_map.id,
@@ -250,9 +251,9 @@ class CombatLifecycleMixin:
             gridWidth=campaign_map.grid_width,
             gridHeight=campaign_map.grid_height,
             calibration=calibration,
-            # Carry campaign-level blocked cells so the map projection can send them
-            # to LimiarMap when combat starts (Phase 1 obstacle persistence).
-            blockedCells=decode_blocked_cells(campaign_map.blocked_cells_json),
+            # Canonical semantic obstacles take priority over legacy blockedCells.
+            obstacles=obstacles,
+            blockedCells=decode_blocked_cells(campaign_map.blocked_cells_json) if obstacles is None else [],
         )
         return selection.model_dump(mode="json")
 

--- a/apps/control-server/app/services/combat_service/limiar_map_projection.py
+++ b/apps/control-server/app/services/combat_service/limiar_map_projection.py
@@ -566,11 +566,14 @@ class LimiarMapCombatProjectionService:
             "sourceImageUrl": source_image_url,
         }
 
-        # Include campaign-level blocked cells so LimiarMap can seed its
-        # encounter obstacles.  authoritative source: CampaignTacticalMap DB row.
-        blocked_cells = raw_selection.get("blockedCells")
-        if isinstance(blocked_cells, list) and blocked_cells:
-            payload["blockedCells"] = blocked_cells
+        # Canonical semantic obstacles take priority over legacy blockedCells.
+        obstacles = raw_selection.get("obstacles")
+        if isinstance(obstacles, list) and obstacles:
+            payload["obstacles"] = obstacles
+        else:
+            blocked_cells = raw_selection.get("blockedCells")
+            if isinstance(blocked_cells, list) and blocked_cells:
+                payload["blockedCells"] = blocked_cells
 
         return payload
 

--- a/apps/control-web/src/entities/campaign/campaign.types.ts
+++ b/apps/control-web/src/entities/campaign/campaign.types.ts
@@ -57,6 +57,106 @@ export type BlockedCell = {
   y: number;
 };
 
+export type ObstacleCover = "none" | "half" | "threeQuarters" | "full";
+
+export type CampaignObstacle = {
+  x: number;
+  y: number;
+  blocksMovement: boolean;
+  blocksEffect: boolean;
+  blocksVision: boolean;
+  cover: ObstacleCover;
+  clipsDiagonalMovement: boolean;
+  movementCostMultiplier: number;
+};
+
+export type ObstaclePresetId =
+  | "solid_wall"
+  | "dense_obstacle"
+  | "barricade"
+  | "transparent_barrier"
+  | "blocked_path"
+  | "spell_blocker"
+  | "difficult_terrain";
+
+export type ObstaclePreset = {
+  id: ObstaclePresetId;
+  label: string;
+  description: string;
+  /** Hex color for visual overlay on the map preview. */
+  color: string;
+  style: Omit<CampaignObstacle, "x" | "y">;
+};
+
+export const CAMPAIGN_OBSTACLE_PRESETS: ObstaclePreset[] = [
+  {
+    id: "solid_wall",
+    label: "Parede sólida",
+    description: "Bloqueia movimento, visão e efeito; cobertura total.",
+    color: "#d24646",
+    style: { blocksMovement: true, blocksEffect: true, blocksVision: true, cover: "full", clipsDiagonalMovement: true, movementCostMultiplier: 1 },
+  },
+  {
+    id: "dense_obstacle",
+    label: "Obstáculo denso",
+    description: "Bloqueia movimento e concede 3/4 de cobertura. Não bloqueia visão nem efeito.",
+    color: "#ffaa44",
+    style: { blocksMovement: true, blocksEffect: false, blocksVision: false, cover: "threeQuarters", clipsDiagonalMovement: true, movementCostMultiplier: 1 },
+  },
+  {
+    id: "barricade",
+    label: "Barricada",
+    description: "Meia cobertura. Não bloqueia movimento, visão nem efeito.",
+    color: "#ffdc78",
+    style: { blocksMovement: false, blocksEffect: false, blocksVision: false, cover: "half", clipsDiagonalMovement: false, movementCostMultiplier: 1 },
+  },
+  {
+    id: "transparent_barrier",
+    label: "Barreira transparente",
+    description: "Bloqueia movimento e efeito, mas não bloqueia visão.",
+    color: "#7c9ef5",
+    style: { blocksMovement: true, blocksEffect: true, blocksVision: false, cover: "none", clipsDiagonalMovement: false, movementCostMultiplier: 1 },
+  },
+  {
+    id: "blocked_path",
+    label: "Caminho bloqueado",
+    description: "Bloqueia movimento sem bloquear visão, efeito ou oferecer cobertura.",
+    color: "#c084fc",
+    style: { blocksMovement: true, blocksEffect: false, blocksVision: false, cover: "none", clipsDiagonalMovement: false, movementCostMultiplier: 1 },
+  },
+  {
+    id: "spell_blocker",
+    label: "Bloqueador de magia",
+    description: "Bloqueia efeito de área sem bloquear movimento ou visão.",
+    color: "#34d399",
+    style: { blocksMovement: false, blocksEffect: true, blocksVision: false, cover: "none", clipsDiagonalMovement: false, movementCostMultiplier: 1 },
+  },
+  {
+    id: "difficult_terrain",
+    label: "Terreno difícil",
+    description: "Não bloqueia, mas custa 2× para atravessar.",
+    color: "#9c7040",
+    style: { blocksMovement: false, blocksEffect: false, blocksVision: false, cover: "none", clipsDiagonalMovement: false, movementCostMultiplier: 2 },
+  },
+];
+
+export function obstacleToPresetId(obs: CampaignObstacle): ObstaclePresetId {
+  for (const preset of CAMPAIGN_OBSTACLE_PRESETS) {
+    const s = preset.style;
+    if (
+      s.blocksMovement === obs.blocksMovement &&
+      s.blocksEffect === obs.blocksEffect &&
+      s.blocksVision === obs.blocksVision &&
+      s.cover === obs.cover &&
+      s.clipsDiagonalMovement === obs.clipsDiagonalMovement &&
+      s.movementCostMultiplier === obs.movementCostMultiplier
+    ) {
+      return preset.id;
+    }
+  }
+  return "solid_wall";
+}
+
 export type CampaignMapConfig = {
   id: string;
   mapName?: string | null;
@@ -64,7 +164,9 @@ export type CampaignMapConfig = {
   gridWidth?: number | null;
   gridHeight?: number | null;
   calibration?: CampaignMapCalibration | null;
-  /** Movement-blocking cells defined at the campaign map level (Phase 1 obstacles). */
+  /** Canonical semantic obstacles. Null = legacy map without obstacles_json. */
+  obstacles?: CampaignObstacle[] | null;
+  /** @deprecated Legacy movement-only blocked cells for pre-semantic maps. */
   blockedCells?: BlockedCell[] | null;
   createdAt: string;
   updatedAt?: string | null;

--- a/apps/control-web/src/entities/campaign/index.ts
+++ b/apps/control-web/src/entities/campaign/index.ts
@@ -1,5 +1,6 @@
-export type { Campaign, CampaignMapCalibration, CampaignMapConfig } from "./campaign.types";
+export type { BlockedCell, Campaign, CampaignMapCalibration, CampaignMapConfig, CampaignObstacle, ObstaclePresetId, ObstaclePreset, ObstacleCover } from "./campaign.types";
 export {
+  CAMPAIGN_OBSTACLE_PRESETS,
   CampaignSystemType,
   campaignSystemLabels,
   defaultCampaignSystemType,
@@ -7,4 +8,5 @@ export {
   enabledCampaignSystemTypes,
   getCampaignSystemLabel,
   isCampaignSystemEnabled,
+  obstacleToPresetId,
 } from "./campaign.types";

--- a/apps/control-web/src/pages/CampaignHomePage/CampaignMapConfig/MapPreviewSurface.tsx
+++ b/apps/control-web/src/pages/CampaignHomePage/CampaignMapConfig/MapPreviewSurface.tsx
@@ -1,7 +1,12 @@
 import { useState, type MouseEvent } from "react";
+import { CAMPAIGN_OBSTACLE_PRESETS } from "../../../entities/campaign";
 import { ManagedImage } from "../../../shared/ui";
 import type { HoveredGridCell, MapPreviewSurfaceProps } from "./types";
 import { formatHoveredCell } from "./utils";
+
+const PRESET_COLOR_MAP = Object.fromEntries(
+  CAMPAIGN_OBSTACLE_PRESETS.map((p) => [p.id, p.color])
+);
 
 export const MapPreviewSurface = ({
   imageUrl,
@@ -14,7 +19,7 @@ export const MapPreviewSurface = ({
   hoverHint,
   hoverMissingGrid,
   hoverCellLabel,
-  blockedCellSet,
+  obstacleMap,
   onCellToggle,
 }: MapPreviewSurfaceProps) => {
   const [hoveredCell, setHoveredCell] = useState<HoveredGridCell | null>(null);
@@ -111,19 +116,21 @@ export const MapPreviewSurface = ({
               height: `${bounds.height * 100}%`,
             }}
           >
-            {/* Blocked cell overlays */}
-            {blockedCellSet != null && gridWidth != null && gridHeight != null &&
-              Array.from(blockedCellSet).map((key) => {
+            {/* Obstacle overlays — color-coded by preset */}
+            {obstacleMap != null && gridWidth != null && gridHeight != null &&
+              Array.from(obstacleMap.entries()).map(([key, presetId]) => {
                 const [cx, cy] = key.split(":").map(Number);
+                const color = PRESET_COLOR_MAP[presetId] ?? "#d24646";
                 return (
                   <div
                     key={key}
-                    className="absolute bg-rose-500/45 border border-rose-400/60"
+                    className="absolute border border-white/20"
                     style={{
                       left: `${(cx / gridWidth) * 100}%`,
                       top: `${(cy / gridHeight) * 100}%`,
                       width: `${100 / gridWidth}%`,
                       height: `${100 / gridHeight}%`,
+                      backgroundColor: `${color}70`,
                     }}
                   />
                 );

--- a/apps/control-web/src/pages/CampaignHomePage/CampaignMapConfig/index.tsx
+++ b/apps/control-web/src/pages/CampaignHomePage/CampaignMapConfig/index.tsx
@@ -5,7 +5,8 @@ import {
   useState,
   type ChangeEvent,
 } from "react";
-import type { CampaignMapConfig } from "../../../entities/campaign";
+import type { CampaignMapConfig, ObstaclePresetId } from "../../../entities/campaign";
+import { CAMPAIGN_OBSTACLE_PRESETS, obstacleToPresetId } from "../../../entities/campaign";
 import { campaignsRepo } from "../../../shared/api/campaignsRepo";
 import { uploadRepo } from "../../../shared/api/uploadRepo";
 import { useLocale } from "../../../shared/hooks/useLocale";
@@ -23,6 +24,20 @@ import {
 } from "./utils";
 import { MapPreviewSurface } from "./MapPreviewSurface";
 import { MapListWidget } from "./MapListWidget";
+
+function buildObstacleMap(config: CampaignMapConfig | null | undefined): Map<string, ObstaclePresetId> {
+  const map = new Map<string, ObstaclePresetId>();
+  if (config?.obstacles) {
+    for (const obs of config.obstacles) {
+      map.set(`${obs.x}:${obs.y}`, obstacleToPresetId(obs));
+    }
+  } else if (config?.blockedCells) {
+    for (const cell of config.blockedCells) {
+      map.set(`${cell.x}:${cell.y}`, "solid_wall");
+    }
+  }
+  return map;
+}
 
 const ACCEPTED_IMAGE_TYPES = "image/jpeg,image/png,image/webp,image/gif";
 const MAX_IMAGE_MB = 30;
@@ -48,10 +63,11 @@ export const CampaignMapConfigCard = ({
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
-  // Obstacle editing state — tracks 0-based cell keys "x:y"
-  const [blockedCellSet, setBlockedCellSet] = useState<Set<string>>(
-    () => new Set((sortedMaps[0]?.blockedCells ?? []).map((c) => `${c.x}:${c.y}`)),
+  // Obstacle editing: map from "x:y" → preset ID; active brush preset
+  const [obstacleMap, setObstacleMap] = useState<Map<string, ObstaclePresetId>>(
+    () => buildObstacleMap(sortedMaps[0]),
   );
+  const [selectedPresetId, setSelectedPresetId] = useState<ObstaclePresetId>("solid_wall");
   const [isObstacleEditMode, setIsObstacleEditMode] = useState(false);
 
   const selectedMap = sortedMaps.find((entry) => entry.id === selectedMapId) ?? null;
@@ -61,7 +77,7 @@ export const CampaignMapConfigCard = ({
     setSelectedMapId(nextSelected?.id ?? null);
     setIsCreatingNew(nextSelected == null);
     setForm(configToForm(nextSelected));
-    setBlockedCellSet(new Set((nextSelected?.blockedCells ?? []).map((c) => `${c.x}:${c.y}`)));
+    setObstacleMap(buildObstacleMap(nextSelected));
     setIsObstacleEditMode(false);
     setError(null);
     setSuccess(null);
@@ -74,14 +90,14 @@ export const CampaignMapConfigCard = ({
 
     if (selectedMap != null) {
       setForm(configToForm(selectedMap));
-      setBlockedCellSet(new Set((selectedMap.blockedCells ?? []).map((c) => `${c.x}:${c.y}`)));
+      setObstacleMap(buildObstacleMap(selectedMap));
       return;
     }
 
     const fallback = sortedMaps[0] ?? null;
     setSelectedMapId(fallback?.id ?? null);
     setForm(configToForm(fallback));
-    setBlockedCellSet(new Set((fallback?.blockedCells ?? []).map((c) => `${c.x}:${c.y}`)));
+    setObstacleMap(buildObstacleMap(fallback));
   }, [isCreatingNew, selectedMap, sortedMaps]);
 
   useEffect(() => {
@@ -103,7 +119,7 @@ export const CampaignMapConfigCard = ({
     setSelectedMapId(map.id);
     setIsCreatingNew(false);
     setForm(configToForm(map));
-    setBlockedCellSet(new Set((map.blockedCells ?? []).map((c) => `${c.x}:${c.y}`)));
+    setObstacleMap(buildObstacleMap(map));
     setIsObstacleEditMode(false);
     setError(null);
     setSuccess(null);
@@ -113,7 +129,7 @@ export const CampaignMapConfigCard = ({
     setSelectedMapId(null);
     setIsCreatingNew(true);
     setForm(EMPTY_FORM);
-    setBlockedCellSet(new Set());
+    setObstacleMap(new Map());
     setIsObstacleEditMode(false);
     setError(null);
     setSuccess(null);
@@ -121,12 +137,12 @@ export const CampaignMapConfigCard = ({
 
   const handleCellToggle = (x: number, y: number) => {
     const key = `${x}:${y}`;
-    setBlockedCellSet((current) => {
-      const next = new Set(current);
-      if (next.has(key)) {
+    setObstacleMap((current) => {
+      const next = new Map(current);
+      if (next.get(key) === selectedPresetId) {
         next.delete(key);
       } else {
-        next.add(key);
+        next.set(key, selectedPresetId);
       }
       return next;
     });
@@ -198,7 +214,7 @@ export const CampaignMapConfigCard = ({
   const handleClear = () => {
     const source = isCreatingNew ? null : selectedMap;
     setForm(configToForm(source));
-    setBlockedCellSet(new Set((source?.blockedCells ?? []).map((c) => `${c.x}:${c.y}`)));
+    setObstacleMap(buildObstacleMap(source));
     setIsObstacleEditMode(false);
     setError(null);
     setSuccess(null);
@@ -270,9 +286,10 @@ export const CampaignMapConfigCard = ({
         calibration = { x, y, width, height };
       }
 
-      const blockedCells = Array.from(blockedCellSet).map((key) => {
+      const obstacles = Array.from(obstacleMap.entries()).map(([key, presetId]) => {
         const [x, y] = key.split(":").map(Number);
-        return { x, y };
+        const preset = CAMPAIGN_OBSTACLE_PRESETS.find((p) => p.id === presetId)!;
+        return { x, y, ...preset.style };
       });
 
       const payload = {
@@ -281,7 +298,7 @@ export const CampaignMapConfigCard = ({
         gridWidth,
         gridHeight,
         calibration,
-        blockedCells,
+        obstacles,
       };
 
       const savedConfig = isCreatingNew
@@ -462,10 +479,10 @@ export const CampaignMapConfigCard = ({
                   gridHeight={previewGridHeight}
                   imageClassName="block w-full"
                   invalidMessage={t("campaignHome.mapPreviewInvalid")}
-                  hoverHint={isObstacleEditMode ? "Clique para marcar/desmarcar célula bloqueada" : t("campaignHome.mapPreviewHoverHint")}
+                  hoverHint={isObstacleEditMode ? "Clique para aplicar/remover obstáculo" : t("campaignHome.mapPreviewHoverHint")}
                   hoverMissingGrid={t("campaignHome.mapPreviewHoverMissingGrid")}
                   hoverCellLabel={t("campaignHome.mapPreviewHoverCell")}
-                  blockedCellSet={blockedCellSet}
+                  obstacleMap={obstacleMap}
                   onCellToggle={isObstacleEditMode ? handleCellToggle : undefined}
                 />
               ) : (
@@ -476,11 +493,34 @@ export const CampaignMapConfigCard = ({
             </div>
 
             {isObstacleEditMode && (
-              <div className="mt-3 rounded-2xl border border-rose-500/20 bg-rose-500/8 px-4 py-3 text-xs text-rose-200">
-                Modo obstáculos ativo — clique nas células do mapa para marcar ou desmarcar terreno bloqueado.
-                {blockedCellSet.size > 0 && (
-                  <span className="ml-2 font-semibold">{blockedCellSet.size} célula{blockedCellSet.size !== 1 ? "s" : ""} bloqueada{blockedCellSet.size !== 1 ? "s" : ""}.</span>
-                )}
+              <div className="mt-3 space-y-2">
+                <div className="flex flex-wrap gap-1.5">
+                  {CAMPAIGN_OBSTACLE_PRESETS.map((preset) => (
+                    <button
+                      key={preset.id}
+                      type="button"
+                      onClick={() => setSelectedPresetId(preset.id)}
+                      title={preset.description}
+                      className={`flex items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] transition-colors ${
+                        selectedPresetId === preset.id
+                          ? "border-white/40 bg-white/10 text-white"
+                          : "border-slate-700 text-slate-400 hover:border-slate-500"
+                      }`}
+                    >
+                      <span
+                        className="inline-block h-2.5 w-2.5 shrink-0 rounded-sm"
+                        style={{ backgroundColor: preset.color }}
+                      />
+                      {preset.label}
+                    </button>
+                  ))}
+                </div>
+                <div className="rounded-2xl border border-slate-700/50 bg-slate-950/60 px-4 py-2 text-xs text-slate-400">
+                  {CAMPAIGN_OBSTACLE_PRESETS.find((p) => p.id === selectedPresetId)?.description}
+                  {obstacleMap.size > 0 && (
+                    <span className="ml-2 font-semibold text-slate-200">{obstacleMap.size} célula{obstacleMap.size !== 1 ? "s" : ""} marcada{obstacleMap.size !== 1 ? "s" : ""}.</span>
+                  )}
+                </div>
               </div>
             )}
 
@@ -768,12 +808,35 @@ export const CampaignMapConfigCard = ({
             </div>
 
             {isObstacleEditMode && (
-              <div className="mt-4 rounded-2xl border border-rose-500/20 bg-rose-500/8 px-4 py-3 text-xs text-rose-200">
-                Modo obstáculos ativo. Células em vermelho estão bloqueadas para movimento.
-                {blockedCellSet.size > 0 && (
-                  <span className="ml-2 font-semibold">{blockedCellSet.size} célula{blockedCellSet.size !== 1 ? "s" : ""} bloqueada{blockedCellSet.size !== 1 ? "s" : ""}.</span>
-                )}
-                {" "}Clique em <strong>"Salvar mapa"</strong> para persistir.
+              <div className="mt-4 space-y-2">
+                <div className="flex flex-wrap gap-1.5">
+                  {CAMPAIGN_OBSTACLE_PRESETS.map((preset) => (
+                    <button
+                      key={preset.id}
+                      type="button"
+                      onClick={() => setSelectedPresetId(preset.id)}
+                      title={preset.description}
+                      className={`flex items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] transition-colors ${
+                        selectedPresetId === preset.id
+                          ? "border-white/40 bg-white/10 text-white"
+                          : "border-slate-700 text-slate-400 hover:border-slate-500"
+                      }`}
+                    >
+                      <span
+                        className="inline-block h-2.5 w-2.5 shrink-0 rounded-sm"
+                        style={{ backgroundColor: preset.color }}
+                      />
+                      {preset.label}
+                    </button>
+                  ))}
+                </div>
+                <div className="rounded-2xl border border-slate-700/50 bg-slate-950/60 px-4 py-2 text-xs text-slate-400">
+                  {CAMPAIGN_OBSTACLE_PRESETS.find((p) => p.id === selectedPresetId)?.description}
+                  {obstacleMap.size > 0 && (
+                    <span className="ml-2 font-semibold text-slate-200">{obstacleMap.size} célula{obstacleMap.size !== 1 ? "s" : ""} marcada{obstacleMap.size !== 1 ? "s" : ""}.</span>
+                  )}
+                  {" "}Salve o mapa para persistir.
+                </div>
               </div>
             )}
 
@@ -788,10 +851,10 @@ export const CampaignMapConfigCard = ({
                     gridHeight={previewGridHeight}
                     imageClassName="block max-h-[72vh] max-w-full"
                     invalidMessage={t("campaignHome.mapPreviewInvalid")}
-                    hoverHint={isObstacleEditMode ? "Clique para marcar/desmarcar célula bloqueada" : t("campaignHome.mapPreviewHoverHint")}
+                    hoverHint={isObstacleEditMode ? "Clique para aplicar/remover obstáculo" : t("campaignHome.mapPreviewHoverHint")}
                     hoverMissingGrid={t("campaignHome.mapPreviewHoverMissingGrid")}
                     hoverCellLabel={t("campaignHome.mapPreviewHoverCell")}
-                    blockedCellSet={blockedCellSet}
+                    obstacleMap={obstacleMap}
                     onCellToggle={isObstacleEditMode ? handleCellToggle : undefined}
                   />
                 </div>

--- a/apps/control-web/src/pages/CampaignHomePage/CampaignMapConfig/types.ts
+++ b/apps/control-web/src/pages/CampaignHomePage/CampaignMapConfig/types.ts
@@ -54,8 +54,8 @@ export type MapPreviewSurfaceProps = {
   hoverHint: string;
   hoverMissingGrid: string;
   hoverCellLabel: string;
-  /** 0-based cell keys ("x:y") that should be rendered as blocked. */
-  blockedCellSet?: ReadonlySet<string>;
+  /** 0-based cell keys ("x:y") → preset ID for obstacle overlay colors. */
+  obstacleMap?: ReadonlyMap<string, string>;
   /** Called with 0-based (x, y) when a cell is clicked in obstacle-edit mode. */
   onCellToggle?: (x: number, y: number) => void;
 };

--- a/apps/control-web/src/shared/api/campaignsRepo.ts
+++ b/apps/control-web/src/shared/api/campaignsRepo.ts
@@ -1,4 +1,4 @@
-import type { BlockedCell, Campaign, CampaignMapConfig, CampaignSystemType } from "../../entities/campaign";
+import type { BlockedCell, CampaignObstacle, Campaign, CampaignMapConfig, CampaignSystemType } from "../../entities/campaign";
 import { http } from "./http";
 
 type CampaignCreatePayload = {
@@ -28,7 +28,9 @@ export type CampaignMapConfigPayload = {
     width: number;
     height: number;
   } | null;
-  /** Pass an array to replace blocked cells; omit to leave them unchanged. */
+  /** Canonical semantic obstacles — replace the full set on each save. */
+  obstacles?: CampaignObstacle[] | null;
+  /** @deprecated Legacy movement-only cells; use obstacles for new maps. */
   blockedCells?: BlockedCell[] | null;
 };
 

--- a/apps/map-server/src/routes/integration/state.routes.ts
+++ b/apps/map-server/src/routes/integration/state.routes.ts
@@ -114,33 +114,57 @@ export function registerStateRoutes(app: FastifyInstance, repository: InMemoryEn
         ? repository.updateBattleMap(sessionId, battleMapSeed)
         : existingEncounter;
 
-    // Phase 2 compatibility mapping for legacy campaign blockedCells:
-    // blocked map cells now seed "solid" tactical obstacles so old campaign
-    // configs keep the same movement behavior while also blocking sight/effect.
-    if (parse.data.battleMap?.blockedCells && battleMapSeed && !isDuplicateAction) {
-      const { gridWidth, gridHeight } = parse.data.battleMap;
+    if (battleMapSeed && !isDuplicateAction) {
+      const { gridWidth, gridHeight } = parse.data.battleMap!;
       const seen = new Set<string>();
-      const validCells = parse.data.battleMap.blockedCells.filter((cell) => {
-        if (cell.x < 0 || cell.y < 0 || cell.x >= gridWidth || cell.y >= gridHeight) return false;
-        const key = `${cell.x}:${cell.y}`;
-        if (seen.has(key)) return false;
-        seen.add(key);
-        return true;
-      });
-      const battleMapId = encounter.battleMap.id;
-      const campaignObstacles = validCells.map((cell, index) => ({
-        id: `campaign-obstacle-${index}`,
-        battleMapId,
-        label: "Terreno bloqueado",
-        cells: [cell],
-        blocksMovement: true,
-        blocksEffect: true,
-        blocksVision: true,
-        cover: "none" as const,
-        clipsDiagonalMovement: false,
-        movementCostMultiplier: 1
-      }));
-      repository.setObstacles(sessionId, campaignObstacles);
+
+      if (parse.data.battleMap?.obstacles?.length) {
+        // Canonical semantic path: each entry carries full tactical semantics.
+        const battleMapId = encounter.battleMap.id;
+        const campaignObstacles = parse.data.battleMap.obstacles
+          .filter((obs) => {
+            if (obs.x < 0 || obs.y < 0 || obs.x >= gridWidth || obs.y >= gridHeight) return false;
+            const key = `${obs.x}:${obs.y}`;
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+          })
+          .map((obs, index) => ({
+            id: `campaign-obstacle-${index}`,
+            battleMapId,
+            cells: [{ x: obs.x, y: obs.y }],
+            blocksMovement: obs.blocksMovement,
+            blocksEffect: obs.blocksEffect,
+            blocksVision: obs.blocksVision,
+            cover: obs.cover,
+            clipsDiagonalMovement: obs.clipsDiagonalMovement,
+            movementCostMultiplier: obs.movementCostMultiplier
+          }));
+        repository.setObstacles(sessionId, campaignObstacles);
+      } else if (parse.data.battleMap?.blockedCells?.length) {
+        // Legacy path: movement-only blocked cells become solid obstacles.
+        const validCells = parse.data.battleMap.blockedCells.filter((cell) => {
+          if (cell.x < 0 || cell.y < 0 || cell.x >= gridWidth || cell.y >= gridHeight) return false;
+          const key = `${cell.x}:${cell.y}`;
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
+        const battleMapId = encounter.battleMap.id;
+        const campaignObstacles = validCells.map((cell, index) => ({
+          id: `campaign-obstacle-${index}`,
+          battleMapId,
+          label: "Terreno bloqueado",
+          cells: [cell],
+          blocksMovement: true,
+          blocksEffect: true,
+          blocksVision: true,
+          cover: "none" as const,
+          clipsDiagonalMovement: false,
+          movementCostMultiplier: 1
+        }));
+        repository.setObstacles(sessionId, campaignObstacles);
+      }
     }
 
     request.log.info(

--- a/packages/shared-contracts/src/integration.ts
+++ b/packages/shared-contracts/src/integration.ts
@@ -25,6 +25,24 @@ export const initiativeEntrySchema = z.object({
   initiativeScore: z.number()
 });
 
+/**
+ * A single per-cell obstacle authored at the campaign level.
+ * Canonical path for maps created after the semantic obstacle feature;
+ * supersedes `blockedCells` when present.
+ */
+export const campaignObstacleInputSchema = z.object({
+  x: z.number().int().min(0),
+  y: z.number().int().min(0),
+  blocksMovement: z.boolean(),
+  blocksEffect: z.boolean().default(false),
+  blocksVision: z.boolean().default(false),
+  cover: obstacleCoverSchema.default("none"),
+  clipsDiagonalMovement: z.boolean().default(false),
+  movementCostMultiplier: z.number().int().min(1).default(1)
+});
+
+export type CampaignObstacleInput = z.infer<typeof campaignObstacleInputSchema>;
+
 export const integrationBattleMapSchema = z.object({
   name: z.string(),
   gridWidth: z.number().int().positive().max(150),
@@ -32,9 +50,11 @@ export const integrationBattleMapSchema = z.object({
   gridCalibration: battleMapSchema.shape.gridCalibration,
   imageUrl: z.string(),
   sourceImageUrl: z.string().nullable().optional(),
-  // Phase 1 obstacles: movement-blocking cells seeded from the campaign map definition.
-  // LimiarControl converts these to Obstacle[] on the map-server at combat start.
-  // Absent or empty = no campaign-level blocked cells.
+  // Canonical semantic obstacles (Phase 2+): each entry maps a single cell to
+  // its full tactical semantics. When present, `blockedCells` is ignored.
+  obstacles: z.array(campaignObstacleInputSchema).optional(),
+  // Phase 1 legacy: movement-only blocked cells. Kept for backward compat with
+  // old campaign maps that pre-date semantic obstacles.
   blockedCells: z.array(coordinateSchema).optional()
 });
 


### PR DESCRIPTION
Closes #43

## Summary

- **shared-contracts**: `campaignObstacleInputSchema` com semântica tática completa; campo `obstacles?` em `integrationBattleMapSchema` — `blockedCells` mantido como legacy compat
- **control-server**: migration 0057 (`obstacles_json`), `CampaignObstacle` Pydantic model, encode/decode helpers; rotas priorizam `obstacles_json` e limpam `blocked_cells_json` ao migrar; projeção de combate envia `obstacles` canonicamente
- **map-server**: `combat/start` aplica obstáculos semânticos diretamente quando presentes; fallback de conversão solid-wall para `blockedCells` legados
- **control-web**: catálogo `CAMPAIGN_OBSTACLE_PRESETS` (7 presets com swatch colors), estado `Map<"x:y", PresetId>` + brush ativo, seletor de preset no modo edição, overlays coloridos por tipo em `MapPreviewSurface`

## Compatibilidade

Mapas existentes com `blocked_cells_json` continuam funcionando — o fallback legacy permanece ativo. Novos mapas salvos via UI escrevem em `obstacles_json` e limpam `blocked_cells_json`.

## Test plan

- [x] Criar novo mapa de campanha, marcar células com presets diferentes, salvar — verificar que `obstacles_json` é persistido corretamente
- [x] Carregar mapa antigo com `blocked_cells_json` — verificar que o preview exibe as células como `solid_wall`
- [x] Iniciar combate a partir de mapa com `obstacles` canônicos — verificar que `spell_blocker` bloqueia efeito sem bloquear visão/movimento, `difficult_terrain` custa 2×, `dense_obstacle` concede cover 3/4
- [x] Iniciar combate a partir de mapa legacy com `blockedCells` — verificar fallback solid-wall intacto
- [x] Verificar que `transparent_barrier` bloqueia movimento e efeito mas não visão

🤖 Generated with [Claude Code](https://claude.com/claude-code)