### PR TITLE
feat(combat): add concentration cleanup for active spell area effects

### DIFF
--- a/apps/control-server/app/services/combat_service/concentration.py
+++ b/apps/control-server/app/services/combat_service/concentration.py
@@ -81,12 +81,47 @@ class CombatConcentrationMixin:
         cls._set_participant_effects(participant, effects)
 
     @classmethod
-    def _remove_effect_group(
+    def _remove_area_effects_for_concentration_group(
         cls,
         state: CombatState,
         *,
         concentration_group: str,
     ) -> list[dict]:
+        removed: list[dict] = []
+        remaining: list[dict] = []
+        for effect in state.active_area_effects or []:
+            if (
+                isinstance(effect, dict)
+                and effect.get("concentration_group") == concentration_group
+            ):
+                removed.append(effect)
+            else:
+                remaining.append(effect)
+        if removed:
+            state.active_area_effects = remaining
+        return removed
+
+    @classmethod
+    def _sync_area_effects_if_changed(
+        cls,
+        session_id: str,
+        state: CombatState,
+        area_removed: list[dict],
+    ) -> None:
+        if not area_removed:
+            return
+        flag_modified(state, "active_area_effects")
+        from .limiar_map_projection import maybe_sync_active_area_effects_to_limiar_map
+
+        maybe_sync_active_area_effects_to_limiar_map(session_id, state)
+
+    @classmethod
+    def _remove_effect_group(
+        cls,
+        state: CombatState,
+        *,
+        concentration_group: str,
+    ) -> dict:
         removed: list[dict] = []
         for participant in state.participants:
             effects = cls._get_participant_effects(participant)
@@ -106,7 +141,10 @@ class CombatConcentrationMixin:
                     continue
                 kept.append(effect)
             cls._set_participant_effects(participant, kept)
-        return removed
+        area_removed = cls._remove_area_effects_for_concentration_group(
+            state, concentration_group=concentration_group
+        )
+        return {"removed_effects": removed, "removed_area_effects": area_removed}
 
     @classmethod
     def _clear_concentration_for_source(
@@ -114,7 +152,7 @@ class CombatConcentrationMixin:
         state: CombatState,
         *,
         source_participant_id: str,
-    ) -> list[dict]:
+    ) -> dict:
         groups: set[str] = set()
         for participant in state.participants:
             for effect in cls._get_participant_effects(participant):
@@ -126,12 +164,16 @@ class CombatConcentrationMixin:
                 ):
                     groups.add(metadata["concentration_group"])
 
-        removed: list[dict] = []
+        all_removed: list[dict] = []
+        all_area_removed: list[dict] = []
         for group_id in groups:
-            removed.extend(
-                cls._remove_effect_group(state, concentration_group=group_id)
-            )
-        return removed
+            result = cls._remove_effect_group(state, concentration_group=group_id)
+            all_removed.extend(result["removed_effects"])
+            all_area_removed.extend(result["removed_area_effects"])
+        return {
+            "removed_effects": all_removed,
+            "removed_area_effects": all_area_removed,
+        }
 
     @classmethod
     def _clear_concentration_for_participant_status(
@@ -139,16 +181,22 @@ class CombatConcentrationMixin:
         state: CombatState | None,
         *,
         source_participant_id: str | None,
-    ) -> list[dict]:
+    ) -> dict:
+        empty = {"removed_effects": [], "removed_area_effects": []}
         if not state or not source_participant_id:
