### PR TITLE
feat(combat): backend contract for per-instance spell target assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ htmlcov/
 historico_commits.txt
 CLAUDE.md
 .codex
+.kilo/

--- a/apps/control-server/app/schemas/combat_spells.py
+++ b/apps/control-server/app/schemas/combat_spells.py
@@ -45,6 +45,11 @@ class CombatAttackResult(BaseModel):
     concentration_check: "CombatConcentrationCheckResult | None" = None
 
 
+class EffectInstanceTarget(BaseModel):
+    instance_index: int = Field(ge=1)
+    target_ref_id: str
+
+
 class CombatCastSpellRequest(BaseModel):
     actor_participant_id: Optional[str] = None
     target_ref_id: str | None = None
@@ -78,6 +83,7 @@ class CombatCastSpellRequest(BaseModel):
     concentration_roll_source: RollSource = "system"
     concentration_manual_roll: int | None = Field(default=None, ge=1, le=20)
     override_resource_limit: bool = False
+    effect_instance_targets: list[EffectInstanceTarget] | None = None
 
 
 class CombatGridCell(BaseModel):
@@ -203,6 +209,21 @@ class CombatMovementPreviewResponse(BaseModel):
     map_version: int | None = None
 
 
+class EffectInstanceOutcome(BaseModel):
+    instance_index: int
+    target_ref_id: str
+    target_display_name: str
+    target_kind: Literal["player", "session_entity"]
+    damage: int = 0
+    healing: int = 0
+    is_hit: bool | None = None
+    is_saved: bool | None = None
+    is_critical: bool = False
+    roll: int | None = None
+    roll_result: RollResult | None = None
+    new_hp: int | None = None
+
+
 class CombatSpellResult(BaseModel):
     spell_name: str
     spell_canonical_key: str | None = None
@@ -252,3 +273,4 @@ class CombatSpellResult(BaseModel):
     effect_instance_count: int | None = None
     effect_instance_dice: str | None = None
     base_effect_instance_count: int | None = None
+    effect_instance_outcomes: list[EffectInstanceOutcome] = Field(default_factory=list)

--- a/apps/control-server/app/services/combat_service/spells/cast_target.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target.py
@@ -6,7 +6,9 @@ from uuid import uuid4
 from sqlalchemy.orm.attributes import flag_modified
 
 from app.models.inventory import InventoryItem
-from app.services.roll_resolution import resolve_saving_throw
+from app.schemas.roll import RollActorStats
+from app.services.combat_service.condition_effects import resolve_attack_advantage, resolve_spell_attack_kind
+from app.services.roll_resolution import resolve_attack_base, resolve_saving_throw
 from app.services.magic_item_effects import (
     consume_inventory_item_charge,
     get_inventory_item_charges_current,
@@ -55,6 +57,347 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
             db, attacker["ref_id"], attacker["kind"], session_id
         )
         return state, attacker, attacker_model
