### PR TITLE
feat(combat): apply Fog Cloud heavy obscurement to LoS targeting

### DIFF
--- a/apps/control-server/tests/test_combat_targeting_integration.py
+++ b/apps/control-server/tests/test_combat_targeting_integration.py
@@ -1254,5 +1254,157 @@ class MeleeReachRangeCellsTests(unittest.TestCase):
         self.assertEqual(player_client.calls[0]["range_cells"], 2)
 
 
+class FogCloudVisibilityIntegrationTests(unittest.TestCase):
+    """Verifies that synced Fog Cloud area effects propagate through map-backed
+    targeting validation. The map server enforces obscurement; control-server
+    surfaces the rejection clearly when ``requires_sight`` is set, and lets the
+    action through when sight is not required.
+    """
+
+    def tearDown(self) -> None:
+        combat_targeting.reset_combat_targeting_service()
+
+    def test_target_inside_fog_cloud_rejects_sight_required_attack(self) -> None:
+        state = build_combat_state()
+        client = StubLimiarMapClient(
+            response=LimiarMapTargetingResponse(
+                is_valid=False,
+                reason="target_heavily_obscured",
+                session_id="session-123",
+                action_id="action-fog",
+                version=7,
+                source_token_id="token-source",
+                target_token_id="token-target",
+            )
+        )
+        service = LimiarMapTargetingService(
+            client, fallback_service=LocalCombatTargetingService()
+        )
+
+        result = service.validate(
+            WeaponAttackIntent(
+                session_id="session-123",
+                action_id="action-fog",
+                actor_ref_id="player-123",
+                actor_kind="player",
+                requested_target_ref_id="enemy-123",
+                weapon_range_type="melee",
+            ),
+            state,
+        )
+
+        self.assertFalse(result.is_valid)
+        self.assertIn("target_heavily_obscured", result.failure_reason)
+        self.assertTrue(client.calls[0]["requires_sight"])
+
+    def test_origin_inside_fog_cloud_rejects_sight_required_attack(self) -> None:
+        state = build_combat_state()
+        client = StubLimiarMapClient(
+            response=LimiarMapTargetingResponse(
+                is_valid=False,
+                reason="origin_heavily_obscured",
+                session_id="session-123",
+                action_id="action-fog-origin",
+                version=8,
+                source_token_id="token-source",
+                target_token_id="token-target",
+            )
+        )
+        service = LimiarMapTargetingService(
+            client, fallback_service=LocalCombatTargetingService()
+        )
+
+        result = service.validate(
+            WeaponAttackIntent(
+                session_id="session-123",
+                action_id="action-fog-origin",
+                actor_ref_id="player-123",
+                actor_kind="player",
+                requested_target_ref_id="enemy-123",
+                weapon_range_type="melee",
+            ),
+            state,
+        )
+
+        self.assertFalse(result.is_valid)
+        self.assertIn("origin_heavily_obscured", result.failure_reason)
+
+    def test_no_sight_required_passes_through_fog_cloud(self) -> None:
+        state = build_combat_state()
+        client = StubLimiarMapClient(
+            response=LimiarMapTargetingResponse(
+                is_valid=True,
+                reason=None,
+                session_id="session-123",
+                action_id="action-no-sight",
+                version=9,
+                source_token_id="token-source",
+                target_token_id="token-target",
+            )
+        )
+        service = LimiarMapTargetingService(
+            client, fallback_service=LocalCombatTargetingService()
+        )
+
+        # Melee weapons set requires_sight=False in the resolved profile.
+        result = service.validate(
+            WeaponAttackIntent(
+                session_id="session-123",
+                action_id="action-no-sight",
+                actor_ref_id="player-123",
+                actor_kind="player",
+                requested_target_ref_id="enemy-123",
+                weapon_range_type="melee",
+            ),
+            state,
+        )
+
+        self.assertTrue(result.is_valid)
+
+    def test_area_anchor_inside_fog_cloud_rejects_point_sight_required_spell(self) -> None:
+        state = build_combat_state()
+        client = StubLimiarMapClient(
+            response=LimiarMapAreaTargetingResponse(
+                is_valid=False,
+                reason="point_heavily_obscured",
+                session_id="session-123",
+                action_id="action-area-fog",
+                version=10,
+                shape="sphere",
+                source_token_id="token-source",
+                affected_cells=(),
+                affected_token_ids=(),
+                affected_combatant_ids=(),
+            )
+        )
+        service = LimiarMapTargetingService(
+            client, fallback_service=LocalCombatTargetingService()
+        )
+
+        result = service.validate(
+            AreaTargetingIntent(
+                session_id="session-123",
+                action_id="action-area-fog",
+                actor_ref_id="player-123",
+                actor_kind="player",
+                requested_target_ref_id=None,
+                spell_canonical_key="fireball",
+                spell_mode="damage",
+                shape="sphere",
+                size_meters=6,
+                range_meters=15,
+                origin_cell={"x": 0, "y": 0},
+                anchor_cell={"x": 4, "y": 0},
+                requires_sight=True,
+                requires_effect=False,
+            ),
+            state,
+        )
+
+        self.assertFalse(result.is_valid)
+        self.assertIn("point_heavily_obscured", result.failure_reason)
+        self.assertTrue(client.area_calls[0]["requires_sight"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/apps/map-server/src/modules/encounters/targeting-service.ts
+++ b/apps/map-server/src/modules/encounters/targeting-service.ts
@@ -1,8 +1,12 @@
-import type { ControllerType, Coordinate, TargetingTemplate } from "@limiarmap/shared-contracts";
+import type {
+  ControllerType,
+  Coordinate,
+  TargetingTemplate
+} from "@limiarmap/shared-contracts";
 import {
   chebyshevDistance,
+  evaluateLineOfSight,
   hasLineOfEffect,
-  hasLineOfSight,
   nextEncounterVersion,
   resolveCone,
   resolveCube,
@@ -25,30 +29,70 @@ export class TargetingService {
   ) {
     const encounter = this.repository.requireEncounter(sessionId);
     if (encounter.actionTracker.has(template.actionId)) {
-      return { accepted: false, rejectionReason: "duplicate_action", encounter };
+      return {
+        accepted: false,
+        rejectionReason: "duplicate_action",
+        encounter
+      };
     }
 
-    const token = encounter.tokens.find((candidate) => candidate.id === template.tokenId);
+    const token = encounter.tokens.find(
+      (candidate) => candidate.id === template.tokenId
+    );
     if (!token) {
       return { accepted: false, rejectionReason: "unknown_token", encounter };
     }
 
-    if (!canSubmitTacticalAction(actorId, actorType, token, encounter.combatState)) {
-      return { accepted: false, rejectionReason: "unauthorized_action", encounter };
+    if (
+      !canSubmitTacticalAction(actorId, actorType, token, encounter.combatState)
+    ) {
+      return {
+        accepted: false,
+        rejectionReason: "unauthorized_action",
+        encounter
+      };
     }
 
-    if (chebyshevDistance(template.originCell, template.anchorCell) > template.rangeCells) {
+    if (
+      chebyshevDistance(template.originCell, template.anchorCell) >
+      template.rangeCells
+    ) {
       return { accepted: false, rejectionReason: "out_of_range", encounter };
     }
 
-    const { obstacles, edgeObstacles } = encounter;
+    const { obstacles, edgeObstacles, activeAreaEffects } = encounter;
 
-    if (options?.requiresSight && !hasLineOfSight(obstacles, template.originCell, template.anchorCell, edgeObstacles)) {
-      return { accepted: false, rejectionReason: "no_line_of_sight", encounter };
+    if (options?.requiresSight) {
+      const sight = evaluateLineOfSight(
+        obstacles,
+        template.originCell,
+        template.anchorCell,
+        edgeObstacles,
+        activeAreaEffects
+      );
+      if (!sight.ok) {
+        const reason =
+          sight.reason === "target_heavily_obscured"
+            ? "point_heavily_obscured"
+            : sight.reason;
+        return { accepted: false, rejectionReason: reason, encounter };
+      }
     }
 
-    if (options?.requiresEffect && !hasLineOfEffect(obstacles, template.originCell, template.anchorCell, edgeObstacles)) {
-      return { accepted: false, rejectionReason: "no_line_of_effect", encounter };
+    if (
+      options?.requiresEffect &&
+      !hasLineOfEffect(
+        obstacles,
+        template.originCell,
+        template.anchorCell,
+        edgeObstacles
+      )
+    ) {
+      return {
+        accepted: false,
+        rejectionReason: "no_line_of_effect",
+        encounter
+      };
     }
 
     // Phase 11: all shape resolvers now receive edgeObstacles so propagation
@@ -74,13 +118,28 @@ export class TargetingService {
         );
         break;
       case "sphere":
-        affectedCells = resolveSphere(template.anchorCell, template.sizeCells, obstacles, edgeObstacles);
+        affectedCells = resolveSphere(
+          template.anchorCell,
+          template.sizeCells,
+          obstacles,
+          edgeObstacles
+        );
         break;
       case "cylinder":
-        affectedCells = resolveCylinder(template.anchorCell, template.sizeCells, obstacles, edgeObstacles);
+        affectedCells = resolveCylinder(
+          template.anchorCell,
+          template.sizeCells,
+          obstacles,
+          edgeObstacles
+        );
         break;
       case "cube":
-        affectedCells = resolveCube(template.anchorCell, template.sizeCells, obstacles, edgeObstacles);
+        affectedCells = resolveCube(
+          template.anchorCell,
+          template.sizeCells,
+          obstacles,
+          edgeObstacles
+        );
         break;
     }
 

--- a/apps/map-server/src/routes/integration/targeting.area.routes.ts
+++ b/apps/map-server/src/routes/integration/targeting.area.routes.ts
@@ -1,11 +1,21 @@
 import { randomUUID } from "node:crypto";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
-import { chebyshevDistance, hasLineOfEffect, hasLineOfSight, nextEncounterVersion } from "@limiarmap/tactical-engine";
+import {
+  chebyshevDistance,
+  evaluateLineOfSight,
+  hasLineOfEffect,
+  nextEncounterVersion
+} from "@limiarmap/tactical-engine";
 import { areaTargetRequestSchema } from "@limiarmap/shared-contracts";
 import type { InMemoryEncounterRepository } from "../../modules/encounters/encounter-repository";
 import type { BroadcastAdapter } from "../../modules/realtime/broadcast";
 import { broadcastAuthoritativeEvent } from "../../modules/realtime/broadcast";
-import { buildAreaRejection, err, isCellInsideMap, resolveAreaTargeting } from "./targeting.helpers";
+import {
+  buildAreaRejection,
+  err,
+  isCellInsideMap,
+  resolveAreaTargeting
+} from "./targeting.helpers";
 
 const LOG_PREFIX = "[integration]";
 
@@ -14,7 +24,7 @@ async function handleAreaRoute(
   reply: FastifyReply,
   repository: InMemoryEncounterRepository,
   broadcaster: BroadcastAdapter | undefined,
-  mutateState: boolean,
+  mutateState: boolean
 ) {
   const { sessionId } = request.params as { sessionId: string };
   const encounter = repository.getEncounter(sessionId);
@@ -24,31 +34,136 @@ async function handleAreaRoute(
 
   const parse = areaTargetRequestSchema.safeParse(request.body);
   if (!parse.success) {
-    return reply.status(400).send({ message: "Invalid request body", errors: parse.error.errors });
+    return reply
+      .status(400)
+      .send({ message: "Invalid request body", errors: parse.error.errors });
   }
 
-  const { actionId, combatantId, shape, originCell, anchorCell, rangeCells, sizeCells, requiresSight, requiresEffect } = parse.data;
-  const sourceToken = encounter.tokens.find((candidate) => candidate.combatantId === combatantId);
+  const {
+    actionId,
+    combatantId,
+    shape,
+    originCell,
+    anchorCell,
+    rangeCells,
+    sizeCells,
+    requiresSight,
+    requiresEffect
+  } = parse.data;
+  const sourceToken = encounter.tokens.find(
+    (candidate) => candidate.combatantId === combatantId
+  );
   if (!sourceToken) {
-    const unlinked = encounter.tokens.find((candidate) => candidate.id === combatantId);
-    return reply.status(200).send(
-      buildAreaRejection(encounter, sessionId, actionId, shape, unlinked ? "token_not_linked" : "unknown_combatant", null),
+    const unlinked = encounter.tokens.find(
+      (candidate) => candidate.id === combatantId
     );
+    return reply
+      .status(200)
+      .send(
+        buildAreaRejection(
+          encounter,
+          sessionId,
+          actionId,
+          shape,
+          unlinked ? "token_not_linked" : "unknown_combatant",
+          null
+        )
+      );
   }
   if (!isCellInsideMap(encounter, originCell)) {
-    return reply.status(200).send(buildAreaRejection(encounter, sessionId, actionId, shape, "invalid_origin", sourceToken.id));
+    return reply
+      .status(200)
+      .send(
+        buildAreaRejection(
+          encounter,
+          sessionId,
+          actionId,
+          shape,
+          "invalid_origin",
+          sourceToken.id
+        )
+      );
   }
   if (!isCellInsideMap(encounter, anchorCell)) {
-    return reply.status(200).send(buildAreaRejection(encounter, sessionId, actionId, shape, "invalid_anchor", sourceToken.id));
+    return reply
+      .status(200)
+      .send(
+        buildAreaRejection(
+          encounter,
+          sessionId,
+          actionId,
+          shape,
+          "invalid_anchor",
+          sourceToken.id
+        )
+      );
   }
-  if (rangeCells !== null && chebyshevDistance(originCell, anchorCell) > rangeCells) {
-    return reply.status(200).send(buildAreaRejection(encounter, sessionId, actionId, shape, "out_of_range", sourceToken.id));
+  if (
+    rangeCells !== null &&
+    chebyshevDistance(originCell, anchorCell) > rangeCells
+  ) {
+    return reply
+      .status(200)
+      .send(
+        buildAreaRejection(
+          encounter,
+          sessionId,
+          actionId,
+          shape,
+          "out_of_range",
+          sourceToken.id
+        )
+      );
   }
-  if (requiresSight && !hasLineOfSight(encounter.obstacles, originCell, anchorCell, encounter.edgeObstacles)) {
-    return reply.status(200).send(buildAreaRejection(encounter, sessionId, actionId, shape, "no_line_of_sight", sourceToken.id));
+  if (requiresSight) {
+    const sight = evaluateLineOfSight(
+      encounter.obstacles,
+      originCell,
+      anchorCell,
+      encounter.edgeObstacles,
+      encounter.activeAreaEffects
+    );
+    if (!sight.ok) {
+      // Area targeting selects a point, not a creature: remap target reason.
+      const reason =
+        sight.reason === "target_heavily_obscured"
+          ? "point_heavily_obscured"
+          : sight.reason;
+      return reply
+        .status(200)
+        .send(
+          buildAreaRejection(
+            encounter,
+            sessionId,
+            actionId,
+            shape,
+            reason,
+            sourceToken.id
+          )
+        );
+    }
   }
-  if (requiresEffect && !hasLineOfEffect(encounter.obstacles, originCell, anchorCell, encounter.edgeObstacles)) {
-    return reply.status(200).send(buildAreaRejection(encounter, sessionId, actionId, shape, "no_line_of_effect", sourceToken.id));
+  if (
+    requiresEffect &&
+    !hasLineOfEffect(
+      encounter.obstacles,
+      originCell,
+      anchorCell,
+      encounter.edgeObstacles
+    )
+  ) {
+    return reply
+      .status(200)
+      .send(
+        buildAreaRejection(
+          encounter,
+          sessionId,
+          actionId,
+          shape,
+          "no_line_of_effect",
+          sourceToken.id
+        )
+      );
   }
 
   const resolved = resolveAreaTargeting(encounter, {
@@ -56,7 +171,7 @@ async function handleAreaRoute(
     originCell,
     rangeCells,
     shape,
-    sizeCells,
+    sizeCells
   });
 
   if (!mutateState) {
@@ -68,9 +183,9 @@ async function handleAreaRoute(
         sourceTokenId: sourceToken.id,
         affectedCells: resolved.affectedCells.length,
         affectedCombatants: resolved.affectedCombatantIds.length,
-        version: encounter.combatState.version,
+        version: encounter.combatState.version
       },
-      `${LOG_PREFIX} area targeting preview`,
+      `${LOG_PREFIX} area targeting preview`
     );
     return reply.status(200).send({
       isValid: true,
@@ -82,12 +197,15 @@ async function handleAreaRoute(
       sourceTokenId: sourceToken.id,
       affectedCells: resolved.affectedCells,
       affectedTokenIds: resolved.affectedTokenIds,
-      affectedCombatantIds: resolved.affectedCombatantIds,
+      affectedCombatantIds: resolved.affectedCombatantIds
     });
   }
 
   if (encounter.actionTracker.has(actionId)) {
-    request.log.info({ sessionId, actionId, shape }, `${LOG_PREFIX} area targeting duplicate_action`);
+    request.log.info(
+      { sessionId, actionId, shape },
+      `${LOG_PREFIX} area targeting duplicate_action`
+    );
     return reply.status(200).send({
       isValid: true,
       reason: null,
@@ -98,14 +216,14 @@ async function handleAreaRoute(
       sourceTokenId: sourceToken.id,
       affectedCells: resolved.affectedCells,
       affectedTokenIds: resolved.affectedTokenIds,
-      affectedCombatantIds: resolved.affectedCombatantIds,
+      affectedCombatantIds: resolved.affectedCombatantIds
     });
   }
 
   encounter.actionTracker.record(actionId);
   encounter.combatState = {
     ...encounter.combatState,
-    version: nextEncounterVersion(encounter.combatState.version),
+    version: nextEncounterVersion(encounter.combatState.version)
   };
   repository.updateCombatState(sessionId, encounter.combatState);
 
@@ -122,9 +240,9 @@ async function handleAreaRoute(
       affectedTokenIds: resolved.affectedTokenIds,
       affectedCombatantIds: resolved.affectedCombatantIds,
       isValid: true,
-      reason: null,
+      reason: null
     },
-    replaySafe: true,
+    replaySafe: true
   });
 
   return reply.status(200).send({
@@ -137,19 +255,23 @@ async function handleAreaRoute(
     sourceTokenId: sourceToken.id,
     affectedCells: resolved.affectedCells,
     affectedTokenIds: resolved.affectedTokenIds,
-    affectedCombatantIds: resolved.affectedCombatantIds,
+    affectedCombatantIds: resolved.affectedCombatantIds
   });
 }
 
 export function registerAreaTargetingRoutes(
   app: FastifyInstance,
   repository: InMemoryEncounterRepository,
-  broadcaster?: BroadcastAdapter,
+  broadcaster?: BroadcastAdapter
 ) {
-  app.post("/integration/sessions/:sessionId/targeting/area", (request, reply) =>
-    handleAreaRoute(request, reply, repository, broadcaster, true),
+  app.post(
+    "/integration/sessions/:sessionId/targeting/area",
+    (request, reply) =>
+      handleAreaRoute(request, reply, repository, broadcaster, true)
   );
-  app.post("/integration/sessions/:sessionId/targeting/area/preview", (request, reply) =>
-    handleAreaRoute(request, reply, repository, broadcaster, false),
+  app.post(
+    "/integration/sessions/:sessionId/targeting/area/preview",
+    (request, reply) =>
+      handleAreaRoute(request, reply, repository, broadcaster, false)
   );
 }

--- a/apps/map-server/src/routes/integration/targeting.single.routes.ts
+++ b/apps/map-server/src/routes/integration/targeting.single.routes.ts
@@ -3,9 +3,9 @@ import type { FastifyInstance } from "fastify";
 import {
   chebyshevDistance,
   evaluateCover,
+  evaluateLineOfSight,
   hasLineOfEffect,
-  hasLineOfSight,
-  nextEncounterVersion,
+  nextEncounterVersion
 } from "@limiarmap/tactical-engine";
 import { singleTargetRequestSchema } from "@limiarmap/shared-contracts";
 import type { InMemoryEncounterRepository } from "../../modules/encounters/encounter-repository";
@@ -18,154 +18,204 @@ const LOG_PREFIX = "[integration]";
 export function registerSingleTargetingRoutes(
   app: FastifyInstance,
   repository: InMemoryEncounterRepository,
-  broadcaster?: BroadcastAdapter,
+  broadcaster?: BroadcastAdapter
 ) {
-  app.post("/integration/sessions/:sessionId/targeting", async (request, reply) => {
-    const { sessionId } = request.params as { sessionId: string };
-    const encounter = repository.getEncounter(sessionId);
-    if (!encounter) {
-      return err(reply, 404, "session_not_found", "Session not found");
-    }
+  app.post(
+    "/integration/sessions/:sessionId/targeting",
+    async (request, reply) => {
+      const { sessionId } = request.params as { sessionId: string };
+      const encounter = repository.getEncounter(sessionId);
+      if (!encounter) {
+        return err(reply, 404, "session_not_found", "Session not found");
+      }
 
-    const parse = singleTargetRequestSchema.safeParse(request.body);
-    if (!parse.success) {
-      return reply.status(400).send({ message: "Invalid request body", errors: parse.error.errors });
-    }
+      const parse = singleTargetRequestSchema.safeParse(request.body);
+      if (!parse.success) {
+        return reply.status(400).send({
+          message: "Invalid request body",
+          errors: parse.error.errors
+        });
+      }
 
-    const { actionId, combatantId, targetCombatantId, rangeCells, requiresSight, requiresEffect } = parse.data;
-    const isPreviewAction = actionId === "preview" || actionId.startsWith("preview:");
-    if (!isPreviewAction && encounter.actionTracker.has(actionId)) {
-      request.log.info({ sessionId, actionId }, `${LOG_PREFIX} targeting duplicate_action`);
+      const {
+        actionId,
+        combatantId,
+        targetCombatantId,
+        rangeCells,
+        requiresSight,
+        requiresEffect
+      } = parse.data;
+      const isPreviewAction =
+        actionId === "preview" || actionId.startsWith("preview:");
+      if (!isPreviewAction && encounter.actionTracker.has(actionId)) {
+        request.log.info(
+          { sessionId, actionId },
+          `${LOG_PREFIX} targeting duplicate_action`
+        );
+        return reply.status(200).send({
+          isValid: true,
+          reason: null,
+          sessionId,
+          actionId,
+          version: encounter.combatState.version,
+          sourceTokenId: null,
+          targetTokenId: null,
+          distanceCells: null
+        });
+      }
+
+      const sourceToken = encounter.tokens.find(
+        (token) => token.combatantId === combatantId
+      );
+      if (!sourceToken) {
+        const unlinked = encounter.tokens.find(
+          (token) => token.id === combatantId
+        );
+        return reply.status(200).send({
+          isValid: false,
+          reason: unlinked ? "token_not_linked" : "unknown_combatant",
+          sessionId,
+          actionId,
+          version: encounter.combatState.version,
+          sourceTokenId: null,
+          targetTokenId: null,
+          distanceCells: null
+        });
+      }
+
+      const targetToken = encounter.tokens.find(
+        (token) => token.combatantId === targetCombatantId
+      );
+      if (!targetToken) {
+        const unlinked = encounter.tokens.find(
+          (token) => token.id === targetCombatantId
+        );
+        return reply.status(200).send({
+          isValid: false,
+          reason: unlinked ? "token_not_linked" : "unknown_combatant",
+          sessionId,
+          actionId,
+          version: encounter.combatState.version,
+          sourceTokenId: sourceToken.id,
+          targetTokenId: null,
+          distanceCells: null
+        });
+      }
+
+      const distance = chebyshevDistance(
+        sourceToken.position,
+        targetToken.position
+      );
+      if (rangeCells !== null && distance > rangeCells) {
+        return reply.status(200).send({
+          isValid: false,
+          reason: "out_of_range",
+          sessionId,
+          actionId,
+          version: encounter.combatState.version,
+          sourceTokenId: sourceToken.id,
+          targetTokenId: targetToken.id,
+          distanceCells: distance
+        });
+      }
+      if (requiresSight) {
+        const sight = evaluateLineOfSight(
+          encounter.obstacles,
+          sourceToken.position,
+          targetToken.position,
+          encounter.edgeObstacles,
+          encounter.activeAreaEffects
+        );
+        if (!sight.ok) {
+          return reply.status(200).send({
+            isValid: false,
+            reason: sight.reason,
+            sessionId,
+            actionId,
+            version: encounter.combatState.version,
+            sourceTokenId: sourceToken.id,
+            targetTokenId: targetToken.id,
+            distanceCells: distance
+          });
+        }
+      }
+      if (
+        requiresEffect &&
+        !hasLineOfEffect(
+          encounter.obstacles,
+          sourceToken.position,
+          targetToken.position,
+          encounter.edgeObstacles
+        )
+      ) {
+        return reply.status(200).send({
+          isValid: false,
+          reason: "no_line_of_effect",
+          sessionId,
+          actionId,
+          version: encounter.combatState.version,
+          sourceTokenId: sourceToken.id,
+          targetTokenId: targetToken.id,
+          distanceCells: distance
+        });
+      }
+
+      const cover = evaluateCover(
+        encounter.obstacles,
+        sourceToken.position,
+        targetToken.position,
+        encounter.edgeObstacles
+      );
+      if (cover === "full") {
+        return reply.status(200).send({
+          isValid: false,
+          reason: "full_cover",
+          sessionId,
+          actionId,
+          version: encounter.combatState.version,
+          sourceTokenId: sourceToken.id,
+          targetTokenId: targetToken.id,
+          distanceCells: distance,
+          cover
+        });
+      }
+
+      if (!isPreviewAction) {
+        encounter.actionTracker.record(actionId);
+        encounter.combatState = {
+          ...encounter.combatState,
+          version: nextEncounterVersion(encounter.combatState.version)
+        };
+        repository.updateCombatState(sessionId, encounter.combatState);
+
+        broadcastAuthoritativeEvent(broadcaster, "targeting.resolved", {
+          eventId: randomUUID(),
+          eventType: "targeting.resolved",
+          encounterId: sessionId,
+          version: encounter.combatState.version,
+          actionId,
+          payload: {
+            sourceTokenId: sourceToken.id,
+            targetTokenId: targetToken.id,
+            isValid: true,
+            reason: null,
+            cover
+          },
+          replaySafe: true
+        });
+      }
+
       return reply.status(200).send({
         isValid: true,
         reason: null,
         sessionId,
         actionId,
         version: encounter.combatState.version,
-        sourceTokenId: null,
-        targetTokenId: null,
-        distanceCells: null,
-      });
-    }
-
-    const sourceToken = encounter.tokens.find((token) => token.combatantId === combatantId);
-    if (!sourceToken) {
-      const unlinked = encounter.tokens.find((token) => token.id === combatantId);
-      return reply.status(200).send({
-        isValid: false,
-        reason: unlinked ? "token_not_linked" : "unknown_combatant",
-        sessionId,
-        actionId,
-        version: encounter.combatState.version,
-        sourceTokenId: null,
-        targetTokenId: null,
-        distanceCells: null,
-      });
-    }
-
-    const targetToken = encounter.tokens.find((token) => token.combatantId === targetCombatantId);
-    if (!targetToken) {
-      const unlinked = encounter.tokens.find((token) => token.id === targetCombatantId);
-      return reply.status(200).send({
-        isValid: false,
-        reason: unlinked ? "token_not_linked" : "unknown_combatant",
-        sessionId,
-        actionId,
-        version: encounter.combatState.version,
-        sourceTokenId: sourceToken.id,
-        targetTokenId: null,
-        distanceCells: null,
-      });
-    }
-
-    const distance = chebyshevDistance(sourceToken.position, targetToken.position);
-    if (rangeCells !== null && distance > rangeCells) {
-      return reply.status(200).send({
-        isValid: false,
-        reason: "out_of_range",
-        sessionId,
-        actionId,
-        version: encounter.combatState.version,
         sourceTokenId: sourceToken.id,
         targetTokenId: targetToken.id,
         distanceCells: distance,
+        cover
       });
     }
-    if (requiresSight && !hasLineOfSight(encounter.obstacles, sourceToken.position, targetToken.position, encounter.edgeObstacles)) {
-      return reply.status(200).send({
-        isValid: false,
-        reason: "no_line_of_sight",
-        sessionId,
-        actionId,
-        version: encounter.combatState.version,
-        sourceTokenId: sourceToken.id,
-        targetTokenId: targetToken.id,
-        distanceCells: distance,
-      });
-    }
-    if (requiresEffect && !hasLineOfEffect(encounter.obstacles, sourceToken.position, targetToken.position, encounter.edgeObstacles)) {
-      return reply.status(200).send({
-        isValid: false,
-        reason: "no_line_of_effect",
-        sessionId,
-        actionId,
-        version: encounter.combatState.version,
-        sourceTokenId: sourceToken.id,
-        targetTokenId: targetToken.id,
-        distanceCells: distance,
-      });
-    }
-
-    const cover = evaluateCover(encounter.obstacles, sourceToken.position, targetToken.position, encounter.edgeObstacles);
-    if (cover === "full") {
-      return reply.status(200).send({
-        isValid: false,
-        reason: "full_cover",
-        sessionId,
-        actionId,
-        version: encounter.combatState.version,
-        sourceTokenId: sourceToken.id,
-        targetTokenId: targetToken.id,
-        distanceCells: distance,
-        cover,
-      });
-    }
-
-    if (!isPreviewAction) {
-      encounter.actionTracker.record(actionId);
-      encounter.combatState = {
-        ...encounter.combatState,
-        version: nextEncounterVersion(encounter.combatState.version),
-      };
-      repository.updateCombatState(sessionId, encounter.combatState);
-
-      broadcastAuthoritativeEvent(broadcaster, "targeting.resolved", {
-        eventId: randomUUID(),
-        eventType: "targeting.resolved",
-        encounterId: sessionId,
-        version: encounter.combatState.version,
-        actionId,
-        payload: {
-          sourceTokenId: sourceToken.id,
-          targetTokenId: targetToken.id,
-          isValid: true,
-          reason: null,
-          cover,
-        },
-        replaySafe: true,
-      });
-    }
-
-    return reply.status(200).send({
-      isValid: true,
-      reason: null,
-      sessionId,
-      actionId,
-      version: encounter.combatState.version,
-      sourceTokenId: sourceToken.id,
-      targetTokenId: targetToken.id,
-      distanceCells: distance,
-      cover,
-    });
-  });
+  );
 }

--- a/apps/map-server/tests/integration/fog-cloud-targeting.integration.test.ts
+++ b/apps/map-server/tests/integration/fog-cloud-targeting.integration.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it, vi } from "vitest";
+import { createApp } from "../../src/app";
+import { registerIntegrationRoutes } from "../../src/routes/integration-routes";
+
+function fogCloudPayload(cells: { x: number; y: number }[]) {
+  return {
+    activeAreaEffects: [
+      {
+        id: "area_effect:fog",
+        sourceSpellCanonicalKey: "fog_cloud",
+        sourceSpellName: "Fog Cloud",
+        casterParticipantId: "p1",
+        casterRefId: "player-123",
+        originPoint: cells[0],
+        anchorCell: cells[0],
+        areaShape: "sphere",
+        sizeMeters: 6,
+        radiusMeters: 6,
+        affectedCells: cells,
+        effectKind: "obscurement",
+        obscurement: "heavily_obscured"
+      }
+    ]
+  };
+}
+
+async function syncFogCloud(
+  app: ReturnType<typeof createApp>["app"],
+  sessionId: string,
+  cells: { x: number; y: number }[]
+) {
+  const r = await app.inject({
+    method: "PUT",
+    url: `/integration/sessions/${sessionId}/area-effects`,
+    payload: fogCloudPayload(cells)
+  });
+  expect(r.statusCode).toBe(200);
+}
+
+describe("Fog Cloud targeting integration", () => {
+  it("blocks single-target sight when target stands inside Fog Cloud", async () => {
+    const { app, repository } = createApp();
+    registerIntegrationRoutes(app, repository, { emit: vi.fn() });
+
+    const encounter = repository.createEncounter("fog-target");
+    encounter.tokens = encounter.tokens.map((token) =>
+      token.combatantId === "cmb_1"
+        ? { ...token, position: { x: 0, y: 0 } }
+        : token.combatantId === "cmb_2"
+          ? { ...token, position: { x: 3, y: 0 } }
+          : token
+    );
+    repository.saveEncounter(encounter);
+
+    await syncFogCloud(app, "fog-target", [{ x: 3, y: 0 }]);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/integration/sessions/fog-target/targeting",
+      payload: {
+        actionId: "target-fog-1",
+        combatantId: "cmb_1",
+        targetCombatantId: "cmb_2",
+        rangeCells: 10,
+        requiresSight: true
+      }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      isValid: false,
+      reason: "target_heavily_obscured"
+    });
+
+    await app.close();
+  });
+
+  it("blocks single-target sight when caster stands inside Fog Cloud", async () => {
+    const { app, repository } = createApp();
+    registerIntegrationRoutes(app, repository, { emit: vi.fn() });
+
+    const encounter = repository.createEncounter("fog-origin");
+    encounter.tokens = encounter.tokens.map((token) =>
+      token.combatantId === "cmb_1"
+        ? { ...token, position: { x: 0, y: 0 } }
+        : token.combatantId === "cmb_2"
+          ? { ...token, position: { x: 3, y: 0 } }
+          : token
+    );
+    repository.saveEncounter(encounter);
+
+    await syncFogCloud(app, "fog-origin", [{ x: 0, y: 0 }]);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/integration/sessions/fog-origin/targeting",
+      payload: {
+        actionId: "target-fog-2",
+        combatantId: "cmb_1",
+        targetCombatantId: "cmb_2",
+        rangeCells: 10,
+        requiresSight: true
+      }
+    });
+
+    expect(response.json()).toMatchObject({
+      isValid: false,
+      reason: "origin_heavily_obscured"
+    });
+    await app.close();
+  });
+
+  it("blocks single-target sight when LoS path crosses Fog Cloud", async () => {
+    const { app, repository } = createApp();
+    registerIntegrationRoutes(app, repository, { emit: vi.fn() });
+
+    const encounter = repository.createEncounter("fog-cross");
+    encounter.tokens = encounter.tokens.map((token) =>
+      token.combatantId === "cmb_1"
+        ? { ...token, position: { x: 0, y: 0 } }
+        : token.combatantId === "cmb_2"
+          ? { ...token, position: { x: 4, y: 0 } }
+          : token
+    );
+    repository.saveEncounter(encounter);
+
+    await syncFogCloud(app, "fog-cross", [{ x: 2, y: 0 }]);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/integration/sessions/fog-cross/targeting",
+      payload: {
+        actionId: "target-fog-3",
+        combatantId: "cmb_1",
+        targetCombatantId: "cmb_2",
+        rangeCells: 10,
+        requiresSight: true
+      }
+    });
+
+    expect(response.json()).toMatchObject({
+      isValid: false,
+      reason: "line_of_sight_obscured"
+    });
+    await app.close();
+  });
+
+  it("does not block targeting when requiresSight is false", async () => {
+    const { app, repository } = createApp();
+    registerIntegrationRoutes(app, repository, { emit: vi.fn() });
+
+    const encounter = repository.createEncounter("fog-nosight");
+    encounter.tokens = encounter.tokens.map((token) =>
+      token.combatantId === "cmb_1"
+        ? { ...token, position: { x: 0, y: 0 } }
+        : token.combatantId === "cmb_2"
+          ? { ...token, position: { x: 3, y: 0 } }
+          : token
+    );
+    repository.saveEncounter(encounter);
+
+    await syncFogCloud(app, "fog-nosight", [{ x: 3, y: 0 }]);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/integration/sessions/fog-nosight/targeting",
+      payload: {
+        actionId: "target-fog-4",
+        combatantId: "cmb_1",
+        targetCombatantId: "cmb_2",
+        rangeCells: 10,
+        requiresSight: false
+      }
+    });
+
+    expect(response.json()).toMatchObject({ isValid: true, reason: null });
+    await app.close();
+  });
+
+  it("blocks area preview point sight when anchor cell is inside Fog Cloud", async () => {
+    const { app, repository } = createApp();
+    registerIntegrationRoutes(app, repository, { emit: vi.fn() });
+
+    const encounter = repository.createEncounter("fog-area");
+    encounter.tokens = encounter.tokens.map((token) =>
+      token.combatantId === "cmb_1"
+        ? { ...token, position: { x: 0, y: 0 } }
+        : token
+    );
+    repository.saveEncounter(encounter);
+
+    await syncFogCloud(app, "fog-area", [{ x: 4, y: 0 }]);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/integration/sessions/fog-area/targeting/area/preview",
+      payload: {
+        actionId: "preview-fog-area-1",
+        combatantId: "cmb_1",
+        shape: "sphere",
+        originCell: { x: 0, y: 0 },
+        anchorCell: { x: 4, y: 0 },
+        rangeCells: 10,
+        sizeCells: 2,
+        requiresSight: true
+      }
+    });
+
+    expect(response.json()).toMatchObject({
+      isValid: false,
+      reason: "point_heavily_obscured"
+    });
+    await app.close();
+  });
+
+  it("does not affect targeting for Spike Growth (hazard, not obscurement)", async () => {
+    const { app, repository } = createApp();
+    registerIntegrationRoutes(app, repository, { emit: vi.fn() });
+
+    const encounter = repository.createEncounter("spike-sight");
+    encounter.tokens = encounter.tokens.map((token) =>
+      token.combatantId === "cmb_1"
+        ? { ...token, position: { x: 0, y: 0 } }
+        : token.combatantId === "cmb_2"
+          ? { ...token, position: { x: 3, y: 0 } }
+          : token
+    );
+    repository.saveEncounter(encounter);
+
+    await app.inject({
+      method: "PUT",
+      url: "/integration/sessions/spike-sight/area-effects",
+      payload: {
+        activeAreaEffects: [
+          {
+            id: "area_effect:spike",
+            sourceSpellCanonicalKey: "spike_growth",
+            sourceSpellName: "Spike Growth",
+            casterParticipantId: "p1",
+            casterRefId: "player-123",
+            originPoint: { x: 2, y: 0 },
+            anchorCell: { x: 2, y: 0 },
+            areaShape: "sphere",
+            sizeMeters: 6,
+            radiusMeters: 6,
+            affectedCells: [{ x: 2, y: 0 }],
+            effectKind: "hazard",
+            terrainEffect: "difficult_terrain",
+            movementDamageDice: "2d4",
+            damageType: "Piercing",
+            damagePerMeters: 1.5
+          }
+        ]
+      }
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/integration/sessions/spike-sight/targeting",
+      payload: {
+        actionId: "target-spike-1",
+        combatantId: "cmb_1",
+        targetCombatantId: "cmb_2",
+        rangeCells: 10,
+        requiresSight: true
+      }
+    });
+
+    expect(response.json()).toMatchObject({ isValid: true, reason: null });
+    await app.close();
+  });
+});

--- a/apps/map-web/src/features/targeting/diagnostics-to-explanation.test.ts
+++ b/apps/map-web/src/features/targeting/diagnostics-to-explanation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildFailureExplanation,
-  type FailureExplanation,
+  type FailureExplanation
 } from "./diagnostics-to-explanation";
 import type { TacticalDiagnostics } from "../battle-map/battle-map-store";
 
@@ -15,7 +15,7 @@ function diag(
     isValid: failureReasons.length === 0,
     failureReasons,
     checks: {},
-    metadata,
+    metadata
   };
 }
 
@@ -23,7 +23,12 @@ function invalidDiag(
   reasons: string[],
   meta: Record<string, number | string | boolean> = {}
 ): TacticalDiagnostics {
-  return { isValid: false, failureReasons: reasons, checks: {}, metadata: meta };
+  return {
+    isValid: false,
+    failureReasons: reasons,
+    checks: {},
+    metadata: meta
+  };
 }
 
 // ─── Null / valid cases ───────────────────────────────────────────────────────
@@ -38,7 +43,7 @@ describe("buildFailureExplanation — valid / null cases", () => {
       isValid: true,
       failureReasons: ["target_out_of_reach"],
       checks: {},
-      metadata: {},
+      metadata: {}
     };
     expect(buildFailureExplanation(d)).toBeNull();
   });
@@ -48,7 +53,7 @@ describe("buildFailureExplanation — valid / null cases", () => {
       isValid: false,
       failureReasons: [],
       checks: {},
-      metadata: {},
+      metadata: {}
     };
     expect(buildFailureExplanation(d)).toBeNull();
   });
@@ -63,10 +68,14 @@ describe("buildFailureExplanation — primary label per failure reason", () => {
     ["target_out_of_reach", "Fora do alcance"],
     ["no_line_of_sight", "Sem linha de visão"],
     ["no_line_of_effect", "Bloqueado"],
+    ["origin_heavily_obscured", "Você está na neblina"],
+    ["target_heavily_obscured", "Alvo na neblina"],
+    ["point_heavily_obscured", "Ponto na neblina"],
+    ["line_of_sight_obscured", "Visão bloqueada por neblina"],
     ["not_visible", "Não visível"],
     ["blocked_by_condition", "Condição bloqueante"],
     ["self_target_not_allowed", "Não pode alvejar a si"],
-    ["map_unreachable", "Mapa indisponível"],
+    ["map_unreachable", "Mapa indisponível"]
   ];
 
   for (const [reason, expectedLabel] of cases) {
@@ -91,15 +100,24 @@ describe("buildFailureExplanation — primary label per failure reason", () => {
 describe("buildFailureExplanation — details from metadata", () => {
   it("target_out_of_reach with full metadata → 2 detail lines", () => {
     const result = buildFailureExplanation(
-      invalidDiag(["target_out_of_reach"], { distance_cells: 3, reach_cells: 1 })
+      invalidDiag(["target_out_of_reach"], {
+        distance_cells: 3,
+        reach_cells: 1
+      })
     );
-    expect(result!.details).toEqual(["Distância: 3 células", "Alcance: 1 célula"]);
+    expect(result!.details).toEqual([
+      "Distância: 3 células",
+      "Alcance: 1 célula"
+    ]);
     expect(result!.context).toEqual({ distance: 3, range: 1 });
   });
 
   it("target_out_of_reach with distance=1 → singular 'célula'", () => {
     const result = buildFailureExplanation(
-      invalidDiag(["target_out_of_reach"], { distance_cells: 1, reach_cells: 1 })
+      invalidDiag(["target_out_of_reach"], {
+        distance_cells: 1,
+        reach_cells: 1
+      })
     );
     expect(result!.details[0]).toBe("Distância: 1 célula");
     expect(result!.details[1]).toBe("Alcance: 1 célula");
@@ -114,7 +132,9 @@ describe("buildFailureExplanation — details from metadata", () => {
   });
 
   it("target_out_of_reach with no metadata → empty details", () => {
-    const result = buildFailureExplanation(invalidDiag(["target_out_of_reach"]));
+    const result = buildFailureExplanation(
+      invalidDiag(["target_out_of_reach"])
+    );
     expect(result!.details).toEqual([]);
     expect(result!.context).toEqual({});
   });
@@ -122,6 +142,41 @@ describe("buildFailureExplanation — details from metadata", () => {
   it("no_line_of_sight → fixed detail string", () => {
     const result = buildFailureExplanation(invalidDiag(["no_line_of_sight"]));
     expect(result!.details).toEqual(["Visão bloqueada por obstáculo"]);
+  });
+
+  it("target_heavily_obscured → wins over generic no_line_of_sight", () => {
+    const result = buildFailureExplanation(
+      invalidDiag(["no_line_of_sight", "target_heavily_obscured"])
+    );
+    expect(result!.primary).toBe("Alvo na neblina");
+    expect(result!.details).toEqual(["Alvo está em área fortemente encoberta"]);
+    expect(result!.context).toEqual({ obscurement: "heavily_obscured" });
+    expect(result!.severity).toBe("red");
+  });
+
+  it("origin_heavily_obscured → caster-side message", () => {
+    const result = buildFailureExplanation(
+      invalidDiag(["origin_heavily_obscured"])
+    );
+    expect(result!.details).toEqual(["Você está em área fortemente encoberta"]);
+  });
+
+  it("point_heavily_obscured → area selected-point message", () => {
+    const result = buildFailureExplanation(
+      invalidDiag(["point_heavily_obscured"])
+    );
+    expect(result!.details).toEqual([
+      "Ponto está em área fortemente encoberta"
+    ]);
+  });
+
+  it("line_of_sight_obscured → path-crossing message", () => {
+    const result = buildFailureExplanation(
+      invalidDiag(["line_of_sight_obscured"])
+    );
+    expect(result!.details).toEqual([
+      "Linha de visão atravessa área encoberta"
+    ]);
   });
 
   it("no_line_of_effect → fixed detail string", () => {
@@ -135,7 +190,9 @@ describe("buildFailureExplanation — details from metadata", () => {
   });
 
   it("blocked_by_condition without condition metadata → generic message", () => {
-    const result = buildFailureExplanation(invalidDiag(["blocked_by_condition"]));
+    const result = buildFailureExplanation(
+      invalidDiag(["blocked_by_condition"])
+    );
     expect(result!.details).toEqual(["Você está incapacitado"]);
     expect(result!.context).toEqual({});
   });
@@ -159,7 +216,9 @@ describe("buildFailureExplanation — details from metadata", () => {
   });
 
   it("self_target_not_allowed → no detail lines", () => {
-    const result = buildFailureExplanation(invalidDiag(["self_target_not_allowed"]));
+    const result = buildFailureExplanation(
+      invalidDiag(["self_target_not_allowed"])
+    );
     expect(result!.details).toEqual([]);
   });
 });
@@ -176,7 +235,7 @@ describe("buildFailureExplanation — severity", () => {
     ["target_not_found", "gray"],
     ["invalid_target_type", "gray"],
     ["self_target_not_allowed", "gray"],
-    ["map_unreachable", "gray"],
+    ["map_unreachable", "gray"]
   ];
 
   for (const [reason, expectedSeverity] of severityCases) {
@@ -244,7 +303,7 @@ describe("buildFailureExplanation — priority ordering", () => {
         "target_out_of_reach",
         "invalid_target_type",
         "target_not_found",
-        "blocked_by_condition",
+        "blocked_by_condition"
       ])
     );
     expect(result!.primary).toBe("Condição bloqueante");
@@ -266,7 +325,10 @@ describe("buildFailureExplanation — context", () => {
 
   it("reach metadata is reflected in context under canonical keys", () => {
     const result = buildFailureExplanation(
-      invalidDiag(["target_out_of_reach"], { distance_cells: 4, reach_cells: 2 })
+      invalidDiag(["target_out_of_reach"], {
+        distance_cells: 4,
+        reach_cells: 2
+      })
     );
     expect(result!.context.distance).toBe(4);
     expect(result!.context.range).toBe(2);

--- a/apps/map-web/src/features/targeting/diagnostics-to-explanation.ts
+++ b/apps/map-web/src/features/targeting/diagnostics-to-explanation.ts
@@ -50,11 +50,15 @@ const FAILURE_PRIORITY: readonly string[] = Object.freeze([
   "target_not_found",
   "invalid_target_type",
   "target_out_of_reach",
+  "origin_heavily_obscured",
+  "target_heavily_obscured",
+  "point_heavily_obscured",
+  "line_of_sight_obscured",
   "no_line_of_sight",
   "no_line_of_effect",
   "not_visible",
   "self_target_not_allowed",
-  "map_unreachable",
+  "map_unreachable"
 ]);
 
 // ─── Detail builders ──────────────────────────────────────────────────────────
@@ -62,9 +66,10 @@ const FAILURE_PRIORITY: readonly string[] = Object.freeze([
 // Each builder receives the full metadata dict and returns up to 2 strings.
 // Builders must be pure — no side effects, no throws.
 
-type DetailBuilder = (
-  meta: Record<string, number | string | boolean>
-) => { details: string[]; context: Record<string, number | string | boolean> };
+type DetailBuilder = (meta: Record<string, number | string | boolean>) => {
+  details: string[];
+  context: Record<string, number | string | boolean>;
+};
 
 const DETAIL_BUILDERS: Record<string, DetailBuilder> = {
   target_out_of_reach: (meta) => {
@@ -87,37 +92,59 @@ const DETAIL_BUILDERS: Record<string, DetailBuilder> = {
 
   no_line_of_sight: () => ({
     details: ["Visão bloqueada por obstáculo"],
-    context: {},
+    context: {}
+  }),
+
+  origin_heavily_obscured: () => ({
+    details: ["Você está em área fortemente encoberta"],
+    context: { obscurement: "heavily_obscured" }
+  }),
+
+  target_heavily_obscured: () => ({
+    details: ["Alvo está em área fortemente encoberta"],
+    context: { obscurement: "heavily_obscured" }
+  }),
+
+  point_heavily_obscured: () => ({
+    details: ["Ponto está em área fortemente encoberta"],
+    context: { obscurement: "heavily_obscured" }
+  }),
+
+  line_of_sight_obscured: () => ({
+    details: ["Linha de visão atravessa área encoberta"],
+    context: { obscurement: "heavily_obscured" }
   }),
 
   no_line_of_effect: () => ({
     details: ["Efeito bloqueado por obstáculo"],
-    context: {},
+    context: {}
   }),
 
   not_visible: () => ({
     details: ["Alvo não pode ser visto"],
-    context: {},
+    context: {}
   }),
 
   blocked_by_condition: (meta) => {
     const condition =
       typeof meta.condition === "string" ? meta.condition : null;
     return {
-      details: [condition ? `Condição: ${condition}` : "Você está incapacitado"],
-      context: condition ? { condition } : {},
+      details: [
+        condition ? `Condição: ${condition}` : "Você está incapacitado"
+      ],
+      context: condition ? { condition } : {}
     };
   },
 
   map_unreachable: () => ({
     details: ["Reconecte ao mapa"],
-    context: {},
+    context: {}
   }),
 
   // Reasons with no useful extra detail — empty builders
   target_not_found: () => ({ details: [], context: {} }),
   invalid_target_type: () => ({ details: [], context: {} }),
-  self_target_not_allowed: () => ({ details: [], context: {} }),
+  self_target_not_allowed: () => ({ details: [], context: {} })
 };
 
 // ─── Public API ───────────────────────────────────────────────────────────────
@@ -136,14 +163,15 @@ export function buildFailureExplanation(
   if (diagnostics.failureReasons.length === 0) return null;
 
   const primary = _pickPrimaryReason(diagnostics.failureReasons);
-  const builder = DETAIL_BUILDERS[primary] ?? (() => ({ details: [], context: {} }));
+  const builder =
+    DETAIL_BUILDERS[primary] ?? (() => ({ details: [], context: {} }));
   const { details, context } = builder(diagnostics.metadata);
 
   return {
     primary: getFailureLabel(primary),
     details,
     context,
-    severity: getFailureSeverity(primary),
+    severity: getFailureSeverity(primary)
   };
 }
 

--- a/apps/map-web/src/features/targeting/preview-labels.ts
+++ b/apps/map-web/src/features/targeting/preview-labels.ts
@@ -24,6 +24,10 @@ const FAILURE_LABELS: Record<string, string> = {
   target_out_of_reach: "Fora do alcance",
   no_line_of_sight: "Sem linha de visão",
   no_line_of_effect: "Bloqueado",
+  origin_heavily_obscured: "Você está na neblina",
+  target_heavily_obscured: "Alvo na neblina",
+  point_heavily_obscured: "Ponto na neblina",
+  line_of_sight_obscured: "Visão bloqueada por neblina",
   not_visible: "Não visível",
   blocked_by_condition: "Condição bloqueante",
   self_target_not_allowed: "Não pode alvejar a si",
@@ -34,13 +38,17 @@ const FAILURE_SEVERITIES: Record<string, FailureSeverity> = {
   target_out_of_reach: "orange",
   no_line_of_sight: "red",
   no_line_of_effect: "red",
+  origin_heavily_obscured: "red",
+  target_heavily_obscured: "red",
+  point_heavily_obscured: "red",
+  line_of_sight_obscured: "red",
   blocked_by_condition: "purple",
   not_visible: "gray",
   target_not_found: "gray",
   invalid_target_type: "gray",
   area_targeting_unavailable: "gray",
   self_target_not_allowed: "gray",
-  map_unreachable: "gray",
+  map_unreachable: "gray"
 };
 
 /** Returns the PT-BR label for a single failure reason code. */
@@ -60,7 +68,9 @@ export function getFailureSeverity(reason: string): FailureSeverity {
  * Note: U2 code should prefer buildFailureExplanation() which applies the
  * canonical priority order instead of relying on list position.
  */
-export function getPrimaryFailureLabel(failureReasons: string[]): string | null {
+export function getPrimaryFailureLabel(
+  failureReasons: string[]
+): string | null {
   if (failureReasons.length === 0) return null;
   return getFailureLabel(failureReasons[0]);
 }

--- a/packages/tactical-engine/src/validation/line-of-sight.js
+++ b/packages/tactical-engine/src/validation/line-of-sight.js
@@ -1,60 +1,110 @@
-import { blocksEffect, blocksVision, getHighestCover, COVER_RANK } from "./obstacle-rules";
+import {
+  blocksEffect,
+  blocksVision,
+  getHighestCover,
+  COVER_RANK
+} from "./obstacle-rules";
 import { traceLine } from "../targeting/line-trace";
 import { findEdgeBetween } from "../grid/grid-state";
-export function hasLineOfSight(obstacles, from, to, edgeObstacles = []) {
-    const intermediate = traceLine(from, to);
-    const fullPath = [from, ...intermediate, to];
-    for (const cell of intermediate) {
-        if (blocksVision(obstacles, cell)) {
-            return false;
-        }
+export function isCellHeavilyObscured(cell, activeAreaEffects = []) {
+  if (!activeAreaEffects.length) return false;
+  for (const effect of activeAreaEffects) {
+    if (effect.effectKind !== "obscurement") continue;
+    if (effect.obscurement !== "heavily_obscured") continue;
+    for (const affected of effect.affectedCells) {
+      if (affected.x === cell.x && affected.y === cell.y) return true;
     }
-    for (let i = 0; i < fullPath.length - 1; i++) {
-        const edge = findEdgeBetween(edgeObstacles, fullPath[i], fullPath[i + 1]);
-        if (edge?.blocksVision) {
-            return false;
-        }
+  }
+  return false;
+}
+export function hasLineOfSight(
+  obstacles,
+  from,
+  to,
+  edgeObstacles = [],
+  activeAreaEffects = []
+) {
+  return evaluateLineOfSight(
+    obstacles,
+    from,
+    to,
+    edgeObstacles,
+    activeAreaEffects
+  ).ok;
+}
+export function evaluateLineOfSight(
+  obstacles,
+  from,
+  to,
+  edgeObstacles = [],
+  activeAreaEffects = []
+) {
+  if (isCellHeavilyObscured(from, activeAreaEffects)) {
+    return { ok: false, reason: "origin_heavily_obscured" };
+  }
+  if (isCellHeavilyObscured(to, activeAreaEffects)) {
+    return { ok: false, reason: "target_heavily_obscured" };
+  }
+  const intermediate = traceLine(from, to);
+  const fullPath = [from, ...intermediate, to];
+  for (const cell of intermediate) {
+    if (isCellHeavilyObscured(cell, activeAreaEffects)) {
+      return { ok: false, reason: "line_of_sight_obscured" };
     }
-    return true;
+    if (blocksVision(obstacles, cell)) {
+      return { ok: false, reason: "no_line_of_sight" };
+    }
+  }
+  for (let i = 0; i < fullPath.length - 1; i++) {
+    const edge = findEdgeBetween(edgeObstacles, fullPath[i], fullPath[i + 1]);
+    if (edge?.blocksVision) {
+      return { ok: false, reason: "no_line_of_sight" };
+    }
+  }
+  return { ok: true };
 }
 export function hasLineOfEffect(obstacles, from, to, edgeObstacles = []) {
-    const intermediate = traceLine(from, to);
-    const fullPath = [from, ...intermediate, to];
-    for (const cell of intermediate) {
-        if (blocksEffect(obstacles, cell)) {
-            return false;
-        }
+  const intermediate = traceLine(from, to);
+  const fullPath = [from, ...intermediate, to];
+  for (const cell of intermediate) {
+    if (blocksEffect(obstacles, cell)) {
+      return false;
     }
-    for (let i = 0; i < fullPath.length - 1; i++) {
-        const edge = findEdgeBetween(edgeObstacles, fullPath[i], fullPath[i + 1]);
-        if (edge?.blocksEffect) {
-            return false;
-        }
+  }
+  for (let i = 0; i < fullPath.length - 1; i++) {
+    const edge = findEdgeBetween(edgeObstacles, fullPath[i], fullPath[i + 1]);
+    if (edge?.blocksEffect) {
+      return false;
     }
-    return true;
+  }
+  return true;
 }
 export function evaluateCover(obstacles, from, to, edgeObstacles = []) {
-    const intermediate = traceLine(from, to);
-    const cellsToCheck = [...intermediate, to];
-    const fullPath = [from, ...intermediate, to];
-    let highest = "none";
-    for (const cell of cellsToCheck) {
-        const cellCover = getHighestCover(obstacles, cell);
-        if (COVER_RANK[cellCover] > COVER_RANK[highest]) {
-            highest = cellCover;
-        }
-        if (highest === "full") {
-            return "full";
-        }
+  const intermediate = traceLine(from, to);
+  const cellsToCheck = [...intermediate, to];
+  const fullPath = [from, ...intermediate, to];
+  let highest = "none";
+  for (const cell of cellsToCheck) {
+    const cellCover = getHighestCover(obstacles, cell);
+    if (COVER_RANK[cellCover] > COVER_RANK[highest]) {
+      highest = cellCover;
     }
-    for (let i = 0; i < fullPath.length - 1; i++) {
-        const edge = findEdgeBetween(edgeObstacles, fullPath[i], fullPath[i + 1]);
-        if (edge && edge.cover !== "none" && COVER_RANK[edge.cover] > COVER_RANK[highest]) {
-            highest = edge.cover;
-        }
-        if (highest === "full") {
-            return "full";
-        }
+    if (highest === "full") {
+      return "full";
     }
-    return highest;
+  }
+  for (let i = 0; i < fullPath.length - 1; i++) {
+    const edge = findEdgeBetween(edgeObstacles, fullPath[i], fullPath[i + 1]);
+    if (
+      edge &&
+      edge.cover !== "none" &&
+      COVER_RANK[edge.cover] > COVER_RANK[highest]
+    ) {
+      highest = edge.cover;
+    }
+    if (highest === "full") {
+      return "full";
+    }
+  }
+  return highest;
 }

--- a/packages/tactical-engine/src/validation/line-of-sight.ts
+++ b/packages/tactical-engine/src/validation/line-of-sight.ts
@@ -1,7 +1,49 @@
-import type { Coordinate, EdgeObstacle, Obstacle, ObstacleCover } from "@limiarmap/shared-contracts";
-import { blocksEffect, blocksVision, getHighestCover, COVER_RANK } from "./obstacle-rules";
+import type {
+  ActiveAreaEffect,
+  Coordinate,
+  EdgeObstacle,
+  Obstacle,
+  ObstacleCover
+} from "@limiarmap/shared-contracts";
+import {
+  blocksEffect,
+  blocksVision,
+  getHighestCover,
+  COVER_RANK
+} from "./obstacle-rules";
 import { traceLine } from "../targeting/line-trace";
 import { findEdgeBetween } from "../grid/grid-state";
+
+/**
+ * Returns true if `cell` is inside any active area effect that creates
+ * heavy obscurement (e.g. Fog Cloud). Effects without
+ * `effectKind === "obscurement"` or `obscurement !== "heavily_obscured"`
+ * are ignored, as are effects whose `affectedCells` list is empty.
+ */
+export function isCellHeavilyObscured(
+  cell: Coordinate,
+  activeAreaEffects: ActiveAreaEffect[] = []
+): boolean {
+  if (!activeAreaEffects.length) return false;
+  for (const effect of activeAreaEffects) {
+    if (effect.effectKind !== "obscurement") continue;
+    if (effect.obscurement !== "heavily_obscured") continue;
+    for (const affected of effect.affectedCells) {
+      if (affected.x === cell.x && affected.y === cell.y) return true;
+    }
+  }
+  return false;
+}
+
+export type LineOfSightFailureReason =
+  | "origin_heavily_obscured"
+  | "target_heavily_obscured"
+  | "line_of_sight_obscured"
+  | "no_line_of_sight";
+
+export type LineOfSightDiagnostic =
+  | { ok: true }
+  | { ok: false; reason: LineOfSightFailureReason };
 
 /**
  * Returns true if there is an unobstructed line of sight from `from` to `to`.
@@ -17,28 +59,63 @@ export function hasLineOfSight(
   obstacles: Obstacle[],
   from: Coordinate,
   to: Coordinate,
-  edgeObstacles: EdgeObstacle[] = []
+  edgeObstacles: EdgeObstacle[] = [],
+  activeAreaEffects: ActiveAreaEffect[] = []
 ): boolean {
+  return evaluateLineOfSight(
+    obstacles,
+    from,
+    to,
+    edgeObstacles,
+    activeAreaEffects
+  ).ok;
+}
+
+/**
+ * Diagnostic variant of {@link hasLineOfSight}. Returns either `{ ok: true }`
+ * or `{ ok: false, reason }` so callers can distinguish obstacle blockers from
+ * heavy obscurement (Fog Cloud and similar). Heavy-obscurement reasons take
+ * precedence over `no_line_of_sight` so the diagnostic surfaced to the user
+ * matches the actual cause.
+ *
+ * Heavy obscurement blocks sight when origin, target, or any traversed
+ * intermediate cell is inside a heavily obscured area effect. Edge obstacles
+ * and cell obstacles still report `no_line_of_sight`.
+ */
+export function evaluateLineOfSight(
+  obstacles: Obstacle[],
+  from: Coordinate,
+  to: Coordinate,
+  edgeObstacles: EdgeObstacle[] = [],
+  activeAreaEffects: ActiveAreaEffect[] = []
+): LineOfSightDiagnostic {
+  if (isCellHeavilyObscured(from, activeAreaEffects)) {
+    return { ok: false, reason: "origin_heavily_obscured" };
+  }
+  if (isCellHeavilyObscured(to, activeAreaEffects)) {
+    return { ok: false, reason: "target_heavily_obscured" };
+  }
+
   const intermediate = traceLine(from, to);
   const fullPath = [from, ...intermediate, to];
 
-  // Check cell obstacles for vision blocking
   for (const cell of intermediate) {
+    if (isCellHeavilyObscured(cell, activeAreaEffects)) {
+      return { ok: false, reason: "line_of_sight_obscured" };
+    }
     if (blocksVision(obstacles, cell)) {
-      return false;
+      return { ok: false, reason: "no_line_of_sight" };
     }
   }
 
-  // Phase 10: Check edge obstacles for vision blocking
-  // We need to check edges that the line crosses between consecutive cells
   for (let i = 0; i < fullPath.length - 1; i++) {
     const edge = findEdgeBetween(edgeObstacles, fullPath[i], fullPath[i + 1]);
     if (edge?.blocksVision) {
-      return false;
+      return { ok: false, reason: "no_line_of_sight" };
     }
   }
 
-  return true;
+  return { ok: true };
 }
 
 /**
@@ -129,7 +206,11 @@ export function evaluateCover(
   // consistent with the cell-cover policy of including the target cell.
   for (let i = 0; i < fullPath.length - 1; i++) {
     const edge = findEdgeBetween(edgeObstacles, fullPath[i], fullPath[i + 1]);
-    if (edge && edge.cover !== "none" && COVER_RANK[edge.cover] > COVER_RANK[highest]) {
+    if (
+      edge &&
+      edge.cover !== "none" &&
+      COVER_RANK[edge.cover] > COVER_RANK[highest]
+    ) {
       highest = edge.cover;
     }
     // Short-circuit: can't get higher than full

--- a/packages/tactical-engine/tests/unit/line-of-sight.test.ts
+++ b/packages/tactical-engine/tests/unit/line-of-sight.test.ts
@@ -1,6 +1,63 @@
 import { describe, expect, it } from "vitest";
-import { obstacleSchema, type Obstacle } from "@limiarmap/shared-contracts";
-import { hasLineOfEffect, hasLineOfSight, evaluateCover } from "../../src";
+import {
+  obstacleSchema,
+  type ActiveAreaEffect,
+  type Obstacle
+} from "@limiarmap/shared-contracts";
+import {
+  evaluateCover,
+  evaluateLineOfSight,
+  hasLineOfEffect,
+  hasLineOfSight,
+  isCellHeavilyObscured
+} from "../../src";
+
+function fogCloudEffect(cells: { x: number; y: number }[]): ActiveAreaEffect {
+  return {
+    id: "fog-1",
+    sourceSpellCanonicalKey: "fog_cloud",
+    sourceSpellName: "Fog Cloud",
+    casterParticipantId: "p1",
+    casterRefId: null,
+    casterCharacterId: null,
+    originPoint: { x: 0, y: 0 },
+    anchorCell: { x: 0, y: 0 },
+    areaShape: "sphere",
+    sizeMeters: 6,
+    radiusMeters: 6,
+    lengthMeters: null,
+    sideMeters: null,
+    affectedCells: cells,
+    effectKind: "obscurement",
+    duration: "Up to 1 hour",
+    concentrationOwnerParticipantId: "p1",
+    concentrationOwnerRefId: null,
+    createdRound: 0,
+    createdTurnIndex: 0,
+    obscurement: "heavily_obscured",
+    terrainEffect: null,
+    movementDamageDice: null,
+    damageType: null,
+    damagePerMeters: null
+  };
+}
+
+function spikeGrowthEffect(
+  cells: { x: number; y: number }[]
+): ActiveAreaEffect {
+  return {
+    ...fogCloudEffect(cells),
+    id: "spike-1",
+    sourceSpellCanonicalKey: "spike_growth",
+    sourceSpellName: "Spike Growth",
+    effectKind: "hazard",
+    obscurement: null,
+    terrainEffect: "difficult_terrain",
+    movementDamageDice: "2d4",
+    damageType: "Piercing",
+    damagePerMeters: 1.5
+  };
+}
 
 describe("line of sight and effect", () => {
   it("blocks line of sight on vision blockers only", () => {
@@ -18,8 +75,12 @@ describe("line of sight and effect", () => {
       }
     ];
 
-    expect(hasLineOfSight(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe(false);
-    expect(hasLineOfEffect(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe(true);
+    expect(hasLineOfSight(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe(
+      false
+    );
+    expect(hasLineOfEffect(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe(
+      true
+    );
   });
 
   it("blocks line of effect on effect blockers only", () => {
@@ -37,8 +98,12 @@ describe("line of sight and effect", () => {
       }
     ];
 
-    expect(hasLineOfSight(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe(true);
-    expect(hasLineOfEffect(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe(false);
+    expect(hasLineOfSight(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe(
+      true
+    );
+    expect(hasLineOfEffect(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe(
+      false
+    );
   });
 
   it("solid obstacles block both sight and effect", () => {
@@ -56,8 +121,12 @@ describe("line of sight and effect", () => {
       }
     ];
 
-    expect(hasLineOfSight(obstacles, { x: 0, y: 0 }, { x: 3, y: 3 })).toBe(false);
-    expect(hasLineOfEffect(obstacles, { x: 0, y: 0 }, { x: 3, y: 3 })).toBe(false);
+    expect(hasLineOfSight(obstacles, { x: 0, y: 0 }, { x: 3, y: 3 })).toBe(
+      false
+    );
+    expect(hasLineOfEffect(obstacles, { x: 0, y: 0 }, { x: 3, y: 3 })).toBe(
+      false
+    );
   });
 
   it("accepts legacy obstacle payloads and maps them to blocksEffect", () => {
@@ -75,7 +144,9 @@ describe("line of sight and effect", () => {
     });
 
     expect(legacyObstacle.blocksEffect).toBe(true);
-    expect(hasLineOfEffect([legacyObstacle], { x: 0, y: 0 }, { x: 3, y: 0 })).toBe(false);
+    expect(
+      hasLineOfEffect([legacyObstacle], { x: 0, y: 0 }, { x: 3, y: 0 })
+    ).toBe(false);
   });
 });
 
@@ -98,7 +169,9 @@ describe("evaluateCover", () => {
         movementCostMultiplier: 1
       }
     ];
-    expect(evaluateCover(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe("half");
+    expect(evaluateCover(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe(
+      "half"
+    );
   });
 
   it("returns threeQuarters when a three-quarters-cover obstacle is intermediate", () => {
@@ -115,7 +188,9 @@ describe("evaluateCover", () => {
         movementCostMultiplier: 1
       }
     ];
-    expect(evaluateCover(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe("threeQuarters");
+    expect(evaluateCover(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe(
+      "threeQuarters"
+    );
   });
 
   it("returns full when a full-cover obstacle is on the target cell", () => {
@@ -132,7 +207,9 @@ describe("evaluateCover", () => {
         movementCostMultiplier: 1
       }
     ];
-    expect(evaluateCover(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe("full");
+    expect(evaluateCover(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe(
+      "full"
+    );
   });
 
   it("aggregates to the strongest cover when multiple obstacles are present", () => {
@@ -161,7 +238,9 @@ describe("evaluateCover", () => {
       }
     ];
     // Strongest wins: threeQuarters > half
-    expect(evaluateCover(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe("threeQuarters");
+    expect(evaluateCover(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe(
+      "threeQuarters"
+    );
   });
 
   it("does not consider the origin cell for cover", () => {
@@ -180,7 +259,9 @@ describe("evaluateCover", () => {
     ];
     // Origin cell is excluded: an obstacle at (0,0) when attacking from (0,0)
     // should not contribute cover for the target
-    expect(evaluateCover(obstacles, { x: 0, y: 0 }, { x: 1, y: 0 })).toBe("none");
+    expect(evaluateCover(obstacles, { x: 0, y: 0 }, { x: 1, y: 0 })).toBe(
+      "none"
+    );
   });
 
   it("includes the target cell when evaluating cover", () => {
@@ -199,7 +280,9 @@ describe("evaluateCover", () => {
     ];
     // Adjacent attack: from (0,0) to (1,0). No intermediate cells from traceLine,
     // but target cell is included by evaluateCover policy
-    expect(evaluateCover(obstacles, { x: 0, y: 0 }, { x: 1, y: 0 })).toBe("half");
+    expect(evaluateCover(obstacles, { x: 0, y: 0 }, { x: 1, y: 0 })).toBe(
+      "half"
+    );
   });
 
   it("evaluates cover independently from LoS/LoE", () => {
@@ -218,8 +301,12 @@ describe("evaluateCover", () => {
       }
     ];
     // LoS fails but cover is still none
-    expect(hasLineOfSight(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe(false);
-    expect(evaluateCover(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe("none");
+    expect(hasLineOfSight(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe(
+      false
+    );
+    expect(evaluateCover(obstacles, { x: 0, y: 0 }, { x: 3, y: 0 })).toBe(
+      "none"
+    );
   });
 
   it("handles diagonal trace with cover on intermediate cell", () => {
@@ -237,7 +324,102 @@ describe("evaluateCover", () => {
       }
     ];
     // Diagonal from (0,0) to (2,2) passes through (1,1)
-    expect(evaluateCover(obstacles, { x: 0, y: 0 }, { x: 2, y: 2 })).toBe("threeQuarters");
+    expect(evaluateCover(obstacles, { x: 0, y: 0 }, { x: 2, y: 2 })).toBe(
+      "threeQuarters"
+    );
   });
 });
 
+describe("Fog Cloud heavy obscurement (line of sight)", () => {
+  it("isCellHeavilyObscured detects cells inside obscurement effects", () => {
+    const fog = fogCloudEffect([
+      { x: 5, y: 5 },
+      { x: 5, y: 6 }
+    ]);
+    expect(isCellHeavilyObscured({ x: 5, y: 5 }, [fog])).toBe(true);
+    expect(isCellHeavilyObscured({ x: 6, y: 6 }, [fog])).toBe(false);
+    expect(isCellHeavilyObscured({ x: 5, y: 5 }, [])).toBe(false);
+  });
+
+  it("Spike Growth (hazard) does not block sight", () => {
+    const spike = spikeGrowthEffect([
+      { x: 1, y: 0 },
+      { x: 2, y: 0 }
+    ]);
+    expect(isCellHeavilyObscured({ x: 1, y: 0 }, [spike])).toBe(false);
+    expect(
+      hasLineOfSight([], { x: 0, y: 0 }, { x: 3, y: 0 }, [], [spike])
+    ).toBe(true);
+  });
+
+  it("blocks sight when target cell is inside Fog Cloud", () => {
+    const fog = fogCloudEffect([{ x: 3, y: 0 }]);
+    const result = evaluateLineOfSight(
+      [],
+      { x: 0, y: 0 },
+      { x: 3, y: 0 },
+      [],
+      [fog]
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("target_heavily_obscured");
+  });
+
+  it("blocks sight when origin cell is inside Fog Cloud", () => {
+    const fog = fogCloudEffect([{ x: 0, y: 0 }]);
+    const result = evaluateLineOfSight(
+      [],
+      { x: 0, y: 0 },
+      { x: 3, y: 0 },
+      [],
+      [fog]
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("origin_heavily_obscured");
+  });
+
+  it("blocks sight when LoS path crosses Fog Cloud", () => {
+    const fog = fogCloudEffect([{ x: 2, y: 0 }]);
+    const result = evaluateLineOfSight(
+      [],
+      { x: 0, y: 0 },
+      { x: 4, y: 0 },
+      [],
+      [fog]
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("line_of_sight_obscured");
+  });
+
+  it("does not block when path runs alongside Fog Cloud", () => {
+    const fog = fogCloudEffect([{ x: 2, y: 1 }]);
+    expect(hasLineOfSight([], { x: 0, y: 0 }, { x: 4, y: 0 }, [], [fog])).toBe(
+      true
+    );
+  });
+
+  it("does not block line of effect (Fog Cloud only obscures sight)", () => {
+    expect(hasLineOfEffect([], { x: 0, y: 0 }, { x: 4, y: 0 }, [])).toBe(true);
+  });
+
+  it("preserves no_line_of_sight reason for plain wall obstacles", () => {
+    const wall: Obstacle = {
+      id: "wall-1",
+      battleMapId: "map",
+      cells: [{ x: 2, y: 0 }],
+      blocksMovement: false,
+      blocksEffect: false,
+      blocksVision: true,
+      cover: "none",
+      clipsDiagonalMovement: false,
+      movementCostMultiplier: 1
+    };
+    const result = evaluateLineOfSight([wall], { x: 0, y: 0 }, { x: 4, y: 0 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("no_line_of_sight");
+  });
+
+  it("hasLineOfSight remains backwards compatible without activeAreaEffects arg", () => {
+    expect(hasLineOfSight([], { x: 0, y: 0 }, { x: 3, y: 0 })).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #71

## Summary

Active area effects with ``effectKind="obscurement"`` and ``obscurement="heavily_obscured"`` (Fog Cloud) now block line of sight in map-backed targeting. Line of effect is unchanged — Fog Cloud blocks sight, not effect propagation. Spike Growth (hazard) is unaffected.

## Behavior

LoS fails when the origin, target/anchor, or any traversed intermediate cell is inside a heavily obscured area. The map server returns one of four specific reason codes so the UI can surface the actual cause:

- ``origin_heavily_obscured`` — caster is in the cloud
- ``target_heavily_obscured`` — single-target attack: target is in the cloud
- ``point_heavily_obscured`` — area spell: anchor cell is in the cloud
- ``line_of_sight_obscured`` — path crosses the cloud

Existing ``no_line_of_sight`` is preserved for walls/obstacles.

## Stack changes

- **tactical-engine**: ``isCellHeavilyObscured`` + ``evaluateLineOfSight`` diagnostic. ``hasLineOfSight`` gains an optional ``activeAreaEffects`` param (backwards compatible).
- **map-server**: single-target route, area-targeting route, and ``TargetingService`` pass ``encounter.activeAreaEffects`` and surface the new reasons. Area routes remap target → point automatically.
- **map-web**: PT-BR labels + detail builders for the four reasons, prioritised above generic ``no_line_of_sight``.
- **control-server**: no production code changes.

## Test plan

- [x] tactical-engine LoS unit tests: 9 new (target/origin/path obscurement, side-by-side path passes, hasLineOfEffect unchanged, walls still report ``no_line_of_sight``, Spike Growth no-op, backwards compat)
- [x] map-server integration tests: 6 new (target inside, caster inside, path crosses, ``requires_sight=false`` passes, area preview ``point_heavily_obscured``, Spike Growth no-op)
- [x] control-server integration tests: 4 new (target/origin/area-anchor obscurement rejections + no-sight-required passes)
- [x] map-web targeting suite: 4 new label/builder cases
- [x] All TS suites green: tactical-engine 144, map-server 230, map-web targeting 65
- [x] control-server full suite: 1307 passed, 1 skipped
- [x] ``git diff --check`` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)