### PR TITLE
Fix combat range and attack roll flows

### DIFF
--- a/apps/control-server/app/api/routes/sessions/combat_preview.py
+++ b/apps/control-server/app/api/routes/sessions/combat_preview.py
@@ -20,6 +20,7 @@ Design constraints:
 from __future__ import annotations
 
 import logging
+from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session as DbSession, select
@@ -37,6 +38,7 @@ from app.schemas.combat_preview import (
     TacticalDiagnosticsPayload,
 )
 from app.services.combat_service.combat_targeting import get_combat_targeting_service
+from app.services.combat_service.reach import resolve_weapon_attack_range_profile
 from app.services.combat_service.targeting_diagnostics import (
     CHECK_IN_RANGE,
     TARGET_OUT_OF_REACH,
@@ -46,11 +48,15 @@ from app.services.combat_service.targeting_intent import (
     SpellCastIntent,
     WeaponAttackIntent,
 )
-from app.services.combat_service.unit_conversion import METERS_PER_CELL
+from app.services.combat_service.unit_conversion import METERS_PER_CELL, meters_to_cells
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _preview_action_id() -> str:
+    return f"preview:{uuid4()}"
 
 
 def _chebyshev(a: PreviewPosition, b: PreviewPosition) -> int:
@@ -73,6 +79,83 @@ def _reach_to_range_meters(reach_cells: int) -> int:
     all integer values of *n* between 1 and 60 at the default 1.5 m/cell scale.
     """
     return round(reach_cells * METERS_PER_CELL)
+
+
+def _build_attack_preview_intent(
+    *,
+    db: DbSession,
+    session_id: str,
+    source_ref_id: str,
+    actor_kind: str,
+    target_ref_id: str,
+    fallback_reach_cells: int,
+) -> tuple[WeaponAttackIntent, int]:
+    range_meters = _reach_to_range_meters(fallback_reach_cells)
+    action_id = _preview_action_id()
+    intent = WeaponAttackIntent(
+        session_id=session_id,
+        action_id=action_id,
+        actor_ref_id=source_ref_id,
+        actor_kind=actor_kind,
+        requested_target_ref_id=target_ref_id,
+        range_meters=range_meters,
+        requires_sight=True,
+        requires_effect=True,
+    )
+
+    if actor_kind != "player":
+        return intent, fallback_reach_cells
+
+    try:
+        from app.services.combat import CombatService
+
+        attacker_model, *_ = CombatService._get_stats(
+            db, source_ref_id, "player", session_id
+        )
+        attacker_data = CombatService._as_dict(attacker_model.state_json)
+        attack_context = CombatService._build_player_attack_context(
+            db,
+            session_id,
+            source_ref_id,
+            attacker_data,
+            None,
+        )
+    except Exception as exc:
+        logger.debug(
+            "[preview] could not derive current weapon for session=%s actor=%s: %s",
+            session_id,
+            source_ref_id,
+            exc,
+        )
+        return intent, fallback_reach_cells
+
+    intent = WeaponAttackIntent(
+        session_id=session_id,
+        action_id=action_id,
+        actor_ref_id=source_ref_id,
+        actor_kind=actor_kind,
+        requested_target_ref_id=target_ref_id,
+        weapon_item_id=attack_context.get("inventory_item_id"),
+        weapon_canonical_key=attack_context.get("weapon_canonical_key"),
+        range_meters=attack_context.get("range_meters"),
+        range_long_meters=attack_context.get("range_long_meters"),
+        weapon_range_type=attack_context.get("weapon_range_type"),
+        has_reach=bool(attack_context.get("has_reach")),
+        requires_sight=True,
+        requires_effect=True,
+    )
+    weapon_profile = resolve_weapon_attack_range_profile(
+        range_meters=intent.range_meters,
+        range_long_meters=intent.range_long_meters,
+        weapon_range_type=intent.weapon_range_type,
+        has_reach=intent.has_reach,
+    )
+    effective_reach_cells = (
+        meters_to_cells(weapon_profile.max_range)
+        if weapon_profile.max_range is not None
+        else fallback_reach_cells
+    )
+    return intent, effective_reach_cells
 
 
 @router.post(
@@ -107,6 +190,9 @@ def combat_preview(
         raise HTTPException(status_code=404, detail="Session not found")
 
     reach = payload.reach_cells
+    combat_state = db.exec(
+        select(CombatState).where(CombatState.session_id == session_id)
+    ).first()
 
     # ── AoE path ─────────────────────────────────────────────────────────────
     # AoE takes priority: when shape + size are provided we skip entity-level
@@ -117,16 +203,15 @@ def combat_preview(
         and payload.source_position is not None
         and payload.target_position is not None
     ):
-        return _handle_aoe_preview(session_id, payload, reach)
+        if not combat_state:
+            return CombatPreviewResponse(effectiveReachCells=reach)
+        return _handle_aoe_preview(session_id, payload, reach, combat_state.use_map)
 
     # ── Reach-only path ───────────────────────────────────────────────────────
     if not payload.target_ref_id:
         return CombatPreviewResponse(effectiveReachCells=reach)
 
     # ── Single-target path ────────────────────────────────────────────────────
-    combat_state = db.exec(
-        select(CombatState).where(CombatState.session_id == session_id)
-    ).first()
     if not combat_state:
         return CombatPreviewResponse(effectiveReachCells=reach)
 
@@ -141,7 +226,7 @@ def combat_preview(
     if payload.action_type == "spell":
         intent = SpellCastIntent(
             session_id=session_id,
-            action_id="preview",
+            action_id=_preview_action_id(),
             actor_ref_id=payload.source_ref_id,
             actor_kind=actor_kind,
             requested_target_ref_id=payload.target_ref_id,
@@ -152,21 +237,21 @@ def combat_preview(
             requires_effect=True,
         )
     else:
-        intent = WeaponAttackIntent(
+        intent, reach = _build_attack_preview_intent(
+            db=db,
             session_id=session_id,
-            action_id="preview",
-            actor_ref_id=payload.source_ref_id,
+            source_ref_id=payload.source_ref_id,
             actor_kind=actor_kind,
-            requested_target_ref_id=payload.target_ref_id,
-            range_meters=range_meters,
-            requires_sight=True,
-            requires_effect=True,
+            target_ref_id=payload.target_ref_id,
+            fallback_reach_cells=reach,
         )
 
     targeting_service = get_combat_targeting_service(combat_state.use_map)
     result = targeting_service.validate(intent, combat_state)
 
     diag: TargetingDiagnostics = result.diagnostics or TargetingDiagnostics()
+    if result.spatial_metadata.distance_meters is not None:
+        diag.set_meta("distance_meters", result.spatial_metadata.distance_meters)
 
     if payload.source_position and payload.target_position:
         distance = _chebyshev(payload.source_position, payload.target_position)
@@ -196,6 +281,7 @@ def _handle_aoe_preview(
     session_id: str,
     payload: CombatPreviewRequest,
     reach: int,
+    use_map: bool,
 ) -> CombatPreviewResponse:
     """Call LimiarMap /targeting/area/preview to compute the AoE footprint.
 
@@ -215,7 +301,7 @@ def _handle_aoe_preview(
     assert payload.source_position is not None
     assert payload.target_position is not None
 
-    if not combat_state.use_map:
+    if not use_map:
         logger.debug("[preview] AoE preview skipped — combat opened without map session=%s", session_id)
         return CombatPreviewResponse(effectiveReachCells=reach)
 
@@ -226,7 +312,7 @@ def _handle_aoe_preview(
         )
         response = client.preview_area_targeting(
             session_id=session_id,
-            action_id="preview",
+            action_id=_preview_action_id(),
             combatant_id=payload.source_ref_id,
             shape=payload.aoe_shape,
             origin_cell={"x": payload.source_position.x, "y": payload.source_position.y},

--- a/apps/control-server/app/schemas/combat.py
+++ b/apps/control-server/app/schemas/combat.py
@@ -52,6 +52,12 @@ from .combat_spells import (
     CombatSpellResult,
 )
 
+_combat_schema_types = {
+    "CombatConcentrationCheckResult": CombatConcentrationCheckResult,
+}
+CombatAttackResult.model_rebuild(_types_namespace=_combat_schema_types)
+CombatSpellResult.model_rebuild(_types_namespace=_combat_schema_types)
+
 __all__ = [
     "ActiveEffect",
     "ActiveEffectConditionType",

--- a/apps/control-server/app/services/combat_service/actions/weapon_attack_damage.py
+++ b/apps/control-server/app/services/combat_service/actions/weapon_attack_damage.py
@@ -82,17 +82,26 @@ class WeaponAttackDamageMixin:
         concentration_summary = f" {concentration_check['summary_text']}" if isinstance(concentration_check, dict) and isinstance(concentration_check.get("summary_text"), str) else ""
         await cls._emit_log(session_id, {"message": f"{attacker['display_name']} rolled damage with {pending_attack.get('weapon_name') or 'Attack'} against {target_display_name}: {damage + extra_damage} damage.{extra_damage_label}{effect_msg}{concentration_summary}", "actorUserId": actor_user_id, "source": "gm_override" if is_gm else "player_turn"})
         return {
-            "weapon_name": pending_attack.get("weapon_name"),
+            "roll": cls._safe_int(pending_attack.get("roll"), 0),
+            "is_hit": True,
+            "is_critical": bool(pending_attack.get("is_critical")),
+            "target_ac": cls._safe_int(pending_attack.get("target_ac"), 10),
+            "target_kind": "session_entity" if target_kind == "entity" else target_kind,
+            "weapon_name": pending_attack.get("weapon_name") or "Attack",
             "damage": damage + extra_damage,
             "new_hp": new_hp,
+            "damage_dice": pending_attack.get("damage_dice") or "",
             "damage_rolls": damage_rolls,
             "extra_damage_rolls": extra_damage_rolls,
             "base_damage": base_damage,
             "damage_bonus": damage_bonus,
+            "attack_bonus": cls._safe_int(pending_attack.get("attack_bonus"), 0),
             "extra_damage": extra_damage,
             "roll_result": roll_result,
             "target_display_name": target_display_name,
             "damage_type": pending_attack.get("damage_type"),
+            "pending_attack_id": None,
+            "damage_roll_required": False,
             "damage_roll_source": req.roll_source,
             "concentration_check": concentration_check,
         }

--- a/apps/control-server/app/services/combat_service/actions/weapon_attack_roll.py
+++ b/apps/control-server/app/services/combat_service/actions/weapon_attack_roll.py
@@ -33,8 +33,6 @@ class WeaponAttackRollMixin:
         attacker_data = cls._as_dict(attacker_model.state_json)
         if cls._as_dict(attacker_data.get("wildShape")).get("active"):
             raise CombatServiceError("Cannot use weapon attacks while in Wild Shape. Use wild-shape-attack instead.", 400)
-        was_overridden = cls._consume_turn_resource(attacker, "action", is_gm=is_gm, override_resource_limit=req.override_resource_limit)
-        cls._clear_participant_pending_attack(attacker)
         attack_context = cls._build_player_attack_context(db, session_id, attacker["ref_id"], attacker_data, req.weapon_item_id)
         targeting_intent = WeaponAttackIntent(
             session_id=session_id,
@@ -59,7 +57,10 @@ class WeaponAttackRollMixin:
         target = next((participant for participant in state.participants if participant["ref_id"] == targeting_result.validated_primary_target_ref_id), None)
         if not target:
             raise CombatServiceError("Target not found in combat")
+        target_kind = "session_entity" if target.get("kind") == "entity" else target.get("kind")
         cls._assert_hostile_action_allowed(attacker, target, action_label="an attack")
+        was_overridden = cls._consume_turn_resource(attacker, "action", is_gm=is_gm, override_resource_limit=req.override_resource_limit)
+        cls._clear_participant_pending_attack(attacker)
         _, target_ac, *_ = cls._get_stats(db, target["ref_id"], target["kind"], session_id)
         target_ac = (target_ac or 10) + cls._sum_numeric_effects(target, "temp_ac_bonus")
         cover = targeting_result.spatial_metadata.cover
@@ -105,7 +106,7 @@ class WeaponAttackRollMixin:
                 {
                     "type": "player_attack",
                     "target_ref_id": target["ref_id"],
-                    "target_kind": target["kind"],
+                    "target_kind": target_kind,
                     "target_display_name": target["display_name"],
                     "target_ac": target_ac,
                     "weapon_name": attack_context["name"],
@@ -155,7 +156,7 @@ class WeaponAttackRollMixin:
             "roll_result": roll_result,
             "target_ac": target_ac,
             "target_display_name": target["display_name"],
-            "target_kind": target["kind"],
+            "target_kind": target_kind,
             "weapon_name": attack_context["name"],
             "damage_dice": attack_context["damage_dice"],
             "damage_bonus": attack_context["damage_bonus"],

--- a/apps/control-server/app/services/combat_service/actions/wild_shape.py
+++ b/apps/control-server/app/services/combat_service/actions/wild_shape.py
@@ -156,6 +156,7 @@ class WildShapeMixin:
         )
         if not target_p:
             raise CombatServiceError("Target not found in combat")
+        target_kind = "session_entity" if target_p.get("kind") == "entity" else target_p.get("kind")
         # ─────────────────────────────────────────────────────────────────────
 
         _, target_ac, *_ = cls._get_stats(db, target_p["ref_id"], target_p["kind"], session_id)
@@ -211,7 +212,7 @@ class WildShapeMixin:
                 {
                     "type": "player_attack",
                     "target_ref_id": target_p["ref_id"],
-                    "target_kind": target_p["kind"],
+                    "target_kind": target_kind,
                     "target_display_name": target_p["display_name"],
                     "target_ac": target_ac,
                     "weapon_name": natural_attack.name,
@@ -264,7 +265,7 @@ class WildShapeMixin:
             "roll_result": roll_result,
             "target_ac": target_ac,
             "target_display_name": target_p["display_name"],
-            "target_kind": target_p["kind"],
+            "target_kind": target_kind,
             "weapon_name": natural_attack.name,
             "damage_dice": natural_attack.damage_dice,
             "damage_bonus": natural_attack.damage_bonus,

--- a/apps/control-server/app/services/combat_service/combat_targeting_map.py
+++ b/apps/control-server/app/services/combat_service/combat_targeting_map.py
@@ -18,8 +18,10 @@ from .targeting_diagnostics import (
     TargetingDiagnostics,
 )
 from .targeting_result import SpatialMetadata, TargetingResult
+from .targeting_intent import WeaponAttackIntent
 from .unit_conversion import METERS_PER_CELL
 from .visibility import can_target_in_combat
+from .reach import resolve_weapon_attack_range_profile
 from .combat_targeting import (
     CombatTargetingService,
     _build_map_spatial_metadata,
@@ -76,6 +78,23 @@ class LimiarMapTargetingService(CombatTargetingService):
         if local_result.diagnostics:
             for k, v in local_result.diagnostics.checks.items():
                 diag.set_check(k, v)
+
+        if isinstance(intent, WeaponAttackIntent):
+            weapon_profile = resolve_weapon_attack_range_profile(
+                range_meters=intent.range_meters,
+                range_long_meters=intent.range_long_meters,
+                weapon_range_type=intent.weapon_range_type,
+                has_reach=intent.has_reach,
+            )
+            if weapon_profile.failure_reason is not None:
+                diag.set_check(CHECK_IN_RANGE, False)
+                diag.fail(weapon_profile.failure_reason)
+                result = TargetingResult.invalid(
+                    "Ranged weapon has no range configured. Cannot validate distance.",
+                    diagnostics=diag,
+                )
+                _log_diagnostics_debug(logger, intent, result)
+                return result
 
         range_cells = _derive_range_cells(intent)
         if range_cells is not None:

--- a/apps/control-server/app/services/combat_service/weapon_resolution.py
+++ b/apps/control-server/app/services/combat_service/weapon_resolution.py
@@ -230,7 +230,21 @@ class CombatWeaponResolutionMixin:
             if isinstance(requested_weapon_item_id, str)
             else None
         )
-        selected_inventory_item_id = requested_id or data.get("currentWeaponId")
+        current_weapon_id_value = data.get("currentWeaponId")
+        current_weapon_id = (
+            current_weapon_id_value.strip()
+            if isinstance(current_weapon_id_value, str)
+            else None
+        )
+        effective_current_weapon_id = (
+            current_weapon_id
+            if isinstance(current_weapon_id, str) and current_weapon_id
+            else "unarmed"
+        )
+        selected_inventory_item_id = current_weapon_id
+
+        if requested_id and requested_id != effective_current_weapon_id:
+            raise CombatServiceError("Weapon attacks must use the currently equipped weapon.", 400)
 
         strength_mod = cls._ability_modifier(
             cls._get_player_ability_score(data, "strength")

--- a/apps/control-server/tests/_combat_test_flow.py
+++ b/apps/control-server/tests/_combat_test_flow.py
@@ -17,6 +17,7 @@ from app.schemas.combat import (
     CombatApplyDamageRequest,
     CombatApplyHealingRequest,
     CombatAttackRequest,
+    CombatAttackResult,
     CombatCastSpellRequest,
     CombatEntityActionRequest,
     CombatParticipant,
@@ -302,6 +303,7 @@ class CombatFlowTestsMixin:
                     self.assertEqual(res["damage"], 0)
                     self.assertFalse(res["damage_roll_required"])
                     self.assertNotIn("pending_attack", self.state.participants[0])
+                    self.assertFalse(CombatAttackResult.model_validate(res).is_hit)
 
     @patch("app.services.combat.CombatService._emit_entity_hp_update")
     @patch("app.services.combat.CombatService._emit_state")
@@ -405,6 +407,22 @@ class CombatFlowTestsMixin:
         self.assertEqual(context["attack_bonus"], 6)
         self.assertTrue(context["is_ranged_weapon"])
 
+    def test_build_player_attack_context_rejects_non_current_weapon_request(self):
+        with self.assertRaises(CombatServiceError) as context:
+            CombatService._build_player_attack_context(
+                self.db,
+                "session-123",
+                "player-123",
+                {
+                    "level": 2,
+                    "abilities": {"strength": 10, "dexterity": 14},
+                    "currentWeaponId": "inv-current",
+                },
+                requested_weapon_item_id="inv-other",
+            )
+
+        self.assertIn("currently equipped weapon", str(context.exception))
+
     @patch("app.services.combat.CombatService._emit_entity_hp_update")
     @patch("app.services.combat.CombatService._emit_state")
     @patch("app.services.combat.CombatService._emit_log")
@@ -459,6 +477,59 @@ class CombatFlowTestsMixin:
         self.assertEqual(res["roll_result"].roll_source, "manual")
         self.assertEqual(res["roll_result"].selected_roll, 17)
         self.assertEqual(res["target_ac"], 14)
+
+    @patch("app.services.combat.CombatService._emit_entity_hp_update")
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_log")
+    async def test_attack_normalizes_legacy_entity_target_kind(
+        self,
+        mock_emit_log,
+        mock_emit_state,
+        mock_emit_entity_hp_update,
+    ):
+        self.state.phase = CombatPhase.active
+        self.state.current_turn_index = 0
+        self.state.use_map = False
+        self.state.local_distances = {
+            "player-123": {"enemy-123": 1.5},
+            "enemy-123": {"player-123": 1.5},
+        }
+        self.state.participants[1]["kind"] = "entity"
+        attacker_state = MagicMock()
+        attacker_state.state_json = {"currentWeaponId": "inv-1"}
+
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state):
+            with patch(
+                "app.services.combat.CombatService._get_stats",
+                side_effect=[
+                    (attacker_state, 12, 16, 14, 2, 0),
+                    (MagicMock(), 14, 10, 10, 2, 0),
+                ],
+            ):
+                with patch(
+                    "app.services.combat.CombatService._build_player_attack_context",
+                    return_value={
+                        "name": "Longsword",
+                        "damage_dice": "1d8",
+                        "damage_bonus": 3,
+                        "attack_bonus": 5,
+                        "damage_type": "slashing",
+                        "weapon_range_type": "melee",
+                    },
+                ):
+                    res = await CombatService.attack(
+                        self.db,
+                        "session-123",
+                        CombatAttackRequest(
+                            target_ref_id="enemy-123",
+                            roll_source="manual",
+                            manual_roll=17,
+                        ),
+                        "user-xyz",
+                        True,
+                    )
+
+        self.assertEqual(res["target_kind"], "session_entity")
 
     @patch("app.services.combat.CombatService._emit_entity_hp_update")
     @patch("app.services.combat.CombatService._emit_state")
@@ -619,6 +690,10 @@ class CombatFlowTestsMixin:
         self.assertEqual(res["damage_rolls"], [4])
         self.assertEqual(res["base_damage"], 4)
         self.assertEqual(res["damage_roll_source"], "manual")
+        validated = CombatAttackResult.model_validate(res)
+        self.assertTrue(validated.is_hit)
+        self.assertFalse(validated.damage_roll_required)
+        self.assertEqual(validated.target_kind, "session_entity")
         self.assertNotIn("pending_attack", self.state.participants[0])
         mock_apply_damage.assert_called_once_with(
             self.db,

--- a/apps/control-server/tests/test_combat_preview.py
+++ b/apps/control-server/tests/test_combat_preview.py
@@ -39,6 +39,7 @@ from app.services.combat_service.targeting_diagnostics import (
 )
 from app.services.combat_service.targeting_result import TargetingResult
 from app.api.routes.sessions.combat_preview import (
+    _build_attack_preview_intent,
     _chebyshev,
     _to_payload,
     _reach_to_range_meters,
@@ -400,6 +401,28 @@ class TestPreviewDelegation(unittest.TestCase):
 
         self.assertEqual(diag.metadata["distance_cells"], 2)
         self.assertEqual(diag.metadata["reach_cells"], 3)
+
+    def test_attack_preview_uses_unique_action_ids(self):
+        first_intent, _ = _build_attack_preview_intent(
+            db=MagicMock(),
+            session_id="session:1",
+            source_ref_id="npc:1",
+            actor_kind="npc",
+            target_ref_id="player:1",
+            fallback_reach_cells=1,
+        )
+        second_intent, _ = _build_attack_preview_intent(
+            db=MagicMock(),
+            session_id="session:1",
+            source_ref_id="npc:1",
+            actor_kind="npc",
+            target_ref_id="player:1",
+            fallback_reach_cells=1,
+        )
+
+        self.assertNotEqual(first_intent.action_id, second_intent.action_id)
+        self.assertTrue(first_intent.action_id.startswith("preview:"))
+        self.assertTrue(second_intent.action_id.startswith("preview:"))
 
 
 if __name__ == "__main__":

--- a/apps/control-server/tests/test_combat_targeting_integration.py
+++ b/apps/control-server/tests/test_combat_targeting_integration.py
@@ -243,6 +243,39 @@ class CombatTargetingIntegrationServiceTests(unittest.TestCase):
         self.assertTrue(client.calls[0]["requires_sight"])
         self.assertTrue(client.calls[0]["requires_effect"])
 
+    def test_ranged_weapon_without_range_is_rejected_before_map_call(self) -> None:
+        state = build_combat_state()
+        client = StubLimiarMapClient(
+            response=LimiarMapTargetingResponse(
+                is_valid=True,
+                reason=None,
+                session_id="session-123",
+                action_id="action-missing-range",
+                version=7,
+                source_token_id="token-source",
+                target_token_id="token-target",
+            )
+        )
+        service = LimiarMapTargetingService(
+            client, fallback_service=LocalCombatTargetingService()
+        )
+
+        result = service.validate(
+            WeaponAttackIntent(
+                session_id="session-123",
+                action_id="action-missing-range",
+                actor_ref_id="player-123",
+                actor_kind="player",
+                requested_target_ref_id="enemy-123",
+                weapon_range_type="ranged",
+            ),
+            state,
+        )
+
+        self.assertFalse(result.is_valid)
+        self.assertIn("range configured", result.failure_reason)
+        self.assertEqual(client.calls, [])
+
     def test_map_enabled_and_invalid_targeting_returns_rejection(self) -> None:
         state = build_combat_state()
         client = StubLimiarMapClient(
@@ -676,6 +709,7 @@ class CombatTargetingIntegrationServiceTests(unittest.TestCase):
                 actor_ref_id="player-123",
                 actor_kind="player",
                 requested_target_ref_id="enemy-123",
+                range_meters=18,
                 weapon_range_type="ranged",
             ),
             state,

--- a/apps/control-web/src/features/combat-ui/components/RangeStatusBadge.tsx
+++ b/apps/control-web/src/features/combat-ui/components/RangeStatusBadge.tsx
@@ -35,7 +35,14 @@ const formatDistance = (meters: number): string => {
 
 export const RangeStatusBadge = ({ preview }: Props) => {
   const { t } = useLocale();
-  const { loading, rangeStatus, distanceMeters, hasDisadvantage } = preview;
+  const {
+    loading,
+    rangeStatus,
+    distanceMeters,
+    normalRangeMeters,
+    maxRangeMeters,
+    hasDisadvantage,
+  } = preview;
 
   if (loading) {
     return (
@@ -47,6 +54,12 @@ export const RangeStatusBadge = ({ preview }: Props) => {
 
   const label = statusLabel(t, rangeStatus);
   const distanceLabel = distanceMeters != null ? formatDistance(distanceMeters) : null;
+  const normalRangeLabel = normalRangeMeters != null ? formatDistance(normalRangeMeters) : null;
+  const maxRangeLabel =
+    maxRangeMeters != null && maxRangeMeters !== normalRangeMeters
+      ? formatDistance(maxRangeMeters)
+      : null;
+  const neededLabel = maxRangeMeters != null ? formatDistance(maxRangeMeters) : null;
 
   return (
     <div
@@ -56,6 +69,18 @@ export const RangeStatusBadge = ({ preview }: Props) => {
         <span>{label}</span>
         {distanceLabel ? <span className="opacity-80">{distanceLabel}</span> : null}
       </div>
+      {distanceLabel || neededLabel ? (
+        <p className="mt-1 text-[11px] font-normal opacity-90">
+          {distanceLabel ? `Distancia atual: ${distanceLabel}` : "Distancia atual: -"}
+          {neededLabel ? ` · precisa <= ${neededLabel}` : ""}
+        </p>
+      ) : null}
+      {normalRangeLabel ? (
+        <p className="mt-1 text-[11px] font-normal opacity-80">
+          Alcance normal: {normalRangeLabel}
+          {maxRangeLabel ? ` · longo: ${maxRangeLabel}` : ""}
+        </p>
+      ) : null}
       {hasDisadvantage ? (
         <p className="mt-1 text-[11px] font-normal text-amber-100">
           {t("combatUi.disadvantageRange")}

--- a/apps/control-web/src/features/combat-ui/hooks/useTargetingPreview.ts
+++ b/apps/control-web/src/features/combat-ui/hooks/useTargetingPreview.ts
@@ -15,6 +15,8 @@ export type TargetingPreviewState = {
   error: string | null;
   diagnostics: TacticalDiagnosticsPayload | null;
   distanceMeters: number | null;
+  normalRangeMeters: number | null;
+  maxRangeMeters: number | null;
   rangeStatus: RangeStatus;
   hasDisadvantage: boolean;
   failureReasons: string[];
@@ -53,6 +55,8 @@ const INITIAL: TargetingPreviewState = {
   error: null,
   diagnostics: null,
   distanceMeters: null,
+  normalRangeMeters: null,
+  maxRangeMeters: null,
   rangeStatus: "unknown",
   hasDisadvantage: false,
   failureReasons: [],
@@ -100,10 +104,26 @@ export function useTargetingPreview(opts: UseTargetingPreviewOptions): Targeting
               : typeof meta["distance_cells"] === "number"
                 ? (meta["distance_cells"] as number) * METERS_PER_CELL
                 : null;
+          const resolvedNormalRangeMeters =
+            typeof meta["normal_range_meters"] === "number"
+              ? (meta["normal_range_meters"] as number)
+              : typeof meta["normal_range_cells"] === "number"
+                ? (meta["normal_range_cells"] as number) * METERS_PER_CELL
+                : normalRangeMeters;
+          const resolvedLongRangeMeters =
+            typeof meta["long_range_meters"] === "number"
+              ? (meta["long_range_meters"] as number)
+              : typeof meta["long_range_cells"] === "number"
+                ? (meta["long_range_cells"] as number) * METERS_PER_CELL
+                : longRangeMeters;
+          const resolvedMaxRangeMeters =
+            typeof meta["max_range_meters"] === "number"
+              ? (meta["max_range_meters"] as number)
+              : resolvedLongRangeMeters ?? resolvedNormalRangeMeters ?? null;
           const { status, hasDisadvantage } = classifyRange(
             distanceMeters,
-            normalRangeMeters,
-            longRangeMeters,
+            resolvedNormalRangeMeters,
+            resolvedLongRangeMeters,
           );
           const checks = diag?.checks ?? {};
           const inRange = checks["in_range"];
@@ -113,6 +133,8 @@ export function useTargetingPreview(opts: UseTargetingPreviewOptions): Targeting
             error: null,
             diagnostics: diag,
             distanceMeters,
+            normalRangeMeters: resolvedNormalRangeMeters ?? null,
+            maxRangeMeters: resolvedMaxRangeMeters,
             rangeStatus: finalStatus,
             hasDisadvantage: finalStatus === "long" ? true : hasDisadvantage,
             failureReasons: diag?.failureReasons ?? [],

--- a/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
+++ b/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
@@ -332,7 +332,7 @@ export const PlayerCombatModeShell = ({
             }
             const isOwnToken =
               selection.combatantId != null && selection.combatantId === myParticipant?.ref_id;
-            if (isOwnToken && canMoveNow && !isTargetingAction) {
+            if (isOwnToken && canMoveNow) {
               setMovementMode(true);
               setMovementSelectedCell(null);
               return;
@@ -370,6 +370,7 @@ export const PlayerCombatModeShell = ({
             selectedSpell={selectedSpell}
             selectedSpellId={selectedSpellId}
             selectedTarget={selectedTarget}
+            sessionId={sessionId}
             setActiveActionPanel={setActiveActionPanel}
             setConsumableItemId={setConsumableItemId}
             setSelectedSpellId={setSelectedSpellId}

--- a/apps/control-web/src/features/combat-ui/player/PlayerTurnPanel.tsx
+++ b/apps/control-web/src/features/combat-ui/player/PlayerTurnPanel.tsx
@@ -2,6 +2,8 @@ import { RollResultCard } from "../../../features/rolls/components/RollResultCar
 import type { StandardActionType } from "../../../shared/api/combatRepo";
 import { useLocale } from "../../../shared/hooks/useLocale";
 import { getCombatStatusLabel } from "../combatUi.helpers";
+import { RangeStatusBadge } from "../components/RangeStatusBadge";
+import { useTargetingPreview } from "../hooks/useTargetingPreview";
 import type { PlayerBoardStatusSummary } from "../../../pages/PlayerBoardPage/playerBoard.types";
 import type { PendingRoll } from "../../../pages/PlayerBoardPage/playerBoard.types";
 import type {
@@ -43,6 +45,7 @@ type Props = {
   selectedSpell: SpellOption | null;
   selectedSpellId: string;
   selectedTarget: { id: string } | null;
+  sessionId: string;
   setActiveActionPanel: (panel: "attack" | "spell" | "standard" | "object") => void;
   setConsumableItemId: (id: string) => void;
   setSelectedSpellId: (id: string) => void;
@@ -99,6 +102,7 @@ export const PlayerTurnPanel = ({
   selectedSpell,
   selectedSpellId,
   selectedTarget,
+  sessionId,
   setActiveActionPanel,
   setConsumableItemId,
   setSelectedSpellId,
@@ -130,6 +134,15 @@ export const PlayerTurnPanel = ({
   const actionUsed = Boolean(myParticipant?.turn_resources?.action_used);
   const canAct = Boolean(combat.isMyTurn && myParticipant?.status === "active");
   const turnSummaryLabel = waitLabelByPhase(combat.state?.phase, combat.isMyTurn, t);
+  const attackRangePreview = useTargetingPreview({
+    sessionId,
+    actorRefId: myParticipant?.ref_id,
+    targetRefId: targetId || null,
+    actionType: "attack",
+    normalRangeMeters: playerStatus?.currentWeapon?.rangeMeters ?? null,
+    longRangeMeters: playerStatus?.currentWeapon?.rangeLongMeters ?? null,
+    enabled: Boolean(combat.state && myParticipant?.ref_id && targetId),
+  });
 
   const selectedConsumableIsHealing = Boolean(selectedConsumable?.isHealingConsumable);
   const useObjectManualRollReady =
@@ -248,6 +261,11 @@ export const PlayerTurnPanel = ({
                       </option>
                     ))}
                 </select>
+                {targetId ? (
+                  <div className="mt-2">
+                    <RangeStatusBadge preview={attackRangePreview} />
+                  </div>
+                ) : null}
               </label>
 
               <div className="rounded-3xl border border-white/8 bg-white/4 px-4 py-4">

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerAttackRollDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerAttackRollDialog.tsx
@@ -85,6 +85,10 @@ export const PlayerAttackRollDialog = ({
     manual_roll?: number;
     roll_source: "manual" | "system";
   }) => {
+    if (outOfRange) {
+      setError("Alvo fora do alcance da arma atual.");
+      return;
+    }
     setLoading(true);
     setError(null);
 
@@ -103,6 +107,7 @@ export const PlayerAttackRollDialog = ({
       setDamageMode("choose");
       if (!resolved.damage_roll_required) {
         await onResolved?.(resolved);
+        onClose();
       }
     } catch (err: any) {
       setError(toPlayerFriendlyError(err?.data?.detail || err?.message || "Falha ao resolver ataque"));
@@ -133,6 +138,7 @@ export const PlayerAttackRollDialog = ({
       });
       setResult(resolved);
       await onResolved?.(resolved);
+      onClose();
     } catch (err: any) {
       setError(toPlayerFriendlyError(err?.data?.detail || err?.message || "Falha ao rolar dano"));
     } finally {
@@ -167,6 +173,11 @@ export const PlayerAttackRollDialog = ({
         {!result ? (
           <div className="mt-4">
             <RangeStatusBadge preview={preview} />
+            {outOfRange ? (
+              <p className="mt-2 text-xs font-semibold text-rose-200">
+                Alvo fora do alcance da arma atual.
+              </p>
+            ) : null}
           </div>
         ) : null}
 

--- a/apps/map-server/src/routes/integration/targeting.single.routes.ts
+++ b/apps/map-server/src/routes/integration/targeting.single.routes.ts
@@ -33,7 +33,8 @@ export function registerSingleTargetingRoutes(
     }
 
     const { actionId, combatantId, targetCombatantId, rangeCells, requiresSight, requiresEffect } = parse.data;
-    if (encounter.actionTracker.has(actionId)) {
+    const isPreviewAction = actionId === "preview" || actionId.startsWith("preview:");
+    if (!isPreviewAction && encounter.actionTracker.has(actionId)) {
       request.log.info({ sessionId, actionId }, `${LOG_PREFIX} targeting duplicate_action`);
       return reply.status(200).send({
         isValid: true,
@@ -130,28 +131,30 @@ export function registerSingleTargetingRoutes(
       });
     }
 
-    encounter.actionTracker.record(actionId);
-    encounter.combatState = {
-      ...encounter.combatState,
-      version: nextEncounterVersion(encounter.combatState.version),
-    };
-    repository.updateCombatState(sessionId, encounter.combatState);
+    if (!isPreviewAction) {
+      encounter.actionTracker.record(actionId);
+      encounter.combatState = {
+        ...encounter.combatState,
+        version: nextEncounterVersion(encounter.combatState.version),
+      };
+      repository.updateCombatState(sessionId, encounter.combatState);
 
-    broadcastAuthoritativeEvent(broadcaster, "targeting.resolved", {
-      eventId: randomUUID(),
-      eventType: "targeting.resolved",
-      encounterId: sessionId,
-      version: encounter.combatState.version,
-      actionId,
-      payload: {
-        sourceTokenId: sourceToken.id,
-        targetTokenId: targetToken.id,
-        isValid: true,
-        reason: null,
-        cover,
-      },
-      replaySafe: true,
-    });
+      broadcastAuthoritativeEvent(broadcaster, "targeting.resolved", {
+        eventId: randomUUID(),
+        eventType: "targeting.resolved",
+        encounterId: sessionId,
+        version: encounter.combatState.version,
+        actionId,
+        payload: {
+          sourceTokenId: sourceToken.id,
+          targetTokenId: targetToken.id,
+          isValid: true,
+          reason: null,
+          cover,
+        },
+        replaySafe: true,
+      });
+    }
 
     return reply.status(200).send({
       isValid: true,

--- a/apps/map-server/tests/integration/single-target-targeting.integration.test.ts
+++ b/apps/map-server/tests/integration/single-target-targeting.integration.test.ts
@@ -340,6 +340,52 @@ describe("single-target targeting integration", () => {
     await app.close();
   });
 
+  it("keeps valid previews read-only and returns distance for repeated preview action ids", async () => {
+    const { app, repository } = createApp();
+    const emit = vi.fn();
+    registerIntegrationRoutes(app, repository, { emit });
+
+    const encounter = repository.createEncounter("session-preview-readonly");
+    encounter.tokens = encounter.tokens.map((token) =>
+      token.combatantId === "cmb_1"
+        ? { ...token, position: { x: 0, y: 0 } }
+        : token.combatantId === "cmb_2"
+          ? { ...token, position: { x: 1, y: 0 } }
+          : token
+    );
+    repository.saveEncounter(encounter);
+
+    const payload = {
+      actionId: "preview",
+      combatantId: "cmb_1",
+      targetCombatantId: "cmb_2",
+      rangeCells: 12,
+      requiresSight: true,
+      requiresEffect: true
+    };
+
+    const first = await app.inject({
+      method: "POST",
+      url: "/integration/sessions/session-preview-readonly/targeting",
+      payload
+    });
+    const second = await app.inject({
+      method: "POST",
+      url: "/integration/sessions/session-preview-readonly/targeting",
+      payload
+    });
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(200);
+    expect(first.json()).toMatchObject({ isValid: true, distanceCells: 1 });
+    expect(second.json()).toMatchObject({ isValid: true, distanceCells: 1 });
+    expect(repository.getEncounter("session-preview-readonly")?.combatState.version).toBe(0);
+    expect(repository.getEncounter("session-preview-readonly")?.actionTracker.has("preview")).toBe(false);
+    expect(emit).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
   it("LoS hard block still prevails when cover is also present", async () => {
     const { app, repository } = createApp();
     registerIntegrationRoutes(app, repository, { emit: vi.fn() });


### PR DESCRIPTION
## Summary

Closes #49.

This PR fixes the combat attack/range flow across backend, map preview, and player UI:

- makes player weapon attacks authoritative against the currently equipped `currentWeaponId`
- rejects requests trying to attack with a non-equipped weapon
- validates weapon normal/long range on map and non-map combat paths
- exposes current distance and required range in the player turn panel
- fixes targeting preview distance disappearing after repeated map preview calls
- keeps single-target map previews read-only
- fixes player movement selection being blocked while attack targeting was active
- fixes attack miss responses returning 500 after consuming the action
- fixes damage roll responses returning 500 after applying/logging damage

## Root Cause

Several failures were happening after state mutation:

- repeated preview calls reused `actionId="preview"`, causing the map-server duplicate path to omit `distanceCells`
- attack and damage responses did not fully satisfy `CombatAttackResult` in some paths, so FastAPI response validation raised `Internal Server Error` after action/damage state had already been committed
- player movement clicks were gated by attack-targeting state, preventing movement selection in player mode

## Validation

- `uv run pytest tests/test_combat.py::TestCombatService::test_attack_damage_accepts_manual_rolls tests/test_combat.py::TestCombatService::test_attack_hit_and_miss tests/test_combat.py::TestCombatService::test_attack_accepts_manual_roll_and_returns_roll_result tests/test_combat_preview.py tests/test_combat_targeting_integration.py -q` -> 75 passed
- `npm run test -w apps/control-web -- --run src/features/combat-ui/hooks/useTargetingPreview.test.ts` -> 10 passed
- `npm test -- --run apps/map-server/tests/integration/single-target-targeting.integration.test.ts` -> 10 passed
- `npm run build -w apps/control-web` -> passed
- `npm run build -w apps/map-server` -> passed
- `uv run python -m py_compile ...` for changed backend modules -> passed

## Notes

The full legacy `tests/test_combat.py` suite still has older failures where tests do not configure map/local distance or LoS data after the new authoritative range checks. The focused attack/range/preview tests above passed on this branch.
