### PR TITLE
feat: add support for active area effects in combat system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ Thumbs.db
 coverage/
 htmlcov/
 historico_commits.txt
+CLAUDE.md

--- a/apps/control-server/alembic/versions/0066_active_area_effects.py
+++ b/apps/control-server/alembic/versions/0066_active_area_effects.py
@@ -1,0 +1,35 @@
+"""Add persistent combat active area effects.
+
+Revision ID: 0066_active_area_effects
+Revises: 0065_spell_targeting_semantics
+Create Date: 2026-04-24 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0066_active_area_effects"
+down_revision: Union[str, None] = "0065_spell_targeting_semantics"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "combat_state",
+        sa.Column(
+            "active_area_effects",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default="[]",
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("combat_state", "active_area_effects")

--- a/apps/control-server/app/integrations/limiar_map_client.py
+++ b/apps/control-server/app/integrations/limiar_map_client.py
@@ -48,6 +48,16 @@ class LimiarMapClient:
         )
         return parse_state_response(data)
 
+    def sync_active_area_effects(
+        self, session_id: str, payload: dict[str, Any]
+    ) -> LimiarMapStateResponse:
+        data = self._request_json(
+            "PUT",
+            f"/integration/sessions/{session_id}/area-effects",
+            json_payload=payload,
+        )
+        return parse_state_response(data)
+
     def start_combat(
         self, session_id: str, payload: dict[str, Any]
     ) -> LimiarMapStateResponse:

--- a/apps/control-server/app/integrations/limiar_map_client_state_parser.py
+++ b/apps/control-server/app/integrations/limiar_map_client_state_parser.py
@@ -235,6 +235,7 @@ def parse_state_response(payload: dict[str, Any]) -> LimiarMapStateResponse:
     combat_state_payload = payload.get("combatState")
     battle_map_payload = payload.get("battleMap")
     obstacles_payload = payload.get("obstacles")
+    active_area_effects_payload = payload.get("activeAreaEffects")
 
     if not isinstance(session_id, str) or not session_id.strip():
         raise LimiarMapClientError(
@@ -259,6 +260,11 @@ def parse_state_response(payload: dict[str, Any]) -> LimiarMapStateResponse:
     if obstacles_payload is not None and not isinstance(obstacles_payload, list):
         raise LimiarMapClientError(
             "LimiarMap state response has invalid obstacles",
+            kind="payload",
+        )
+    if active_area_effects_payload is not None and not isinstance(active_area_effects_payload, list):
+        raise LimiarMapClientError(
+            "LimiarMap state response has invalid activeAreaEffects",
             kind="payload",
         )
 
@@ -296,6 +302,15 @@ def parse_state_response(payload: dict[str, Any]) -> LimiarMapStateResponse:
             )
         obstacles.append(_parse_obstacle_entry(obstacle_payload))
 
+    active_area_effects: list[dict[str, Any]] = []
+    for effect_payload in active_area_effects_payload or []:
+        if not isinstance(effect_payload, dict):
+            raise LimiarMapClientError(
+                "LimiarMap active area effect entry is invalid",
+                kind="payload",
+            )
+        active_area_effects.append(effect_payload)
+
     return LimiarMapStateResponse(
         session_id=session_id,
         version=version,
@@ -303,6 +318,7 @@ def parse_state_response(payload: dict[str, Any]) -> LimiarMapStateResponse:
         grid_width=grid_width,
         grid_height=grid_height,
         obstacles=tuple(obstacles),
+        active_area_effects=tuple(active_area_effects),
         active_combatant_id=active_combatant_id,
         round_number=round_number,
         turn_index=turn_index,

--- a/apps/control-server/app/integrations/limiar_map_client_types.py
+++ b/apps/control-server/app/integrations/limiar_map_client_types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -40,6 +41,7 @@ class LimiarMapStateResponse:
     grid_width: int | None = None
     grid_height: int | None = None
     obstacles: tuple[LimiarMapObstacleState, ...] = ()
+    active_area_effects: tuple[dict[str, Any], ...] = ()
     active_combatant_id: str | None = None
     round_number: int | None = None
     turn_index: int | None = None

--- a/apps/control-server/app/models/combat.py
+++ b/apps/control-server/app/models/combat.py
@@ -44,6 +44,10 @@ class CombatState(SQLModel, table=True):
         default_factory=dict,
         sa_column=Column(JSON, nullable=False, server_default="{}"),
     )
+    active_area_effects: list[dict] = Field(
+        default_factory=list,
+        sa_column=Column(JSONB, nullable=False, server_default="[]"),
+    )
     created_at: datetime = Field(
         sa_column=Column(DateTime(timezone=True), server_default=func.now())
     )

--- a/apps/control-server/app/schemas/combat.py
+++ b/apps/control-server/app/schemas/combat.py
@@ -37,6 +37,7 @@ from .combat_lifecycle import (
     CombatUpdateDistancesRequest,
 )
 from .combat_spells import (
+    CombatActiveAreaEffect,
     CombatAreaPreviewRequest,
     CombatAreaPreviewResponse,
     CombatAreaTargetOutcome,
@@ -65,6 +66,7 @@ __all__ = [
     "ActiveEffectDurationType",
     "ActiveEffectKind",
     "CombatActionCost",
+    "CombatActiveAreaEffect",
     "CombatApplyDamageRequest",
     "CombatApplyEffectRequest",
     "CombatApplyHealingRequest",

--- a/apps/control-server/app/schemas/combat_spells.py
+++ b/apps/control-server/app/schemas/combat_spells.py
@@ -115,6 +115,34 @@ class CombatMapPreviewObstacle(BaseModel):
     cover: str | None = None
 
 
+class CombatActiveAreaEffect(BaseModel):
+    id: str
+    source_spell_canonical_key: str | None = None
+    source_spell_name: str
+    caster_participant_id: str
+    caster_ref_id: str | None = None
+    caster_character_id: str | None = None
+    origin_point: CombatGridCell
+    anchor_cell: CombatGridCell
+    area_shape: Literal["sphere", "cone", "line", "cube", "cylinder"]
+    size_meters: float
+    radius_meters: float | None = None
+    length_meters: float | None = None
+    side_meters: float | None = None
+    affected_cells: list[CombatGridCell] = Field(default_factory=list)
+    effect_kind: str
+    duration: str | None = None
+    concentration_owner_participant_id: str | None = None
+    concentration_owner_ref_id: str | None = None
+    created_round: int | None = None
+    created_turn_index: int | None = None
+    obscurement: str | None = None
+    terrain_effect: str | None = None
+    movement_damage_dice: str | None = None
+    damage_type: str | None = None
+    damage_per_meters: float | None = None
+
+
 class CombatMapPreviewState(BaseModel):
     session_id: str
     version: int
@@ -122,6 +150,7 @@ class CombatMapPreviewState(BaseModel):
     grid_height: int
     tokens: list[CombatMapPreviewToken] = Field(default_factory=list)
     obstacles: list[CombatMapPreviewObstacle] = Field(default_factory=list)
+    active_area_effects: list[CombatActiveAreaEffect] = Field(default_factory=list)
 
 
 class CombatMapEnsureResponse(BaseModel):
@@ -216,6 +245,7 @@ class CombatSpellResult(BaseModel):
     affected_cells: list[CombatGridCell] = Field(default_factory=list)
     area_target_outcomes: list[CombatAreaTargetOutcome] = Field(default_factory=list)
     target_count: int = 0
+    active_area_effect: CombatActiveAreaEffect | None = None
     elemental_affinity_eligible: bool = False
     elemental_affinity_damage_type: str | None = None
     elemental_affinity_bonus: int | None = None

--- a/apps/control-server/app/services/combat_service/lifecycle_turns.py
+++ b/apps/control-server/app/services/combat_service/lifecycle_turns.py
@@ -101,6 +101,7 @@ class CombatLifecycleTurnsMixin:
         if not state:
             raise CombatServiceError("Combat not found", 404)
         state.phase = CombatPhase.ended
+        state.active_area_effects = []
         db.add(state)
         db.commit()
         db.refresh(state)

--- a/apps/control-server/app/services/combat_service/limiar_map_projection.py
+++ b/apps/control-server/app/services/combat_service/limiar_map_projection.py
@@ -24,6 +24,7 @@ from .limiar_map_projection_payloads import (
     _build_combatants_payload,
 )
 from .limiar_map_projection_sync import _sync_existing_map_turn
+from .persistent_area_effects import active_area_effects_for_map
 
 logger = logging.getLogger(__name__)
 
@@ -257,6 +258,21 @@ class LimiarMapCombatProjectionService:
         except LimiarMapClientError as exc:
             logger.warning("[conditions] sync failed session=%s participants=%d: %s", session_id, len(payload_tokens), exc)
 
+    def sync_active_area_effects_to_map(self, session_id: str, state: CombatState) -> None:
+        effects = active_area_effects_for_map(state)
+        try:
+            self._limiar_map_client.sync_active_area_effects(
+                session_id,
+                {"activeAreaEffects": effects},
+            )
+        except LimiarMapClientError as exc:
+            logger.warning(
+                "[area-effects] sync failed session=%s effects=%d: %s",
+                session_id,
+                len(effects),
+                exc,
+            )
+
     def project_combat_advance(self, session_id: str, state: CombatState) -> None:
         if state.phase not in (CombatPhase.active, "active"):
             return
@@ -361,3 +377,9 @@ def maybe_sync_conditions_to_limiar_map(session_id: str, state: CombatState) -> 
     if not settings.limiar_map_enabled or not state.use_map:
         return
     get_limiar_map_projection_service().sync_conditions_to_map(session_id, state)
+
+
+def maybe_sync_active_area_effects_to_limiar_map(session_id: str, state: CombatState) -> None:
+    if not settings.limiar_map_enabled or not state.use_map:
+        return
+    get_limiar_map_projection_service().sync_active_area_effects_to_map(session_id, state)

--- a/apps/control-server/app/services/combat_service/persistent_area_effects.py
+++ b/apps/control-server/app/services/combat_service/persistent_area_effects.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from app.models.combat import CombatState
+
+
+def _safe_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _metadata_for_spell(spell_context: dict[str, Any]) -> dict[str, Any]:
+    canonical_key = spell_context.get("spell_canonical_key")
+    if canonical_key == "fog_cloud":
+        return {
+            "effect_kind": "obscurement",
+            "obscurement": "heavily_obscured",
+        }
+    if canonical_key == "spike_growth":
+        return {
+            "effect_kind": "hazard",
+            "terrain_effect": "difficult_terrain",
+            "movement_damage_dice": "2d4",
+            "damage_type": "Piercing",
+            "damage_per_meters": 1.5,
+        }
+    return {"effect_kind": "spell_area"}
+
+
+def build_persistent_spell_area_effect(
+    *,
+    state: CombatState,
+    attacker: dict[str, Any],
+    spell_context: dict[str, Any],
+    area_spec: dict[str, Any],
+    targeting_result: Any,
+    origin_cell: dict[str, int] | None,
+    anchor_cell: dict[str, int] | None,
+) -> dict[str, Any]:
+    shape = str(area_spec["shape"])
+    size_meters = _safe_float(area_spec.get("size_meters")) or 0.0
+    origin = (
+        anchor_cell
+        if spell_context.get("origin_type") == "selected_point"
+        else origin_cell
+    ) or anchor_cell
+    anchor = anchor_cell or origin_cell
+    if origin is None or anchor is None:
+        raise ValueError("Persistent area effects require origin and anchor cells.")
+
+    effect: dict[str, Any] = {
+        "id": f"area_effect:{uuid4()}",
+        "source_spell_canonical_key": spell_context.get("spell_canonical_key"),
+        "source_spell_name": spell_context.get("spell_name") or "Spell area",
+        "caster_participant_id": attacker["id"],
+        "caster_ref_id": attacker.get("ref_id"),
+        "caster_character_id": attacker.get("actor_user_id") or attacker.get("ref_id"),
+        "origin_point": {"x": int(origin["x"]), "y": int(origin["y"])},
+        "anchor_cell": {"x": int(anchor["x"]), "y": int(anchor["y"])},
+        "area_shape": shape,
+        "size_meters": size_meters,
+        "radius_meters": _safe_float(spell_context.get("radius_meters")),
+        "length_meters": _safe_float(spell_context.get("length_meters")),
+        "side_meters": _safe_float(spell_context.get("side_meters")),
+        "affected_cells": list(targeting_result.spatial_metadata.affected_cells),
+        "duration": spell_context.get("duration"),
+        "concentration_owner_participant_id": attacker["id"]
+        if spell_context.get("concentration")
+        else None,
+        "concentration_owner_ref_id": attacker.get("ref_id")
+        if spell_context.get("concentration")
+        else None,
+        "created_round": state.round,
+        "created_turn_index": state.current_turn_index,
+    }
+    effect.update(_metadata_for_spell(spell_context))
+    return effect
+
+
+def active_area_effects_for_map(state: CombatState) -> list[dict[str, Any]]:
+    effects = state.active_area_effects if isinstance(state.active_area_effects, list) else []
+    return [
+        {
+            "id": effect["id"],
+            "sourceSpellCanonicalKey": effect.get("source_spell_canonical_key"),
+            "sourceSpellName": effect.get("source_spell_name") or "Spell area",
+            "casterParticipantId": effect.get("caster_participant_id"),
+            "casterRefId": effect.get("caster_ref_id"),
+            "casterCharacterId": effect.get("caster_character_id"),
+            "originPoint": effect.get("origin_point"),
+            "anchorCell": effect.get("anchor_cell"),
+            "areaShape": effect.get("area_shape"),
+            "sizeMeters": effect.get("size_meters"),
+            "radiusMeters": effect.get("radius_meters"),
+            "lengthMeters": effect.get("length_meters"),
+            "sideMeters": effect.get("side_meters"),
+            "affectedCells": effect.get("affected_cells") or [],
+            "effectKind": effect.get("effect_kind") or "spell_area",
+            "duration": effect.get("duration"),
+            "concentrationOwnerParticipantId": effect.get("concentration_owner_participant_id"),
+            "concentrationOwnerRefId": effect.get("concentration_owner_ref_id"),
+            "createdRound": effect.get("created_round"),
+            "createdTurnIndex": effect.get("created_turn_index"),
+            "obscurement": effect.get("obscurement"),
+            "terrainEffect": effect.get("terrain_effect"),
+            "movementDamageDice": effect.get("movement_damage_dice"),
+            "damageType": effect.get("damage_type"),
+            "damagePerMeters": effect.get("damage_per_meters"),
+        }
+        for effect in effects
+        if isinstance(effect, dict) and isinstance(effect.get("id"), str)
+    ]

--- a/apps/control-server/app/services/combat_service/spells/area_targeting.py
+++ b/apps/control-server/app/services/combat_service/spells/area_targeting.py
@@ -234,6 +234,7 @@ class AreaTargetingMixin:
                 }
                 for obstacle in map_state.obstacles
             ],
+            active_area_effects=list(state.active_area_effects or []),
         )
 
     @classmethod

--- a/apps/control-server/app/services/combat_service/spells/cast_area.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_area.py
@@ -13,6 +13,8 @@ from app.services.roll_resolution import resolve_saving_throw
 
 from ..combat_targeting import get_combat_targeting_service
 from ..exceptions import CombatServiceError
+from ..limiar_map_projection import maybe_sync_active_area_effects_to_limiar_map
+from ..persistent_area_effects import build_persistent_spell_area_effect
 from ..targeting_intent import AreaTargetingIntent
 
 
@@ -328,9 +330,30 @@ class CastAreaMixin:
             db.add(attacker_model)
             slot_spent = True
 
+        active_area_effect: dict[str, Any] | None = None
+        if spell_context.get("effect_timing") == "persistent":
+            try:
+                active_area_effect = build_persistent_spell_area_effect(
+                    state=state,
+                    attacker=attacker,
+                    spell_context=spell_context,
+                    area_spec=area_spec,
+                    targeting_result=targeting_result,
+                    origin_cell=req.origin_cell.model_dump() if req.origin_cell is not None else None,
+                    anchor_cell=req.anchor_cell.model_dump() if req.anchor_cell is not None else None,
+                )
+            except ValueError as exc:
+                raise CombatServiceError(str(exc), 400) from exc
+            state.active_area_effects = [
+                *(state.active_area_effects or []),
+                active_area_effect,
+            ]
+
         db.add(state)
         db.commit()
         db.refresh(state)
+        if active_area_effect is not None:
+            maybe_sync_active_area_effects_to_limiar_map(session_id, state)
 
         if slot_spent:
             target_state, *_ = cls._get_stats(db, attacker["ref_id"], "player", session_id)
@@ -389,6 +412,7 @@ class CastAreaMixin:
             "affected_cells": affected_cells,
             "area_target_outcomes": [],
             "target_count": len(affected_target_ref_ids),
+            "active_area_effect": active_area_effect,
             "elemental_affinity_eligible": bool(spell_context.get("elemental_affinity_eligible")),
             "elemental_affinity_damage_type": spell_context.get("elemental_affinity_damage_type"),
             "elemental_affinity_bonus": spell_context.get("elemental_affinity_bonus"),

--- a/apps/control-server/app/services/combat_service/spells/spell_context_resolve.py
+++ b/apps/control-server/app/services/combat_service/spells/spell_context_resolve.py
@@ -276,6 +276,8 @@ class SpellContextResolveMixin:
             "radius_meters": getattr(catalog_spell, "radius_meters", None),
             "length_meters": getattr(catalog_spell, "length_meters", None),
             "side_meters": getattr(catalog_spell, "side_meters", None),
+            "duration": getattr(catalog_spell, "duration", None),
+            "concentration": getattr(catalog_spell, "concentration", None),
             "requires_target_sight": resolved_mode["targeting_requirements"].requires_target_sight,
             "requires_target_effect": resolved_mode["targeting_requirements"].requires_target_effect,
             "requires_point_sight": resolved_mode["targeting_requirements"].requires_point_sight,

--- a/apps/control-server/tests/test_persistent_area_effects.py
+++ b/apps/control-server/tests/test_persistent_area_effects.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from _combat_test_shared import TestCombatServiceBase
+from app.models.combat import CombatPhase
+from app.models.session_state import SessionState
+from app.schemas.combat import CombatCastSpellRequest, CombatGridCell
+from app.services.combat import CombatService
+from app.services.combat_service.targeting_result import SpatialMetadata, TargetingResult
+
+
+class PersistentAreaEffectCastTests(TestCombatServiceBase):
+    def setUp(self):
+        super().setUp()
+        self.state.phase = CombatPhase.active
+        self.state.current_turn_index = 0
+        self.attacker = self.state.participants[0]
+        self.attacker_model = SessionState(
+            id="state-player",
+            session_id="session-123",
+            player_user_id="player-123",
+            state_json={
+                "spellcasting": {
+                    "slots": {"1": {"used": 0, "max": 2}, "2": {"used": 0, "max": 2}},
+                },
+            },
+        )
+
+    def _targeting_result(self, *, shape: str = "sphere") -> TargetingResult:
+        return TargetingResult(
+            is_valid=True,
+            validated_primary_target_ref_id="",
+            affected_target_ref_ids=[],
+            target_kind="",
+            spatial_metadata=SpatialMetadata(
+                affected_cells=[{"x": 10, "y": 10}, {"x": 10, "y": 9}],
+                affected_token_ids=[],
+                area_shape=shape,
+                map_version=12,
+                targeting_authority="limiar_map",
+            ),
+        )
+
+    def _spell_context(self, canonical_key: str, **overrides):
+        base = {
+            "spell_name": "Fog Cloud" if canonical_key == "fog_cloud" else "Spike Growth",
+            "spell_canonical_key": canonical_key,
+            "spell_mode": "utility",
+            "effect_kind": None,
+            "effect_timing": "persistent",
+            "origin_type": "selected_point",
+            "target_anchor": "selected_point",
+            "selection_type": "point",
+            "attack_type": "none",
+            "range_kind": "distance",
+            "area_shape": "sphere",
+            "range_meters": 36,
+            "radius_meters": 6,
+            "length_meters": None,
+            "side_meters": None,
+            "duration": "Up to 1 hour",
+            "concentration": True,
+            "action_cost": "action",
+            "source_kind": "prepared_spell",
+            "slot_level": 1,
+            "damage_type": None,
+            "effect_dice": None,
+            "effect_bonus": 0,
+            "save_ability": None,
+            "save_dc": None,
+            "save_success_outcome": None,
+            "elemental_affinity_eligible": False,
+            "elemental_affinity_damage_type": None,
+            "elemental_affinity_bonus": None,
+        }
+        base.update(overrides)
+        return base
+
+    async def _cast_persistent_area(self, canonical_key: str, **context_overrides):
+        targeting_result = self._targeting_result()
+        with patch(
+            "app.services.combat_service.spells.cast_area.get_combat_targeting_service",
+            return_value=SimpleNamespace(validate=MagicMock(return_value=targeting_result)),
+        ), patch(
+            "app.services.combat_service.spells.cast_area.maybe_sync_active_area_effects_to_limiar_map",
+        ) as mock_sync, patch(
+            "app.services.combat.CombatService._emit_state",
+            new_callable=AsyncMock,
+        ), patch(
+            "app.services.combat.CombatService._emit_log",
+            new_callable=AsyncMock,
+        ), patch(
+            "app.services.combat.CombatService._emit_player_state_update",
+            new_callable=AsyncMock,
+        ), patch(
+            "app.services.combat.CombatService._get_stats",
+            return_value=(self.attacker_model, 10, 10, 10, 2, 3),
+        ):
+            result = await CombatService._cast_area_spell(
+                self.db,
+                "session-123",
+                CombatCastSpellRequest(
+                    actor_participant_id="p1",
+                    origin_cell=CombatGridCell(x=8, y=8),
+                    anchor_cell=CombatGridCell(x=10, y=10),
+                    spell_canonical_key=canonical_key,
+                    slot_level=1,
+                ),
+                attacker=self.attacker,
+                attacker_model=self.attacker_model,
+                actor_user_id="user-1",
+                is_gm=False,
+                state=self.state,
+                spell_context=self._spell_context(canonical_key, **context_overrides),
+                area_spec={"shape": "sphere", "size_meters": 6, "range_meters": 36},
+            )
+        return result, mock_sync
+
+    async def test_fog_cloud_creates_obscurement_area_effect(self):
+        result, mock_sync = await self._cast_persistent_area("fog_cloud")
+
+        self.assertEqual(len(self.state.active_area_effects), 1)
+        effect = self.state.active_area_effects[0]
+        self.assertEqual(effect["source_spell_canonical_key"], "fog_cloud")
+        self.assertEqual(effect["effect_kind"], "obscurement")
+        self.assertEqual(effect["obscurement"], "heavily_obscured")
+        self.assertEqual(effect["area_shape"], "sphere")
+        self.assertEqual(effect["radius_meters"], 6.0)
+        self.assertEqual(effect["origin_point"], {"x": 10, "y": 10})
+        self.assertEqual(effect["anchor_cell"], {"x": 10, "y": 10})
+        self.assertEqual(effect["concentration_owner_participant_id"], "p1")
+        self.assertEqual(result["active_area_effect"]["id"], effect["id"])
+        mock_sync.assert_called_once_with("session-123", self.state)
+
+    async def test_spike_growth_creates_hazard_area_effect(self):
+        await self._cast_persistent_area(
+            "spike_growth",
+            spell_name="Spike Growth",
+            duration="Up to 10 minutes",
+            slot_level=2,
+            range_meters=45,
+        )
+
+        effect = self.state.active_area_effects[0]
+        self.assertEqual(effect["source_spell_canonical_key"], "spike_growth")
+        self.assertEqual(effect["effect_kind"], "hazard")
+        self.assertEqual(effect["terrain_effect"], "difficult_terrain")
+        self.assertEqual(effect["movement_damage_dice"], "2d4")
+        self.assertEqual(effect["damage_type"], "Piercing")
+        self.assertEqual(effect["damage_per_meters"], 1.5)
+
+    async def test_triggered_area_spell_does_not_create_persistent_overlay(self):
+        result, mock_sync = await self._cast_persistent_area(
+            "hail_of_thorns",
+            spell_name="Hail of Thorns",
+            effect_timing="triggered",
+            origin_type="caster",
+            target_anchor="trigger_target",
+            selection_type="none",
+            range_kind="self",
+        )
+
+        self.assertEqual(self.state.active_area_effects, [])
+        self.assertIsNone(result["active_area_effect"])
+        mock_sync.assert_not_called()

--- a/apps/control-web/src/features/combat-ui/gm/GmCombatModeShell.tsx
+++ b/apps/control-web/src/features/combat-ui/gm/GmCombatModeShell.tsx
@@ -12,7 +12,7 @@ import { GmPendingReactionsPanel } from "./GmPendingReactionsPanel";
 import { GmPendingSavesPanel } from "./GmPendingSavesPanel";
 import { GmQuickActionsPanel } from "./GmQuickActionsPanel";
 import { useGmCombatShell } from "./useGmCombatShell";
-import { CombatMapFrame } from "../map/CombatMapFrame";
+import { CombatMapFrame, toCombatMapFrameAreaEffects } from "../map/CombatMapFrame";
 import { GmDistancesPanel } from "./GmDistancesPanel";
 import {
   formatMovementMeters,
@@ -197,6 +197,7 @@ export const GmCombatModeShell = ({
             actor={{ actorId: "gm-control", actorType: "gm" }}
             selectionMode={mapSelectionMode}
             previewCells={[]}
+            activeAreaEffects={toCombatMapFrameAreaEffects(shell.combat.state?.active_area_effects)}
             selectedCell={movementEnabled ? movementSelectedCell : null}
             selectedTargetRefId={
               movementEnabled ? null : shell.selectedTargetRefId || null

--- a/apps/control-web/src/features/combat-ui/map/CombatMapFrame.tsx
+++ b/apps/control-web/src/features/combat-ui/map/CombatMapFrame.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { combatRepo } from "../../../shared/api/combatRepo";
+import { combatRepo, type CombatActiveAreaEffect } from "../../../shared/api/combatRepo";
 
 export type CombatMapSelectionMode = "none" | "select-token" | "select-cell";
 
@@ -12,6 +12,65 @@ type MapActorContext = {
   actorId: string;
   actorType: "player" | "gm";
 };
+
+export type CombatMapFrameActiveAreaEffect = {
+  id: string;
+  sourceSpellCanonicalKey?: string | null;
+  sourceSpellName: string;
+  casterParticipantId: string;
+  casterRefId?: string | null;
+  casterCharacterId?: string | null;
+  originPoint: Coordinate;
+  anchorCell: Coordinate;
+  areaShape: "sphere" | "cone" | "line" | "cube" | "cylinder";
+  sizeMeters: number;
+  radiusMeters?: number | null;
+  lengthMeters?: number | null;
+  sideMeters?: number | null;
+  affectedCells: Coordinate[];
+  effectKind: string;
+  duration?: string | null;
+  concentrationOwnerParticipantId?: string | null;
+  concentrationOwnerRefId?: string | null;
+  createdRound?: number | null;
+  createdTurnIndex?: number | null;
+  obscurement?: string | null;
+  terrainEffect?: string | null;
+  movementDamageDice?: string | null;
+  damageType?: string | null;
+  damagePerMeters?: number | null;
+};
+
+export const toCombatMapFrameAreaEffects = (
+  effects?: CombatActiveAreaEffect[] | null,
+): CombatMapFrameActiveAreaEffect[] =>
+  (effects ?? []).map((effect) => ({
+    id: effect.id,
+    sourceSpellCanonicalKey: effect.source_spell_canonical_key,
+    sourceSpellName: effect.source_spell_name,
+    casterParticipantId: effect.caster_participant_id,
+    casterRefId: effect.caster_ref_id,
+    casterCharacterId: effect.caster_character_id,
+    originPoint: effect.origin_point,
+    anchorCell: effect.anchor_cell,
+    areaShape: effect.area_shape,
+    sizeMeters: effect.size_meters,
+    radiusMeters: effect.radius_meters,
+    lengthMeters: effect.length_meters,
+    sideMeters: effect.side_meters,
+    affectedCells: effect.affected_cells ?? [],
+    effectKind: effect.effect_kind,
+    duration: effect.duration,
+    concentrationOwnerParticipantId: effect.concentration_owner_participant_id,
+    concentrationOwnerRefId: effect.concentration_owner_ref_id,
+    createdRound: effect.created_round,
+    createdTurnIndex: effect.created_turn_index,
+    obscurement: effect.obscurement,
+    terrainEffect: effect.terrain_effect,
+    movementDamageDice: effect.movement_damage_dice,
+    damageType: effect.damage_type,
+    damagePerMeters: effect.damage_per_meters,
+  }));
 
 export type CombatMapTokenSelection = {
   tokenId: string;
@@ -34,6 +93,7 @@ type Props = {
   actor?: MapActorContext | null;
   selectionMode?: CombatMapSelectionMode;
   previewCells?: Coordinate[];
+  activeAreaEffects?: CombatMapFrameActiveAreaEffect[];
   selectedCell?: Coordinate | null;
   selectedTargetRefId?: string | null;
   className?: string;
@@ -93,6 +153,7 @@ export const CombatMapFrame = ({
   actor = null,
   selectionMode = "none",
   previewCells = [],
+  activeAreaEffects = [],
   selectedCell = null,
   selectedTargetRefId = null,
   className,
@@ -125,6 +186,7 @@ export const CombatMapFrame = ({
           actor,
           selectionMode,
           previewCells,
+          activeAreaEffects,
           selectedCell,
           selectedTargetRefId,
           combatPhase,
@@ -291,6 +353,7 @@ export const CombatMapFrame = ({
     frameLoaded,
     mapReady,
     previewCells,
+    activeAreaEffects,
     selectedCell,
     selectedTargetRefId,
     selectionMode,

--- a/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
+++ b/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
@@ -28,7 +28,7 @@ import type {
 } from "../../../pages/PlayerBoardPage/playerBoard.types";
 import { usePlayerCombatMode } from "./usePlayerCombatMode";
 import { PlayerTurnPanel } from "./PlayerTurnPanel";
-import { CombatMapFrame } from "../map/CombatMapFrame";
+import { CombatMapFrame, toCombatMapFrameAreaEffects } from "../map/CombatMapFrame";
 import {
   formatMovementMeters,
   getMovementPreviewReasonLabel,
@@ -317,6 +317,7 @@ export const PlayerCombatModeShell = ({
           actor={userId ? { actorId: userId, actorType: "player" } : null}
           selectionMode={mapSelectionMode}
           previewCells={[]}
+          activeAreaEffects={toCombatMapFrameAreaEffects(combat.state?.active_area_effects)}
           selectedCell={movementEnabled ? movementSelectedCell : null}
           selectedTargetRefId={movementEnabled ? null : (targetId || null)}
           frameClassName="h-[420px] w-full border-0 bg-slate-950 md:h-[560px] xl:h-[720px]"

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/AreaTargetingGrid.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/AreaTargetingGrid.tsx
@@ -1,5 +1,8 @@
 import { useMemo } from "react";
-import { CombatMapFrame } from "../../../features/combat-ui/map/CombatMapFrame";
+import {
+  CombatMapFrame,
+  toCombatMapFrameAreaEffects,
+} from "../../../features/combat-ui/map/CombatMapFrame";
 import type { CombatMapPreviewState, CombatParticipant } from "../../../shared/api/combatRepo";
 import { formatAffectedTargetNames, resolveAffectedTargetNames, type GridCell } from "./areaTargetingUi";
 
@@ -97,6 +100,7 @@ export const AreaTargetingGrid = ({
         }}
         selectionMode="select-cell"
         previewCells={previewCells}
+        activeAreaEffects={toCombatMapFrameAreaEffects(mapState.active_area_effects)}
         selectedCell={anchorCell}
         className="rounded-2xl border border-white/10 bg-slate-950/70 p-3"
         frameClassName="h-[420px] w-full border-0 bg-slate-950"

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/areaSpellPreview.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/areaSpellPreview.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { combatRepo } from "../../../shared/api/combatRepo";
 import { http } from "../../../shared/api/http";
+import { toCombatMapFrameAreaEffects } from "../../../features/combat-ui/map/CombatMapFrame";
 import { buildAreaCastPayload, buildAreaPreviewPayload } from "./areaTargetingUi";
 
 vi.mock("../../../shared/api/http", () => ({
@@ -143,6 +144,39 @@ describe("area targeting confirmation gate", () => {
 
   it("blocks when anchor is cleared after a valid preview", () => {
     expect(canSubmitArea(null, { x: 1, y: 1 }, { is_valid: true })).toBe(false);
+  });
+});
+
+describe("persistent area overlays", () => {
+  it("maps Control active area effects to embedded map overlay payloads", () => {
+    const effects = toCombatMapFrameAreaEffects([
+      {
+        id: "area_effect:1",
+        source_spell_canonical_key: "fog_cloud",
+        source_spell_name: "Fog Cloud",
+        caster_participant_id: "p1",
+        caster_ref_id: "player-1",
+        origin_point: { x: 10, y: 10 },
+        anchor_cell: { x: 10, y: 10 },
+        area_shape: "sphere",
+        size_meters: 6,
+        radius_meters: 6,
+        affected_cells: [{ x: 10, y: 10 }],
+        effect_kind: "obscurement",
+        obscurement: "heavily_obscured",
+      },
+    ]);
+
+    expect(effects).toEqual([
+      expect.objectContaining({
+        id: "area_effect:1",
+        sourceSpellCanonicalKey: "fog_cloud",
+        sourceSpellName: "Fog Cloud",
+        anchorCell: { x: 10, y: 10 },
+        affectedCells: [{ x: 10, y: 10 }],
+        effectKind: "obscurement",
+      }),
+    ]);
   });
 });
 

--- a/apps/control-web/src/shared/api/combatRepo.ts
+++ b/apps/control-web/src/shared/api/combatRepo.ts
@@ -121,6 +121,7 @@ export type CombatState = {
   participants: CombatParticipant[];
   use_map: boolean;
   local_distances: Record<string, Record<string, number>>;
+  active_area_effects?: CombatActiveAreaEffect[];
   created_at: string;
   updated_at?: string | null;
 };
@@ -306,6 +307,34 @@ export type CombatMapPreviewObstacle = {
   cover?: string | null;
 };
 
+export type CombatActiveAreaEffect = {
+  id: string;
+  source_spell_canonical_key?: string | null;
+  source_spell_name: string;
+  caster_participant_id: string;
+  caster_ref_id?: string | null;
+  caster_character_id?: string | null;
+  origin_point: { x: number; y: number };
+  anchor_cell: { x: number; y: number };
+  area_shape: "sphere" | "cone" | "line" | "cube" | "cylinder";
+  size_meters: number;
+  radius_meters?: number | null;
+  length_meters?: number | null;
+  side_meters?: number | null;
+  affected_cells: Array<{ x: number; y: number }>;
+  effect_kind: "obscurement" | "hazard" | "spell_area" | string;
+  duration?: string | null;
+  concentration_owner_participant_id?: string | null;
+  concentration_owner_ref_id?: string | null;
+  created_round?: number | null;
+  created_turn_index?: number | null;
+  obscurement?: string | null;
+  terrain_effect?: string | null;
+  movement_damage_dice?: string | null;
+  damage_type?: string | null;
+  damage_per_meters?: number | null;
+};
+
 export type CombatMapPreviewState = {
   session_id: string;
   version: number;
@@ -313,6 +342,7 @@ export type CombatMapPreviewState = {
   grid_height: number;
   tokens: CombatMapPreviewToken[];
   obstacles: CombatMapPreviewObstacle[];
+  active_area_effects?: CombatActiveAreaEffect[];
 };
 
 export type CombatMapEnsureResponse = {

--- a/apps/map-server/src/modules/encounters/encounter-repository.ts
+++ b/apps/map-server/src/modules/encounters/encounter-repository.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type {
+  ActiveAreaEffect,
   BattleMap,
   CombatState,
   Coordinate,
@@ -17,6 +18,7 @@ export interface EncounterState {
   tokens: Token[];
   obstacles: Obstacle[];
   edgeObstacles: EdgeObstacle[];
+  activeAreaEffects: ActiveAreaEffect[];
   combatState: CombatState;
   actionTracker: ActionIdempotencyTracker;
 }
@@ -125,6 +127,7 @@ function createDemoEncounter(
     tokens,
     obstacles,
     edgeObstacles: [], // Phase 10: Initialize empty edge obstacles for backward compatibility
+    activeAreaEffects: [],
     combatState,
     actionTracker: new ActionIdempotencyTracker()
   };
@@ -230,6 +233,12 @@ export class InMemoryEncounterRepository {
   setEdgeObstacles(sessionId: string, edgeObstacles: EdgeObstacle[]): EncounterState {
     const encounter = this.requireEncounter(sessionId);
     encounter.edgeObstacles = edgeObstacles;
+    return this.saveEncounter(encounter);
+  }
+
+  setActiveAreaEffects(sessionId: string, activeAreaEffects: ActiveAreaEffect[]): EncounterState {
+    const encounter = this.requireEncounter(sessionId);
+    encounter.activeAreaEffects = activeAreaEffects;
     return this.saveEncounter(encounter);
   }
 

--- a/apps/map-server/src/modules/encounters/encounter-snapshot.ts
+++ b/apps/map-server/src/modules/encounters/encounter-snapshot.ts
@@ -13,7 +13,8 @@ export function toEncounterSnapshot(
     combatState: encounter.combatState,
     tokens: encounter.tokens,
     obstacles: encounter.obstacles,
-    edgeObstacles: encounter.edgeObstacles
+    edgeObstacles: encounter.edgeObstacles,
+    activeAreaEffects: encounter.activeAreaEffects
   };
 }
 
@@ -32,6 +33,7 @@ export function toIntegrationSnapshot(
     combatState: encounter.combatState,
     tokens: encounter.tokens,
     obstacles: encounter.obstacles,
-    edgeObstacles: encounter.edgeObstacles
+    edgeObstacles: encounter.edgeObstacles,
+    activeAreaEffects: encounter.activeAreaEffects
   };
 }

--- a/apps/map-server/src/routes/integration/state.routes.ts
+++ b/apps/map-server/src/routes/integration/state.routes.ts
@@ -14,6 +14,7 @@ import {
   advanceTurnRequestSchema,
   endCombatRequestSchema,
   setInitiativeRequestSchema,
+  syncActiveAreaEffectsRequestSchema,
   singleTargetRequestSchema,
   startCombatRequestSchema,
   syncTokensRequestSchema
@@ -309,7 +310,28 @@ export function registerStateRoutes(app: FastifyInstance, repository: InMemoryEn
       return reply.status(200).send(toIntegrationSnapshot(encounter));
     }
 
-    return reply.status(200).send(toIntegrationSnapshot(result.encounter));
+    const nextEncounter = repository.setActiveAreaEffects(sessionId, []);
+    return reply.status(200).send(toIntegrationSnapshot(nextEncounter));
+  });
+
+  app.put("/integration/sessions/:sessionId/area-effects", async (request, reply) => {
+    const { sessionId } = request.params as { sessionId: string };
+    const encounter = repository.getEncounter(sessionId);
+    if (!encounter) {
+      return err(reply, 404, "session_not_found", "Session not found");
+    }
+
+    const parse = syncActiveAreaEffectsRequestSchema.safeParse(request.body);
+    if (!parse.success) {
+      return reply.status(400).send({ message: "Invalid request body", errors: parse.error.errors });
+    }
+
+    const updated = repository.setActiveAreaEffects(sessionId, parse.data.activeAreaEffects);
+    request.log.info(
+      { sessionId, activeAreaEffects: parse.data.activeAreaEffects.length },
+      `${LOG_PREFIX} PUT area-effects`
+    );
+    return reply.status(200).send(toIntegrationSnapshot(updated));
   });
 
 }

--- a/apps/map-server/tests/contract/combat.contract.test.ts
+++ b/apps/map-server/tests/contract/combat.contract.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { combatAdvanceRequestSchema, combatAdvancedEventSchema } from "@limiarmap/shared-contracts";
+import {
+  combatAdvanceRequestSchema,
+  combatAdvancedEventSchema,
+  syncActiveAreaEffectsRequestSchema,
+} from "@limiarmap/shared-contracts";
 
 describe("combat contract", () => {
   it("accepts combat advance requests", () => {
@@ -23,6 +27,30 @@ describe("combat contract", () => {
         actionId: "a",
         payload: { roundNumber: 2, turnIndex: 1, activeCombatantId: "cmb_2" },
         replaySafe: true
+      })
+    ).not.toThrow();
+  });
+
+  it("accepts active area effect sync requests", () => {
+    expect(() =>
+      syncActiveAreaEffectsRequestSchema.parse({
+        activeAreaEffects: [
+          {
+            id: "area_effect:1",
+            sourceSpellCanonicalKey: "fog_cloud",
+            sourceSpellName: "Fog Cloud",
+            casterParticipantId: "p1",
+            casterRefId: "player-123",
+            originPoint: { x: 10, y: 10 },
+            anchorCell: { x: 10, y: 10 },
+            areaShape: "sphere",
+            sizeMeters: 6,
+            radiusMeters: 6,
+            affectedCells: [{ x: 10, y: 10 }],
+            effectKind: "obscurement",
+            obscurement: "heavily_obscured",
+          },
+        ],
       })
     ).not.toThrow();
   });

--- a/apps/map-server/tests/integration/active-area-effects.integration.test.ts
+++ b/apps/map-server/tests/integration/active-area-effects.integration.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { createApp } from "../../src/app";
+import { registerIntegrationRoutes } from "../../src/routes/integration-routes";
+
+describe("active area effects integration", () => {
+  it("stores synced persistent spell area effects and returns them in state", async () => {
+    const { app, repository } = createApp();
+    registerIntegrationRoutes(app, repository);
+    repository.ensureEncounter("session-123");
+
+    const response = await app.inject({
+      method: "PUT",
+      url: "/integration/sessions/session-123/area-effects",
+      payload: {
+        activeAreaEffects: [
+          {
+            id: "area_effect:1",
+            sourceSpellCanonicalKey: "spike_growth",
+            sourceSpellName: "Spike Growth",
+            casterParticipantId: "p1",
+            casterRefId: "player-123",
+            originPoint: { x: 12, y: 12 },
+            anchorCell: { x: 12, y: 12 },
+            areaShape: "sphere",
+            sizeMeters: 6,
+            radiusMeters: 6,
+            affectedCells: [{ x: 12, y: 12 }],
+            effectKind: "hazard",
+            terrainEffect: "difficult_terrain",
+            movementDamageDice: "2d4",
+            damageType: "Piercing",
+            damagePerMeters: 1.5,
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().activeAreaEffects).toHaveLength(1);
+    expect(response.json().activeAreaEffects[0]).toMatchObject({
+      sourceSpellCanonicalKey: "spike_growth",
+      effectKind: "hazard",
+      terrainEffect: "difficult_terrain",
+    });
+
+    const stateResponse = await app.inject({
+      method: "GET",
+      url: "/integration/sessions/session-123/state",
+    });
+    expect(stateResponse.json().activeAreaEffects).toHaveLength(1);
+
+    await app.close();
+  });
+
+  it("clears active area effects when combat ends", async () => {
+    const { app, repository } = createApp();
+    registerIntegrationRoutes(app, repository);
+    repository.ensureEncounter("session-123");
+    repository.setActiveAreaEffects("session-123", [
+      {
+        id: "area_effect:1",
+        sourceSpellCanonicalKey: "fog_cloud",
+        sourceSpellName: "Fog Cloud",
+        casterParticipantId: "p1",
+        originPoint: { x: 10, y: 10 },
+        anchorCell: { x: 10, y: 10 },
+        areaShape: "sphere",
+        sizeMeters: 6,
+        radiusMeters: 6,
+        affectedCells: [{ x: 10, y: 10 }],
+        effectKind: "obscurement",
+        obscurement: "heavily_obscured",
+      },
+    ]);
+
+    await app.inject({
+      method: "POST",
+      url: "/integration/sessions/session-123/combat/start",
+      payload: {
+        actionId: "start-1",
+        combatants: [{ combatantId: "player-123", initiativeScore: 18 }],
+      },
+    });
+    const response = await app.inject({
+      method: "POST",
+      url: "/integration/sessions/session-123/combat/end",
+      payload: { actionId: "end-1" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().activeAreaEffects).toEqual([]);
+
+    await app.close();
+  });
+});

--- a/apps/map-web/src/features/battle-map/battle-map-pixi-runtime.ts
+++ b/apps/map-web/src/features/battle-map/battle-map-pixi-runtime.ts
@@ -224,7 +224,7 @@ export function buildDrawFunction(
       drawReachAndAoe(refs.reachAoeGfxRef.current, calibration, gridWidth, gridHeight, screen.width, screen.height, uiState.tacticalPreview.reachableCells, uiState.tacticalPreview.aoeCells);
     }
     if (refs.cellFillsGfxRef.current) {
-      drawCellFills(refs.cellFillsGfxRef.current, calibration, gridWidth, gridHeight, screen.width, screen.height, encounter.obstacles, uiState.movementPreview, uiState.targetingPreview, uiState.embeddedPreview, uiState.embeddedSelectedCell ?? null);
+      drawCellFills(refs.cellFillsGfxRef.current, calibration, gridWidth, gridHeight, screen.width, screen.height, encounter.obstacles, uiState.movementPreview, uiState.targetingPreview, uiState.embeddedPreview, [...(encounter.activeAreaEffects ?? []), ...uiState.embeddedActiveAreaEffects], uiState.embeddedSelectedCell ?? null);
     }
     if (refs.edgeObstaclesGfxRef.current) drawEdgeObstacles(refs.edgeObstaclesGfxRef.current, calibration, gridWidth, gridHeight, screen.width, screen.height, encounter.edgeObstacles ?? []);
     if (refs.tokenContainerRef.current) drawTokenLayer(refs.tokenContainerRef.current, encounter.tokens, calibration, gridWidth, gridHeight, screen.width, screen.height, selectedTokenId, uiState.embeddedSelectedTargetRefId ?? null, encounter.combatState.activeCombatantId);

--- a/apps/map-web/src/features/battle-map/battle-map-store.ts
+++ b/apps/map-web/src/features/battle-map/battle-map-store.ts
@@ -1,5 +1,6 @@
 import type {
   Coordinate,
+  ActiveAreaEffect,
   EncounterSnapshotResponse,
   GridCalibration,
   ObstaclePaintMode,
@@ -37,6 +38,7 @@ class BattleMapStore {
     targetingPreview: [],
     embeddedSelectionMode: "none",
     embeddedPreview: [],
+    embeddedActiveAreaEffects: [],
     isGridEditMode: false,
     isObstaclePaintMode: false,
     obstacleBrushRadius: 1,
@@ -102,6 +104,7 @@ class BattleMapStore {
   setEmbeddedInteractionContext(ctx: {
     selectionMode: EmbeddedSelectionMode;
     previewCells: Coordinate[];
+    activeAreaEffects?: ActiveAreaEffect[];
     selectedCell?: Coordinate | null;
     selectedTargetRefId?: string | null;
     combatPhase?: EmbeddedCombatPhase | null;
@@ -109,6 +112,7 @@ class BattleMapStore {
     this.set({
       embeddedSelectionMode: ctx.selectionMode,
       embeddedPreview: ctx.previewCells,
+      embeddedActiveAreaEffects: ctx.activeAreaEffects ?? [],
       embeddedSelectedCell: ctx.selectedCell ?? undefined,
       embeddedSelectedTargetRefId: ctx.selectedTargetRefId ?? undefined,
       embeddedCombatPhase: ctx.combatPhase ?? undefined
@@ -118,7 +122,7 @@ class BattleMapStore {
   setEmbeddedSelectedCell(c?: Coordinate | null): void { this.set({ embeddedSelectedCell: c ?? undefined }); }
 
   clearEmbeddedInteraction(): void {
-    this.set({ embeddedSelectionMode: "none", embeddedPreview: [], embeddedSelectedCell: undefined, embeddedSelectedTargetRefId: undefined, embeddedCombatPhase: undefined });
+    this.set({ embeddedSelectionMode: "none", embeddedPreview: [], embeddedActiveAreaEffects: [], embeddedSelectedCell: undefined, embeddedSelectedTargetRefId: undefined, embeddedCombatPhase: undefined });
   }
 
   setTokenMovementRejection(rejection: TokenMovementRejectionState): void {

--- a/apps/map-web/src/features/battle-map/battle-map-store.types.ts
+++ b/apps/map-web/src/features/battle-map/battle-map-store.types.ts
@@ -1,5 +1,6 @@
 import type {
   Coordinate,
+  ActiveAreaEffect,
   GridCalibration,
   ObstaclePaintMode,
   EdgeDirection
@@ -43,6 +44,7 @@ export interface BattleMapUIState {
   targetingPreview: Coordinate[];
   embeddedSelectionMode: EmbeddedSelectionMode;
   embeddedPreview: Coordinate[];
+  embeddedActiveAreaEffects: ActiveAreaEffect[];
   embeddedSelectedCell?: Coordinate;
   embeddedSelectedTargetRefId?: string;
   embeddedCombatPhase?: EmbeddedCombatPhase;

--- a/apps/map-web/src/features/battle-map/canvas-renderers-grid.ts
+++ b/apps/map-web/src/features/battle-map/canvas-renderers-grid.ts
@@ -1,6 +1,7 @@
 import { Graphics } from "pixi.js";
 import type {
   Coordinate,
+  ActiveAreaEffect,
   EdgeDirection,
   GridCalibration,
   Obstacle,
@@ -65,6 +66,7 @@ export function drawCellFills(
   movementPreview: Coordinate[],
   targetingPreview: Coordinate[],
   embeddedPreview: Coordinate[],
+  embeddedActiveAreaEffects: ActiveAreaEffect[],
   embeddedSelectedCell: Coordinate | null
 ): void {
   gfx.clear();
@@ -73,6 +75,12 @@ export function drawCellFills(
   const movementSet = new Set(movementPreview.map(coordKey));
   const targetingSet = new Set(
     [...targetingPreview, ...embeddedPreview].map(coordKey)
+  );
+  const activeAreaCells = embeddedActiveAreaEffects.flatMap((effect) =>
+    effect.affectedCells.map((cell) => ({
+      cell,
+      effectKind: effect.effectKind,
+    }))
   );
 
   for (const [key, obs] of obstacleCellMap) {
@@ -142,6 +150,28 @@ export function drawCellFills(
     gfx
       .rect(x, y, w, h)
       .fill({ color: C.movPreview, alpha: C.movPreviewAlpha });
+  }
+
+  for (const entry of activeAreaCells) {
+    const coordHash = coordKey(entry.cell);
+    if (obstacleCellMap.has(coordHash) || movementSet.has(coordHash)) continue;
+    const { x, y, w, h } = cellRect(
+      entry.cell.x,
+      entry.cell.y,
+      cal,
+      gridW,
+      gridH,
+      canvasW,
+      canvasH
+    );
+    const isHazard = entry.effectKind === "hazard";
+    const color = isHazard ? 0xdc2626 : 0x94a3b8;
+    gfx.rect(x, y, w, h).fill({ color, alpha: isHazard ? 0.22 : 0.2 });
+    gfx.rect(x + 2, y + 2, w - 4, h - 4).stroke({
+      width: 1.2,
+      color: isHazard ? 0xfca5a5 : 0xe2e8f0,
+      alpha: 0.65,
+    });
   }
 
   if (embeddedSelectedCell) {

--- a/apps/map-web/src/services/embedded-map-bridge.test.ts
+++ b/apps/map-web/src/services/embedded-map-bridge.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { battleMapStore } from "../features/battle-map/battle-map-store";
+import { applyEmbeddedMapContext, isEmbeddedMapContextMessage } from "./embedded-map-bridge";
+
+vi.mock("./centrifugo-client", () => ({
+  reconnectAs: vi.fn(),
+}));
+
+describe("embedded map area effects", () => {
+  it("accepts active area effects in embedded map context messages", () => {
+    const message = {
+      type: "limiar-control:map-context",
+      payload: {
+        sessionId: "session-123",
+        selectionMode: "none",
+        previewCells: [],
+        activeAreaEffects: [
+          {
+            id: "area_effect:1",
+            sourceSpellName: "Fog Cloud",
+            casterParticipantId: "p1",
+            originPoint: { x: 10, y: 10 },
+            anchorCell: { x: 10, y: 10 },
+            areaShape: "sphere",
+            sizeMeters: 6,
+            affectedCells: [{ x: 10, y: 10 }],
+            effectKind: "obscurement",
+          },
+        ],
+      },
+    };
+
+    expect(isEmbeddedMapContextMessage(message)).toBe(true);
+  });
+
+  it("stores active area effects separately from preview cells", () => {
+    battleMapStore.clearEmbeddedInteraction();
+
+    applyEmbeddedMapContext({
+      sessionId: "session-123",
+      selectionMode: "select-cell",
+      previewCells: [{ x: 1, y: 1 }],
+      activeAreaEffects: [
+        {
+          id: "area_effect:1",
+          sourceSpellCanonicalKey: "spike_growth",
+          sourceSpellName: "Spike Growth",
+          casterParticipantId: "p1",
+          originPoint: { x: 10, y: 10 },
+          anchorCell: { x: 10, y: 10 },
+          areaShape: "sphere",
+          sizeMeters: 6,
+          radiusMeters: 6,
+          affectedCells: [{ x: 10, y: 10 }],
+          effectKind: "hazard",
+          terrainEffect: "difficult_terrain",
+        },
+      ],
+    });
+
+    const state = battleMapStore.getState();
+    expect(state.embeddedPreview).toEqual([{ x: 1, y: 1 }]);
+    expect(state.embeddedActiveAreaEffects).toHaveLength(1);
+    expect(state.embeddedActiveAreaEffects[0]?.sourceSpellName).toBe("Spike Growth");
+  });
+});

--- a/apps/map-web/src/services/embedded-map-bridge.ts
+++ b/apps/map-web/src/services/embedded-map-bridge.ts
@@ -1,4 +1,4 @@
-import type { Coordinate, Token } from "@limiarmap/shared-contracts";
+import type { ActiveAreaEffect, Coordinate, Token } from "@limiarmap/shared-contracts";
 import { reconnectAs } from "./centrifugo-client";
 import {
   battleMapStore,
@@ -18,6 +18,7 @@ type EmbeddedMapContextMessage = {
     } | null;
     selectionMode?: EmbeddedSelectionMode;
     previewCells?: Coordinate[];
+    activeAreaEffects?: ActiveAreaEffect[];
     selectedCell?: Coordinate | null;
     selectedTargetRefId?: string | null;
     combatPhase?: EmbeddedCombatPhase | null;
@@ -86,6 +87,7 @@ export const isEmbeddedMapContextMessage = (
     actor?: { actorId?: unknown; actorType?: unknown } | null;
     selectionMode?: unknown;
     previewCells?: unknown;
+    activeAreaEffects?: unknown;
     selectedCell?: unknown;
     selectedTargetRefId?: unknown;
     combatPhase?: unknown;
@@ -103,6 +105,27 @@ export const isEmbeddedMapContextMessage = (
   const previewCellsValid =
     payload.previewCells == null ||
     (Array.isArray(payload.previewCells) && payload.previewCells.every(isCoordinate));
+  const activeAreaEffectsValid =
+    payload.activeAreaEffects == null ||
+    (Array.isArray(payload.activeAreaEffects) &&
+      payload.activeAreaEffects.every((effect) => {
+        if (!effect || typeof effect !== "object") return false;
+        const candidate = effect as {
+          id?: unknown;
+          sourceSpellName?: unknown;
+          anchorCell?: unknown;
+          areaShape?: unknown;
+          affectedCells?: unknown;
+        };
+        return (
+          typeof candidate.id === "string" &&
+          typeof candidate.sourceSpellName === "string" &&
+          isCoordinate(candidate.anchorCell) &&
+          typeof candidate.areaShape === "string" &&
+          Array.isArray(candidate.affectedCells) &&
+          candidate.affectedCells.every(isCoordinate)
+        );
+      }));
   const selectedCellValid =
     payload.selectedCell == null || isCoordinate(payload.selectedCell);
   const selectedTargetValid =
@@ -119,6 +142,7 @@ export const isEmbeddedMapContextMessage = (
     actorValid &&
     selectionModeValid &&
     previewCellsValid &&
+    activeAreaEffectsValid &&
     selectedCellValid &&
     selectedTargetValid &&
     combatPhaseValid
@@ -133,6 +157,7 @@ export function applyEmbeddedMapContext(message: EmbeddedMapContextMessage["payl
   battleMapStore.setEmbeddedInteractionContext({
     selectionMode: message.selectionMode ?? "none",
     previewCells: message.previewCells ?? [],
+    activeAreaEffects: message.activeAreaEffects ?? [],
     selectedCell: message.selectedCell ?? null,
     selectedTargetRefId: message.selectedTargetRefId ?? null,
     combatPhase: message.combatPhase ?? null,

--- a/packages/shared-contracts/src/domain.js
+++ b/packages/shared-contracts/src/domain.js
@@ -29,6 +29,7 @@ export const combatStatusSchema = z.enum(["inactive", "active", "completed"]);
 export const targetingShapeSchema = z.enum(["line", "cone", "sphere", "cube", "cylinder"]);
 export const obstacleCoverSchema = z.enum(["none", "half", "threeQuarters", "full"]);
 export const obstaclePaintModeSchema = z.enum(["paint", "erase"]);
+export const activeAreaEffectKindSchema = z.enum(["obscurement", "hazard", "spell_area"]);
 export const battleMapSchema = z.object({
     id: z.string(),
     name: z.string(),
@@ -127,6 +128,33 @@ export const targetingTemplateSchema = z.object({
     affectedCells: z.array(coordinateSchema).default([]),
     result: actionResultSchema.default("pending"),
     rejectionReason: z.string().optional()
+});
+export const activeAreaEffectSchema = z.object({
+    id: z.string(),
+    sourceSpellCanonicalKey: z.string().nullable().optional(),
+    sourceSpellName: z.string(),
+    casterParticipantId: z.string(),
+    casterRefId: z.string().nullable().optional(),
+    casterCharacterId: z.string().nullable().optional(),
+    originPoint: coordinateSchema,
+    anchorCell: coordinateSchema,
+    areaShape: targetingShapeSchema,
+    sizeMeters: z.number().positive(),
+    radiusMeters: z.number().positive().nullable().optional(),
+    lengthMeters: z.number().positive().nullable().optional(),
+    sideMeters: z.number().positive().nullable().optional(),
+    affectedCells: z.array(coordinateSchema).default([]),
+    effectKind: activeAreaEffectKindSchema,
+    duration: z.string().nullable().optional(),
+    concentrationOwnerParticipantId: z.string().nullable().optional(),
+    concentrationOwnerRefId: z.string().nullable().optional(),
+    createdRound: z.number().int().nonnegative().nullable().optional(),
+    createdTurnIndex: z.number().int().nonnegative().nullable().optional(),
+    obscurement: z.string().nullable().optional(),
+    terrainEffect: z.string().nullable().optional(),
+    movementDamageDice: z.string().nullable().optional(),
+    damageType: z.string().nullable().optional(),
+    damagePerMeters: z.number().positive().nullable().optional()
 });
 export const realtimeActionEventSchema = z.object({
     eventId: z.string(),

--- a/packages/shared-contracts/src/domain.ts
+++ b/packages/shared-contracts/src/domain.ts
@@ -42,6 +42,7 @@ export const combatStatusSchema = z.enum(["inactive", "active", "completed"]);
 export const targetingShapeSchema = z.enum(["line", "cone", "sphere", "cube", "cylinder"]);
 export const obstacleCoverSchema = z.enum(["none", "half", "threeQuarters", "full"]);
 export const obstaclePaintModeSchema = z.enum(["paint", "erase"]);
+export const activeAreaEffectKindSchema = z.enum(["obscurement", "hazard", "spell_area"]);
 
 /**
  * Phase 10: Edge obstacle direction.
@@ -210,6 +211,34 @@ export const targetingTemplateSchema = z.object({
   rejectionReason: z.string().optional()
 });
 
+export const activeAreaEffectSchema = z.object({
+  id: z.string(),
+  sourceSpellCanonicalKey: z.string().nullable().optional(),
+  sourceSpellName: z.string(),
+  casterParticipantId: z.string(),
+  casterRefId: z.string().nullable().optional(),
+  casterCharacterId: z.string().nullable().optional(),
+  originPoint: coordinateSchema,
+  anchorCell: coordinateSchema,
+  areaShape: targetingShapeSchema,
+  sizeMeters: z.number().positive(),
+  radiusMeters: z.number().positive().nullable().optional(),
+  lengthMeters: z.number().positive().nullable().optional(),
+  sideMeters: z.number().positive().nullable().optional(),
+  affectedCells: z.array(coordinateSchema).default([]),
+  effectKind: activeAreaEffectKindSchema,
+  duration: z.string().nullable().optional(),
+  concentrationOwnerParticipantId: z.string().nullable().optional(),
+  concentrationOwnerRefId: z.string().nullable().optional(),
+  createdRound: z.number().int().nonnegative().nullable().optional(),
+  createdTurnIndex: z.number().int().nonnegative().nullable().optional(),
+  obscurement: z.string().nullable().optional(),
+  terrainEffect: z.string().nullable().optional(),
+  movementDamageDice: z.string().nullable().optional(),
+  damageType: z.string().nullable().optional(),
+  damagePerMeters: z.number().positive().nullable().optional()
+});
+
 export const realtimeActionEventSchema = z.object({
   eventId: z.string(),
   eventType: z.string(),
@@ -226,6 +255,7 @@ export type GridDimensions = z.infer<typeof gridDimensionsSchema>;
 export type ControllerType = z.infer<typeof controllerTypeSchema>;
 export type ObstacleCover = z.infer<typeof obstacleCoverSchema>;
 export type ObstaclePaintMode = z.infer<typeof obstaclePaintModeSchema>;
+export type ActiveAreaEffectKind = z.infer<typeof activeAreaEffectKindSchema>;
 export type EdgeDirection = z.infer<typeof edgeDirectionSchema>;
 export type BattleMap = z.infer<typeof battleMapSchema>;
 export type ObstacleStyle = z.infer<typeof obstacleStyleSchema>;
@@ -235,4 +265,5 @@ export type Token = z.infer<typeof tokenSchema>;
 export type CombatState = z.infer<typeof combatStateSchema>;
 export type MovementAction = z.infer<typeof movementActionSchema>;
 export type TargetingTemplate = z.infer<typeof targetingTemplateSchema>;
+export type ActiveAreaEffect = z.infer<typeof activeAreaEffectSchema>;
 export type RealtimeActionEvent = z.infer<typeof realtimeActionEventSchema>;

--- a/packages/shared-contracts/src/http.js
+++ b/packages/shared-contracts/src/http.js
@@ -1,11 +1,13 @@
 import { z } from "zod";
-import { battleMapSchema, combatStateSchema, obstacleSchema, tokenSchema } from "./domain";
+import { activeAreaEffectSchema, battleMapSchema, combatStateSchema, edgeObstacleSchema, obstacleSchema, tokenSchema } from "./domain";
 export const encounterSnapshotResponseSchema = z.object({
     sessionId: z.string(),
     battleMap: battleMapSchema,
     combatState: combatStateSchema,
     tokens: z.array(tokenSchema),
-    obstacles: z.array(obstacleSchema)
+    obstacles: z.array(obstacleSchema),
+    edgeObstacles: z.array(edgeObstacleSchema).default([]),
+    activeAreaEffects: z.array(activeAreaEffectSchema).default([])
 });
 export const resyncRequestSchema = z.object({
     lastKnownVersion: z.number().int().nonnegative(),

--- a/packages/shared-contracts/src/http.ts
+++ b/packages/shared-contracts/src/http.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import {
   battleMapSchema,
+  activeAreaEffectSchema,
   combatStateSchema,
   edgeObstacleSchema,
   obstacleSchema,
@@ -13,7 +14,8 @@ export const encounterSnapshotResponseSchema = z.object({
   combatState: combatStateSchema,
   tokens: z.array(tokenSchema),
   obstacles: z.array(obstacleSchema),
-  edgeObstacles: z.array(edgeObstacleSchema).default([])
+  edgeObstacles: z.array(edgeObstacleSchema).default([]),
+  activeAreaEffects: z.array(activeAreaEffectSchema).default([])
 });
 
 export const resyncRequestSchema = z.object({

--- a/packages/shared-contracts/src/integration.combat.ts
+++ b/packages/shared-contracts/src/integration.combat.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import {
   battleMapSchema,
+  activeAreaEffectSchema,
   combatStateSchema,
   coordinateSchema,
   controllerTypeSchema,
@@ -87,6 +88,10 @@ export const syncTokensRequestSchema = z.object({
   tokens: z.array(tokenSyncEntrySchema).min(1),
 });
 
+export const syncActiveAreaEffectsRequestSchema = z.object({
+  activeAreaEffects: z.array(activeAreaEffectSchema),
+});
+
 export const integrationStateResponseSchema = z.object({
   sessionId: z.string(),
   version: z.number().int().nonnegative(),
@@ -95,6 +100,7 @@ export const integrationStateResponseSchema = z.object({
   tokens: z.array(tokenSchema),
   obstacles: z.array(obstacleSchema),
   edgeObstacles: z.array(edgeObstacleSchema).default([]),
+  activeAreaEffects: z.array(activeAreaEffectSchema).default([]),
 });
 
 export const movementPreviewRequestSchema = z.object({
@@ -127,6 +133,7 @@ export type AdvanceTurnRequest = z.infer<typeof advanceTurnRequestSchema>;
 export type EndCombatRequest = z.infer<typeof endCombatRequestSchema>;
 export type TokenSyncEntry = z.infer<typeof tokenSyncEntrySchema>;
 export type SyncTokensRequest = z.infer<typeof syncTokensRequestSchema>;
+export type SyncActiveAreaEffectsRequest = z.infer<typeof syncActiveAreaEffectsRequestSchema>;
 export type IntegrationStateResponse = z.infer<typeof integrationStateResponseSchema>;
 export type MovementPreviewRequest = z.infer<typeof movementPreviewRequestSchema>;
 export type MovementPreviewResponse = z.infer<typeof movementPreviewResponseSchema>;

--- a/packages/shared-contracts/src/integration.js
+++ b/packages/shared-contracts/src/integration.js
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import {
     battleMapSchema,
+    activeAreaEffectSchema,
     combatStateSchema,
     coordinateSchema,
     controllerTypeSchema,
@@ -72,6 +73,9 @@ export const tokenSyncEntrySchema = z.object({
 export const syncTokensRequestSchema = z.object({
     tokens: z.array(tokenSyncEntrySchema).min(1)
 });
+export const syncActiveAreaEffectsRequestSchema = z.object({
+    activeAreaEffects: z.array(activeAreaEffectSchema)
+});
 export const singleTargetRequestSchema = z.object({
     actionId: z.string(),
     combatantId: z.string(),
@@ -99,7 +103,8 @@ export const integrationStateResponseSchema = z.object({
     combatState: combatStateSchema,
     tokens: z.array(tokenSchema),
     obstacles: z.array(obstacleSchema),
-    edgeObstacles: z.array(edgeObstacleSchema).default([])
+    edgeObstacles: z.array(edgeObstacleSchema).default([]),
+    activeAreaEffects: z.array(activeAreaEffectSchema).default([])
 });
 export const singleTargetResponseSchema = z.object({
     isValid: z.boolean(),


### PR DESCRIPTION
## Summary

Implements persistent spell area effects for map-backed combat.

Persistent area spells now create active combat/map effects that remain visible after cast confirmation and are synchronized to the tactical map separately from temporary AoE previews.

## What Changed

- Added migration `0066_active_area_effects`.
- Added `active_area_effects` to `CombatState`.
- Updated persistent area spell casts to create active effects for:
  - Fog Cloud
  - Spike Growth
- Preserved immediate spell behavior:
  - Fireball and other immediate AoEs do not create persistent overlays.
- Returned active area effects in combat state responses.
- Included active area effects in map preview state.
- Added synchronization to LimiarMap through:
  - `/integration/sessions/:sessionId/area-effects`
- Updated combat end cleanup to clear active area effects.
- Updated Control Web iframe messaging to send confirmed overlays separately from `previewCells`.
- Updated Map Web rendering for persistent overlays with a distinct visual style from previews.
- Updated Map Server storage/return flow for `activeAreaEffects`.

## Behavior

- Casting Fog Cloud creates a persistent active area overlay.
- Casting Spike Growth creates a persistent active area overlay.
- Persistent overlays remain visible after cast confirmation.
- Temporary AoE preview cells remain separate from confirmed persistent area effects.
- Immediate AoE spells such as Fireball continue resolving without persistent overlays.
- Ending combat clears active area effects.

## Validation

- `uv run pytest` in `apps/control-server`: 1292 passed, 1 skipped
- `npm test`: 88 passed, 768 tests
- `npm run build:map`: passed
- `npm run build:control`: passed
- `npm run lint`: passed
- `git diff --check`: clean

Note: `ruff` was not available in the local environment, so that check was not run.