-            return []
-        removed = cls._clear_concentration_for_source(
+            return empty
+        result = cls._clear_concentration_for_source(
             state,
             source_participant_id=source_participant_id,
         )
-        if removed:
+        if result["removed_effects"]:
             flag_modified(state, "participants")
-        return removed
+        if result["removed_area_effects"]:
+            flag_modified(state, "active_area_effects")
+            from .limiar_map_projection import maybe_sync_active_area_effects_to_limiar_map
+
+            maybe_sync_active_area_effects_to_limiar_map(state.session_id, state)
+        return result
 
     @classmethod
     def _get_hunters_mark_effect_for_target(
@@ -271,12 +319,19 @@ class CombatConcentrationMixin:
         broken_effect_labels: list[str] = []
         source_spell_keys: set[str] = set()
         if not succeeded:
-            removed = cls._clear_concentration_for_source(
+            result = cls._clear_concentration_for_source(
                 state,
                 source_participant_id=target_participant.get("id", ""),
             )
+            removed = result["removed_effects"]
+            area_removed = result["removed_area_effects"]
             if removed:
                 flag_modified(state, "participants")
+            if area_removed:
+                flag_modified(state, "active_area_effects")
+                from .limiar_map_projection import maybe_sync_active_area_effects_to_limiar_map
+
+                maybe_sync_active_area_effects_to_limiar_map(session_id, state)
             for effect in removed:
                 label = effect.get("display_label")
                 if not isinstance(label, str) or not label.strip():
@@ -285,6 +340,13 @@ class CombatConcentrationMixin:
                     broken_effect_labels.append(label)
                 metadata = cls._get_effect_metadata(effect)
                 spell_key = metadata.get("source_spell_key")
+                if isinstance(spell_key, str) and spell_key.strip():
+                    source_spell_keys.add(spell_key)
+            for area_effect in area_removed:
+                label = area_effect.get("source_spell_name")
+                if isinstance(label, str) and label.strip() and label not in broken_effect_labels:
+                    broken_effect_labels.append(label)
+                spell_key = area_effect.get("source_spell_canonical_key")
                 if isinstance(spell_key, str) and spell_key.strip():
                     source_spell_keys.add(spell_key)
 

--- a/apps/control-server/app/services/combat_service/effects_actions.py
+++ b/apps/control-server/app/services/combat_service/effects_actions.py
@@ -97,7 +97,8 @@ class CombatEffectsActionsMixin(CombatEffectsCoreMixin):
         cls._set_participant_effects(target, keep)
         removed_metadata = cls._get_effect_metadata(removed)
         if removed_metadata.get("concentration") is True and isinstance(removed_metadata.get("concentration_group"), str):
-            cls._remove_effect_group(state, concentration_group=removed_metadata["concentration_group"])
+            group_result = cls._remove_effect_group(state, concentration_group=removed_metadata["concentration_group"])
+            cls._sync_area_effects_if_changed(session_id, state, group_result["removed_area_effects"])
         flag_modified(state, "participants")
         db.add(state)
         db.commit()

--- a/apps/control-server/app/services/combat_service/persistent_area_effects.py
+++ b/apps/control-server/app/services/combat_service/persistent_area_effects.py
@@ -41,6 +41,7 @@ def build_persistent_spell_area_effect(
     targeting_result: Any,
     origin_cell: dict[str, int] | None,
     anchor_cell: dict[str, int] | None,
+    concentration_group: str | None = None,
 ) -> dict[str, Any]:
     shape = str(area_spec["shape"])
     size_meters = _safe_float(area_spec.get("size_meters")) or 0.0
@@ -77,6 +78,7 @@ def build_persistent_spell_area_effect(
         else None,
         "created_round": state.round,
         "created_turn_index": state.current_turn_index,
+        "concentration_group": concentration_group,
     }
     effect.update(_metadata_for_spell(spell_context))
     return effect

--- a/apps/control-server/app/services/combat_service/spell_automation.py
+++ b/apps/control-server/app/services/combat_service/spell_automation.py
@@ -174,9 +174,12 @@ class CombatSpellAutomationMixin:
         actor_user_id: str, is_gm: bool, req, state: CombatState,
         spell_context: dict, target_participant: dict,
     ) -> dict:
-        removed = cls._clear_concentration_for_source(
+        result = cls._clear_concentration_for_source(
             state,
             source_participant_id=attacker["id"],
+        )
+        cls._sync_area_effects_if_changed(
+            session_id, state, result["removed_area_effects"],
         )
         concentration_group = str(uuid4())
         spell_name = spell_context["spell_name"]
@@ -217,7 +220,7 @@ class CombatSpellAutomationMixin:
         flag_modified(state, "participants")
 
         summary_text = f"{spell_name} aplicada em {target_participant['display_name']}."
-        if removed:
+        if result["removed_effects"] or result["removed_area_effects"]:
             summary_text += " A concentração anterior terminou."
 
         return cls._base_spell_result(

--- a/apps/control-server/app/services/combat_service/spells/cast_area.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_area.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 from uuid import uuid4
 
+from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import Session
 
 from app.models.combat import CombatState
@@ -331,7 +332,18 @@ class CastAreaMixin:
             slot_spent = True
 
         active_area_effect: dict[str, Any] | None = None
+        concentration_group: str | None = None
         if spell_context.get("effect_timing") == "persistent":
+            if spell_context.get("concentration"):
+                prev = cls._clear_concentration_for_source(
+                    state, source_participant_id=attacker["id"],
+                )
+                if prev["removed_effects"]:
+                    flag_modified(state, "participants")
+                if prev["removed_area_effects"]:
+                    flag_modified(state, "active_area_effects")
+                    maybe_sync_active_area_effects_to_limiar_map(session_id, state)
+                concentration_group = str(uuid4())
             try:
                 active_area_effect = build_persistent_spell_area_effect(
                     state=state,
@@ -341,6 +353,7 @@ class CastAreaMixin:
                     targeting_result=targeting_result,
                     origin_cell=req.origin_cell.model_dump() if req.origin_cell is not None else None,
                     anchor_cell=req.anchor_cell.model_dump() if req.anchor_cell is not None else None,
+                    concentration_group=concentration_group,
                 )
             except ValueError as exc:
                 raise CombatServiceError(str(exc), 400) from exc
@@ -348,6 +361,23 @@ class CastAreaMixin:
                 *(state.active_area_effects or []),
                 active_area_effect,
             ]
+            if concentration_group:
+                cls._append_effect_to_participant(
+                    attacker,
+                    cls._build_active_effect(
+                        kind="spell_effect",
+                        source_participant_id=attacker["id"],
+                        duration_type="manual",
+                        metadata={
+                            "concentration": True,
+                            "concentration_group": concentration_group,
+                            "source_spell_key": spell_context["spell_canonical_key"],
+                            "concentration_area_effect_id": active_area_effect["id"],
+                        },
+                        display_label=spell_context["spell_name"],
+                    ),
+                )
+                flag_modified(state, "participants")
 
         db.add(state)
         db.commit()

--- a/apps/control-server/tests/test_persistent_area_effects.py
+++ b/apps/control-server/tests/test_persistent_area_effects.py
@@ -165,3 +165,500 @@ class PersistentAreaEffectCastTests(TestCombatServiceBase):
         self.assertEqual(self.state.active_area_effects, [])
         self.assertIsNone(result["active_area_effect"])
         mock_sync.assert_not_called()
+
+
+class ConcentrationAreaEffectCleanupTests(TestCombatServiceBase):
+    def setUp(self):
+        super().setUp()
+        self.state.phase = CombatPhase.active
+        self.state.current_turn_index = 0
+        self.attacker = self.state.participants[0]
+        self.attacker_model = SessionState(
+            id="state-player",
+            session_id="session-123",
+            player_user_id="player-123",
+            state_json={
+                "spellcasting": {
+                    "slots": {"1": {"used": 0, "max": 2}, "2": {"used": 0, "max": 2}},
+                },
+            },
+        )
+
+    def _targeting_result(self, *, shape: str = "sphere") -> TargetingResult:
+        return TargetingResult(
+            is_valid=True,
+            validated_primary_target_ref_id="",
+            affected_target_ref_ids=[],
+            target_kind="",
+            spatial_metadata=SpatialMetadata(
+                affected_cells=[{"x": 10, "y": 10}, {"x": 10, "y": 9}],
+                affected_token_ids=[],
+                area_shape=shape,
+                map_version=12,
+                targeting_authority="limiar_map",
+            ),
+        )
+
+    def _spell_context(self, canonical_key: str, **overrides):
+        base = {
+            "spell_name": "Fog Cloud" if canonical_key == "fog_cloud" else "Spike Growth",
+            "spell_canonical_key": canonical_key,
+            "spell_mode": "utility",
+            "effect_kind": None,
+            "effect_timing": "persistent",
+            "origin_type": "selected_point",
+            "target_anchor": "selected_point",
+            "selection_type": "point",
+            "attack_type": "none",
+            "range_kind": "distance",
+            "area_shape": "sphere",
+            "range_meters": 36,
+            "radius_meters": 6,
+            "length_meters": None,
+            "side_meters": None,
+            "duration": "Up to 1 hour",
+            "concentration": True,
+            "action_cost": "action",
+            "source_kind": "prepared_spell",
+            "slot_level": 1,
+            "damage_type": None,
+            "effect_dice": None,
+            "effect_bonus": 0,
+            "save_ability": None,
+            "save_dc": None,
+            "save_success_outcome": None,
+            "elemental_affinity_eligible": False,
+            "elemental_affinity_damage_type": None,
+            "elemental_affinity_bonus": None,
+        }
+        base.update(overrides)
+        return base
+
+    async def _cast_persistent_area(self, canonical_key: str, **context_overrides):
+        targeting_result = self._targeting_result()
+        with patch(
+            "app.services.combat_service.spells.cast_area.get_combat_targeting_service",
+            return_value=SimpleNamespace(validate=MagicMock(return_value=targeting_result)),
+        ), patch(
+            "app.services.combat_service.spells.cast_area.maybe_sync_active_area_effects_to_limiar_map",
+        ) as mock_sync, patch(
+            "app.services.combat.CombatService._emit_state",
+            new_callable=AsyncMock,
+        ), patch(
+            "app.services.combat.CombatService._emit_log",
+            new_callable=AsyncMock,
+        ), patch(
+            "app.services.combat.CombatService._emit_player_state_update",
+            new_callable=AsyncMock,
+        ), patch(
+            "app.services.combat.CombatService._get_stats",
+            return_value=(self.attacker_model, 10, 10, 10, 2, 3),
+        ):
+            result = await CombatService._cast_area_spell(
+                self.db,
+                "session-123",
+                CombatCastSpellRequest(
+                    actor_participant_id="p1",
+                    origin_cell=CombatGridCell(x=8, y=8),
+                    anchor_cell=CombatGridCell(x=10, y=10),
+                    spell_canonical_key=canonical_key,
+                    slot_level=1,
+                ),
+                attacker=self.attacker,
+                attacker_model=self.attacker_model,
+                actor_user_id="user-1",
+                is_gm=False,
+                state=self.state,
+                spell_context=self._spell_context(canonical_key, **context_overrides),
+                area_spec={"shape": "sphere", "size_meters": 6, "range_meters": 36},
+            )
+        return result, mock_sync
+
+    def _setup_concentrating_caster_with_area_effect(
+        self,
+        spell_key: str = "fog_cloud",
+        spell_name: str = "Fog Cloud",
+        concentration_group: str = "conc-test-1",
+    ):
+        self.attacker["active_effects"] = [
+            {
+                "id": "conc-effect-1",
+                "kind": "spell_effect",
+                "source_participant_id": "p1",
+                "duration_type": "manual",
+                "created_at": "2026-04-25T00:00:00Z",
+                "display_label": spell_name,
+                "metadata": {
+                    "concentration": True,
+                    "concentration_group": concentration_group,
+                    "source_spell_key": spell_key,
+                    "concentration_area_effect_id": "area-effect-1",
+                },
+            }
+        ]
+        self.state.active_area_effects = [
+            {
+                "id": "area-effect-1",
+                "source_spell_canonical_key": spell_key,
+                "source_spell_name": spell_name,
+                "caster_participant_id": "p1",
+                "caster_ref_id": "player-123",
+                "caster_character_id": "user-1",
+                "origin_point": {"x": 10, "y": 10},
+                "anchor_cell": {"x": 10, "y": 10},
+                "area_shape": "sphere",
+                "size_meters": 6.0,
+                "radius_meters": 6.0,
+                "length_meters": None,
+                "side_meters": None,
+                "affected_cells": [{"x": 10, "y": 10}, {"x": 10, "y": 9}],
+                "duration": "Up to 1 hour",
+                "concentration_owner_participant_id": "p1",
+                "concentration_owner_ref_id": "player-123",
+                "concentration_group": concentration_group,
+                "created_round": 1,
+                "created_turn_index": 0,
+                "effect_kind": "obscurement",
+                "obscurement": "heavily_obscured",
+            }
+        ]
+
+    async def test_fog_cloud_creates_concentration_effect_on_caster(self):
+        await self._cast_persistent_area("fog_cloud")
+
+        caster_effects = self.attacker.get("active_effects", [])
+        self.assertEqual(len(caster_effects), 1)
+        effect = caster_effects[0]
+        self.assertEqual(effect["kind"], "spell_effect")
+        self.assertEqual(effect["source_participant_id"], "p1")
+        metadata = effect.get("metadata", {})
+        self.assertTrue(metadata.get("concentration"))
+        self.assertIsInstance(metadata.get("concentration_group"), str)
+        self.assertEqual(metadata.get("source_spell_key"), "fog_cloud")
+        self.assertEqual(
+            metadata.get("concentration_area_effect_id"),
+            self.state.active_area_effects[0]["id"],
+        )
+
+    async def test_spike_growth_creates_concentration_effect_on_caster(self):
+        await self._cast_persistent_area(
+            "spike_growth",
+            spell_name="Spike Growth",
+            duration="Up to 10 minutes",
+            slot_level=2,
+            range_meters=45,
+        )
+
+        caster_effects = self.attacker.get("active_effects", [])
+        self.assertEqual(len(caster_effects), 1)
+        effect = caster_effects[0]
+        metadata = effect.get("metadata", {})
+        self.assertTrue(metadata.get("concentration"))
+        self.assertEqual(metadata.get("source_spell_key"), "spike_growth")
+
+    async def test_concentration_area_effect_has_concentration_group(self):
+        await self._cast_persistent_area("fog_cloud")
+
+        area_effect = self.state.active_area_effects[0]
+        self.assertIsInstance(area_effect.get("concentration_group"), str)
+
+        caster_effect = self.attacker["active_effects"][0]
+        self.assertEqual(
+            area_effect["concentration_group"],
+            caster_effect["metadata"]["concentration_group"],
+        )
+
+    @patch("app.services.combat_service.spell_automation.resolve_saving_throw")
+    @patch("app.services.combat.CombatService._build_roll_actor_stats_for_save")
+    def test_damage_breaks_concentration_removes_fog_cloud(
+        self,
+        mock_build_roll_stats,
+        mock_resolve_saving_throw,
+    ):
+        self._setup_concentrating_caster_with_area_effect("fog_cloud", "Fog Cloud")
+        mock_resolve_saving_throw.return_value = MagicMock(total=5, success=False)
+        session_state = SessionState(
+            id="state-1",
+            session_id="session-123",
+            player_user_id="player-123",
+            state_json={"currentHP": 20, "maxHP": 20, "deathSaves": {"successes": 0, "failures": 0}},
+        )
+
+        with patch(
+            "app.services.combat.CombatService._get_stats",
+            return_value=(session_state, 10, 10, 10, 2, 0),
+        ), patch(
+            "app.services.combat_service.limiar_map_projection.maybe_sync_active_area_effects_to_limiar_map",
+        ) as mock_sync:
+            CombatService._apply_damage_to_target(
+                self.db, "player-123", "player", 8, False, self.state,
+            )
+
+        self.assertEqual(self.state.active_area_effects, [])
+        self.assertEqual(self.attacker.get("active_effects", []), [])
+        mock_sync.assert_called_once_with("session-123", self.state)
+
+    @patch("app.services.combat_service.spell_automation.resolve_saving_throw")
+    @patch("app.services.combat.CombatService._build_roll_actor_stats_for_save")
+    def test_damage_breaks_concentration_removes_spike_growth(
+        self,
+        mock_build_roll_stats,
+        mock_resolve_saving_throw,
+    ):
+        self._setup_concentrating_caster_with_area_effect(
+            "spike_growth", "Spike Growth",
+        )
+        mock_resolve_saving_throw.return_value = MagicMock(total=5, success=False)
+        session_state = SessionState(
+            id="state-1",
+            session_id="session-123",
+            player_user_id="player-123",
+            state_json={"currentHP": 20, "maxHP": 20, "deathSaves": {"successes": 0, "failures": 0}},
+        )
+
+        with patch(
+            "app.services.combat.CombatService._get_stats",
+            return_value=(session_state, 10, 10, 10, 2, 0),
+        ), patch(
+            "app.services.combat_service.limiar_map_projection.maybe_sync_active_area_effects_to_limiar_map",
+        ) as mock_sync:
+            CombatService._apply_damage_to_target(
+                self.db, "player-123", "player", 8, False, self.state,
+            )
+
+        self.assertEqual(self.state.active_area_effects, [])
+        self.assertEqual(self.attacker.get("active_effects", []), [])
+        mock_sync.assert_called_once()
+
+    async def test_new_concentration_replaces_prior_area_effect(self):
+        await self._cast_persistent_area("fog_cloud")
+        self.assertEqual(len(self.state.active_area_effects), 1)
+        fog_id = self.state.active_area_effects[0]["id"]
+        fog_group = self.state.active_area_effects[0]["concentration_group"]
+
+        self.attacker["turn_resources"] = dict(CombatService._DEFAULT_TURN_RESOURCES)
+
+        await self._cast_persistent_area(
+            "spike_growth",
+            spell_name="Spike Growth",
+            duration="Up to 10 minutes",
+            slot_level=2,
+            range_meters=45,
+        )
+
+        self.assertEqual(len(self.state.active_area_effects), 1)
+        spike = self.state.active_area_effects[0]
+        self.assertEqual(spike["source_spell_canonical_key"], "spike_growth")
+        self.assertNotEqual(spike["id"], fog_id)
+        self.assertNotEqual(spike["concentration_group"], fog_group)
+
+        caster_effects = self.attacker.get("active_effects", [])
+        self.assertEqual(len(caster_effects), 1)
+        self.assertEqual(caster_effects[0]["metadata"]["source_spell_key"], "spike_growth")
+
+    async def test_non_concentration_area_effect_survives_cleanup(self):
+        self._setup_concentrating_caster_with_area_effect()
+        non_conc_effect = {
+            "id": "non-conc-effect",
+            "source_spell_canonical_key": "some_spell",
+            "source_spell_name": "Non-Conc Spell",
+            "caster_participant_id": "p1",
+            "caster_ref_id": "player-123",
+            "origin_point": {"x": 5, "y": 5},
+            "anchor_cell": {"x": 5, "y": 5},
+            "area_shape": "sphere",
+            "size_meters": 6.0,
+            "radius_meters": 6.0,
+            "affected_cells": [{"x": 5, "y": 5}],
+            "concentration_owner_participant_id": None,
+            "concentration_owner_ref_id": None,
+            "concentration_group": None,
+            "effect_kind": "spell_area",
+        }
+        self.state.active_area_effects = [*self.state.active_area_effects, non_conc_effect]
+        self.assertEqual(len(self.state.active_area_effects), 2)
+
+        result = CombatService._clear_concentration_for_source(
+            self.state, source_participant_id="p1",
+        )
+
+        self.assertEqual(len(self.state.active_area_effects), 1)
+        self.assertEqual(self.state.active_area_effects[0]["id"], "non-conc-effect")
+        self.assertEqual(result["removed_area_effects"][0]["id"], "area-effect-1")
+
+    def test_concentration_break_on_status_change_removes_area_effects(self):
+        self._setup_concentrating_caster_with_area_effect()
+        self.state.active_area_effects[0]["concentration_group"] = "conc-test-1"
+
+        with patch(
+            "app.services.combat_service.limiar_map_projection.maybe_sync_active_area_effects_to_limiar_map",
+        ) as mock_sync:
+            CombatService._clear_concentration_for_participant_status(
+                self.state,
+                source_participant_id="p1",
+            )
+
+        self.assertEqual(self.state.active_area_effects, [])
+        self.assertEqual(self.attacker.get("active_effects", []), [])
+        mock_sync.assert_called_once_with("session-123", self.state)
+
+    @patch("app.services.combat_service.spell_automation.resolve_saving_throw")
+    @patch("app.services.combat.CombatService._build_roll_actor_stats_for_save")
+    def test_concentration_check_includes_area_effect_names(
+        self,
+        mock_build_roll_stats,
+        mock_resolve_saving_throw,
+    ):
+        self._setup_concentrating_caster_with_area_effect("fog_cloud", "Fog Cloud")
+        mock_resolve_saving_throw.return_value = MagicMock(total=5, success=False)
+        session_state = SessionState(
+            id="state-1",
+            session_id="session-123",
+            player_user_id="player-123",
+            state_json={"currentHP": 20, "maxHP": 20, "deathSaves": {"successes": 0, "failures": 0}},
+        )
+
+        with patch(
+            "app.services.combat.CombatService._get_stats",
+            return_value=(session_state, 10, 10, 10, 2, 0),
+        ), patch(
+            "app.services.combat_service.limiar_map_projection.maybe_sync_active_area_effects_to_limiar_map",
+        ):
+            _, _, _, concentration_check = CombatService._apply_damage_to_target(
+                self.db, "player-123", "player", 8, False, self.state,
+            )
+
+        self.assertIsNotNone(concentration_check)
+        self.assertIn("fog_cloud", concentration_check["source_spell_keys"])
+        self.assertTrue(
+            any("Fog Cloud" in label for label in concentration_check["broken_effect_labels"]),
+        )
+
+    async def test_manual_effect_removal_cleans_up_area_effects(self):
+        self._setup_concentrating_caster_with_area_effect()
+
+        from app.schemas.combat import CombatRemoveEffectRequest
+
+        with patch(
+            "app.services.combat.CombatService.get_state",
+            return_value=self.state,
+        ), patch(
+            "app.services.combat_service.limiar_map_projection.maybe_sync_active_area_effects_to_limiar_map",
+        ) as mock_sync, patch(
+            "app.services.combat.CombatService._emit_state",
+            new_callable=AsyncMock,
+        ), patch(
+            "app.services.combat.CombatService._emit_log",
+            new_callable=AsyncMock,
+        ):
+            await CombatService.remove_effect(
+                self.db,
+                "session-123",
+                CombatRemoveEffectRequest(
+                    target_participant_id="p1",
+                    effect_id="conc-effect-1",
+                ),
+            )
+
+        self.assertEqual(self.state.active_area_effects, [])
+        self.assertEqual(self.attacker.get("active_effects", []), [])
+        mock_sync.assert_called_once_with("session-123", self.state)
+
+    async def test_hunters_mark_cast_after_fog_cloud_removes_area_effect(self):
+        await self._cast_persistent_area("fog_cloud")
+        self.assertEqual(len(self.state.active_area_effects), 1)
+        self.assertEqual(
+            self.state.active_area_effects[0]["source_spell_canonical_key"], "fog_cloud",
+        )
+
+        self.attacker["turn_resources"] = dict(CombatService._DEFAULT_TURN_RESOURCES)
+
+        target = self.state.participants[1]
+        with patch(
+            "app.services.combat_service.limiar_map_projection.maybe_sync_active_area_effects_to_limiar_map",
+        ) as mock_sync:
+            await CombatService._cast_hunters_mark_automation(
+                self.db,
+                "session-123",
+                attacker=self.attacker,
+                attacker_model=self.attacker_model,
+                actor_user_id="user-1",
+                is_gm=False,
+                req=MagicMock(),
+                state=self.state,
+                spell_context={"spell_name": "Hunter's Mark", "spell_canonical_key": "hunters_mark"},
+                target_participant=target,
+            )
+
+        self.assertEqual(self.state.active_area_effects, [])
+
+        caster_effects = self.attacker.get("active_effects", [])
+        hm_keys = [
+            e["metadata"]["source_spell_key"]
+            for e in caster_effects
+            if isinstance(e.get("metadata"), dict)
+        ]
+        self.assertIn("hunters_mark", hm_keys)
+        self.assertNotIn("fog_cloud", hm_keys)
+        mock_sync.assert_called_once()
+
+    async def test_spike_growth_cast_after_hunters_mark_removes_mark_effects(self):
+        target = self.state.participants[1]
+        with patch(
+            "app.services.combat_service.limiar_map_projection.maybe_sync_active_area_effects_to_limiar_map",
+        ):
+            await CombatService._cast_hunters_mark_automation(
+                self.db,
+                "session-123",
+                attacker=self.attacker,
+                attacker_model=self.attacker_model,
+                actor_user_id="user-1",
+                is_gm=False,
+                req=MagicMock(),
+                state=self.state,
+                spell_context={"spell_name": "Hunter's Mark", "spell_canonical_key": "hunters_mark"},
+                target_participant=target,
+            )
+
+        self.assertEqual(len(self.attacker.get("active_effects", [])), 1)
+        self.assertEqual(len(target.get("active_effects", [])), 1)
+        self.assertEqual(self.state.active_area_effects, [])
+
+        self.attacker["turn_resources"] = dict(CombatService._DEFAULT_TURN_RESOURCES)
+
+        await self._cast_persistent_area(
+            "spike_growth",
+            spell_name="Spike Growth",
+            duration="Up to 10 minutes",
+            slot_level=2,
+            range_meters=45,
+        )
+
+        self.assertEqual(len(self.state.active_area_effects), 1)
+        self.assertEqual(
+            self.state.active_area_effects[0]["source_spell_canonical_key"], "spike_growth",
+        )
+
+        all_effect_keys = []
+        for p in self.state.participants:
+            for e in p.get("active_effects", []):
+                m = e.get("metadata", {})
+                if isinstance(m, dict) and m.get("source_spell_key"):
+                    all_effect_keys.append(m["source_spell_key"])
+        self.assertNotIn("hunters_mark", all_effect_keys)
+
+    def test_removed_spike_growth_not_in_map_sync_payload(self):
+        self._setup_concentrating_caster_with_area_effect(
+            "spike_growth", "Spike Growth",
+        )
+        from app.services.combat_service.persistent_area_effects import (
+            active_area_effects_for_map,
+        )
+
+        self.assertEqual(len(active_area_effects_for_map(self.state)), 1)
+
+        CombatService._clear_concentration_for_source(
+            self.state, source_participant_id="p1",
+        )
+
+        self.assertEqual(active_area_effects_for_map(self.state), [])


### PR DESCRIPTION
## Summary

- Remove active spell area effects when their caster loses concentration, drops concentration, or casts a new concentration spell.
- Create per-participant concentration tracking effects on the caster when persistent concentration area spells (Fog Cloud, Spike Growth) are cast, so the existing concentration check pipeline (damage → CON save → break) works for these spells.
- Sync updated area effect state to LimiarMap after any concentration cleanup, ensuring overlays and tactical effects (movement cost, hazard damage, visibility blocking) are removed.

## Changes

| File | Change |
|---|---|
| `concentration.py` | New `_remove_area_effects_for_concentration_group()` and `_sync_area_effects_if_changed()`. `_remove_effect_group` / `_clear_concentration_for_source` now also remove matching area effects. `_resolve_concentration_check_after_damage` syncs map + includes area effect names in labels. `_clear_concentration_for_participant_status` syncs map on status change. |
| `cast_area.py` | On persistent concentration spell cast: clear existing concentration, generate `concentration_group`, create per-participant concentration effect on caster, pass group to area effect builder. |
| `persistent_area_effects.py` | `build_persistent_spell_area_effect` accepts optional `concentration_group` param, stored as internal-only field. |
| `spell_automation.py` | `_cast_hunters_mark_automation` handles new return type + syncs area effects. |
| `effects_actions.py` | Manual GM effect removal triggers area effect cleanup + map sync. |

## Test coverage (13 new tests)

- Fog Cloud / Spike Growth create per-participant concentration effect on caster
- Area effect has internal `concentration_group` matching per-participant effect
- Damage → failed CON save removes area effects + syncs map (Fog Cloud, Spike Growth)
- Casting new concentration spell replaces prior area effects (Fog Cloud → Spike Growth)
- Fog Cloud → Hunter's Mark cross-path: area effect removed, HM per-participant effects active
- Hunter's Mark → Spike Growth cross-path: HM effects removed, Spike Growth area effect created
- Non-concentration area effect survives unrelated concentration cleanup
- Concentration break on status change (death/downed) removes area effects + syncs map
- Manual effect removal cleans up area effects + syncs map
- Removed Spike Growth not in `active_area_effects_for_map` payload (mechanical effects gone)

## Validation

- 1309 passed, 1 skipped, 0 failures (full control-server suite)
- `npm run lint` clean
- `git diff --check` clean
- No schema/migration changes required