### PR TITLE
Show affected target names in AoE preview

### DIFF
--- a/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
+++ b/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
@@ -496,6 +496,7 @@ export const PlayerCombatModeShell = ({
               void onInventoryChanged?.();
             }
           }}
+          participants={combat.state.participants}
           sessionId={sessionId}
           spell={selectedSpell}
           spellDamageType={spellDamageType}

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerCombatDebugPanel.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerCombatDebugPanel.tsx
@@ -190,6 +190,7 @@ export const PlayerCombatDebugPanel = ({
           actorParticipantId={currentParticipant.id}
           onClose={closeSpellDialog}
           onResolved={handleSpellResolved}
+          participants={state.participants}
           sessionId={sessionId}
           spell={selectedSpell}
           spellDamageType={spellDamageType}

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/AreaTargetingGrid.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/AreaTargetingGrid.tsx
@@ -1,16 +1,19 @@
+import { useMemo } from "react";
 import { CombatMapFrame } from "../../../features/combat-ui/map/CombatMapFrame";
 import type { CombatMapPreviewState, CombatParticipant } from "../../../shared/api/combatRepo";
-import type { GridCell } from "./areaTargetingUi";
+import { formatAffectedTargetNames, resolveAffectedTargetNames, type GridCell } from "./areaTargetingUi";
 
 type Props = {
   actor: CombatParticipant;
   anchorCell: GridCell | null;
+  canRevealHiddenTargets?: boolean;
   mapError: string | null;
   mapLoading: boolean;
   mapState: CombatMapPreviewState | null;
   originCell: GridCell | null;
+  participants: CombatParticipant[];
   previewAffectedCellCount: number;
-  previewAffectedTargetCount: number;
+  previewAffectedTargetRefIds: string[];
   previewCells: GridCell[];
   previewError: string | null;
   previewLoading: boolean;
@@ -23,12 +26,14 @@ type Props = {
 export const AreaTargetingGrid = ({
   actor,
   anchorCell,
+  canRevealHiddenTargets = false,
   mapError,
   mapLoading,
   mapState,
   originCell,
+  participants,
   previewAffectedCellCount,
-  previewAffectedTargetCount,
+  previewAffectedTargetRefIds,
   previewCells,
   previewError,
   previewLoading,
@@ -37,6 +42,18 @@ export const AreaTargetingGrid = ({
   sessionId,
   onCellSelected,
 }: Props) => {
+  const affectedTargetNames = useMemo(
+    () =>
+      resolveAffectedTargetNames({
+        affectedTargetRefIds: previewAffectedTargetRefIds,
+        canRevealHiddenTargets,
+        participants,
+        tokens: mapState?.tokens ?? [],
+      }),
+    [canRevealHiddenTargets, mapState?.tokens, participants, previewAffectedTargetRefIds],
+  );
+  const affectedTargetText = formatAffectedTargetNames(affectedTargetNames);
+
   if (mapLoading) {
     return <p className="mt-4 text-sm text-slate-400">Carregando mapa...</p>;
   }
@@ -59,10 +76,13 @@ export const AreaTargetingGrid = ({
           {previewLoading
             ? "Atualizando preview..."
             : previewValid
-              ? `${previewAffectedCellCount} celulas · ${previewAffectedTargetCount} alvos`
+              ? `${previewAffectedCellCount} celulas · ${affectedTargetNames.length} alvos`
               : previewReason ?? "Sem preview"}
         </span>
       </div>
+      {!previewLoading && previewValid ? (
+        <p className="text-xs text-slate-300">{affectedTargetText}</p>
+      ) : null}
       <CombatMapFrame
         sessionId={sessionId}
         title="Mapa tatico"

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
@@ -22,8 +22,10 @@ import { useAreaTargeting } from "./useAreaTargeting";
 type Props = {
   actor: CombatParticipant;
   actorParticipantId: string;
+  canRevealHiddenTargets?: boolean;
   onClose: () => void;
   onResolved?: (result: CombatSpellResult) => void | Promise<void>;
+  participants: CombatParticipant[];
   sessionId: string;
   spell: CombatSpellOption;
   spellDamageType: string;
@@ -37,8 +39,10 @@ type Props = {
 export const PlayerSpellCastDialog = ({
   actor,
   actorParticipantId,
+  canRevealHiddenTargets = false,
   onClose,
   onResolved,
+  participants,
   sessionId,
   spell,
   spellDamageType,
@@ -315,12 +319,14 @@ export const PlayerSpellCastDialog = ({
           <AreaTargetingGrid
             actor={actor}
             anchorCell={anchorCell}
+            canRevealHiddenTargets={canRevealHiddenTargets}
             mapError={mapError}
             mapLoading={mapLoading}
             mapState={mapState}
             originCell={originCell}
+            participants={participants}
             previewAffectedCellCount={preview?.affected_cells.length ?? 0}
-            previewAffectedTargetCount={preview?.affected_target_ref_ids.length ?? 0}
+            previewAffectedTargetRefIds={preview?.affected_target_ref_ids ?? []}
             previewCells={preview?.affected_cells ?? []}
             previewError={previewError}
             previewLoading={previewLoading}

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/areaTargetingUi.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/areaTargetingUi.test.ts
@@ -3,8 +3,10 @@ import {
   buildAreaCastPayload,
   buildAreaPreviewPayload,
   createInitialTargetingMode,
+  formatAffectedTargetNames,
   getAnchorCombatantIdAtCell,
   isAreaShape,
+  resolveAffectedTargetNames,
   resolveActorOriginCell,
 } from "./areaTargetingUi";
 
@@ -20,6 +22,18 @@ const baseSpell = {
   savingThrow: "dexterity",
   availableSlotLevels: [3, 4, 5],
   targetType: "ranged" as const, areaShape: "sphere" as const,
+};
+
+const baseParticipant = {
+  id: "participant-1",
+  kind: "session_entity" as const,
+  ref_id: "enemy-1",
+  display_name: "Goblin A",
+  initiative: 12,
+  status: "active" as const,
+  team: "enemies" as const,
+  visible: true,
+  actor_user_id: null,
 };
 
 describe("areaTargetingUi", () => {
@@ -247,5 +261,119 @@ describe("preview affected cell/target count derivation", () => {
     });
     expect(counts.cellCount).toBe(0);
     expect(counts.targetCount).toBe(0);
+  });
+});
+
+describe("affected target preview names", () => {
+  it("maps visible affected target refs to token names", () => {
+    const names = resolveAffectedTargetNames({
+      affectedTargetRefIds: ["enemy-1", "enemy-2"],
+      participants: [
+        baseParticipant,
+        {
+          ...baseParticipant,
+          id: "participant-2",
+          ref_id: "enemy-2",
+          display_name: "Orc Brute",
+        },
+      ],
+      tokens: [
+        {
+          token_id: "token-1",
+          label: "Goblin A",
+          position: { x: 5, y: 5 },
+          combatant_id: "enemy-1",
+          controller_type: "session_entity",
+        },
+        {
+          token_id: "token-2",
+          label: "Orc Brute",
+          position: { x: 6, y: 5 },
+          combatant_id: "enemy-2",
+          controller_type: "session_entity",
+        },
+      ],
+    });
+
+    expect(names).toEqual(["Goblin A", "Orc Brute"]);
+    expect(formatAffectedTargetNames(names)).toBe("Afetados: Goblin A, Orc Brute");
+  });
+
+  it("formats empty target lists without crashing", () => {
+    expect(
+      resolveAffectedTargetNames({
+        affectedTargetRefIds: [],
+        participants: [baseParticipant],
+        tokens: [],
+      }),
+    ).toEqual([]);
+    expect(formatAffectedTargetNames([])).toBe("Nenhum alvo afetado");
+  });
+
+  it("uses a safe fallback for unresolved target refs", () => {
+    const names = resolveAffectedTargetNames({
+      affectedTargetRefIds: ["missing-ref"],
+      participants: [baseParticipant],
+      tokens: [],
+    });
+
+    expect(names).toEqual(["Alvo desconhecido"]);
+    expect(formatAffectedTargetNames(names)).toBe("Afetados: Alvo desconhecido");
+  });
+
+  it("does not reveal hidden participants to players", () => {
+    const names = resolveAffectedTargetNames({
+      affectedTargetRefIds: ["enemy-1", "hidden-enemy"],
+      participants: [
+        baseParticipant,
+        {
+          ...baseParticipant,
+          id: "participant-hidden",
+          ref_id: "hidden-enemy",
+          display_name: "Hidden Assassin",
+          visible: false,
+        },
+      ],
+      tokens: [
+        {
+          token_id: "token-hidden",
+          label: "Hidden Assassin",
+          position: { x: 7, y: 5 },
+          combatant_id: "hidden-enemy",
+          controller_type: "session_entity",
+        },
+      ],
+    });
+
+    expect(names).toEqual(["Goblin A"]);
+    expect(names).toHaveLength(1);
+    expect(formatAffectedTargetNames(names)).toBe("Afetados: Goblin A");
+  });
+
+  it("allows GM views to reveal hidden affected target names", () => {
+    const names = resolveAffectedTargetNames({
+      affectedTargetRefIds: ["hidden-enemy"],
+      canRevealHiddenTargets: true,
+      participants: [
+        {
+          ...baseParticipant,
+          id: "participant-hidden",
+          ref_id: "hidden-enemy",
+          display_name: "Hidden Assassin",
+          visible: false,
+        },
+      ],
+      tokens: [
+        {
+          token_id: "token-hidden",
+          label: "Hidden Assassin",
+          position: { x: 7, y: 5 },
+          combatant_id: "hidden-enemy",
+          controller_type: "session_entity",
+        },
+      ],
+    });
+
+    expect(names).toEqual(["Hidden Assassin"]);
   });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/areaTargetingUi.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/areaTargetingUi.ts
@@ -32,6 +32,47 @@ export const getAnchorCombatantIdAtCell = (
 ): string | null =>
   tokens.find((token) => token.position.x === anchorCell.x && token.position.y === anchorCell.y)?.combatant_id ?? null;
 
+type ResolveAffectedTargetNamesParams = {
+  affectedTargetRefIds: string[];
+  canRevealHiddenTargets?: boolean;
+  participants: CombatParticipant[];
+  tokens: CombatMapPreviewToken[];
+  unknownTargetLabel?: string;
+};
+
+export const resolveAffectedTargetNames = ({
+  affectedTargetRefIds,
+  canRevealHiddenTargets = false,
+  participants,
+  tokens,
+  unknownTargetLabel = "Alvo desconhecido",
+}: ResolveAffectedTargetNamesParams): string[] =>
+  affectedTargetRefIds.flatMap((targetRefId) => {
+    const participant = participants.find((candidate) => candidate.ref_id === targetRefId);
+    const mayRevealParticipant = Boolean(participant && (canRevealHiddenTargets || participant.visible !== false));
+
+    if (!participant) {
+      if (!canRevealHiddenTargets) {
+        return [unknownTargetLabel];
+      }
+      const tokenLabel = tokens.find((token) => token.combatant_id === targetRefId)?.label?.trim();
+      return [tokenLabel || unknownTargetLabel];
+    }
+
+    if (!mayRevealParticipant) {
+      return [];
+    }
+
+    const tokenLabel = tokens.find((token) => token.combatant_id === targetRefId)?.label?.trim();
+    const participantName = participant.display_name.trim();
+    return [tokenLabel || participantName || unknownTargetLabel];
+  });
+
+export const formatAffectedTargetNames = (
+  targetNames: string[],
+  emptyLabel = "Nenhum alvo afetado",
+): string => (targetNames.length > 0 ? `Afetados: ${targetNames.join(", ")}` : emptyLabel);
+
 type BuildAreaPayloadParams = {
   actorParticipantId: string;
   spell: CombatSpellOption;


### PR DESCRIPTION
## Summary

Closes #61

Shows affected target names in the AoE preview UI so players can confirm who will be hit before casting, while preserving `affected_target_ref_ids` for machine-readable behavior.

## Changes

- Resolve affected target refs against combat participants and map tokens in `areaTargetingUi`.
- Display a concise affected target list in `AreaTargetingGrid`.
- Show `Nenhum alvo afetado` for empty visible target lists.
- Use `Alvo desconhecido` for unresolved refs instead of crashing.
- Filter hidden participants out of player-facing names and counts.
- Keep a `canRevealHiddenTargets` escape hatch for GM-facing preview contexts.
- Pass combat participants into the spell cast dialog so preview labels can honor visibility.

## Visibility contract

- Player-facing target count and target names use the same filtered list.
- Hidden/unrevealed participants are not leaked through text or count.
- GM-facing contexts can opt in to revealing hidden names.

## Validation

- `npm test --workspace @limiar/control-web -- areaTargetingUi.test.ts areaSpellPreview.test.ts`
- `npm test --workspace @limiar/control-web`
- `npm run build --workspace @limiar/control-web`
- `uv run pytest tests/test_aoe_preview_contract.py` from `apps/control-server`
- `git diff --check`