### PR TITLE
Align spell eligibility rules

### DIFF
--- a/apps/control-server/tests/_combat_test_flow.py
+++ b/apps/control-server/tests/_combat_test_flow.py
@@ -1467,6 +1467,70 @@ class CombatFlowTestsMixin:
         self.assertEqual(context.exception.status_code, 400)
         self.assertIn("No spell slots", str(context.exception.detail))
 
+    async def test_player_leveled_known_spell_rejects_when_unprepared(
+        self,
+    ):
+        self.state.phase = CombatPhase.active
+        self.state.current_turn_index = 0
+        attacker_state = SessionState(
+            id="state-player",
+            session_id="session-123",
+            player_user_id="player-123",
+            state_json={
+                "spellcasting": {
+                    "mode": "known",
+                    "spells": [
+                        {
+                            "name": "Magic Missile",
+                            "canonicalKey": "magic_missile",
+                            "level": 1,
+                            "prepared": False,
+                        }
+                    ],
+                    "slots": {"1": {"used": 0, "max": 2}},
+                }
+            },
+        )
+
+        with patch(
+            "app.services.combat.CombatService.get_state", return_value=self.state
+        ):
+            with patch(
+                "app.services.combat.CombatService._get_spell_catalog_entry_for_session",
+                return_value=MagicMock(
+                    canonical_key="magic_missile",
+                    name_en="Magic Missile",
+                    name_pt=None,
+                    level=1,
+                    damage_type="force",
+                    saving_throw=None,
+                    resolution_type="damage",
+                ),
+            ):
+                with patch(
+                    "app.services.combat.CombatService._get_stats",
+                    return_value=(attacker_state, 12, 10, 10, 2, 3),
+                ):
+                    with self.assertRaises(CombatServiceError) as context:
+                        await CombatService.cast_spell(
+                            self.db,
+                            "session-123",
+                            CombatCastSpellRequest(
+                                actor_participant_id="p1",
+                                target_ref_id="enemy-123",
+                                spell_canonical_key="magic_missile",
+                                spell_mode="direct_damage",
+                                slot_level=1,
+                                damage_bonus=4,
+                                damage_type="force",
+                            ),
+                            "user-1",
+                            False,
+                        )
+
+        self.assertEqual(context.exception.status_code, 400)
+        self.assertIn("Spell is not prepared", str(context.exception.detail))
+
     @patch("app.services.combat.CombatService._emit_player_state_update")
     @patch("app.services.combat.CombatService._emit_entity_hp_update")
     @patch("app.services.combat.CombatService._emit_state")

--- a/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.test.ts
+++ b/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.test.ts
@@ -205,6 +205,93 @@ describe("buildSpellOptions", () => {
     ]);
   });
 
+  it("does not offer unprepared leveled known spells that backend rejects", () => {
+    seedSpellCatalogCache([
+      {
+        campaignSpellId: null,
+        canonicalKey: "magic_missile",
+        name: "Magic Missile",
+        level: 1,
+        school: "evocation",
+        castingTimeType: "action",
+        castingTime: "1 action",
+        range: "36 m",
+        components: "V, S",
+        duration: "Instantaneous",
+        concentration: false,
+        ritual: false,
+        description: "Test spell.",
+        resolutionType: "damage",
+        damageType: "Force",
+        savingThrow: null,
+        saveSuccessOutcome: null,
+        healDice: null,
+        upcast: null,
+        classes: ["Wizard"],
+      },
+      {
+        campaignSpellId: null,
+        canonicalKey: "fire_bolt",
+        name: "Fire Bolt",
+        level: 0,
+        school: "evocation",
+        castingTimeType: "action",
+        castingTime: "1 action",
+        range: "36 m",
+        components: "V, S",
+        duration: "Instantaneous",
+        concentration: false,
+        ritual: false,
+        description: "Test cantrip.",
+        resolutionType: "damage",
+        damageType: "Fire",
+        savingThrow: null,
+        saveSuccessOutcome: null,
+        healDice: null,
+        upcast: null,
+        classes: ["Wizard"],
+      },
+    ]);
+
+    const playerSheet = {
+      spellcasting: {
+        ability: "intelligence",
+        mode: "known",
+        slots: { 1: { max: 2, used: 0 } },
+        spells: [
+          {
+            id: "spell-1",
+            name: "Magic Missile",
+            canonicalKey: "magic_missile",
+            campaignSpellId: null,
+            level: 1,
+            school: "evocation",
+            prepared: false,
+            notes: "",
+          },
+          {
+            id: "spell-2",
+            name: "Fire Bolt",
+            canonicalKey: "fire_bolt",
+            campaignSpellId: null,
+            level: 0,
+            school: "evocation",
+            prepared: false,
+            notes: "",
+          },
+        ],
+      },
+    } as CharacterSheet;
+
+    expect(buildSpellOptions(playerSheet)).toEqual([
+      expect.objectContaining({
+        id: "spell-2",
+        canonicalKey: "fire_bolt",
+        level: 0,
+      }),
+    ]);
+  });
+
   it("includes cast_spell magic items from inventory without requiring spellcasting", () => {
     seedSpellCatalogCache([
       {

--- a/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.ts
+++ b/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.ts
@@ -84,7 +84,7 @@ export const buildSpellOptions = (
     ? spellcasting.spells
         .filter(
           (spell) =>
-            spell.level === 0 || spell.prepared || spellcasting.mode === "known"
+            spell.level === 0 || spell.prepared
         )
         .map((spell) => {
           const catalogSpell = resolveSpellByAuthority(catalog, spell);


### PR DESCRIPTION
## Summary

- Align combat spell eligibility in the frontend with backend cast validation.
- Stop showing leveled known-mode spells when `prepared: false` because the backend rejects them.
- Add frontend and backend regressions for the mismatch.

## Root Cause

The frontend treated `spellcasting.mode === "known"` as enough to show a leveled spell, while the backend rejects any leveled sheet spell with `prepared === false`.

## Validation

- `npm test -w apps/control-web -- usePlayerCombatModeHelpers`
- `npm test -w apps/control-web -- creationSpells`
- `npm run build -w apps/control-web`
- `apps/control-server/.venv/bin/python -m pytest apps/control-server/tests/test_combat.py -k "leveled_known_spell_rejects_when_unprepared"`

Closes #51
