### PR TITLE
feat(combat): apply Spike Growth movement-triggered damage

### DIFF
--- a/apps/control-server/app/api/routes/combat_spells.py
+++ b/apps/control-server/app/api/routes/combat_spells.py
@@ -83,13 +83,13 @@ def action_cast_spell_preview(
     "/sessions/{session_id}/combat/action/move/preview",
     response_model=CombatMovementPreviewResponse,
 )
-def action_move_preview(
+async def action_move_preview(
     session_id: str,
     req: CombatMovementPreviewRequest,
     db: Session = Depends(get_session),
     user: User = Depends(get_current_user),
 ):
-    return CombatService.preview_movement(
+    return await CombatService.preview_movement(
         db,
         session_id,
         req,
@@ -102,13 +102,13 @@ def action_move_preview(
     "/sessions/{session_id}/combat/action/move",
     response_model=CombatMovementPreviewResponse,
 )
-def action_move(
+async def action_move(
     session_id: str,
     req: CombatMovementPreviewRequest,
     db: Session = Depends(get_session),
     user: User = Depends(get_current_user),
 ):
-    return CombatService.confirm_movement(
+    return await CombatService.confirm_movement(
         db,
         session_id,
         req,

--- a/apps/control-server/app/services/combat_service/movement.py
+++ b/apps/control-server/app/services/combat_service/movement.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from uuid import uuid4
 
 from sqlmodel import Session
@@ -10,12 +11,13 @@ from app.schemas.combat import (
     CombatMovementPreviewResponse,
 )
 from .exceptions import CombatServiceError
+from .movement_hazards import compute_movement_hazard_outcomes
 from .spells.area_targeting import AreaTargetingMixin
 
 
 class CombatMovementMixin(AreaTargetingMixin):
     @classmethod
-    def _preview_or_confirm_movement(
+    async def _preview_or_confirm_movement(
         cls,
         db: Session,
         session_id: str,
@@ -68,6 +70,16 @@ class CombatMovementMixin(AreaTargetingMixin):
                 503,
             ) from exc
 
+        if confirm and response.is_valid:
+            await cls._apply_movement_hazards(
+                db,
+                session_id=session_id,
+                state=state,
+                actor=actor,
+                response=response,
+                actor_user_id=actor_user_id,
+            )
+
         return CombatMovementPreviewResponse(
             is_valid=response.is_valid,
             reason=response.reason,
@@ -89,7 +101,93 @@ class CombatMovementMixin(AreaTargetingMixin):
         )
 
     @classmethod
-    def preview_movement(
+    async def _apply_movement_hazards(
+        cls,
+        db: Session,
+        *,
+        session_id: str,
+        state: Any,
+        actor: dict[str, Any],
+        response: Any,
+        actor_user_id: str,
+    ) -> None:
+        active_area_effects = (
+            state.active_area_effects if isinstance(state.active_area_effects, list) else []
+        )
+        if not active_area_effects:
+            return
+        path_cells = [{"x": cell.x, "y": cell.y} for cell in response.path]
+        outcomes = compute_movement_hazard_outcomes(active_area_effects, path_cells)
+        if not outcomes:
+            return
+
+        target_ref_id = actor.get("ref_id")
+        target_kind = actor.get("kind")
+        if not target_ref_id or target_kind not in ("player", "session_entity"):
+            return
+
+        previous_hp_player: int | None = None
+        previous_hp_entity: int | None = None
+        applied: list[tuple[dict[str, Any], int, str]] = []
+        for outcome in outcomes:
+            new_hp, effect_msg, previous_hp, _concentration = cls._apply_damage_to_target(
+                db,
+                target_ref_id,
+                target_kind,
+                outcome["damage"],
+                damage_type=outcome.get("damage_type"),
+                is_crit=False,
+                state=state,
+            )
+            if target_kind == "session_entity":
+                if previous_hp_entity is None:
+                    previous_hp_entity = previous_hp
+            else:
+                if previous_hp_player is None:
+                    previous_hp_player = previous_hp
+            applied.append((outcome, new_hp, effect_msg))
+
+        db.commit()
+
+        if target_kind == "player":
+            target_state, *_ = cls._get_stats(db, target_ref_id, target_kind, session_id)
+            await cls._emit_player_state_update(db, session_id, target_ref_id, target_state)
+        elif previous_hp_entity is not None:
+            await cls._emit_entity_hp_update(db, session_id, target_ref_id, previous_hp_entity)
+        if state:
+            await cls._emit_state(session_id, state)
+
+        actor_name = actor.get("display_name") or "Combatant"
+        for outcome, _new_hp, effect_msg in applied:
+            spell_name = outcome["source_spell_name"]
+            cells = outcome["cells_inside"]
+            damage = outcome["damage"]
+            damage_type = outcome.get("damage_type")
+            type_suffix = f" {damage_type}" if isinstance(damage_type, str) and damage_type else ""
+            cell_word = "cell" if cells == 1 else "cells"
+            message = (
+                f"{actor_name} took {damage}{type_suffix} damage from {spell_name} "
+                f"({cells} {cell_word} traversed).{effect_msg}"
+            )
+            await cls._emit_log(
+                session_id,
+                {
+                    "message": message,
+                    "source": "movement_hazard",
+                    "actorUserId": actor_user_id,
+                    "spellCanonicalKey": outcome.get("source_spell_canonical_key"),
+                    "effectId": outcome.get("effect_id"),
+                    "damage": damage,
+                    "damageType": damage_type,
+                    "diceExpression": outcome.get("dice_expression"),
+                    "damageInstances": outcome.get("damage_instances"),
+                    "cellsTraversed": cells,
+                    "metersTraversed": outcome.get("meters_inside"),
+                },
+            )
+
+    @classmethod
+    async def preview_movement(
         cls,
         db: Session,
         session_id: str,
@@ -98,7 +196,7 @@ class CombatMovementMixin(AreaTargetingMixin):
         actor_user_id: str,
         is_gm: bool,
     ) -> CombatMovementPreviewResponse:
-        return cls._preview_or_confirm_movement(
+        return await cls._preview_or_confirm_movement(
             db,
             session_id,
             req,
@@ -108,7 +206,7 @@ class CombatMovementMixin(AreaTargetingMixin):
         )
 
     @classmethod
-    def confirm_movement(
+    async def confirm_movement(
         cls,
         db: Session,
         session_id: str,
@@ -117,7 +215,7 @@ class CombatMovementMixin(AreaTargetingMixin):
         actor_user_id: str,
         is_gm: bool,
     ) -> CombatMovementPreviewResponse:
-        return cls._preview_or_confirm_movement(
+        return await cls._preview_or_confirm_movement(
             db,
             session_id,
             req,

--- a/apps/control-server/app/services/combat_service/movement_hazards.py
+++ b/apps/control-server/app/services/combat_service/movement_hazards.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from .exceptions import _roll_dice_expression
+from .unit_conversion import METERS_PER_CELL
+
+
+def _coordinate_key(cell: Any) -> tuple[int, int] | None:
+    if cell is None:
+        return None
+    if isinstance(cell, dict):
+        x, y = cell.get("x"), cell.get("y")
+    else:
+        x, y = getattr(cell, "x", None), getattr(cell, "y", None)
+    if not isinstance(x, int) or not isinstance(y, int):
+        return None
+    return (x, y)
+
+
+def _is_movement_hazard(effect: dict[str, Any]) -> bool:
+    """A hazard whose footprint deals damage as a creature traverses it.
+
+    The shape mirrors the metadata seeded for Spike Growth in
+    ``persistent_area_effects._metadata_for_spell``: a difficult-terrain
+    effect that also declares damage dice and a per-distance interval. Pure
+    obscurement (Fog Cloud) and difficult-terrain entries without damage
+    metadata are deliberately excluded.
+    """
+
+    if not isinstance(effect, dict):
+        return False
+    if effect.get("terrain_effect") != "difficult_terrain":
+        return False
+    dice = effect.get("movement_damage_dice")
+    if not isinstance(dice, str) or not dice.strip():
+        return False
+    per_meters = effect.get("damage_per_meters")
+    if not isinstance(per_meters, (int, float)) or per_meters <= 0:
+        return False
+    return True
+
+
+def _cells_inside_effect(effect: dict[str, Any], path: Iterable[Any]) -> int:
+    affected = effect.get("affected_cells")
+    if not isinstance(affected, list):
+        return 0
+    inside = {key for cell in affected if (key := _coordinate_key(cell)) is not None}
+    if not inside:
+        return 0
+    count = 0
+    for step in path:
+        key = _coordinate_key(step)
+        if key is not None and key in inside:
+            count += 1
+    return count
+
+
+def compute_movement_hazard_outcomes(
+    active_area_effects: Iterable[dict[str, Any]] | None,
+    path: Iterable[Any] | None,
+    *,
+    meters_per_cell: float = METERS_PER_CELL,
+) -> list[dict[str, Any]]:
+    """Compute per-effect damage outcomes for a confirmed movement path.
+
+    One outcome per active area effect that the path actually entered. Each
+    distinct overlapping effect rolls its own dice — the chosen safe-stacking
+    rule (one application per distinct active effect, no double-apply for the
+    same effect on the same path).
+
+    The path argument is the list of cells the actor *enters* — i.e. the
+    response path returned by the map server, which already excludes the
+    source cell. Zero-length paths therefore yield no outcomes.
+    """
+
+    if not active_area_effects or not path:
+        return []
+    path_list = list(path)
+    if not path_list:
+        return []
+    outcomes: list[dict[str, Any]] = []
+    for effect in active_area_effects:
+        if not _is_movement_hazard(effect):
+            continue
+        cells_inside = _cells_inside_effect(effect, path_list)
+        if cells_inside <= 0:
+            continue
+        per_meters = float(effect["damage_per_meters"])
+        meters_inside = cells_inside * meters_per_cell
+        damage_instances = int(meters_inside // per_meters)
+        if damage_instances <= 0:
+            continue
+        dice_expression = str(effect["movement_damage_dice"])
+        damage_total = sum(
+            _roll_dice_expression(dice_expression) for _ in range(damage_instances)
+        )
+        if damage_total <= 0:
+            continue
+        outcomes.append(
+            {
+                "effect_id": effect.get("id"),
+                "source_spell_canonical_key": effect.get("source_spell_canonical_key"),
+                "source_spell_name": effect.get("source_spell_name") or "Spell area",
+                "damage_type": effect.get("damage_type"),
+                "cells_inside": cells_inside,
+                "meters_inside": meters_inside,
+                "damage_instances": damage_instances,
+                "dice_expression": dice_expression,
+                "damage": damage_total,
+            }
+        )
+    return outcomes

--- a/apps/control-server/tests/test_combat_movement_preview.py
+++ b/apps/control-server/tests/test_combat_movement_preview.py
@@ -1,3 +1,4 @@
+import asyncio
 import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -8,6 +9,14 @@ from app.integrations.limiar_map_client import (
 )
 from app.schemas.combat import CombatMovementPreviewRequest
 from app.services.combat import CombatService
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 class TestCombatMovementPreview(unittest.TestCase):
@@ -26,7 +35,7 @@ class TestCombatMovementPreview(unittest.TestCase):
         _mock_require_status,
         _mock_require_movement,
     ) -> None:
-        mock_get_state.return_value = SimpleNamespace(use_map=True)
+        mock_get_state.return_value = SimpleNamespace(use_map=True, active_area_effects=[])
         mock_resolve_actor.return_value = {"id": "participant-1", "ref_id": "combatant-1", "status": "active"}
         client = MagicMock()
         client.preview_movement.return_value = LimiarMapMovementResponse(
@@ -47,12 +56,14 @@ class TestCombatMovementPreview(unittest.TestCase):
         )
         mock_build_client.return_value = client
 
-        result = CombatService.preview_movement(
-            db=MagicMock(),
-            session_id="session-1",
-            req=CombatMovementPreviewRequest(destination_cell={"x": 3, "y": 1}),
-            actor_user_id="user-1",
-            is_gm=False,
+        result = _run(
+            CombatService.preview_movement(
+                db=MagicMock(),
+                session_id="session-1",
+                req=CombatMovementPreviewRequest(destination_cell={"x": 3, "y": 1}),
+                actor_user_id="user-1",
+                is_gm=False,
+            )
         )
 
         self.assertTrue(result.is_valid)
@@ -78,7 +89,7 @@ class TestCombatMovementPreview(unittest.TestCase):
         _mock_require_status,
         _mock_require_movement,
     ) -> None:
-        mock_get_state.return_value = SimpleNamespace(use_map=True)
+        mock_get_state.return_value = SimpleNamespace(use_map=True, active_area_effects=[])
         mock_resolve_actor.return_value = {"id": "participant-1", "ref_id": "combatant-1", "status": "active"}
         client = MagicMock()
         client.preview_movement.return_value = LimiarMapMovementResponse(
@@ -99,12 +110,14 @@ class TestCombatMovementPreview(unittest.TestCase):
         )
         mock_build_client.return_value = client
 
-        result = CombatService.preview_movement(
-            db=MagicMock(),
-            session_id="session-1",
-            req=CombatMovementPreviewRequest(destination_cell={"x": 8, "y": 1}),
-            actor_user_id="user-1",
-            is_gm=False,
+        result = _run(
+            CombatService.preview_movement(
+                db=MagicMock(),
+                session_id="session-1",
+                req=CombatMovementPreviewRequest(destination_cell={"x": 8, "y": 1}),
+                actor_user_id="user-1",
+                is_gm=False,
+            )
         )
 
         self.assertFalse(result.is_valid)
@@ -126,7 +139,7 @@ class TestCombatMovementPreview(unittest.TestCase):
         _mock_require_status,
         _mock_require_movement,
     ) -> None:
-        mock_get_state.return_value = SimpleNamespace(use_map=True)
+        mock_get_state.return_value = SimpleNamespace(use_map=True, active_area_effects=[])
         mock_resolve_actor.return_value = {"id": "participant-1", "ref_id": "combatant-1", "status": "active"}
         client = MagicMock()
         client.move_combatant.return_value = LimiarMapMovementResponse(
@@ -147,15 +160,195 @@ class TestCombatMovementPreview(unittest.TestCase):
         )
         mock_build_client.return_value = client
 
-        CombatService.confirm_movement(
-            db=MagicMock(),
-            session_id="session-1",
-            req=CombatMovementPreviewRequest(destination_cell={"x": 2, "y": 1}),
-            actor_user_id="user-1",
-            is_gm=False,
+        _run(
+            CombatService.confirm_movement(
+                db=MagicMock(),
+                session_id="session-1",
+                req=CombatMovementPreviewRequest(destination_cell={"x": 2, "y": 1}),
+                actor_user_id="user-1",
+                is_gm=False,
+            )
         )
 
         client.move_combatant.assert_called_once()
+
+
+class TestConfirmMovementAppliesHazards(unittest.TestCase):
+    @patch.object(CombatService, "_emit_log")
+    @patch.object(CombatService, "_emit_state")
+    @patch.object(CombatService, "_emit_player_state_update")
+    @patch.object(CombatService, "_get_stats")
+    @patch.object(CombatService, "_apply_damage_to_target")
+    @patch.object(CombatService, "_require_movement_capable")
+    @patch.object(CombatService, "_require_actor_status")
+    @patch.object(CombatService, "_require_active")
+    @patch.object(CombatService, "_resolve_actor_participant")
+    @patch.object(CombatService, "get_state")
+    @patch.object(CombatService, "_build_limiar_map_client")
+    def test_confirmed_movement_through_spike_growth_applies_damage_and_logs(
+        self,
+        mock_build_client,
+        mock_get_state,
+        mock_resolve_actor,
+        _mock_require_active,
+        _mock_require_status,
+        _mock_require_movement,
+        mock_apply_damage,
+        mock_get_stats,
+        mock_emit_player,
+        mock_emit_state,
+        mock_emit_log,
+    ) -> None:
+        spike_growth = {
+            "id": "effect-1",
+            "source_spell_canonical_key": "spike_growth",
+            "source_spell_name": "Spike Growth",
+            "effect_kind": "hazard",
+            "terrain_effect": "difficult_terrain",
+            "movement_damage_dice": "2d4",
+            "damage_type": "Piercing",
+            "damage_per_meters": 1.5,
+            "affected_cells": [{"x": 2, "y": 1}, {"x": 3, "y": 1}],
+        }
+        state = SimpleNamespace(
+            use_map=True,
+            active_area_effects=[spike_growth],
+            session_id="session-1",
+        )
+        mock_get_state.return_value = state
+        mock_resolve_actor.return_value = {
+            "id": "participant-1",
+            "ref_id": "combatant-1",
+            "kind": "player",
+            "status": "active",
+            "display_name": "Hero",
+        }
+
+        mock_apply_damage.return_value = (5, "", 10, None)
+        mock_get_stats.return_value = (SimpleNamespace(), 5, 10, 10, 2, 3)
+
+        async def _emit_log(*args, **kwargs):
+            return None
+
+        async def _emit_state(*args, **kwargs):
+            return None
+
+        async def _emit_player(*args, **kwargs):
+            return None
+
+        mock_emit_log.side_effect = _emit_log
+        mock_emit_state.side_effect = _emit_state
+        mock_emit_player.side_effect = _emit_player
+
+        client = MagicMock()
+        client.move_combatant.return_value = LimiarMapMovementResponse(
+            is_valid=True,
+            reason=None,
+            session_id="session-1",
+            action_id="move-1",
+            version=15,
+            token_id="token-1",
+            combatant_id="combatant-1",
+            source_cell=LimiarMapMovementCell(x=1, y=1),
+            destination_cell=LimiarMapMovementCell(x=3, y=1),
+            path=(LimiarMapMovementCell(x=2, y=1), LimiarMapMovementCell(x=3, y=1)),
+            path_cost_units=20,
+            movement_budget=30,
+            movement_speed_cells=6,
+            remaining_budget=10,
+        )
+        mock_build_client.return_value = client
+
+        _run(
+            CombatService.confirm_movement(
+                db=MagicMock(),
+                session_id="session-1",
+                req=CombatMovementPreviewRequest(destination_cell={"x": 3, "y": 1}),
+                actor_user_id="user-1",
+                is_gm=False,
+            )
+        )
+
+        self.assertEqual(mock_apply_damage.call_count, 1)
+        _, kwargs = mock_apply_damage.call_args_list[0][0], mock_apply_damage.call_args_list[0][1]
+        self.assertEqual(kwargs.get("damage_type"), "Piercing")
+
+        log_calls = [c for c in mock_emit_log.call_args_list]
+        self.assertEqual(len(log_calls), 1)
+        payload = log_calls[0][0][1]
+        self.assertEqual(payload["source"], "movement_hazard")
+        self.assertEqual(payload["spellCanonicalKey"], "spike_growth")
+        self.assertEqual(payload["cellsTraversed"], 2)
+        self.assertIn("Spike Growth", payload["message"])
+
+    @patch.object(CombatService, "_apply_damage_to_target")
+    @patch.object(CombatService, "_require_movement_capable")
+    @patch.object(CombatService, "_require_actor_status")
+    @patch.object(CombatService, "_require_active")
+    @patch.object(CombatService, "_resolve_actor_participant")
+    @patch.object(CombatService, "get_state")
+    @patch.object(CombatService, "_build_limiar_map_client")
+    def test_preview_does_not_apply_hazards(
+        self,
+        mock_build_client,
+        mock_get_state,
+        mock_resolve_actor,
+        _mock_require_active,
+        _mock_require_status,
+        _mock_require_movement,
+        mock_apply_damage,
+    ) -> None:
+        spike_growth = {
+            "id": "effect-1",
+            "source_spell_canonical_key": "spike_growth",
+            "source_spell_name": "Spike Growth",
+            "terrain_effect": "difficult_terrain",
+            "movement_damage_dice": "2d4",
+            "damage_type": "Piercing",
+            "damage_per_meters": 1.5,
+            "affected_cells": [{"x": 2, "y": 1}],
+        }
+        mock_get_state.return_value = SimpleNamespace(
+            use_map=True,
+            active_area_effects=[spike_growth],
+            session_id="session-1",
+        )
+        mock_resolve_actor.return_value = {
+            "id": "p1",
+            "ref_id": "c1",
+            "kind": "player",
+            "status": "active",
+        }
+        client = MagicMock()
+        client.preview_movement.return_value = LimiarMapMovementResponse(
+            is_valid=True,
+            reason=None,
+            session_id="session-1",
+            action_id="preview-1",
+            version=14,
+            token_id="t1",
+            combatant_id="c1",
+            source_cell=LimiarMapMovementCell(x=1, y=1),
+            destination_cell=LimiarMapMovementCell(x=2, y=1),
+            path=(LimiarMapMovementCell(x=2, y=1),),
+            path_cost_units=10,
+            movement_budget=30,
+            movement_speed_cells=6,
+            remaining_budget=20,
+        )
+        mock_build_client.return_value = client
+
+        _run(
+            CombatService.preview_movement(
+                db=MagicMock(),
+                session_id="session-1",
+                req=CombatMovementPreviewRequest(destination_cell={"x": 2, "y": 1}),
+                actor_user_id="user-1",
+                is_gm=False,
+            )
+        )
+
+        mock_apply_damage.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/apps/control-server/tests/test_movement_hazards.py
+++ b/apps/control-server/tests/test_movement_hazards.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from app.services.combat_service.movement_hazards import (
+    compute_movement_hazard_outcomes,
+)
+
+
+def _spike_growth_effect(
+    *,
+    affected_cells: list[dict[str, int]],
+    effect_id: str = "effect-spike-1",
+) -> dict:
+    return {
+        "id": effect_id,
+        "source_spell_canonical_key": "spike_growth",
+        "source_spell_name": "Spike Growth",
+        "effect_kind": "hazard",
+        "terrain_effect": "difficult_terrain",
+        "movement_damage_dice": "2d4",
+        "damage_type": "Piercing",
+        "damage_per_meters": 1.5,
+        "affected_cells": affected_cells,
+    }
+
+
+def _fog_cloud_effect(affected_cells: list[dict[str, int]]) -> dict:
+    return {
+        "id": "effect-fog",
+        "source_spell_canonical_key": "fog_cloud",
+        "source_spell_name": "Fog Cloud",
+        "effect_kind": "obscurement",
+        "obscurement": "heavily_obscured",
+        "affected_cells": affected_cells,
+    }
+
+
+def _bare_difficult_terrain(affected_cells: list[dict[str, int]]) -> dict:
+    return {
+        "id": "effect-rough",
+        "source_spell_name": "Rough ground",
+        "terrain_effect": "difficult_terrain",
+        "affected_cells": affected_cells,
+    }
+
+
+class TestMovementHazardOutcomes(unittest.TestCase):
+    def test_path_outside_effect_yields_no_outcome(self):
+        effect = _spike_growth_effect(affected_cells=[{"x": 5, "y": 5}, {"x": 5, "y": 6}])
+        path = [{"x": 1, "y": 1}, {"x": 2, "y": 1}, {"x": 3, "y": 1}]
+
+        outcomes = compute_movement_hazard_outcomes([effect], path)
+
+        self.assertEqual(outcomes, [])
+
+    @patch(
+        "app.services.combat_service.movement_hazards._roll_dice_expression",
+        return_value=5,
+    )
+    def test_path_partially_through_effect_rolls_per_cell(self, mock_roll):
+        effect = _spike_growth_effect(
+            affected_cells=[{"x": 3, "y": 1}, {"x": 4, "y": 1}],
+        )
+        # Path enters 2 affected cells -> 3.0 meters -> floor(3.0/1.5)=2 instances
+        path = [{"x": 2, "y": 1}, {"x": 3, "y": 1}, {"x": 4, "y": 1}]
+
+        outcomes = compute_movement_hazard_outcomes([effect], path)
+
+        self.assertEqual(len(outcomes), 1)
+        outcome = outcomes[0]
+        self.assertEqual(outcome["cells_inside"], 2)
+        self.assertEqual(outcome["damage_instances"], 2)
+        self.assertEqual(outcome["damage"], 10)
+        self.assertEqual(outcome["dice_expression"], "2d4")
+        self.assertEqual(outcome["damage_type"], "Piercing")
+        self.assertEqual(mock_roll.call_count, 2)
+
+    @patch(
+        "app.services.combat_service.movement_hazards._roll_dice_expression",
+        return_value=4,
+    )
+    def test_path_fully_inside_effect(self, mock_roll):
+        effect = _spike_growth_effect(
+            affected_cells=[
+                {"x": 1, "y": 1},
+                {"x": 2, "y": 1},
+                {"x": 3, "y": 1},
+                {"x": 4, "y": 1},
+            ],
+        )
+        path = [{"x": 2, "y": 1}, {"x": 3, "y": 1}, {"x": 4, "y": 1}]
+
+        outcomes = compute_movement_hazard_outcomes([effect], path)
+
+        self.assertEqual(len(outcomes), 1)
+        self.assertEqual(outcomes[0]["cells_inside"], 3)
+        self.assertEqual(outcomes[0]["damage_instances"], 3)
+        self.assertEqual(outcomes[0]["damage"], 12)
+        self.assertEqual(mock_roll.call_count, 3)
+
+    def test_empty_path_yields_no_outcome(self):
+        effect = _spike_growth_effect(affected_cells=[{"x": 1, "y": 1}])
+        self.assertEqual(compute_movement_hazard_outcomes([effect], []), [])
+        self.assertEqual(compute_movement_hazard_outcomes([effect], None), [])
+
+    def test_no_active_effects_yields_no_outcome(self):
+        path = [{"x": 1, "y": 1}, {"x": 2, "y": 1}]
+        self.assertEqual(compute_movement_hazard_outcomes([], path), [])
+        self.assertEqual(compute_movement_hazard_outcomes(None, path), [])
+
+    def test_fog_cloud_is_no_op(self):
+        effect = _fog_cloud_effect(
+            affected_cells=[{"x": 2, "y": 1}, {"x": 3, "y": 1}],
+        )
+        path = [{"x": 2, "y": 1}, {"x": 3, "y": 1}]
+
+        outcomes = compute_movement_hazard_outcomes([effect], path)
+
+        self.assertEqual(outcomes, [])
+
+    def test_bare_difficult_terrain_without_damage_dice_is_no_op(self):
+        effect = _bare_difficult_terrain(
+            affected_cells=[{"x": 2, "y": 1}, {"x": 3, "y": 1}],
+        )
+        path = [{"x": 2, "y": 1}, {"x": 3, "y": 1}]
+
+        outcomes = compute_movement_hazard_outcomes([effect], path)
+
+        self.assertEqual(outcomes, [])
+
+    @patch(
+        "app.services.combat_service.movement_hazards._roll_dice_expression",
+        return_value=3,
+    )
+    def test_overlapping_distinct_effects_each_roll_independently(self, mock_roll):
+        effect_a = _spike_growth_effect(
+            affected_cells=[{"x": 2, "y": 1}, {"x": 3, "y": 1}],
+            effect_id="effect-a",
+        )
+        effect_b = _spike_growth_effect(
+            affected_cells=[{"x": 3, "y": 1}, {"x": 4, "y": 1}],
+            effect_id="effect-b",
+        )
+        path = [{"x": 2, "y": 1}, {"x": 3, "y": 1}, {"x": 4, "y": 1}]
+
+        outcomes = compute_movement_hazard_outcomes([effect_a, effect_b], path)
+
+        self.assertEqual(len(outcomes), 2)
+        ids = sorted(o["effect_id"] for o in outcomes)
+        self.assertEqual(ids, ["effect-a", "effect-b"])
+        # 4 total roll calls (2 instances per effect)
+        self.assertEqual(mock_roll.call_count, 4)
+
+    def test_short_path_below_per_meters_threshold_yields_no_outcome(self):
+        effect = _spike_growth_effect(affected_cells=[{"x": 2, "y": 1}])
+        # 1 cell = 1.5m -> exactly 1 instance, not zero
+        with patch(
+            "app.services.combat_service.movement_hazards._roll_dice_expression",
+            return_value=2,
+        ):
+            outcomes = compute_movement_hazard_outcomes(
+                [effect], [{"x": 2, "y": 1}]
+            )
+        self.assertEqual(len(outcomes), 1)
+        self.assertEqual(outcomes[0]["damage_instances"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #69

## Summary

- Adds `compute_movement_hazard_outcomes` helper that detects hazardous area effects (difficult terrain with damage metadata) overlapping a movement path and rolls per-effect piercing damage based on `damage_per_meters`.
- `confirm_movement` now applies the rolled damage to the moving combatant, commits, emits HP/state updates, and writes a `movement_hazard` combat log entry per distinct effect. Preview is unchanged (no HP mutation).
- Stacking rule: **one damage application per distinct active effect**. Each effect rolls independently; no double-apply for the same effect on the same path.

## Behavior

- Spike Growth: `2d4` piercing per `1.5m` (= per cell) traversed inside the affected area.
- Fog Cloud and bare difficult terrain without damage dice are no-ops.
- Invalid moves, previews, and zero-length paths apply no damage.

## Test plan

- [x] `pytest apps/control-server/tests/test_movement_hazards.py` — 9 unit tests (outside / partial / full / empty / no-effects / Fog Cloud / bare-DT / overlapping distinct effects / single-cell threshold)
- [x] `pytest apps/control-server/tests/test_combat_movement_preview.py` — 5 tests including `confirmed_movement_through_spike_growth_applies_damage_and_logs` and `preview_does_not_apply_hazards`
- [x] Full control-server suite: 1303 passed, 1 skipped
- [x] `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)