### PR TITLE
Apply Spike Growth as difficult terrain for movement

### DIFF
--- a/apps/map-server/src/modules/encounters/movement-service.ts
+++ b/apps/map-server/src/modules/encounters/movement-service.ts
@@ -32,7 +32,8 @@ export class MovementService {
       map: encounter.battleMap,
       obstacles: encounter.obstacles,
       edgeObstacles: encounter.edgeObstacles,
-      tokens: encounter.tokens
+      tokens: encounter.tokens,
+      activeAreaEffects: encounter.activeAreaEffects
     };
     const preview = findMovementPath(
       gridState,
@@ -229,7 +230,8 @@ export class MovementService {
       map: encounter.battleMap,
       obstacles: encounter.obstacles,
       edgeObstacles: encounter.edgeObstacles,
-      tokens: encounter.tokens
+      tokens: encounter.tokens,
+      activeAreaEffects: encounter.activeAreaEffects
     };
     const validation = validateMovement(
       gridState,

--- a/apps/map-server/tests/integration/movement-preview.integration.test.ts
+++ b/apps/map-server/tests/integration/movement-preview.integration.test.ts
@@ -103,6 +103,137 @@ describe("integration movement preview", () => {
     await app.close();
   });
 
+  it("treats Spike Growth active area effects as difficult terrain in preview", async () => {
+    const { app, repository } = createApp();
+    registerIntegrationRoutes(app, repository);
+
+    await app.inject({
+      method: "POST",
+      url: "/integration/sessions/session-spike/combat/start",
+      payload: {
+        actionId: "start-spike-1",
+        combatants: [{ combatantId: "cmb_1", initiativeScore: 20 }],
+        battleMap: BASE_BATTLE_MAP
+      }
+    });
+    await app.inject({
+      method: "PUT",
+      url: "/integration/sessions/session-spike/tokens",
+      payload: { tokens: [{ tokenId: "tok_player", combatantId: "cmb_1" }] }
+    });
+
+    // Token starts at (4,4); Spike Growth covers (5,4) and (6,4).
+    await app.inject({
+      method: "PUT",
+      url: "/integration/sessions/session-spike/area-effects",
+      payload: {
+        activeAreaEffects: [
+          {
+            id: "aae_spike",
+            sourceSpellCanonicalKey: "spike_growth",
+            sourceSpellName: "Spike Growth",
+            casterParticipantId: "caster",
+            originPoint: { x: 5, y: 4 },
+            anchorCell: { x: 5, y: 4 },
+            areaShape: "sphere",
+            sizeMeters: 6,
+            affectedCells: [
+              { x: 5, y: 4 },
+              { x: 6, y: 4 }
+            ],
+            effectKind: "hazard",
+            terrainEffect: "difficult_terrain",
+            movementDamageDice: "2d4",
+            damageType: "Piercing",
+            damagePerMeters: 1.5
+          }
+        ]
+      }
+    });
+
+    // Straight path through Spike Growth: (4,4)→(5,4) costs 10, (5,4)→(6,4) costs 10. Total 20.
+    const through = await app.inject({
+      method: "POST",
+      url: "/integration/sessions/session-spike/movement/preview",
+      payload: {
+        actionId: "preview-spike-through",
+        combatantId: "cmb_1",
+        destinationCell: { x: 6, y: 4 }
+      }
+    });
+    expect(through.statusCode).toBe(200);
+    expect(through.json()).toMatchObject({
+      isValid: true,
+      pathCostUnits: 20,
+      remainingBudget: 10
+    });
+
+    await app.close();
+  });
+
+  it("does not let Fog Cloud (obscurement) modify movement cost", async () => {
+    const { app, repository } = createApp();
+    registerIntegrationRoutes(app, repository);
+
+    await app.inject({
+      method: "POST",
+      url: "/integration/sessions/session-fog/combat/start",
+      payload: {
+        actionId: "start-fog-1",
+        combatants: [{ combatantId: "cmb_1", initiativeScore: 20 }],
+        battleMap: BASE_BATTLE_MAP
+      }
+    });
+    await app.inject({
+      method: "PUT",
+      url: "/integration/sessions/session-fog/tokens",
+      payload: { tokens: [{ tokenId: "tok_player", combatantId: "cmb_1" }] }
+    });
+
+    await app.inject({
+      method: "PUT",
+      url: "/integration/sessions/session-fog/area-effects",
+      payload: {
+        activeAreaEffects: [
+          {
+            id: "aae_fog",
+            sourceSpellCanonicalKey: "fog_cloud",
+            sourceSpellName: "Fog Cloud",
+            casterParticipantId: "caster",
+            originPoint: { x: 5, y: 4 },
+            anchorCell: { x: 5, y: 4 },
+            areaShape: "sphere",
+            sizeMeters: 6,
+            affectedCells: [
+              { x: 5, y: 4 },
+              { x: 6, y: 4 }
+            ],
+            effectKind: "obscurement",
+            obscurement: "heavy"
+          }
+        ]
+      }
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/integration/sessions/session-fog/movement/preview",
+      payload: {
+        actionId: "preview-fog-1",
+        combatantId: "cmb_1",
+        destinationCell: { x: 6, y: 4 }
+      }
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      isValid: true,
+      pathCostUnits: 10,
+      remainingBudget: 20
+    });
+
+    await app.close();
+  });
+
   it("rejects initial placement onto occupied, blocked, or out-of-bounds cells", async () => {
     const { app, repository } = createApp();
     registerIntegrationRoutes(app, repository);

--- a/apps/map-web/src/features/battle-map/use-battle-map-pixi.ts
+++ b/apps/map-web/src/features/battle-map/use-battle-map-pixi.ts
@@ -5,9 +5,19 @@ import type { BattleMapUIState } from "./battle-map-store";
 import type { GridEditInteraction } from "./types";
 import { battleMapStore } from "./battle-map-store";
 import { DEFAULT_MAP_IMAGE_URL, C } from "./constants";
-import { applyGridCalibrationInteraction, canControlToken, canInteractWithToken } from "./utils";
+import {
+  applyGridCalibrationInteraction,
+  canControlToken,
+  canInteractWithToken
+} from "./utils";
 import { findReachableCells } from "@limiarmap/tactical-engine";
-import { attachPixiLayers, bindPixiStageEvents, buildDrawFunction, resetPixiRefs, type BattleMapPixiRefs } from "./battle-map-pixi-runtime";
+import {
+  attachPixiLayers,
+  bindPixiStageEvents,
+  buildDrawFunction,
+  resetPixiRefs,
+  type BattleMapPixiRefs
+} from "./battle-map-pixi-runtime";
 
 type CurrentActor = { actorId: string; actorType: "player" | "gm" };
 
@@ -18,10 +28,21 @@ export function useBattleMapPixi(params: {
   selectedTokenId: string | null;
   setSelectedTokenId: React.Dispatch<React.SetStateAction<string | null>>;
   selectedToken: EncounterSnapshotResponse["tokens"][number] | null;
-}): { containerRef: React.RefObject<HTMLDivElement | null>; imageAspectRatio: number } {
-  const { encounter, currentActor, uiState, selectedTokenId, setSelectedTokenId, selectedToken } = params;
+}): {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  imageAspectRatio: number;
+} {
+  const {
+    encounter,
+    currentActor,
+    uiState,
+    selectedTokenId,
+    setSelectedTokenId,
+    selectedToken
+  } = params;
   const [imageAspectRatio, setImageAspectRatio] = useState(16 / 9);
-  const [gridEditInteraction, setGridEditInteraction] = useState<GridEditInteraction | null>(null);
+  const [gridEditInteraction, setGridEditInteraction] =
+    useState<GridEditInteraction | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const previewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const drawRef = useRef<(() => void) | null>(null);
@@ -37,7 +58,7 @@ export function useBattleMapPixi(params: {
     tokenContainerRef: useRef<Container | null>(null),
     tacticalOverlayContainerRef: useRef<Container | null>(null),
     editHandlesContainerRef: useRef<Container | null>(null),
-    hudContainerRef: useRef<Container | null>(null),
+    hudContainerRef: useRef<Container | null>(null)
   };
 
   useEffect(() => {
@@ -50,11 +71,23 @@ export function useBattleMapPixi(params: {
       if (!containerRef.current) return;
       const app = new Application();
       try {
-        await app.init({ resizeTo: containerRef.current, background: C.bg, preference: "webgl", antialias: true, autoDensity: true, resolution: window.devicePixelRatio ?? 1 });
+        await app.init({
+          resizeTo: containerRef.current,
+          background: C.bg,
+          preference: "webgl",
+          antialias: true,
+          autoDensity: true,
+          resolution: window.devicePixelRatio ?? 1
+        });
       } catch (error) {
         if (!cancelled) {
-          console.error("[map-web] failed to initialize Pixi application", error);
-          battleMapStore.setMessage("Nao foi possivel inicializar o renderer tatico do mapa.");
+          console.error(
+            "[map-web] failed to initialize Pixi application",
+            error
+          );
+          battleMapStore.setMessage(
+            "Nao foi possivel inicializar o renderer tatico do mapa."
+          );
         }
         app.destroy(true);
         return;
@@ -66,7 +99,13 @@ export function useBattleMapPixi(params: {
       refs.appRef.current = app;
       containerRef.current.appendChild(app.canvas);
       attachPixiLayers(app, refs);
-      bindPixiStageEvents(app, cbRef, previewTimerRef, setSelectedTokenId, setGridEditInteraction);
+      bindPixiStageEvents(
+        app,
+        cbRef,
+        previewTimerRef,
+        setSelectedTokenId,
+        setGridEditInteraction
+      );
       drawRef.current = buildDrawFunction(refs, cbRef, setGridEditInteraction);
       app.renderer.on("resize", () => {
         if (refs.bgSpriteRef.current) {
@@ -77,8 +116,12 @@ export function useBattleMapPixi(params: {
         drawRef.current?.();
       });
       drawRef.current();
-      const initialBgUrl = cbRef.current.encounter?.battleMap.imageUrl ?? DEFAULT_MAP_IMAGE_URL;
-      if (refs.bgSpriteRef.current && refs.backgroundUrlRef.current !== initialBgUrl) {
+      const initialBgUrl =
+        cbRef.current.encounter?.battleMap.imageUrl ?? DEFAULT_MAP_IMAGE_URL;
+      if (
+        refs.bgSpriteRef.current &&
+        refs.backgroundUrlRef.current !== initialBgUrl
+      ) {
         const img = new Image();
         img.decoding = "async";
         img.onload = () => {
@@ -89,13 +132,19 @@ export function useBattleMapPixi(params: {
             const ratio = img.naturalWidth / img.naturalHeight;
             setImageAspectRatio(ratio);
             battleMapStore.setMapImageAspectRatio(ratio);
-            battleMapStore.setMapImageNaturalSize(img.naturalWidth, img.naturalHeight);
+            battleMapStore.setMapImageNaturalSize(
+              img.naturalWidth,
+              img.naturalHeight
+            );
           }
           battleMapStore.setMessage(undefined);
           drawRef.current?.();
         };
         img.onerror = () => {
-          if (!cancelled) battleMapStore.setMessage("Nao foi possivel carregar o background do mapa.");
+          if (!cancelled)
+            battleMapStore.setMessage(
+              "Nao foi possivel carregar o background do mapa."
+            );
         };
         img.src = initialBgUrl;
       }
@@ -105,7 +154,8 @@ export function useBattleMapPixi(params: {
       cancelled = true;
       drawRef.current = null;
       if (previewTimerRef.current) clearTimeout(previewTimerRef.current);
-      if (refs.appRef.current) refs.appRef.current.destroy(true, { children: true });
+      if (refs.appRef.current)
+        refs.appRef.current.destroy(true, { children: true });
       resetPixiRefs(refs);
     };
   }, []);
@@ -115,8 +165,13 @@ export function useBattleMapPixi(params: {
   }, [encounter, uiState, selectedTokenId]);
 
   useEffect(() => {
-    const nextBackgroundUrl = encounter?.battleMap.imageUrl ?? DEFAULT_MAP_IMAGE_URL;
-    if (!refs.bgSpriteRef.current || refs.backgroundUrlRef.current === nextBackgroundUrl) return;
+    const nextBackgroundUrl =
+      encounter?.battleMap.imageUrl ?? DEFAULT_MAP_IMAGE_URL;
+    if (
+      !refs.bgSpriteRef.current ||
+      refs.backgroundUrlRef.current === nextBackgroundUrl
+    )
+      return;
     let cancelled = false;
     const image = new Image();
     image.decoding = "async";
@@ -128,13 +183,19 @@ export function useBattleMapPixi(params: {
         const ratio = image.naturalWidth / image.naturalHeight;
         setImageAspectRatio(ratio);
         battleMapStore.setMapImageAspectRatio(ratio);
-        battleMapStore.setMapImageNaturalSize(image.naturalWidth, image.naturalHeight);
+        battleMapStore.setMapImageNaturalSize(
+          image.naturalWidth,
+          image.naturalHeight
+        );
       }
       battleMapStore.setMessage(undefined);
       drawRef.current?.();
     };
     image.onerror = () => {
-      if (!cancelled) battleMapStore.setMessage("Nao foi possivel carregar o background do mapa.");
+      if (!cancelled)
+        battleMapStore.setMessage(
+          "Nao foi possivel carregar o background do mapa."
+        );
     };
     image.src = nextBackgroundUrl;
     return () => {
@@ -144,8 +205,10 @@ export function useBattleMapPixi(params: {
 
   useEffect(() => {
     if (!gridEditInteraction || !encounter) return;
-    const minWidth = 1 / (uiState.gridWidthDraft ?? encounter.battleMap.gridWidth);
-    const minHeight = 1 / (uiState.gridHeightDraft ?? encounter.battleMap.gridHeight);
+    const minWidth =
+      1 / (uiState.gridWidthDraft ?? encounter.battleMap.gridWidth);
+    const minHeight =
+      1 / (uiState.gridHeightDraft ?? encounter.battleMap.gridHeight);
     function handleMove(event: PointerEvent): void {
       if (!containerRef.current) return;
       const interaction = gridEditInteraction;
@@ -158,8 +221,8 @@ export function useBattleMapPixi(params: {
           (event.clientX - interaction.startClientX) / bounds.width,
           (event.clientY - interaction.startClientY) / bounds.height,
           minWidth,
-          minHeight,
-        ),
+          minHeight
+        )
       );
     }
     function handleUp(): void {
@@ -171,7 +234,12 @@ export function useBattleMapPixi(params: {
       window.removeEventListener("pointermove", handleMove);
       window.removeEventListener("pointerup", handleUp);
     };
-  }, [encounter, gridEditInteraction, uiState.gridHeightDraft, uiState.gridWidthDraft]);
+  }, [
+    encounter,
+    gridEditInteraction,
+    uiState.gridHeightDraft,
+    uiState.gridWidthDraft
+  ]);
 
   useEffect(() => {
     if (!encounter || !selectedTokenId) return;
@@ -183,11 +251,26 @@ export function useBattleMapPixi(params: {
         : canInteractWithToken(currentActor, token, encounter.combatState)
       : false;
     if (!canKeepSelection) setSelectedTokenId(null);
-  }, [currentActor, encounter, selectedTokenId, setSelectedTokenId, uiState.embeddedCombatPhase]);
+  }, [
+    currentActor,
+    encounter,
+    selectedTokenId,
+    setSelectedTokenId,
+    uiState.embeddedCombatPhase
+  ]);
 
   useEffect(() => {
-    if ((uiState.isGridEditMode || uiState.isObstaclePaintMode) && selectedTokenId) setSelectedTokenId(null);
-  }, [selectedTokenId, setSelectedTokenId, uiState.isGridEditMode, uiState.isObstaclePaintMode]);
+    if (
+      (uiState.isGridEditMode || uiState.isObstaclePaintMode) &&
+      selectedTokenId
+    )
+      setSelectedTokenId(null);
+  }, [
+    selectedTokenId,
+    setSelectedTokenId,
+    uiState.isGridEditMode,
+    uiState.isObstaclePaintMode
+  ]);
 
   useEffect(() => {
     if (!selectedToken || !encounter) {
@@ -196,7 +279,17 @@ export function useBattleMapPixi(params: {
     }
     battleMapStore.activateTacticalPreview(selectedToken.id, "move");
     battleMapStore.setTacticalPreviewReachableCells(
-      findReachableCells({ map: encounter.battleMap, obstacles: encounter.obstacles, edgeObstacles: encounter.edgeObstacles, tokens: encounter.tokens }, selectedToken, encounter.combatState),
+      findReachableCells(
+        {
+          map: encounter.battleMap,
+          obstacles: encounter.obstacles,
+          edgeObstacles: encounter.edgeObstacles,
+          tokens: encounter.tokens,
+          activeAreaEffects: encounter.activeAreaEffects
+        },
+        selectedToken,
+        encounter.combatState
+      )
     );
   }, [encounter, selectedToken, selectedTokenId]);
 

--- a/packages/tactical-engine/src/grid/grid-state.js
+++ b/packages/tactical-engine/src/grid/grid-state.js
@@ -1,50 +1,55 @@
 import { coordinateKey } from "./coordinates";
 export function isInsideMap(gridState, coordinate) {
-    return (coordinate.x >= 0 &&
-        coordinate.y >= 0 &&
-        coordinate.x < gridState.map.gridWidth &&
-        coordinate.y < gridState.map.gridHeight);
+  return (
+    coordinate.x >= 0 &&
+    coordinate.y >= 0 &&
+    coordinate.x < gridState.map.gridWidth &&
+    coordinate.y < gridState.map.gridHeight
+  );
 }
 export function isBlockedCell(gridState, coordinate) {
-    const key = coordinateKey(coordinate);
-    return gridState.obstacles.some((obstacle) => obstacle.blocksMovement && obstacle.cells.some((cell) => coordinateKey(cell) === key));
+  const key = coordinateKey(coordinate);
+  return gridState.obstacles.some(
+    (obstacle) =>
+      obstacle.blocksMovement &&
+      obstacle.cells.some((cell) => coordinateKey(cell) === key)
+  );
 }
 export function findOccupyingToken(gridState, coordinate) {
-    const key = coordinateKey(coordinate);
-    return gridState.tokens.find((token) => coordinateKey(token.position) === key);
+  const key = coordinateKey(coordinate);
+  return gridState.tokens.find(
+    (token) => coordinateKey(token.position) === key
+  );
 }
 export function findEdgeBetween(edgeObstacles = [], fromCell, toCell) {
-    const dx = toCell.x - fromCell.x;
-    const dy = toCell.y - fromCell.y;
-    if (Math.abs(dx) + Math.abs(dy) !== 1)
-        return undefined;
-    let direction;
-    if (dx === 1)
-        direction = "E";
-    else if (dx === -1)
-        direction = "W";
-    else if (dy === 1)
-        direction = "S";
-    else
-        direction = "N";
-    return edgeObstacles.find((e) => e.x === fromCell.x && e.y === fromCell.y && e.direction === direction);
+  const dx = toCell.x - fromCell.x;
+  const dy = toCell.y - fromCell.y;
+  if (Math.abs(dx) + Math.abs(dy) !== 1) return undefined;
+  let direction;
+  if (dx === 1) direction = "E";
+  else if (dx === -1) direction = "W";
+  else if (dy === 1) direction = "S";
+  else direction = "N";
+  return edgeObstacles.find(
+    (e) => e.x === fromCell.x && e.y === fromCell.y && e.direction === direction
+  );
 }
 export function getEdgeBetweenCells(gridState, fromCell, toCell) {
-    return findEdgeBetween(gridState.edgeObstacles, fromCell, toCell);
+  return findEdgeBetween(gridState.edgeObstacles, fromCell, toCell);
 }
 export function isEdgeBlocked(gridState, fromCell, toCell) {
-    const edge = getEdgeBetweenCells(gridState, fromCell, toCell);
-    return edge?.blocksMovement ?? false;
+  const edge = getEdgeBetweenCells(gridState, fromCell, toCell);
+  return edge?.blocksMovement ?? false;
 }
 export function isEdgeBlockingVision(gridState, fromCell, toCell) {
-    const edge = getEdgeBetweenCells(gridState, fromCell, toCell);
-    return edge?.blocksVision ?? false;
+  const edge = getEdgeBetweenCells(gridState, fromCell, toCell);
+  return edge?.blocksVision ?? false;
 }
 export function isEdgeBlockingEffect(gridState, fromCell, toCell) {
-    const edge = getEdgeBetweenCells(gridState, fromCell, toCell);
-    return edge?.blocksEffect ?? false;
+  const edge = getEdgeBetweenCells(gridState, fromCell, toCell);
+  return edge?.blocksEffect ?? false;
 }
 export function getEdgeCover(gridState, fromCell, toCell) {
-    const edge = getEdgeBetweenCells(gridState, fromCell, toCell);
-    return edge?.cover ?? "none";
+  const edge = getEdgeBetweenCells(gridState, fromCell, toCell);
+  return edge?.cover ?? "none";
 }

--- a/packages/tactical-engine/src/grid/grid-state.ts
+++ b/packages/tactical-engine/src/grid/grid-state.ts
@@ -1,4 +1,11 @@
-import type { BattleMap, Coordinate, EdgeObstacle, Obstacle, Token } from "@limiarmap/shared-contracts";
+import type {
+  ActiveAreaEffect,
+  BattleMap,
+  Coordinate,
+  EdgeObstacle,
+  Obstacle,
+  Token
+} from "@limiarmap/shared-contracts";
 import { coordinateKey } from "./coordinates";
 
 export interface GridState {
@@ -6,9 +13,18 @@ export interface GridState {
   obstacles: Obstacle[];
   edgeObstacles?: EdgeObstacle[];
   tokens: Token[];
+  /**
+   * Persistent combat-state-only area effects (e.g. Spike Growth) that may
+   * influence movement cost or other tactical resolution. Map-level terrain
+   * lives on `obstacles`; these never mutate the campaign map.
+   */
+  activeAreaEffects?: ActiveAreaEffect[];
 }
 
-export function isInsideMap(gridState: GridState, coordinate: Coordinate): boolean {
+export function isInsideMap(
+  gridState: GridState,
+  coordinate: Coordinate
+): boolean {
   return (
     coordinate.x >= 0 &&
     coordinate.y >= 0 &&
@@ -17,17 +33,26 @@ export function isInsideMap(gridState: GridState, coordinate: Coordinate): boole
   );
 }
 
-export function isBlockedCell(gridState: GridState, coordinate: Coordinate): boolean {
+export function isBlockedCell(
+  gridState: GridState,
+  coordinate: Coordinate
+): boolean {
   const key = coordinateKey(coordinate);
   return gridState.obstacles.some(
     (obstacle) =>
-      obstacle.blocksMovement && obstacle.cells.some((cell) => coordinateKey(cell) === key)
+      obstacle.blocksMovement &&
+      obstacle.cells.some((cell) => coordinateKey(cell) === key)
   );
 }
 
-export function findOccupyingToken(gridState: GridState, coordinate: Coordinate): Token | undefined {
+export function findOccupyingToken(
+  gridState: GridState,
+  coordinate: Coordinate
+): Token | undefined {
   const key = coordinateKey(coordinate);
-  return gridState.tokens.find((token) => coordinateKey(token.position) === key);
+  return gridState.tokens.find(
+    (token) => coordinateKey(token.position) === key
+  );
 }
 
 /**
@@ -72,7 +97,11 @@ export function getEdgeBetweenCells(
 /**
  * Phase 10: Check if movement is blocked by an edge between two cells.
  */
-export function isEdgeBlocked(gridState: GridState, fromCell: Coordinate, toCell: Coordinate): boolean {
+export function isEdgeBlocked(
+  gridState: GridState,
+  fromCell: Coordinate,
+  toCell: Coordinate
+): boolean {
   const edge = getEdgeBetweenCells(gridState, fromCell, toCell);
   return edge?.blocksMovement ?? false;
 }
@@ -80,7 +109,11 @@ export function isEdgeBlocked(gridState: GridState, fromCell: Coordinate, toCell
 /**
  * Phase 10: Check if vision is blocked by an edge between two cells.
  */
-export function isEdgeBlockingVision(gridState: GridState, fromCell: Coordinate, toCell: Coordinate): boolean {
+export function isEdgeBlockingVision(
+  gridState: GridState,
+  fromCell: Coordinate,
+  toCell: Coordinate
+): boolean {
   const edge = getEdgeBetweenCells(gridState, fromCell, toCell);
   return edge?.blocksVision ?? false;
 }
@@ -88,7 +121,11 @@ export function isEdgeBlockingVision(gridState: GridState, fromCell: Coordinate,
 /**
  * Phase 10: Check if effects are blocked by an edge between two cells.
  */
-export function isEdgeBlockingEffect(gridState: GridState, fromCell: Coordinate, toCell: Coordinate): boolean {
+export function isEdgeBlockingEffect(
+  gridState: GridState,
+  fromCell: Coordinate,
+  toCell: Coordinate
+): boolean {
   const edge = getEdgeBetweenCells(gridState, fromCell, toCell);
   return edge?.blocksEffect ?? false;
 }
@@ -96,7 +133,11 @@ export function isEdgeBlockingEffect(gridState: GridState, fromCell: Coordinate,
 /**
  * Phase 10: Get edge cover value between two cells.
  */
-export function getEdgeCover(gridState: GridState, fromCell: Coordinate, toCell: Coordinate): "none" | "half" | "threeQuarters" | "full" {
+export function getEdgeCover(
+  gridState: GridState,
+  fromCell: Coordinate,
+  toCell: Coordinate
+): "none" | "half" | "threeQuarters" | "full" {
   const edge = getEdgeBetweenCells(gridState, fromCell, toCell);
   return edge?.cover ?? "none";
 }

--- a/packages/tactical-engine/src/movement/validate-movement.js
+++ b/packages/tactical-engine/src/movement/validate-movement.js
@@ -52,7 +52,7 @@ export function findReachableCells(gridState, token, combatState) {
                     ? (1 - current.diagonalParity)
                     : current.diagonalParity;
                 const nextCost = current.pathCostUnits +
-                    stepCost(current.coordinate, candidate, current.diagonalParity, getMovementCostMultiplier(gridState.obstacles, candidate));
+                    stepCost(current.coordinate, candidate, current.diagonalParity, getMovementCostMultiplier(gridState.obstacles, candidate, gridState.activeAreaEffects));
                 if (nextCost > token.movementBudget) {
                     continue;
                 }
@@ -124,7 +124,7 @@ export function validateMovement(gridState, token, path, combatState) {
             return { accepted: false, pathCostUnits: 0, rejectionReason };
         }
     }
-    const pathCostUnits = computePathCost(fullPath, (cell) => getMovementCostMultiplier(gridState.obstacles, cell));
+    const pathCostUnits = computePathCost(fullPath, (cell) => getMovementCostMultiplier(gridState.obstacles, cell, gridState.activeAreaEffects));
     if (pathCostUnits > token.movementBudget) {
         return { accepted: false, pathCostUnits, rejectionReason: "movement_budget_exceeded" };
     }
@@ -198,7 +198,7 @@ export function findMovementPath(gridState, token, destination, combatState) {
                 const nextParity = isDiagonalStep(current.coordinate, candidate)
                     ? (1 - current.diagonalParity)
                     : current.diagonalParity;
-                const cost = stepCost(current.coordinate, candidate, current.diagonalParity, getMovementCostMultiplier(gridState.obstacles, candidate));
+                const cost = stepCost(current.coordinate, candidate, current.diagonalParity, getMovementCostMultiplier(gridState.obstacles, candidate, gridState.activeAreaEffects));
                 const nextCost = current.pathCostUnits + cost;
                 const nextKey = `${candidate.x}:${candidate.y}:${nextParity}`;
                 const previousBest = bestByState.get(nextKey);

--- a/packages/tactical-engine/src/movement/validate-movement.ts
+++ b/packages/tactical-engine/src/movement/validate-movement.ts
@@ -1,6 +1,20 @@
-import type { CombatState, Coordinate, Token } from "@limiarmap/shared-contracts";
-import { findOccupyingToken, getEdgeBetweenCells, isBlockedCell, isEdgeBlocked, isInsideMap, type GridState } from "../grid/grid-state";
-import { clipsDiagonalMovement, getMovementCostMultiplier } from "../validation/obstacle-rules";
+import type {
+  CombatState,
+  Coordinate,
+  Token
+} from "@limiarmap/shared-contracts";
+import {
+  findOccupyingToken,
+  getEdgeBetweenCells,
+  isBlockedCell,
+  isEdgeBlocked,
+  isInsideMap,
+  type GridState
+} from "../grid/grid-state";
+import {
+  clipsDiagonalMovement,
+  getMovementCostMultiplier
+} from "../validation/obstacle-rules";
 import { computePathCost, isDiagonalStep, stepCost } from "./path-cost";
 
 export interface MovementValidationResult {
@@ -22,7 +36,10 @@ export function findReachableCells(
     return [];
   }
 
-  if (combatState?.status === "active" && token.combatantId !== combatState.activeCombatantId) {
+  if (
+    combatState?.status === "active" &&
+    token.combatantId !== combatState.activeCombatantId
+  ) {
     return [];
   }
 
@@ -39,7 +56,9 @@ export function findReachableCells(
       pathCostUnits: 0
     }
   ];
-  const bestByState = new Map<string, number>([[`${token.position.x}:${token.position.y}:0`, 0]]);
+  const bestByState = new Map<string, number>([
+    [`${token.position.x}:${token.position.y}:0`, 0]
+  ]);
   const visited = new Set<string>();
   const reachableByCoordinate = new Map<string, Coordinate>();
 
@@ -59,7 +78,8 @@ export function findReachableCells(
     visited.add(currentKey);
 
     const isOrigin =
-      current.coordinate.x === token.position.x && current.coordinate.y === token.position.y;
+      current.coordinate.x === token.position.x &&
+      current.coordinate.y === token.position.y;
     if (!isOrigin) {
       reachableByCoordinate.set(
         `${current.coordinate.x}:${current.coordinate.y}`,
@@ -77,7 +97,12 @@ export function findReachableCells(
           x: current.coordinate.x + xDelta,
           y: current.coordinate.y + yDelta
         };
-        const rejectionReason = getStepRejectionReason(gridState, token, current.coordinate, candidate);
+        const rejectionReason = getStepRejectionReason(
+          gridState,
+          token,
+          current.coordinate,
+          candidate
+        );
         if (rejectionReason) {
           continue;
         }
@@ -91,7 +116,11 @@ export function findReachableCells(
             current.coordinate,
             candidate,
             current.diagonalParity,
-            getMovementCostMultiplier(gridState.obstacles, candidate)
+            getMovementCostMultiplier(
+              gridState.obstacles,
+              candidate,
+              gridState.activeAreaEffects
+            )
           );
         if (nextCost > token.movementBudget) {
           continue;
@@ -140,8 +169,15 @@ function getStepRejectionReason(
       return "blocked_path";
     }
   } else if (xDelta === 1 && yDelta === 1) {
-    const cornerH = getEdgeBetweenCells(gridState, previous, { x: current.x, y: previous.y });
-    const cornerV = getEdgeBetweenCells(gridState, { x: current.x, y: previous.y }, current);
+    const cornerH = getEdgeBetweenCells(gridState, previous, {
+      x: current.x,
+      y: previous.y
+    });
+    const cornerV = getEdgeBetweenCells(
+      gridState,
+      { x: current.x, y: previous.y },
+      current
+    );
     if (cornerH?.blocksMovement || cornerV?.blocksMovement) {
       return "blocked_path";
     }
@@ -154,8 +190,14 @@ function getStepRejectionReason(
   if (
     xDelta === 1 &&
     yDelta === 1 &&
-    (clipsDiagonalMovement(gridState.obstacles, { x: current.x, y: previous.y }) ||
-      clipsDiagonalMovement(gridState.obstacles, { x: previous.x, y: current.y }))
+    (clipsDiagonalMovement(gridState.obstacles, {
+      x: current.x,
+      y: previous.y
+    }) ||
+      clipsDiagonalMovement(gridState.obstacles, {
+        x: previous.x,
+        y: current.y
+      }))
   ) {
     return "diagonal_clipped";
   }
@@ -178,15 +220,27 @@ export function validateMovement(
     return { accepted: false, pathCostUnits: 0, rejectionReason: "empty_path" };
   }
 
-  if (combatState?.status === "active" && token.combatantId !== combatState.activeCombatantId) {
-    return { accepted: false, pathCostUnits: 0, rejectionReason: "out_of_turn" };
+  if (
+    combatState?.status === "active" &&
+    token.combatantId !== combatState.activeCombatantId
+  ) {
+    return {
+      accepted: false,
+      pathCostUnits: 0,
+      rejectionReason: "out_of_turn"
+    };
   }
 
   const fullPath = [token.position, ...path];
   for (let index = 1; index < fullPath.length; index += 1) {
     const current = fullPath[index];
     const previous = fullPath[index - 1];
-    const rejectionReason = getStepRejectionReason(gridState, token, previous, current);
+    const rejectionReason = getStepRejectionReason(
+      gridState,
+      token,
+      previous,
+      current
+    );
     if (rejectionReason) {
       return { accepted: false, pathCostUnits: 0, rejectionReason };
     }
@@ -195,12 +249,19 @@ export function validateMovement(
   // Phase 7: terrain multipliers are applied per destination cell.
   // Blocked cells were already rejected above; this only affects traversable
   // cells whose movementCostMultiplier > 1 (e.g. difficult terrain = 2).
-  const pathCostUnits = computePathCost(
-    fullPath,
-    (cell) => getMovementCostMultiplier(gridState.obstacles, cell)
+  const pathCostUnits = computePathCost(fullPath, (cell) =>
+    getMovementCostMultiplier(
+      gridState.obstacles,
+      cell,
+      gridState.activeAreaEffects
+    )
   );
   if (pathCostUnits > token.movementBudget) {
-    return { accepted: false, pathCostUnits, rejectionReason: "movement_budget_exceeded" };
+    return {
+      accepted: false,
+      pathCostUnits,
+      rejectionReason: "movement_budget_exceeded"
+    };
   }
 
   return { accepted: true, pathCostUnits };
@@ -212,25 +273,56 @@ export function findMovementPath(
   destination: Coordinate,
   combatState?: CombatState
 ): MovementPathResult {
-  if (combatState?.status === "active" && token.combatantId !== combatState.activeCombatantId) {
-    return { accepted: false, path: [], pathCostUnits: 0, rejectionReason: "out_of_turn" };
+  if (
+    combatState?.status === "active" &&
+    token.combatantId !== combatState.activeCombatantId
+  ) {
+    return {
+      accepted: false,
+      path: [],
+      pathCostUnits: 0,
+      rejectionReason: "out_of_turn"
+    };
   }
 
-  if (destination.x === token.position.x && destination.y === token.position.y) {
-    return { accepted: false, path: [], pathCostUnits: 0, rejectionReason: "empty_path" };
+  if (
+    destination.x === token.position.x &&
+    destination.y === token.position.y
+  ) {
+    return {
+      accepted: false,
+      path: [],
+      pathCostUnits: 0,
+      rejectionReason: "empty_path"
+    };
   }
 
   if (!isInsideMap(gridState, destination)) {
-    return { accepted: false, path: [], pathCostUnits: 0, rejectionReason: "outside_map" };
+    return {
+      accepted: false,
+      path: [],
+      pathCostUnits: 0,
+      rejectionReason: "outside_map"
+    };
   }
 
   if (isBlockedCell(gridState, destination)) {
-    return { accepted: false, path: [], pathCostUnits: 0, rejectionReason: "blocked_path" };
+    return {
+      accepted: false,
+      path: [],
+      pathCostUnits: 0,
+      rejectionReason: "blocked_path"
+    };
   }
 
   const destinationOccupant = findOccupyingToken(gridState, destination);
   if (destinationOccupant && destinationOccupant.id !== token.id) {
-    return { accepted: false, path: [], pathCostUnits: 0, rejectionReason: "occupied_cell" };
+    return {
+      accepted: false,
+      path: [],
+      pathCostUnits: 0,
+      rejectionReason: "occupied_cell"
+    };
   }
 
   type SearchNode = {
@@ -246,7 +338,9 @@ export function findMovementPath(
       pathCostUnits: 0
     }
   ];
-  const bestByState = new Map<string, number>([[`${token.position.x}:${token.position.y}:0`, 0]]);
+  const bestByState = new Map<string, number>([
+    [`${token.position.x}:${token.position.y}:0`, 0]
+  ]);
   const previousByState = new Map<
     string,
     { previousKey: string; coordinate: Coordinate; diagonalParity: 0 | 1 }
@@ -269,7 +363,10 @@ export function findMovementPath(
     }
     visited.add(currentKey);
 
-    if (current.coordinate.x === destination.x && current.coordinate.y === destination.y) {
+    if (
+      current.coordinate.x === destination.x &&
+      current.coordinate.y === destination.y
+    ) {
       const fullPath: Coordinate[] = [current.coordinate];
       let cursorKey = currentKey;
       while (previousByState.has(cursorKey)) {
@@ -279,7 +376,12 @@ export function findMovementPath(
       }
       fullPath.reverse();
       const previewPath = fullPath.slice(1);
-      const validation = validateMovement(gridState, token, previewPath, combatState);
+      const validation = validateMovement(
+        gridState,
+        token,
+        previewPath,
+        combatState
+      );
       return {
         accepted: validation.accepted,
         path: previewPath,
@@ -298,7 +400,12 @@ export function findMovementPath(
           x: current.coordinate.x + xDelta,
           y: current.coordinate.y + yDelta
         };
-        const rejectionReason = getStepRejectionReason(gridState, token, current.coordinate, candidate);
+        const rejectionReason = getStepRejectionReason(
+          gridState,
+          token,
+          current.coordinate,
+          candidate
+        );
         if (rejectionReason) {
           continue;
         }
@@ -310,7 +417,11 @@ export function findMovementPath(
           current.coordinate,
           candidate,
           current.diagonalParity,
-          getMovementCostMultiplier(gridState.obstacles, candidate)
+          getMovementCostMultiplier(
+            gridState.obstacles,
+            candidate,
+            gridState.activeAreaEffects
+          )
         );
         const nextCost = current.pathCostUnits + cost;
         const nextKey = `${candidate.x}:${candidate.y}:${nextParity}`;

--- a/packages/tactical-engine/src/validation/obstacle-rules.js
+++ b/packages/tactical-engine/src/validation/obstacle-rules.js
@@ -1,45 +1,76 @@
 import { coordinateKey } from "../grid/coordinates";
+const DIFFICULT_TERRAIN_MULTIPLIER = 2;
 function hasObstacleAtCell(obstacles, coordinate, predicate) {
-    const key = coordinateKey(coordinate);
-    return obstacles.some((obstacle) => predicate(obstacle) && obstacle.cells.some((cell) => coordinateKey(cell) === key));
+  const key = coordinateKey(coordinate);
+  return obstacles.some(
+    (obstacle) =>
+      predicate(obstacle) &&
+      obstacle.cells.some((cell) => coordinateKey(cell) === key)
+  );
 }
 export function blocksEffect(obstacles, coordinate) {
-    return hasObstacleAtCell(obstacles, coordinate, (obstacle) => obstacle.blocksEffect);
+  return hasObstacleAtCell(
+    obstacles,
+    coordinate,
+    (obstacle) => obstacle.blocksEffect
+  );
 }
 export function blocksVision(obstacles, coordinate) {
-    return hasObstacleAtCell(obstacles, coordinate, (obstacle) => obstacle.blocksVision);
+  return hasObstacleAtCell(
+    obstacles,
+    coordinate,
+    (obstacle) => obstacle.blocksVision
+  );
 }
 export function clipsDiagonalMovement(obstacles, coordinate) {
-    return hasObstacleAtCell(obstacles, coordinate, (obstacle) => obstacle.clipsDiagonalMovement);
+  return hasObstacleAtCell(
+    obstacles,
+    coordinate,
+    (obstacle) => obstacle.clipsDiagonalMovement
+  );
 }
-export function getMovementCostMultiplier(obstacles, coordinate) {
-    const key = coordinateKey(coordinate);
-    let max = 1;
-    for (const obstacle of obstacles) {
-        if (obstacle.movementCostMultiplier > 1 &&
-            obstacle.cells.some((cell) => coordinateKey(cell) === key)) {
-            max = Math.max(max, obstacle.movementCostMultiplier);
-        }
+export function getMovementCostMultiplier(
+  obstacles,
+  coordinate,
+  activeAreaEffects = []
+) {
+  const key = coordinateKey(coordinate);
+  let max = 1;
+  for (const obstacle of obstacles) {
+    if (
+      obstacle.movementCostMultiplier > 1 &&
+      obstacle.cells.some((cell) => coordinateKey(cell) === key)
+    ) {
+      max = Math.max(max, obstacle.movementCostMultiplier);
     }
-    return max;
+  }
+  for (const effect of activeAreaEffects) {
+    if (
+      effect.terrainEffect === "difficult_terrain" &&
+      effect.affectedCells.some((cell) => coordinateKey(cell) === key)
+    ) {
+      max = Math.max(max, DIFFICULT_TERRAIN_MULTIPLIER);
+    }
+  }
+  return max;
 }
 export const COVER_RANK = {
-    none: 0,
-    half: 1,
-    threeQuarters: 2,
-    full: 3
+  none: 0,
+  half: 1,
+  threeQuarters: 2,
+  full: 3
 };
 const coverRank = COVER_RANK;
 export function getHighestCover(obstacles, coordinate) {
-    let highestCover = "none";
-    const key = coordinateKey(coordinate);
-    obstacles.forEach((obstacle) => {
-        if (!obstacle.cells.some((cell) => coordinateKey(cell) === key)) {
-            return;
-        }
-        if (coverRank[obstacle.cover] > coverRank[highestCover]) {
-            highestCover = obstacle.cover;
-        }
-    });
-    return highestCover;
+  let highestCover = "none";
+  const key = coordinateKey(coordinate);
+  obstacles.forEach((obstacle) => {
+    if (!obstacle.cells.some((cell) => coordinateKey(cell) === key)) {
+      return;
+    }
+    if (coverRank[obstacle.cover] > coverRank[highestCover]) {
+      highestCover = obstacle.cover;
+    }
+  });
+  return highestCover;
 }

--- a/packages/tactical-engine/src/validation/obstacle-rules.ts
+++ b/packages/tactical-engine/src/validation/obstacle-rules.ts
@@ -1,23 +1,64 @@
-import type { Coordinate, Obstacle, ObstacleCover } from "@limiarmap/shared-contracts";
+import type {
+  ActiveAreaEffect,
+  Coordinate,
+  Obstacle,
+  ObstacleCover
+} from "@limiarmap/shared-contracts";
 import { coordinateKey } from "../grid/coordinates";
 
-function hasObstacleAtCell(obstacles: Obstacle[], coordinate: Coordinate, predicate: (obstacle: Obstacle) => boolean): boolean {
+/**
+ * Multiplier applied to movement cost for cells covered by an active area
+ * effect whose `terrainEffect` marks them as difficult terrain (e.g. Spike
+ * Growth). Stacking with map-level difficult terrain is handled by `max`
+ * semantics in `getMovementCostMultiplier` — overlapping difficult terrains
+ * do not double-apply.
+ */
+const DIFFICULT_TERRAIN_MULTIPLIER = 2;
+
+function hasObstacleAtCell(
+  obstacles: Obstacle[],
+  coordinate: Coordinate,
+  predicate: (obstacle: Obstacle) => boolean
+): boolean {
   const key = coordinateKey(coordinate);
   return obstacles.some(
-    (obstacle) => predicate(obstacle) && obstacle.cells.some((cell) => coordinateKey(cell) === key)
+    (obstacle) =>
+      predicate(obstacle) &&
+      obstacle.cells.some((cell) => coordinateKey(cell) === key)
   );
 }
 
-export function blocksEffect(obstacles: Obstacle[], coordinate: Coordinate): boolean {
-  return hasObstacleAtCell(obstacles, coordinate, (obstacle) => obstacle.blocksEffect);
+export function blocksEffect(
+  obstacles: Obstacle[],
+  coordinate: Coordinate
+): boolean {
+  return hasObstacleAtCell(
+    obstacles,
+    coordinate,
+    (obstacle) => obstacle.blocksEffect
+  );
 }
 
-export function blocksVision(obstacles: Obstacle[], coordinate: Coordinate): boolean {
-  return hasObstacleAtCell(obstacles, coordinate, (obstacle) => obstacle.blocksVision);
+export function blocksVision(
+  obstacles: Obstacle[],
+  coordinate: Coordinate
+): boolean {
+  return hasObstacleAtCell(
+    obstacles,
+    coordinate,
+    (obstacle) => obstacle.blocksVision
+  );
 }
 
-export function clipsDiagonalMovement(obstacles: Obstacle[], coordinate: Coordinate): boolean {
-  return hasObstacleAtCell(obstacles, coordinate, (obstacle) => obstacle.clipsDiagonalMovement);
+export function clipsDiagonalMovement(
+  obstacles: Obstacle[],
+  coordinate: Coordinate
+): boolean {
+  return hasObstacleAtCell(
+    obstacles,
+    coordinate,
+    (obstacle) => obstacle.clipsDiagonalMovement
+  );
 }
 
 /**
@@ -32,7 +73,8 @@ export function clipsDiagonalMovement(obstacles: Obstacle[], coordinate: Coordin
  */
 export function getMovementCostMultiplier(
   obstacles: Obstacle[],
-  coordinate: Coordinate
+  coordinate: Coordinate,
+  activeAreaEffects: ActiveAreaEffect[] = []
 ): number {
   const key = coordinateKey(coordinate);
   let max = 1;
@@ -42,6 +84,14 @@ export function getMovementCostMultiplier(
       obstacle.cells.some((cell) => coordinateKey(cell) === key)
     ) {
       max = Math.max(max, obstacle.movementCostMultiplier);
+    }
+  }
+  for (const effect of activeAreaEffects) {
+    if (
+      effect.terrainEffect === "difficult_terrain" &&
+      effect.affectedCells.some((cell) => coordinateKey(cell) === key)
+    ) {
+      max = Math.max(max, DIFFICULT_TERRAIN_MULTIPLIER);
     }
   }
   return max;
@@ -58,7 +108,10 @@ export const COVER_RANK: Record<ObstacleCover, number> = {
   full: 3
 };
 
-export function getHighestCover(obstacles: Obstacle[], coordinate: Coordinate): ObstacleCover {
+export function getHighestCover(
+  obstacles: Obstacle[],
+  coordinate: Coordinate
+): ObstacleCover {
   let highestCover: ObstacleCover = "none";
   const key = coordinateKey(coordinate);
 

--- a/packages/tactical-engine/tests/unit/movement-rules.test.ts
+++ b/packages/tactical-engine/tests/unit/movement-rules.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { BattleMap, CombatState, Obstacle, Token } from "@limiarmap/shared-contracts";
+import type {
+  ActiveAreaEffect,
+  BattleMap,
+  CombatState,
+  Obstacle,
+  Token
+} from "@limiarmap/shared-contracts";
 import { METERS_PER_CELL } from "@limiarmap/shared-contracts";
 import {
   computePathCost,
@@ -130,7 +136,11 @@ describe("movement rules", () => {
   });
 
   it("returns the cheapest path cost even when movement budget is exceeded", () => {
-    const tokenWith10: Token = { ...token, movementSpeedCells: 2, movementBudget: 10 };
+    const tokenWith10: Token = {
+      ...token,
+      movementSpeedCells: 2,
+      movementBudget: 10
+    };
 
     const result = findMovementPath(
       { map, obstacles: [], tokens: [tokenWith10] },
@@ -163,7 +173,12 @@ describe("movement rules", () => {
         movementCostMultiplier: 1
       }
     ];
-    const result = validateMovement({ map, obstacles, tokens: [token] }, token, [{ x: 2, y: 2 }], combatState);
+    const result = validateMovement(
+      { map, obstacles, tokens: [token] },
+      token,
+      [{ x: 2, y: 2 }],
+      combatState
+    );
     expect(result.accepted).toBe(false);
     expect(result.rejectionReason).toBe("blocked_path");
   });
@@ -183,7 +198,12 @@ describe("movement rules", () => {
       }
     ];
 
-    const result = validateMovement({ map, obstacles, tokens: [token] }, token, [{ x: 2, y: 2 }], combatState);
+    const result = validateMovement(
+      { map, obstacles, tokens: [token] },
+      token,
+      [{ x: 2, y: 2 }],
+      combatState
+    );
     expect(result.accepted).toBe(false);
     expect(result.rejectionReason).toBe("diagonal_clipped");
   });
@@ -199,43 +219,96 @@ describe("movement rules", () => {
         { x: 6, y: 1 },
         { x: 7, y: 1 }
       ];
-      const result = validateMovement({ map, obstacles: [], tokens: [token] }, token, path, combatState);
+      const result = validateMovement(
+        { map, obstacles: [], tokens: [token] },
+        token,
+        path,
+        combatState
+      );
       expect(result.accepted).toBe(true);
       expect(result.pathCostUnits).toBe(30);
     });
 
     it("accepts movement that exactly exhausts the budget", () => {
       // movementSpeedCells=4 cells → budget=20 path-cost units (4*5)
-      const tokenWith20: Token = { ...token, movementSpeedCells: 4, movementBudget: 20 };
+      const tokenWith20: Token = {
+        ...token,
+        movementSpeedCells: 4,
+        movementBudget: 20
+      };
       // 4 straight steps = 20 units
-      const path = [{ x: 2, y: 1 }, { x: 3, y: 1 }, { x: 4, y: 1 }, { x: 5, y: 1 }];
-      const result = validateMovement({ map, obstacles: [], tokens: [tokenWith20] }, tokenWith20, path, combatState);
+      const path = [
+        { x: 2, y: 1 },
+        { x: 3, y: 1 },
+        { x: 4, y: 1 },
+        { x: 5, y: 1 }
+      ];
+      const result = validateMovement(
+        { map, obstacles: [], tokens: [tokenWith20] },
+        tokenWith20,
+        path,
+        combatState
+      );
       expect(result.accepted).toBe(true);
       expect(result.pathCostUnits).toBe(20);
     });
 
     it("rejects movement that exceeds remaining budget", () => {
       // movementSpeedCells=2 cells → budget=10 path-cost units (2*5)
-      const tokenWith10: Token = { ...token, movementSpeedCells: 2, movementBudget: 10 };
+      const tokenWith10: Token = {
+        ...token,
+        movementSpeedCells: 2,
+        movementBudget: 10
+      };
       // 3 straight steps = 15 units > 10 budget
-      const path = [{ x: 2, y: 1 }, { x: 3, y: 1 }, { x: 4, y: 1 }];
-      const result = validateMovement({ map, obstacles: [], tokens: [tokenWith10] }, tokenWith10, path, combatState);
+      const path = [
+        { x: 2, y: 1 },
+        { x: 3, y: 1 },
+        { x: 4, y: 1 }
+      ];
+      const result = validateMovement(
+        { map, obstacles: [], tokens: [tokenWith10] },
+        tokenWith10,
+        path,
+        combatState
+      );
       expect(result.accepted).toBe(false);
       expect(result.rejectionReason).toBe("movement_budget_exceeded");
     });
 
     it("respects reduced budget after a prior move", () => {
       // Simulate a token that already moved 20 units (10 path-cost units = 2 cells remaining)
-      const tokenAfterMove: Token = { ...token, movementBudget: 10, position: { x: 5, y: 1 } };
+      const tokenAfterMove: Token = {
+        ...token,
+        movementBudget: 10,
+        position: { x: 5, y: 1 }
+      };
       // 2 straight steps = 10 — exactly matches remaining budget
-      const path = [{ x: 6, y: 1 }, { x: 7, y: 1 }];
-      const valid = validateMovement({ map, obstacles: [], tokens: [tokenAfterMove] }, tokenAfterMove, path, combatState);
+      const path = [
+        { x: 6, y: 1 },
+        { x: 7, y: 1 }
+      ];
+      const valid = validateMovement(
+        { map, obstacles: [], tokens: [tokenAfterMove] },
+        tokenAfterMove,
+        path,
+        combatState
+      );
       expect(valid.accepted).toBe(true);
       expect(valid.pathCostUnits).toBe(10);
 
       // 3 steps = 15 — exceeds remaining budget
-      const path2 = [{ x: 6, y: 1 }, { x: 7, y: 1 }, { x: 8, y: 1 }];
-      const rejected = validateMovement({ map, obstacles: [], tokens: [tokenAfterMove] }, tokenAfterMove, path2, combatState);
+      const path2 = [
+        { x: 6, y: 1 },
+        { x: 7, y: 1 },
+        { x: 8, y: 1 }
+      ];
+      const rejected = validateMovement(
+        { map, obstacles: [], tokens: [tokenAfterMove] },
+        tokenAfterMove,
+        path2,
+        combatState
+      );
       expect(rejected.accepted).toBe(false);
       expect(rejected.rejectionReason).toBe("movement_budget_exceeded");
     });
@@ -244,7 +317,11 @@ describe("movement rules", () => {
 
 describe("reachable movement cells", () => {
   it("uses the remaining movement budget and excludes the origin cell", () => {
-    const reachable = findReachableCells({ map, obstacles: [], tokens: [token] }, token, combatState);
+    const reachable = findReachableCells(
+      { map, obstacles: [], tokens: [token] },
+      token,
+      combatState
+    );
 
     expect(reachable).not.toContainEqual({ x: 1, y: 1 });
     expect(reachable).toContainEqual({ x: 7, y: 1 });
@@ -282,7 +359,11 @@ describe("reachable movement cells", () => {
   });
 
   it("respects difficult terrain cost when computing reachable cells", () => {
-    const tightToken: Token = { ...token, movementSpeedCells: 1, movementBudget: 5 };
+    const tightToken: Token = {
+      ...token,
+      movementSpeedCells: 1,
+      movementBudget: 5
+    };
 
     const reachable = findReachableCells(
       { map, obstacles: [difficultTerrain], tokens: [tightToken] },
@@ -295,7 +376,11 @@ describe("reachable movement cells", () => {
   });
 
   it("respects alternating diagonal costs while expanding reach", () => {
-    const diagonalToken: Token = { ...token, movementSpeedCells: 2, movementBudget: 10 };
+    const diagonalToken: Token = {
+      ...token,
+      movementSpeedCells: 2,
+      movementBudget: 10
+    };
 
     const reachable = findReachableCells(
       { map, obstacles: [], tokens: [diagonalToken] },
@@ -315,7 +400,11 @@ describe("reachable movement cells", () => {
 const difficultTerrain: Obstacle = {
   id: "dt",
   battleMapId: "map",
-  cells: [{ x: 3, y: 1 }, { x: 4, y: 1 }, { x: 5, y: 1 }],
+  cells: [
+    { x: 3, y: 1 },
+    { x: 4, y: 1 },
+    { x: 5, y: 1 }
+  ],
   blocksMovement: false,
   blocksEffect: false,
   blocksVision: false,
@@ -326,7 +415,12 @@ const difficultTerrain: Obstacle = {
 
 describe("difficult terrain — path-cost unit tests", () => {
   it("normal orthogonal step has base cost 5 (no terrain)", () => {
-    expect(computePathCost([{ x: 1, y: 1 }, { x: 2, y: 1 }])).toBe(5);
+    expect(
+      computePathCost([
+        { x: 1, y: 1 },
+        { x: 2, y: 1 }
+      ])
+    ).toBe(5);
   });
 
   it("orthogonal step into difficult terrain costs 10 (2× multiplier)", () => {
@@ -334,7 +428,13 @@ describe("difficult terrain — path-cost unit tests", () => {
     const multiplierAt = (cell: { x: number; y: number }) =>
       getMovementCostMultiplier(obstacles, cell);
     // step from (2,1) → (3,1): (3,1) is difficult terrain
-    const cost = computePathCost([{ x: 2, y: 1 }, { x: 3, y: 1 }], multiplierAt);
+    const cost = computePathCost(
+      [
+        { x: 2, y: 1 },
+        { x: 3, y: 1 }
+      ],
+      multiplierAt
+    );
     expect(cost).toBe(10);
   });
 
@@ -348,7 +448,13 @@ describe("difficult terrain — path-cost unit tests", () => {
     const multiplierAt = (cell: { x: number; y: number }) =>
       getMovementCostMultiplier(obstacles, cell);
     // 1st diagonal (index 0) base = 5 → ×2 = 10
-    const cost = computePathCost([{ x: 2, y: 1 }, { x: 3, y: 2 }], multiplierAt);
+    const cost = computePathCost(
+      [
+        { x: 2, y: 1 },
+        { x: 3, y: 2 }
+      ],
+      multiplierAt
+    );
     expect(cost).toBe(10);
   });
 
@@ -358,18 +464,27 @@ describe("difficult terrain — path-cost unit tests", () => {
     const multiplierAt = (cell: { x: number; y: number }) =>
       getMovementCostMultiplier(obstacles, cell);
     const cost = computePathCost(
-      [{ x: 1, y: 1 }, { x: 2, y: 1 }, { x: 3, y: 1 }, { x: 4, y: 1 }],
+      [
+        { x: 1, y: 1 },
+        { x: 2, y: 1 },
+        { x: 3, y: 1 },
+        { x: 4, y: 1 }
+      ],
       multiplierAt
     );
     expect(cost).toBe(5 + 10 + 10);
   });
 
   it("getMovementCostMultiplier returns 1 for a cell with no terrain obstacle", () => {
-    expect(getMovementCostMultiplier([difficultTerrain], { x: 10, y: 10 })).toBe(1);
+    expect(
+      getMovementCostMultiplier([difficultTerrain], { x: 10, y: 10 })
+    ).toBe(1);
   });
 
   it("getMovementCostMultiplier returns 2 for a difficult terrain cell", () => {
-    expect(getMovementCostMultiplier([difficultTerrain], { x: 3, y: 1 })).toBe(2);
+    expect(getMovementCostMultiplier([difficultTerrain], { x: 3, y: 1 })).toBe(
+      2
+    );
   });
 
   it("getMovementCostMultiplier returns 1 for obstacles that have no multiplier (backward compat)", () => {
@@ -394,7 +509,11 @@ describe("difficult terrain — movement validation integration", () => {
     const result = validateMovement(
       { map, obstacles: [difficultTerrain], tokens: [token] },
       token,
-      [{ x: 2, y: 1 }, { x: 3, y: 1 }, { x: 4, y: 1 }],
+      [
+        { x: 2, y: 1 },
+        { x: 3, y: 1 },
+        { x: 4, y: 1 }
+      ],
       combatState
     );
     // step (1,1)→(2,1) normal=5, (2,1)→(3,1) difficult=10, (3,1)→(4,1) difficult=10 → total 25
@@ -408,7 +527,10 @@ describe("difficult terrain — movement validation integration", () => {
     const result = validateMovement(
       { map, obstacles: [difficultTerrain], tokens: [tightToken] },
       tightToken,
-      [{ x: 2, y: 1 }, { x: 3, y: 1 }],
+      [
+        { x: 2, y: 1 },
+        { x: 3, y: 1 }
+      ],
       combatState
     );
     expect(result.accepted).toBe(false);
@@ -420,7 +542,11 @@ describe("difficult terrain — movement validation integration", () => {
     const withoutTerrain = validateMovement(
       { map, obstacles: [], tokens: [token] },
       token,
-      [{ x: 2, y: 1 }, { x: 3, y: 1 }, { x: 4, y: 1 }],
+      [
+        { x: 2, y: 1 },
+        { x: 3, y: 1 },
+        { x: 4, y: 1 }
+      ],
       combatState
     );
     expect(withoutTerrain.accepted).toBe(true);
@@ -431,7 +557,12 @@ describe("difficult terrain — movement validation integration", () => {
     const withTerrain = validateMovement(
       { map, obstacles: [difficultTerrain], tokens: [longToken] },
       longToken,
-      [{ x: 2, y: 1 }, { x: 3, y: 1 }, { x: 4, y: 1 }, { x: 5, y: 1 }],
+      [
+        { x: 2, y: 1 },
+        { x: 3, y: 1 },
+        { x: 4, y: 1 },
+        { x: 5, y: 1 }
+      ],
       combatState
     );
     expect(withTerrain.accepted).toBe(false);
@@ -453,7 +584,10 @@ describe("difficult terrain — movement validation integration", () => {
     const result = validateMovement(
       { map, obstacles: [blockedWithMultiplier], tokens: [token] },
       token,
-      [{ x: 2, y: 1 }, { x: 3, y: 1 }],
+      [
+        { x: 2, y: 1 },
+        { x: 3, y: 1 }
+      ],
       combatState
     );
     expect(result.accepted).toBe(false);
@@ -476,10 +610,225 @@ describe("difficult terrain — movement validation integration", () => {
     const result = validateMovement(
       { map, obstacles: [oldStyleObs], tokens: [token] },
       token,
-      [{ x: 2, y: 1 }, { x: 3, y: 1 }, { x: 4, y: 1 }],
+      [
+        { x: 2, y: 1 },
+        { x: 3, y: 1 },
+        { x: 4, y: 1 }
+      ],
       combatState
     );
     expect(result.accepted).toBe(true);
     expect(result.pathCostUnits).toBe(15);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Active area effects (e.g. Spike Growth) as movement-affecting difficult terrain
+// ─────────────────────────────────────────────────────────────────────────────
+
+function spikeGrowthEffect(
+  cells: Array<{ x: number; y: number }>
+): ActiveAreaEffect {
+  return {
+    id: "aae_spike",
+    sourceSpellCanonicalKey: "spike_growth",
+    sourceSpellName: "Spike Growth",
+    casterParticipantId: "caster",
+    originPoint: cells[0]!,
+    anchorCell: cells[0]!,
+    areaShape: "sphere",
+    sizeMeters: 6,
+    affectedCells: cells,
+    effectKind: "hazard",
+    terrainEffect: "difficult_terrain",
+    movementDamageDice: "2d4",
+    damageType: "Piercing",
+    damagePerMeters: 1.5
+  };
+}
+
+function fogCloudEffect(
+  cells: Array<{ x: number; y: number }>
+): ActiveAreaEffect {
+  return {
+    id: "aae_fog",
+    sourceSpellCanonicalKey: "fog_cloud",
+    sourceSpellName: "Fog Cloud",
+    casterParticipantId: "caster",
+    originPoint: cells[0]!,
+    anchorCell: cells[0]!,
+    areaShape: "sphere",
+    sizeMeters: 6,
+    affectedCells: cells,
+    effectKind: "obscurement",
+    obscurement: "heavy"
+  };
+}
+
+describe("active area effects — Spike Growth difficult terrain", () => {
+  const spikeCells = [
+    { x: 3, y: 1 },
+    { x: 4, y: 1 },
+    { x: 5, y: 1 }
+  ];
+
+  it("path fully outside Spike Growth costs base cost only", () => {
+    const result = validateMovement(
+      {
+        map,
+        obstacles: [],
+        tokens: [token],
+        activeAreaEffects: [spikeGrowthEffect(spikeCells)]
+      },
+      token,
+      [
+        { x: 1, y: 2 },
+        { x: 1, y: 3 },
+        { x: 1, y: 4 }
+      ],
+      combatState
+    );
+    expect(result.accepted).toBe(true);
+    expect(result.pathCostUnits).toBe(15);
+  });
+
+  it("path partially through Spike Growth applies the multiplier on affected cells only", () => {
+    // (1,1)→(2,1) normal=5, (2,1)→(3,1) spike=10, (3,1)→(4,1) spike=10 → 25
+    const result = validateMovement(
+      {
+        map,
+        obstacles: [],
+        tokens: [token],
+        activeAreaEffects: [spikeGrowthEffect(spikeCells)]
+      },
+      token,
+      [
+        { x: 2, y: 1 },
+        { x: 3, y: 1 },
+        { x: 4, y: 1 }
+      ],
+      combatState
+    );
+    expect(result.accepted).toBe(true);
+    expect(result.pathCostUnits).toBe(25);
+  });
+
+  it("path fully through Spike Growth pays the multiplier on every step", () => {
+    // (2,1)→(3,1)[10]→(4,1)[10]→(5,1)[10] = 30
+    const fromAdjacent: Token = { ...token, position: { x: 2, y: 1 } };
+    const result = validateMovement(
+      {
+        map,
+        obstacles: [],
+        tokens: [fromAdjacent],
+        activeAreaEffects: [spikeGrowthEffect(spikeCells)]
+      },
+      fromAdjacent,
+      [
+        { x: 3, y: 1 },
+        { x: 4, y: 1 },
+        { x: 5, y: 1 }
+      ],
+      combatState
+    );
+    expect(result.accepted).toBe(true);
+    expect(result.pathCostUnits).toBe(30);
+  });
+
+  it("does not double-apply when a cell is both obstacle difficult terrain and Spike Growth", () => {
+    const result = validateMovement(
+      {
+        map,
+        obstacles: [difficultTerrain],
+        tokens: [token],
+        activeAreaEffects: [spikeGrowthEffect(spikeCells)]
+      },
+      token,
+      [
+        { x: 2, y: 1 },
+        { x: 3, y: 1 }
+      ],
+      combatState
+    );
+    // (1,1)→(2,1) normal=5, (2,1)→(3,1) max(2,2)=2 → 10. Total = 15.
+    expect(result.accepted).toBe(true);
+    expect(result.pathCostUnits).toBe(15);
+  });
+
+  it("rejects movement when extra Spike Growth cost exceeds budget", () => {
+    const tightToken: Token = { ...token, movementBudget: 12 };
+    const result = validateMovement(
+      {
+        map,
+        obstacles: [],
+        tokens: [tightToken],
+        activeAreaEffects: [spikeGrowthEffect(spikeCells)]
+      },
+      tightToken,
+      [
+        { x: 2, y: 1 },
+        { x: 3, y: 1 }
+      ],
+      combatState
+    );
+    // 5 + 10 = 15 > 12
+    expect(result.accepted).toBe(false);
+    expect(result.rejectionReason).toBe("movement_budget_exceeded");
+  });
+
+  it("findMovementPath prefers a cheaper route around Spike Growth when one exists", () => {
+    // Spike Growth straight east of token blocks the cheap horizontal path; the
+    // engine should detour south of the spike row.
+    const result = findMovementPath(
+      {
+        map,
+        obstacles: [],
+        tokens: [token],
+        activeAreaEffects: [spikeGrowthEffect(spikeCells)]
+      },
+      token,
+      { x: 6, y: 1 },
+      combatState
+    );
+    expect(result.accepted).toBe(true);
+    // No path step should land on a Spike Growth cell.
+    for (const step of result.path) {
+      expect(spikeCells).not.toContainEqual(step);
+    }
+  });
+
+  it("Fog Cloud (obscurement) does not modify movement cost", () => {
+    const result = validateMovement(
+      {
+        map,
+        obstacles: [],
+        tokens: [token],
+        activeAreaEffects: [fogCloudEffect([{ x: 3, y: 1 }])]
+      },
+      token,
+      [
+        { x: 2, y: 1 },
+        { x: 3, y: 1 }
+      ],
+      combatState
+    );
+    expect(result.accepted).toBe(true);
+    expect(result.pathCostUnits).toBe(10);
+  });
+
+  it("getMovementCostMultiplier returns 2 inside a Spike Growth cell", () => {
+    expect(
+      getMovementCostMultiplier([], { x: 3, y: 1 }, [
+        spikeGrowthEffect(spikeCells)
+      ])
+    ).toBe(2);
+  });
+
+  it("getMovementCostMultiplier returns 1 outside Spike Growth", () => {
+    expect(
+      getMovementCostMultiplier([], { x: 9, y: 9 }, [
+        spikeGrowthEffect(spikeCells)
+      ])
+    ).toBe(1);
   });
 });


### PR DESCRIPTION
Closes #67

## Summary
- Active area effects with `terrainEffect="difficult_terrain"` (Spike Growth) now multiply movement cost ×2 on every affected cell — both in preview and confirmation.
- Combat-state-only: campaign map terrain is never mutated. Overlapping difficult terrains take the max multiplier (no double-apply).
- Obscurement effects (Fog Cloud) and immediate AoEs (Fireball) do not modify movement.

## Changes
- **tactical-engine**: `GridState.activeAreaEffects?: ActiveAreaEffect[]`; `getMovementCostMultiplier(obstacles, cell, activeAreaEffects)`. All four call sites in `validate-movement` updated. `.js` mirrors regenerated to match.
- **map-server**: `MovementService.previewMovement` and `MovementService.moveToken` include `encounter.activeAreaEffects` in the `GridState`.
- **map-web**: `findReachableCells` in `use-battle-map-pixi` consumes `encounter.activeAreaEffects` so the reachable-cells overlay matches authoritative cost.

## Test plan
- [x] `npx vitest run --root packages/tactical-engine` — 135 passed
- [x] `npx vitest run --root apps/map-server` — 224 passed
- [x] New tactical-engine unit tests cover: outside / partial / full Spike Growth; overlap with obstacle difficult terrain; budget overflow; `findMovementPath` detours around Spike Growth; Fog Cloud no-op; direct multiplier helpers.
- [x] New map-server integration tests cover: preview HTTP through Spike Growth (cost 20, remaining 10) and Fog Cloud (cost 10, remaining 20).
- [x] Manual: cast Spike Growth in combat, drag-preview a path crossing it, confirm increased cost matches preview and a cheaper detour avoids it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)