+
+    @classmethod
+    def _validate_instance_targets(cls, *, req, spell_context, state):
+        raw = getattr(req, "effect_instance_targets", None)
+        if not raw:
+            return None
+
+        instance_count = spell_context.get("effect_instance_count", 1)
+        if instance_count <= 1:
+            raise CombatServiceError(
+                "effect_instance_targets is only supported for multi-instance spells.", 400
+            )
+
+        indices = set()
+        for t in raw:
+            idx = t.instance_index
+            if idx < 1 or idx > instance_count:
+                raise CombatServiceError(
+                    f"Instance index {idx} is out of range (1..{instance_count}).", 400
+                )
+            if idx in indices:
+                raise CombatServiceError(
+                    f"Duplicate instance index: {idx}.", 400
+                )
+            indices.add(idx)
+
+        missing = set(range(1, instance_count + 1)) - indices
+        if missing:
+            sorted_missing = sorted(missing)
+            raise CombatServiceError(
+                f"Missing instance target assignments: {', '.join(str(m) for m in sorted_missing)}.", 400
+            )
+
+        participants_by_ref = {p["ref_id"]: p for p in state.participants}
+        validated = []
+        for t in raw:
+            participant = participants_by_ref.get(t.target_ref_id)
+            if participant is None:
+                raise CombatServiceError(
+                    f"Invalid target_ref_id for instance {t.instance_index}: {t.target_ref_id}.", 400
+                )
+            validated.append({
+                "instance_index": t.instance_index,
+                "target_ref_id": t.target_ref_id,
+                "participant": participant,
+            })
+
+        return validated
+
+    @classmethod
+    def _resolve_instance_direct(cls, db, state, attacker, target_p, spell_context, req):
+        instance_dice = spell_context.get("effect_instance_dice")
+        if not instance_dice:
+            raise CombatServiceError(
+                "Multi-instance spell is missing effect_instance_dice.", 400
+            )
+        effect_kind = spell_context.get("effect_kind") or "damage"
+        damage_type = spell_context.get("damage_type")
+
+        _, total = cls._resolve_damage_roll(instance_dice, roll_source="system")
+        amount = max(0, total)
+
+        new_hp = None
+        previous_hp = None
+        if amount > 0:
+            new_hp, _, previous_hp, _ = cls._apply_spell_effect(
+                db, state,
+                target_p["ref_id"], target_p["kind"],
+                effect_kind, amount,
+                damage_type=damage_type,
+                concentration_roll_source=req.concentration_roll_source,
+                concentration_manual_roll=req.concentration_manual_roll,
+            )
+
+        return {
+            "target_ref_id": target_p["ref_id"],
+            "target_display_name": target_p.get("display_name", ""),
+            "target_kind": target_p.get("kind", "session_entity"),
+            "damage": amount if effect_kind != "healing" else 0,
+            "healing": amount if effect_kind == "healing" else 0,
+            "is_hit": None,
+            "is_saved": None,
+            "is_critical": False,
+            "roll": None,
+            "roll_result": None,
+            "new_hp": new_hp,
+            "previous_hp": previous_hp,
+        }
+
+    @classmethod
+    def _resolve_instance_attack(cls, db, session_id, state, attacker, target_p, spell_context, req, is_gm):
+        instance_dice = spell_context.get("effect_instance_dice")
+        if not instance_dice:
+            raise CombatServiceError(
+                "Multi-instance spell is missing effect_instance_dice.", 400
+            )
+        effect_kind = spell_context.get("effect_kind") or "damage"
+        damage_type = spell_context.get("damage_type")
+        attack_bonus = cls._safe_int(spell_context.get("attack_bonus"), 0)
+
+        _, target_ac, *_ = cls._get_stats(db, target_p["ref_id"], target_p["kind"], session_id)
+        target_ac = target_ac or 10
+
+        adv_ctx = resolve_attack_advantage(attacker, target_p, resolve_spell_attack_kind())
+        has_adv = req.has_advantage or bool(adv_ctx.advantage_sources)
+        has_dis = req.has_disadvantage or bool(adv_ctx.disadvantage_sources)
+        adv_mode = (
+            "advantage" if has_adv and not has_dis
+            else "disadvantage" if has_dis and not has_adv
+            else "normal"
+        )
+
+        roll_result = resolve_attack_base(
+            RollActorStats(
+                display_name=attacker["display_name"],
+                abilities={},
+                actor_kind="player",
+                actor_ref_id=attacker["ref_id"],
+            ),
+            advantage_mode=adv_mode,
+            bonus_override=attack_bonus,
+            target_ac=target_ac,
+            roll_source="system",
+        )
+        roll_result.is_gm_roll = is_gm
+        roll_result.roll_source = "system"
+
+        is_critical = roll_result.selected_roll == 20
+        is_hit = bool(roll_result.success)
+
+        damage = 0
+        healing = 0
+        new_hp = None
+        previous_hp = None
+
+        if is_hit:
+            _, total = cls._resolve_damage_roll(instance_dice, critical=is_critical, roll_source="system")
+            amount = max(0, total)
+            if amount > 0:
+                new_hp, _, previous_hp, _ = cls._apply_spell_effect(
+                    db, state,
+                    target_p["ref_id"], target_p["kind"],
+                    effect_kind, amount,
+                    damage_type=damage_type,
+                    is_critical=is_critical,
+                    concentration_roll_source=req.concentration_roll_source,
+                    concentration_manual_roll=req.concentration_manual_roll,
+                )
+                if effect_kind == "healing":
+                    healing = amount
+                else:
+                    damage = amount
+        else:
+            flag_modified(state, "participants")
+
+        return {
+            "target_ref_id": target_p["ref_id"],
+            "target_display_name": target_p.get("display_name", ""),
+            "target_kind": target_p.get("kind", "session_entity"),
+            "damage": damage,
+            "healing": healing,
+            "is_hit": is_hit,
+            "is_saved": None,
+            "is_critical": is_critical,
+            "roll": roll_result.total,
+            "roll_result": roll_result,
+            "new_hp": new_hp,
+            "previous_hp": previous_hp,
+        }
+
+    @classmethod
+    async def _resolve_multi_instance_cast(
+        cls, db, session_id, req, state, attacker, attacker_model,
+        spell_context, actor_user_id, is_gm, validated_targets,
+    ):
+        slot_spent = False
+        if spell_context.get("source_kind") == "magic_item":
+            inventory_item = spell_context.get("inventory_item")
+            source_item = spell_context.get("source_item")
+            if not isinstance(inventory_item, InventoryItem):
+                raise CombatServiceError("Magic item inventory entry is missing.", 400)
+            remaining_charges = get_inventory_item_charges_current(inventory_item, source_item)
+            if isinstance(remaining_charges, int) and remaining_charges <= 0:
+                raise CombatServiceError("This item has no charges remaining.", 400)
+
+        action_cost = spell_context.get("action_cost") or "action"
+        was_overridden = cls._consume_turn_resource(
+            attacker, action_cost,
+            is_gm=is_gm,
+            override_resource_limit=req.override_resource_limit,
+        )
+
+        if spell_context.get("source_kind") == "magic_item":
+            inventory_item = spell_context.get("inventory_item")
+            source_item = spell_context.get("source_item")
+            if not isinstance(inventory_item, InventoryItem):
+                raise CombatServiceError("Magic item inventory entry is missing.", 400)
+            try:
+                consume_inventory_item_charge(inventory_item, source_item)
+            except ValueError as exc:
+                raise CombatServiceError(str(exc), 400) from exc
+            db.add(inventory_item)
+        elif isinstance(spell_context.get("slot_level"), int):
+            cls._consume_player_spell_slot(attacker_model, spell_context["slot_level"])
+            db.add(attacker_model)
+            slot_spent = True
+
+        spell_mode = spell_context["spell_mode"]
+        is_hostile = spell_mode in ("spell_attack", "saving_throw", "direct_damage")
+        if is_hostile:
+            seen = set()
+            for vt in validated_targets:
+                ref_id = vt["target_ref_id"]
+                if ref_id not in seen:
+                    cls._assert_hostile_action_allowed(
+                        attacker, vt["participant"], action_label="a hostile spell",
+                    )
+                    seen.add(ref_id)
+
+        logger.info(
+            "[cast_spell] pipeline=multi_instance spell=%s instances=%d session=%s actor=%s",
+            spell_context["spell_canonical_key"],
+            len(validated_targets),
+            session_id,
+            attacker.get("ref_id"),
+        )
+
+        outcomes = []
+        entity_previous_hp_map = {}
+
+        for vt in validated_targets:
+            target_p = vt["participant"]
+
+            if spell_mode == "spell_attack":
+                outcome = cls._resolve_instance_attack(
+                    db, session_id, state, attacker, target_p, spell_context, req, is_gm,
+                )
+            else:
+                outcome = cls._resolve_instance_direct(
+                    db, state, attacker, target_p, spell_context, req,
+                )
+
+            outcome["instance_index"] = vt["instance_index"]
+            outcomes.append(outcome)
+
+            ref_id = vt["target_ref_id"]
+            if ref_id not in entity_previous_hp_map and outcome.get("previous_hp") is not None:
+                entity_previous_hp_map[ref_id] = outcome["previous_hp"]
+
+        flag_modified(state, "participants")
+        db.add(state)
+        db.commit()
+        db.refresh(state)
+
+        player_state_ids = set()
+        if slot_spent:
+            player_state_ids.add(attacker["ref_id"])
+
+        for outcome in outcomes:
+            if outcome["damage"] > 0 or outcome["healing"] > 0:
+                if outcome["target_kind"] == "player":
+                    player_state_ids.add(outcome["target_ref_id"])
+
+        for player_ref_id in player_state_ids:
+            target_state, *_ = cls._get_stats(db, player_ref_id, "player", session_id)
+            await cls._emit_player_state_update(db, session_id, player_ref_id, target_state)
+
+        for ref_id, prev_hp in entity_previous_hp_map.items():
+            target_p_entity = next(
+                (p for p in state.participants if p["ref_id"] == ref_id), None,
+            )
+            if target_p_entity and target_p_entity.get("kind") == "session_entity":
+                await cls._emit_entity_hp_update(db, session_id, ref_id, prev_hp)
+
+        await cls._emit_state(session_id, state)
+
+        log_message = cls._build_multi_instance_log_message(
+            attacker=attacker,
+            spell_context=spell_context,
+            outcomes=outcomes,
+            was_overridden=was_overridden,
+            action_cost=action_cost,
+        )
+        await cls._emit_log(session_id, {
+            "message": log_message,
+            "actorUserId": actor_user_id,
+            "source": "gm_override" if is_gm else "player_turn",
+            "is_override": was_overridden,
+            "overridden_resource": action_cost if was_overridden else None,
+        })
+
+        total_damage = sum(o["damage"] for o in outcomes)
+        total_healing = sum(o["healing"] for o in outcomes)
+        first_outcome = outcomes[0] if outcomes else None
+
+        return {
+            "spell_name": spell_context["spell_name"],
+            "spell_canonical_key": spell_context["spell_canonical_key"],
+            "action_kind": spell_mode,
+            "effect_kind": spell_context.get("effect_kind"),
+            "damage": total_damage,
+            "healing": total_healing,
+            "damage_type": spell_context.get("damage_type"),
+            "is_critical": None,
+            "is_hit": None,
+            "is_saved": None,
+            "new_hp": None,
+            "roll": None,
+            "roll_result": None,
+            "target_ac": None,
+            "target_display_name": first_outcome["target_display_name"] if first_outcome else "",
+            "target_kind": first_outcome["target_kind"] if first_outcome else "session_entity",
+            "save_ability": spell_context.get("save_ability"),
+            "save_dc": spell_context.get("save_dc"),
+            "save_success_outcome": spell_context.get("save_success_outcome"),
+            "effect_dice": spell_context.get("effect_instance_dice"),
+            "effect_bonus": 0,
+            "pending_spell_id": None,
+            "pending_save_id": None,
+            "effect_roll_required": False,
+            "effect_rolls": [],
+            "base_effect": None,
+            "effect_roll_source": None,
+            "action_cost": action_cost,
+            "summary_text": None,
+            "inventory_refresh_required": spell_context.get("source_kind") == "magic_item",
+            "concentration_check": None,
+            "concentration_checks": [],
+            "area_shape": None,
+            "affected_target_ref_ids": [],
+            "affected_cells": [],
+            "area_target_outcomes": [],
+            "target_count": len(validated_targets),
+            "elemental_affinity_eligible": bool(spell_context.get("elemental_affinity_eligible")),
+            "elemental_affinity_damage_type": spell_context.get("elemental_affinity_damage_type"),
+            "elemental_affinity_bonus": spell_context.get("elemental_affinity_bonus"),
+            "effect_instance_count": spell_context.get("effect_instance_count"),
+            "effect_instance_dice": spell_context.get("effect_instance_dice"),
+            "base_effect_instance_count": spell_context.get("base_effect_instance_count"),
+            "effect_instance_outcomes": outcomes,
+        }
 
     @classmethod
     async def _resolve_cast_resolution(
@@ -434,6 +777,14 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
         spell_context = cls._resolve_player_spell_context(
             db, session_id, attacker, attacker_model, req,
         )
+        validated_targets = cls._validate_instance_targets(
+            req=req, spell_context=spell_context, state=state,
+        )
+        if validated_targets is not None:
+            return await cls._resolve_multi_instance_cast(
+                db, session_id, req, state, attacker, attacker_model,
+                spell_context, actor_user_id, is_gm, validated_targets,
+            )
         area_spell_spec = cls._resolve_supported_area_spell_spec(spell_context)
         if cls._normalize_area_shape(spell_context.get("area_shape")) is not None:
             if area_spell_spec is None:

--- a/apps/control-server/app/services/combat_service/spells/spell_response.py
+++ b/apps/control-server/app/services/combat_service/spells/spell_response.py
@@ -10,6 +10,37 @@ from ..exceptions import CombatServiceError
 class SpellResponseMixin:
 
     @classmethod
+    def _build_multi_instance_log_message(
+        cls,
+        *,
+        attacker: dict,
+        spell_context: dict,
+        outcomes: list[dict],
+        was_overridden: bool,
+        action_cost: str,
+    ) -> str:
+        spell_name = spell_context["spell_name"]
+        damage_type = spell_context.get("damage_type") or "energia"
+        n = len(outcomes)
+
+        lines = [f"{attacker['display_name']} conjurou {spell_name}: {n} instâncias."]
+        for o in outcomes:
+            idx = o["instance_index"]
+            name = o["target_display_name"]
+            dmg = o["damage"]
+            if o.get("is_hit") is False:
+                lines.append(f"  Instância {idx} → {name}: errou.")
+            elif dmg > 0:
+                lines.append(f"  Instância {idx} → {name}: {dmg} de dano de {damage_type}.")
+            else:
+                lines.append(f"  Instância {idx} → {name}: sem dano.")
+
+        log_message = "\n".join(lines)
+        if was_overridden:
+            log_message = f"[OVERRIDE: Limit for '{action_cost}' ignored] {log_message}"
+        return log_message
+
+    @classmethod
     def _build_cast_log_message(
         cls,
         *,
@@ -200,4 +231,5 @@ class SpellResponseMixin:
             "effect_instance_count": spell_context.get("effect_instance_count"),
             "effect_instance_dice": spell_context.get("effect_instance_dice"),
             "base_effect_instance_count": spell_context.get("base_effect_instance_count"),
+            "effect_instance_outcomes": [],
         }

--- a/apps/control-server/tests/test_instance_target_assignment.py
+++ b/apps/control-server/tests/test_instance_target_assignment.py
@@ -1,0 +1,533 @@
+"""Tests for per-instance target assignment.
+
+Covers:
+  - _validate_instance_targets validation rules
+  - _resolve_instance_direct per-instance damage resolution
+  - _resolve_instance_attack per-instance attack resolution
+  - _resolve_multi_instance_cast orchestration
+  - _build_multi_instance_log_message formatting
+  - Backward compatibility (no effect_instance_targets)
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.models.combat import CombatPhase, CombatState
+from app.schemas.combat_spells import EffectInstanceTarget
+from app.services.combat import CombatService, CombatServiceError
+
+
+def _build_state(participants=None):
+    if participants is None:
+        participants = [
+            {
+                "id": "p1",
+                "ref_id": "player-1",
+                "kind": "player",
+                "display_name": "Hero",
+                "status": "active",
+                "team": "players",
+                "visible": True,
+                "actor_user_id": "user-1",
+            },
+            {
+                "id": "e1",
+                "ref_id": "entity:goblin-a",
+                "kind": "session_entity",
+                "display_name": "Goblin A",
+                "status": "active",
+                "team": "enemies",
+                "visible": True,
+                "actor_user_id": None,
+            },
+            {
+                "id": "e2",
+                "ref_id": "entity:goblin-b",
+                "kind": "session_entity",
+                "display_name": "Goblin B",
+                "status": "active",
+                "team": "enemies",
+                "visible": True,
+                "actor_user_id": None,
+            },
+            {
+                "id": "e3",
+                "ref_id": "entity:goblin-c",
+                "kind": "session_entity",
+                "display_name": "Goblin C",
+                "status": "active",
+                "team": "enemies",
+                "visible": True,
+                "actor_user_id": None,
+            },
+        ]
+    return CombatState(
+        id="combat-1",
+        session_id="session-1",
+        phase=CombatPhase.active,
+        round=1,
+        current_turn_index=0,
+        participants=participants,
+    )
+
+
+def _req_with_targets(targets):
+    return SimpleNamespace(effect_instance_targets=targets)
+
+
+def _spell_context(count=5, dice="1d4+1", spell_mode="direct_damage"):
+    return {
+        "effect_instance_count": count,
+        "effect_instance_dice": dice,
+        "spell_mode": spell_mode,
+        "spell_canonical_key": "magic_missile",
+        "spell_name": "Magic Missile",
+        "effect_kind": "damage",
+        "damage_type": "Force",
+    }
+
+
+class ValidateInstanceTargetsTests(unittest.TestCase):
+    def test_returns_none_when_no_targets(self):
+        state = _build_state()
+        req = SimpleNamespace(effect_instance_targets=None)
+        result = CombatService._validate_instance_targets(
+            req=req, spell_context=_spell_context(), state=state,
+        )
+        self.assertIsNone(result)
+
+    def test_returns_none_when_empty_list(self):
+        state = _build_state()
+        req = SimpleNamespace(effect_instance_targets=[])
+        result = CombatService._validate_instance_targets(
+            req=req, spell_context=_spell_context(), state=state,
+        )
+        self.assertIsNone(result)
+
+    def test_accepts_valid_5_instance_assignment(self):
+        state = _build_state()
+        targets = [
+            EffectInstanceTarget(instance_index=1, target_ref_id="entity:goblin-a"),
+            EffectInstanceTarget(instance_index=2, target_ref_id="entity:goblin-a"),
+            EffectInstanceTarget(instance_index=3, target_ref_id="entity:goblin-b"),
+            EffectInstanceTarget(instance_index=4, target_ref_id="entity:goblin-b"),
+            EffectInstanceTarget(instance_index=5, target_ref_id="entity:goblin-c"),
+        ]
+        req = _req_with_targets(targets)
+        result = CombatService._validate_instance_targets(
+            req=req, spell_context=_spell_context(), state=state,
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 5)
+        self.assertEqual(result[0]["instance_index"], 1)
+        self.assertEqual(result[0]["target_ref_id"], "entity:goblin-a")
+        self.assertEqual(result[0]["participant"]["display_name"], "Goblin A")
+
+    def test_accepts_all_instances_same_target(self):
+        state = _build_state()
+        targets = [
+            EffectInstanceTarget(instance_index=i, target_ref_id="entity:goblin-a")
+            for i in range(1, 6)
+        ]
+        req = _req_with_targets(targets)
+        result = CombatService._validate_instance_targets(
+            req=req, spell_context=_spell_context(), state=state,
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 5)
+        for entry in result:
+            self.assertEqual(entry["target_ref_id"], "entity:goblin-a")
+
+    def test_accepts_2_instance_assignment(self):
+        state = _build_state()
+        targets = [
+            EffectInstanceTarget(instance_index=1, target_ref_id="entity:goblin-a"),
+            EffectInstanceTarget(instance_index=2, target_ref_id="entity:goblin-b"),
+        ]
+        ctx = _spell_context(count=2, dice="1d10", spell_mode="spell_attack")
+        req = _req_with_targets(targets)
+        result = CombatService._validate_instance_targets(
+            req=req, spell_context=ctx, state=state,
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 2)
+
+    def test_rejects_single_instance_spell(self):
+        state = _build_state()
+        targets = [EffectInstanceTarget(instance_index=1, target_ref_id="entity:goblin-a")]
+        ctx = _spell_context(count=1)
+        req = _req_with_targets(targets)
+        with self.assertRaises(CombatServiceError) as cm:
+            CombatService._validate_instance_targets(
+                req=req, spell_context=ctx, state=state,
+            )
+        self.assertIn("only supported for multi-instance spells", str(cm.exception))
+
+    def test_rejects_index_out_of_range(self):
+        state = _build_state()
+        targets = [
+            EffectInstanceTarget(instance_index=1, target_ref_id="entity:goblin-a"),
+            EffectInstanceTarget(instance_index=2, target_ref_id="entity:goblin-a"),
+            EffectInstanceTarget(instance_index=3, target_ref_id="entity:goblin-b"),
+            EffectInstanceTarget(instance_index=4, target_ref_id="entity:goblin-b"),
+            EffectInstanceTarget(instance_index=6, target_ref_id="entity:goblin-c"),
+        ]
+        req = _req_with_targets(targets)
+        with self.assertRaises(CombatServiceError) as cm:
+            CombatService._validate_instance_targets(
+                req=req, spell_context=_spell_context(), state=state,
+            )
+        self.assertIn("out of range", str(cm.exception))
+        self.assertIn("6", str(cm.exception))
+
+    def test_rejects_duplicate_index(self):
+        state = _build_state()
+        targets = [
+            EffectInstanceTarget(instance_index=1, target_ref_id="entity:goblin-a"),
+            EffectInstanceTarget(instance_index=1, target_ref_id="entity:goblin-b"),
+        ]
+        ctx = _spell_context(count=2)
+        req = _req_with_targets(targets)
+        with self.assertRaises(CombatServiceError) as cm:
+            CombatService._validate_instance_targets(
+                req=req, spell_context=ctx, state=state,
+            )
+        self.assertIn("Duplicate instance index", str(cm.exception))
+
+    def test_rejects_incomplete_assignment(self):
+        state = _build_state()
+        targets = [
+            EffectInstanceTarget(instance_index=1, target_ref_id="entity:goblin-a"),
+            EffectInstanceTarget(instance_index=2, target_ref_id="entity:goblin-a"),
+            EffectInstanceTarget(instance_index=3, target_ref_id="entity:goblin-b"),
+        ]
+        req = _req_with_targets(targets)
+        with self.assertRaises(CombatServiceError) as cm:
+            CombatService._validate_instance_targets(
+                req=req, spell_context=_spell_context(), state=state,
+            )
+        self.assertIn("Missing instance target assignments", str(cm.exception))
+        self.assertIn("4", str(cm.exception))
+        self.assertIn("5", str(cm.exception))
+
+    def test_rejects_invalid_target_ref(self):
+        state = _build_state()
+        targets = [
+            EffectInstanceTarget(instance_index=1, target_ref_id="entity:goblin-a"),
+            EffectInstanceTarget(instance_index=2, target_ref_id="entity:nonexistent"),
+        ]
+        ctx = _spell_context(count=2)
+        req = _req_with_targets(targets)
+        with self.assertRaises(CombatServiceError) as cm:
+            CombatService._validate_instance_targets(
+                req=req, spell_context=ctx, state=state,
+            )
+        self.assertIn("Invalid target_ref_id for instance 2", str(cm.exception))
+
+
+class InstanceDirectResolutionTests(unittest.TestCase):
+    @patch("random.randint", return_value=3)
+    def test_resolves_direct_damage_per_instance(self, mock_rand):
+        state = _build_state()
+        db = MagicMock()
+        target = state.participants[1]
+        spell_context = _spell_context()
+        req = SimpleNamespace(
+            concentration_roll_source="system",
+            concentration_manual_roll=None,
+        )
+
+        CombatService._apply_spell_effect = MagicMock(return_value=(8, "dano aplicado", 10, None))
+        outcome = CombatService._resolve_instance_direct(
+            db, state, state.participants[0], target, spell_context, req,
+        )
+        self.assertEqual(outcome["target_ref_id"], "entity:goblin-a")
+        self.assertEqual(outcome["target_display_name"], "Goblin A")
+        self.assertEqual(outcome["target_kind"], "session_entity")
+        self.assertEqual(outcome["damage"], 4)
+        self.assertEqual(outcome["healing"], 0)
+        self.assertIsNone(outcome["is_hit"])
+        self.assertFalse(outcome["is_critical"])
+
+    def test_rejects_missing_instance_dice(self):
+        state = _build_state()
+        db = MagicMock()
+        target = state.participants[1]
+        spell_context = _spell_context()
+        spell_context["effect_instance_dice"] = None
+        req = SimpleNamespace(
+            concentration_roll_source="system",
+            concentration_manual_roll=None,
+        )
+        with self.assertRaises(CombatServiceError) as cm:
+            CombatService._resolve_instance_direct(
+                db, state, state.participants[0], target, spell_context, req,
+            )
+        self.assertIn("missing effect_instance_dice", str(cm.exception))
+
+
+class InstanceAttackResolutionTests(unittest.TestCase):
+    @patch.object(CombatService, "_get_stats", return_value=(MagicMock(), 12, MagicMock(), MagicMock(), MagicMock(), MagicMock()))
+    @patch("random.randint", return_value=15)
+    def test_resolves_attack_hit_per_instance(self, mock_rand, mock_stats):
+        from app.schemas.roll import RollActorStats
+
+        state = _build_state()
+        db = MagicMock()
+        target = state.participants[1]
+        attacker = state.participants[0]
+        spell_context = _spell_context(count=2, dice="1d10", spell_mode="spell_attack")
+        spell_context["attack_bonus"] = 5
+        req = SimpleNamespace(
+            has_advantage=False,
+            has_disadvantage=False,
+            roll_source="system",
+            concentration_roll_source="system",
+            concentration_manual_roll=None,
+        )
+
+        CombatService._apply_spell_effect = MagicMock(return_value=(8, "dano aplicado", 20, None))
+        CombatService._resolve_damage_roll = MagicMock(return_value=([], 15))
+
+        outcome = CombatService._resolve_instance_attack(
+            db, "session-1", state, attacker, target, spell_context, req, is_gm=False,
+        )
+        self.assertEqual(outcome["target_ref_id"], "entity:goblin-a")
+        self.assertIn(outcome["is_hit"], (True, False))
+
+    @patch.object(CombatService, "_get_stats", return_value=(MagicMock(), 20, MagicMock(), MagicMock(), MagicMock(), MagicMock()))
+    def test_resolves_attack_miss_zero_damage(self, mock_stats):
+        state = _build_state()
+        db = MagicMock()
+        target = state.participants[1]
+        attacker = state.participants[0]
+        spell_context = _spell_context(count=2, dice="1d10", spell_mode="spell_attack")
+        spell_context["attack_bonus"] = 0
+        req = SimpleNamespace(
+            has_advantage=False,
+            has_disadvantage=False,
+            roll_source="system",
+            concentration_roll_source="system",
+            concentration_manual_roll=None,
+        )
+
+        outcome = CombatService._resolve_instance_attack(
+            db, "session-1", state, attacker, target, spell_context, req, is_gm=False,
+        )
+        self.assertEqual(outcome["damage"], 0)
+
+    @patch.object(CombatService, "_get_stats", return_value=(MagicMock(), 12, MagicMock(), MagicMock(), MagicMock(), MagicMock()))
+    @patch("random.randint", return_value=15)
+    def test_condition_advantage_applies(self, mock_rand, mock_stats):
+        state = _build_state()
+        goblin = state.participants[1]
+        goblin["conditions"] = [{"type": "restrained"}]
+        attacker = state.participants[0]
+        db = MagicMock()
+        spell_context = _spell_context(count=2, dice="1d10", spell_mode="spell_attack")
+        spell_context["attack_bonus"] = 5
+        req = SimpleNamespace(
+            has_advantage=False,
+            has_disadvantage=False,
+            roll_source="system",
+            concentration_roll_source="system",
+            concentration_manual_roll=None,
+        )
+
+        CombatService._apply_spell_effect = MagicMock(return_value=(8, "", 20, None))
+        CombatService._resolve_damage_roll = MagicMock(return_value=([], 10))
+
+        outcome = CombatService._resolve_instance_attack(
+            db, "session-1", state, attacker, goblin, spell_context, req, is_gm=False,
+        )
+        self.assertIsNotNone(outcome["roll_result"])
+
+    @patch.object(CombatService, "_get_stats", return_value=(MagicMock(), 12, MagicMock(), MagicMock(), MagicMock(), MagicMock()))
+    def test_attacker_condition_disadvantage_applies(self, mock_stats):
+        state = _build_state()
+        target = state.participants[1]
+        attacker = state.participants[0]
+        attacker["conditions"] = [{"type": "poisoned"}]
+        db = MagicMock()
+        spell_context = _spell_context(count=2, dice="1d10", spell_mode="spell_attack")
+        spell_context["attack_bonus"] = 5
+        req = SimpleNamespace(
+            has_advantage=False,
+            has_disadvantage=False,
+            roll_source="system",
+            concentration_roll_source="system",
+            concentration_manual_roll=None,
+        )
+
+        CombatService._apply_spell_effect = MagicMock(return_value=(8, "", 20, None))
+        CombatService._resolve_damage_roll = MagicMock(return_value=([], 10))
+
+        outcome = CombatService._resolve_instance_attack(
+            db, "session-1", state, attacker, target, spell_context, req, is_gm=False,
+        )
+        self.assertIsNotNone(outcome["roll_result"])
+
+
+class MultiInstanceLogMessageTests(unittest.TestCase):
+    def test_formats_multi_instance_log(self):
+        outcomes = [
+            {"instance_index": 1, "target_display_name": "Goblin A", "damage": 3, "is_hit": None},
+            {"instance_index": 2, "target_display_name": "Goblin A", "damage": 5, "is_hit": None},
+            {"instance_index": 3, "target_display_name": "Goblin B", "damage": 2, "is_hit": None},
+        ]
+        msg = CombatService._build_multi_instance_log_message(
+            attacker={"display_name": "Hero"},
+            spell_context={"spell_name": "Magic Missile", "damage_type": "Force"},
+            outcomes=outcomes,
+            was_overridden=False,
+            action_cost="action",
+        )
+        self.assertIn("Hero conjurou Magic Missile: 3 instâncias.", msg)
+        self.assertIn("Instância 1 → Goblin A: 3 de dano de Force.", msg)
+        self.assertIn("Instância 2 → Goblin A: 5 de dano de Force.", msg)
+        self.assertIn("Instância 3 → Goblin B: 2 de dano de Force.", msg)
+
+    def test_formats_miss_instance(self):
+        outcomes = [
+            {"instance_index": 1, "target_display_name": "Goblin A", "damage": 0, "is_hit": False},
+        ]
+        msg = CombatService._build_multi_instance_log_message(
+            attacker={"display_name": "Hero"},
+            spell_context={"spell_name": "Eldritch Blast", "damage_type": "Force"},
+            outcomes=outcomes,
+            was_overridden=False,
+            action_cost="action",
+        )
+        self.assertIn("errou", msg)
+
+    def test_includes_override_prefix(self):
+        outcomes = [
+            {"instance_index": 1, "target_display_name": "Goblin A", "damage": 4, "is_hit": None},
+        ]
+        msg = CombatService._build_multi_instance_log_message(
+            attacker={"display_name": "Hero"},
+            spell_context={"spell_name": "Magic Missile", "damage_type": "Force"},
+            outcomes=outcomes,
+            was_overridden=True,
+            action_cost="action",
+        )
+        self.assertTrue(msg.startswith("[OVERRIDE:"))
+
+
+class EffectInstanceTargetSchemaTests(unittest.TestCase):
+    def test_valid_target(self):
+        t = EffectInstanceTarget(instance_index=1, target_ref_id="entity:goblin-a")
+        self.assertEqual(t.instance_index, 1)
+        self.assertEqual(t.target_ref_id, "entity:goblin-a")
+
+    def test_rejects_zero_index(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            EffectInstanceTarget(instance_index=0, target_ref_id="entity:goblin-a")
+
+    def test_rejects_negative_index(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            EffectInstanceTarget(instance_index=-1, target_ref_id="entity:goblin-a")
+
+
+class EffectInstanceOutcomeSchemaTests(unittest.TestCase):
+    def test_minimal_outcome(self):
+        from app.schemas.combat_spells import EffectInstanceOutcome
+        o = EffectInstanceOutcome(
+            instance_index=1,
+            target_ref_id="entity:goblin-a",
+            target_display_name="Goblin A",
+            target_kind="session_entity",
+        )
+        self.assertEqual(o.instance_index, 1)
+        self.assertEqual(o.damage, 0)
+        self.assertIsNone(o.is_hit)
+
+    def test_full_outcome(self):
+        from app.schemas.combat_spells import EffectInstanceOutcome
+        o = EffectInstanceOutcome(
+            instance_index=3,
+            target_ref_id="entity:goblin-c",
+            target_display_name="Goblin C",
+            target_kind="session_entity",
+            damage=5,
+            healing=0,
+            is_hit=True,
+            is_saved=None,
+            is_critical=False,
+            roll=18,
+            new_hp=3,
+        )
+        self.assertEqual(o.damage, 5)
+        self.assertTrue(o.is_hit)
+        self.assertEqual(o.new_hp, 3)
+
+
+class CombatSpellResultInstanceOutcomesTests(unittest.TestCase):
+    def test_result_has_empty_outcomes_by_default(self):
+        from app.schemas.combat_spells import CombatSpellResult
+        r = CombatSpellResult(
+            spell_name="Magic Missile",
+            action_kind="direct_damage",
+            target_display_name="Goblin",
+            target_kind="session_entity",
+        )
+        self.assertEqual(r.effect_instance_outcomes, [])
+
+    def test_result_with_instance_outcomes(self):
+        from app.schemas.combat_spells import CombatSpellResult, EffectInstanceOutcome
+        outcomes = [
+            EffectInstanceOutcome(
+                instance_index=1,
+                target_ref_id="entity:goblin-a",
+                target_display_name="Goblin A",
+                target_kind="session_entity",
+                damage=4,
+            ),
+            EffectInstanceOutcome(
+                instance_index=2,
+                target_ref_id="entity:goblin-b",
+                target_display_name="Goblin B",
+                target_kind="session_entity",
+                damage=3,
+            ),
+        ]
+        r = CombatSpellResult(
+            spell_name="Magic Missile",
+            action_kind="direct_damage",
+            target_display_name="Goblin A",
+            target_kind="session_entity",
+            effect_instance_outcomes=outcomes,
+        )
+        self.assertEqual(len(r.effect_instance_outcomes), 2)
+        self.assertEqual(r.effect_instance_outcomes[0].damage, 4)
+        self.assertEqual(r.effect_instance_outcomes[1].target_ref_id, "entity:goblin-b")
+
+
+class ValidateInstanceTargetsEdgeCasesTests(unittest.TestCase):
+    def test_validates_against_participants_not_ref_ids(self):
+        state = _build_state(participants=[
+            {
+                "id": "p1",
+                "ref_id": "player-1",
+                "kind": "player",
+                "display_name": "Hero",
+                "status": "active",
+                "team": "players",
+                "visible": True,
+                "actor_user_id": "user-1",
+            },
+        ])
+        targets = [EffectInstanceTarget(instance_index=1, target_ref_id="entity:ghost")]
+        ctx = _spell_context(count=1)
+        ctx["effect_instance_count"] = 1
+        req = _req_with_targets(targets)
+        with self.assertRaises(CombatServiceError) as cm:
+            CombatService._validate_instance_targets(
+                req=req, spell_context=ctx, state=state,
+            )
+        self.assertIn("only supported for multi-instance", str(cm.exception))


### PR DESCRIPTION
## Summary

- Introduces `effect_instance_targets` on the spell cast request, allowing each effect instance to be assigned to an independent target
- Adds full validation (index range, duplicates, gaps, valid participants) and per-instance resolution through the existing damage pipeline
- Preserves legacy flow unchanged when `effect_instance_targets` is absent

## Context

The runtime already exposes `effect_instance_count` and `effect_instance_dice` for multi-instance spells (Magic Missile, Eldritch Blast), but the cast pipeline only accepted a single `target_ref_id`. This PR adds the backend contract so each instance can target the same or different creatures independently.

## Changes

**Schema** (`combat_spells.py`):
- `EffectInstanceTarget` model (`instance_index >= 1`, `target_ref_id`)
- `EffectInstanceOutcome` model (per-instance damage, hit, roll, HP)
- `effect_instance_targets` field on request, `effect_instance_outcomes` on response

**Validation** (`cast_target.py`):
- `_validate_instance_targets` — validates indices in `1..effect_instance_count`, rejects duplicates, gaps, and invalid target refs

**Runtime** (`cast_target.py`):
- `_resolve_instance_direct` — rolls `effect_instance_dice` per instance, applies via `_apply_spell_effect` (resistances, death saves, concentration, wild shape, status all handled)
- `_resolve_instance_attack` — rolls attack with condition-based advantage (`resolve_attack_advantage`), then instance dice on hit
- `_resolve_multi_instance_cast` — single resource consumption, per-instance loop, single commit

**Response** (`spell_response.py`):
- `_build_multi_instance_log_message` — per-instance log breakdown
- Updated `_build_cast_response` to include `effect_instance_outcomes`

**Tests** (`test_instance_target_assignment.py`):
- 27 tests: validation (10), direct resolution (2), attack resolution (4), log formatting (3), schema (6), edge cases (2)

## Design decisions

- **Inline resolution** — all instances resolve immediately, no pending spell effects per instance. The two-step pending system remains for single-target casts only.
- **Condition-based advantage** — `resolve_attack_advantage` is called per instance (prone, frightened, invisible, etc.). Cover and visibility require per-instance spatial data and are deferred to map integration.
- **Damage pipeline** — both instance paths delegate to `_apply_spell_effect` → `_apply_damage_to_target`, so resistance, death saves, concentration checks, wild shape, and status sync are all preserved.
- **No hardcoding by spell key** — behavioral differences driven by `spell_mode` from spell context.

## Test plan

- [x] 27 new tests pass
- [x] 273 existing tests pass (0 regressions)
- [x] Legacy Magic Missile without `effect_instance_targets` flows through existing path
- [x] Manual: send `effect_instance_targets` payload via API for Magic Missile slot 3
- [x] Manual: send `effect_instance_targets` payload for Eldritch Blast level 5

## Out of scope

- Frontend `InstanceTargetSelector` component
- Per-instance cover/visibility from tactical map
- Pending spell effect support for multi-instance
- AoE preview or map prediction changes