### PR TITLE
Add frontend per-instance target assignment UI

### DIFF
--- a/apps/control-web/src/entities/base-spell/baseSpell.types.ts
+++ b/apps/control-web/src/entities/base-spell/baseSpell.types.ts
@@ -137,6 +137,7 @@ export type SpellUpcast = {
   dice?: string | null;
   flat?: number | null;
   perLevel?: number | null;
+  baseEffectInstances?: number | null;
   maxLevel?: number | null;
   scalingKey?: string | null;
   scalingSummary?: string | null;

--- a/apps/control-web/src/entities/dnd-base/spellCatalogApi.ts
+++ b/apps/control-web/src/entities/dnd-base/spellCatalogApi.ts
@@ -11,6 +11,7 @@ import type {
   ResolutionType,
   SpellAttackType,
   SpellEffectTiming,
+  SpellCantripScaling,
   SpellOriginType,
   SpellRangeKind,
   SpellSelectionType,
@@ -57,6 +58,7 @@ export type BaseSpell = {
   requiresPointSight?: boolean | null;
   requiresPointEffect?: boolean | null;
   upcast?: ApiBaseSpell["upcast"];
+  cantripScaling?: SpellCantripScaling | null;
   classes: string[];
 };
 
@@ -130,6 +132,7 @@ const adapt = (api: ApiBaseSpell, scope: "base" | "campaign"): BaseSpell => ({
   requiresPointSight: api.requiresPointSight ?? null,
   requiresPointEffect: api.requiresPointEffect ?? null,
   upcast: api.upcast ?? null,
+  cantripScaling: api.cantripScaling ?? null,
   classes: api.classesJson ?? []
 });
 

--- a/apps/control-web/src/features/combat-ui/player/usePlayerCombatMode.types.ts
+++ b/apps/control-web/src/features/combat-ui/player/usePlayerCombatMode.types.ts
@@ -1,6 +1,6 @@
 import type { InventoryItem } from "../../../entities/inventory";
 import type { Item } from "../../../entities/item";
-import type { SpellUpcast } from "../../../entities/base-spell";
+import type { SpellCantripScaling, SpellUpcast } from "../../../entities/base-spell";
 import type {
   SpellAttackType,
   SpellEffectTiming,
@@ -48,6 +48,8 @@ export type CombatSpellOption = {
   suggestedMode: CombatSpellMode | null;
   availableSlotLevels: number[];
   upcast?: SpellUpcast | null;
+  cantripScaling?: SpellCantripScaling | null;
+  characterLevel?: number | null;
 };
 
 export type CombatConsumableOption = {

--- a/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.ts
+++ b/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.ts
@@ -123,6 +123,8 @@ export const buildSpellOptions = (
             saveSuccessOutcome: catalogSpell?.saveSuccessOutcome ?? null,
             savingThrow: catalogSpell?.savingThrow ?? null,
             suggestedMode: resolveSuggestedMode(canonicalKey, catalogSpell),
+            cantripScaling: catalogSpell?.cantripScaling ?? null,
+            characterLevel: playerSheet?.level ?? null,
             availableSlotLevels:
               spell.level > 0
                 ? availableSlotLevels.filter(
@@ -189,6 +191,8 @@ export const buildSpellOptions = (
           catalogSpell.canonicalKey,
           catalogSpell
         ),
+        cantripScaling: catalogSpell.cantripScaling ?? null,
+        characterLevel: playerSheet?.level ?? null,
         availableSlotLevels:
           magicEffect.castLevel > 0 ? [magicEffect.castLevel] : [],
         upcast: null

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/InstanceTargetSelector.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/InstanceTargetSelector.tsx
@@ -1,0 +1,214 @@
+import type { CombatParticipant } from "../../../shared/api/combatRepo";
+import type { CombatSpellOption } from "./types";
+
+export type EffectInstanceTargetInput = {
+  instance_index: number;
+  target_ref_id: string;
+};
+
+export type InstanceTargetSelectorProps = {
+  instanceCount: number;
+  instanceDice?: string | null;
+  participants: CombatParticipant[];
+  spellCanonicalKey?: string | null;
+  disabled?: boolean;
+  value: EffectInstanceTargetInput[];
+  onChange: (value: EffectInstanceTargetInput[]) => void;
+};
+
+type ResolvedEffectInstanceContext = {
+  instanceCount: number;
+  instanceDice: string | null;
+};
+
+export function getInstanceLabel(spellCanonicalKey: string | null | undefined, index: number): string {
+  switch (spellCanonicalKey) {
+    case "magic_missile":
+      return `Míssil ${index}`;
+    case "eldritch_blast":
+      return `Feixe ${index}`;
+    default:
+      return `Instância ${index}`;
+  }
+}
+
+export const normalizeEffectInstanceTargets = (
+  value: EffectInstanceTargetInput[],
+  instanceCount: number,
+): EffectInstanceTargetInput[] =>
+  Array.from({ length: instanceCount }, (_, offset) => offset + 1)
+    .map((instanceIndex) => {
+      const entry = value.find((candidate) => candidate.instance_index === instanceIndex);
+      const targetRefId = entry?.target_ref_id?.trim() ?? "";
+      return targetRefId
+        ? {
+            instance_index: instanceIndex,
+            target_ref_id: targetRefId,
+          }
+        : null;
+    })
+    .filter((entry): entry is EffectInstanceTargetInput => entry !== null);
+
+export const reconcileEffectInstanceTargets = (
+  value: EffectInstanceTargetInput[],
+  instanceCount: number,
+  fallbackTargetRefId?: string | null,
+): EffectInstanceTargetInput[] => {
+  const normalizedCurrent = normalizeEffectInstanceTargets(value, instanceCount);
+
+  return Array.from({ length: instanceCount }, (_, offset) => {
+    const instanceIndex = offset + 1;
+    const existing = normalizedCurrent.find((entry) => entry.instance_index === instanceIndex);
+    if (existing) {
+      return existing;
+    }
+    const targetRefId = fallbackTargetRefId?.trim() ?? "";
+    return targetRefId
+      ? {
+          instance_index: instanceIndex,
+          target_ref_id: targetRefId,
+        }
+      : null;
+  }).filter((entry): entry is EffectInstanceTargetInput => entry !== null);
+};
+
+export const hasCompleteEffectInstanceTargets = (
+  value: EffectInstanceTargetInput[],
+  instanceCount: number,
+): boolean => normalizeEffectInstanceTargets(value, instanceCount).length === instanceCount;
+
+/**
+ * Frontend-only pre-cast estimate for instance-target UI.
+ * If the backend starts exposing resolved pre-cast instance metadata here,
+ * prefer consuming that instead of recomputing scaling rules in the client.
+ */
+export const resolveEffectInstanceContext = (
+  spell: Pick<CombatSpellOption, "cantripScaling" | "characterLevel" | "level" | "upcast">,
+  selectedSlotLevel: number | null,
+): ResolvedEffectInstanceContext => {
+  const cantripScaling = spell.cantripScaling;
+  if (spell.level === 0 && cantripScaling?.scalingEffectType === "effect_instances") {
+    const thresholds = [...cantripScaling.thresholds].sort(
+      (left, right) => left.characterLevel - right.characterLevel,
+    );
+    const characterLevel = spell.characterLevel ?? 1;
+    const activeThreshold = thresholds.reduce<(typeof thresholds)[number] | null>((best, threshold) => {
+      if (threshold.characterLevel > characterLevel) {
+        return best;
+      }
+      return threshold;
+    }, null);
+    if (activeThreshold && "instances" in activeThreshold) {
+      return {
+        instanceCount: activeThreshold.instances,
+        instanceDice: activeThreshold.instanceDamage?.dice ?? null,
+      };
+    }
+  }
+
+  if (spell.upcast?.mode === "additional_effect_instances") {
+    const baseCount = spell.upcast.baseEffectInstances ?? 1;
+    const perLevel = spell.upcast.perLevel ?? 0;
+    const slotLevel = selectedSlotLevel ?? spell.level;
+    const addedInstances = Math.max(0, slotLevel - spell.level) * perLevel;
+    return {
+      instanceCount: baseCount + addedInstances,
+      instanceDice: spell.upcast.dice ?? null,
+    };
+  }
+
+  return {
+    instanceCount: 1,
+    instanceDice: null,
+  };
+};
+
+const buildParticipantGroups = (participants: CombatParticipant[]) => {
+  const living = participants.filter(
+    (participant) => participant.status !== "dead" && participant.status !== "defeated",
+  );
+  const defeated = participants.filter(
+    (participant) => participant.status === "dead" || participant.status === "defeated",
+  );
+  return { defeated, living };
+};
+
+export const InstanceTargetSelector = ({
+  instanceCount,
+  instanceDice = null,
+  participants,
+  spellCanonicalKey,
+  disabled = false,
+  value,
+  onChange,
+}: InstanceTargetSelectorProps) => {
+  const normalizedValue = normalizeEffectInstanceTargets(value, instanceCount);
+  const valueByIndex = new Map(normalizedValue.map((entry) => [entry.instance_index, entry.target_ref_id]));
+  const { defeated, living } = buildParticipantGroups(participants);
+
+  return (
+    <div className="mt-5 space-y-3 rounded-2xl border border-white/10 bg-slate-950/50 p-4">
+      <div className="space-y-1">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-300">
+          Alvos por instância
+        </p>
+        <p className="text-xs text-slate-400">Escolha um alvo para cada instância da magia.</p>
+      </div>
+
+      <div className="space-y-3">
+        {Array.from({ length: instanceCount }, (_, offset) => {
+          const instanceIndex = offset + 1;
+          const label = getInstanceLabel(spellCanonicalKey, instanceIndex);
+          return (
+            <label
+              key={instanceIndex}
+              className="grid gap-2 rounded-2xl border border-white/5 bg-slate-900/50 p-3 md:grid-cols-[minmax(0,1fr)_140px_minmax(0,1.4fr)] md:items-center"
+            >
+              <span className="text-sm font-semibold text-white">{label}</span>
+              <span className="text-xs text-slate-400">{instanceDice ? instanceDice : "Sem dado por instância"}</span>
+              <select
+                aria-label={label}
+                disabled={disabled}
+                value={valueByIndex.get(instanceIndex) ?? ""}
+                onChange={(event) => {
+                  const next = normalizeEffectInstanceTargets(
+                    [
+                      ...normalizedValue.filter((entry) => entry.instance_index !== instanceIndex),
+                      {
+                        instance_index: instanceIndex,
+                        target_ref_id: event.target.value,
+                      },
+                    ],
+                    instanceCount,
+                  );
+                  onChange(next);
+                }}
+                className="w-full rounded-2xl border border-white/10 bg-slate-950/70 px-3 py-2 text-sm text-white outline-none transition focus:border-fuchsia-400 disabled:opacity-50"
+              >
+                <option value="">Escolha um alvo</option>
+                {living.length > 0 ? (
+                  <optgroup label="Vivos / em combate">
+                    {living.map((participant) => (
+                      <option key={participant.id} value={participant.ref_id}>
+                        {participant.display_name} [{participant.status}]
+                      </option>
+                    ))}
+                  </optgroup>
+                ) : null}
+                {defeated.length > 0 ? (
+                  <optgroup label="Mortos / derrotados">
+                    {defeated.map((participant) => (
+                      <option key={participant.id} value={participant.ref_id} disabled>
+                        {participant.display_name} [{participant.status}]
+                      </option>
+                    ))}
+                  </optgroup>
+                ) : null}
+              </select>
+            </label>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 import type { AbilityName } from "../../../entities/roll/rollResolution.types";
 import { participantHasActiveConcentration } from "../../../features/combat-ui/combatUi.helpers";
-import type { CombatParticipant, CombatSpellMode, CombatSpellResult } from "../../../shared/api/combatRepo";
+import type {
+  CombatCastSpellRequest,
+  CombatParticipant,
+  CombatSpellMode,
+  CombatSpellResult,
+} from "../../../shared/api/combatRepo";
 import { combatRepo } from "../../../shared/api/combatRepo";
 import { toPlayerFriendlyError } from "../../../features/combat-ui/combatErrors";
 import { useTargetingPreview } from "../../../features/combat-ui/hooks/useTargetingPreview";
@@ -12,6 +17,14 @@ import {
 } from "../../../shared/utils/diceExpression";
 import { buildAreaCastPayload, createInitialTargetingMode } from "./areaTargetingUi";
 import { AreaTargetingGrid } from "./AreaTargetingGrid";
+import {
+  hasCompleteEffectInstanceTargets,
+  InstanceTargetSelector,
+  normalizeEffectInstanceTargets,
+  reconcileEffectInstanceTargets,
+  resolveEffectInstanceContext,
+  type EffectInstanceTargetInput,
+} from "./InstanceTargetSelector";
 import { SpellCastDialogActions } from "./SpellCastDialogActions";
 import { parseBonus } from "./spellCastHelpers";
 import { SpellCastDialogHeader } from "./SpellCastDialogHeader";
@@ -35,6 +48,69 @@ type Props = {
   spellSaveAbility: AbilityName | "";
   target?: CombatParticipant | null;
 };
+
+const MULTI_INSTANCE_TARGET_ERROR = "Escolha um alvo para cada instância da magia.";
+
+type BuildNonAreaSpellCastPayloadParams = {
+  actorParticipantId: string;
+  concentrationManualRoll: number | null;
+  concentrationRollMode: "system" | "manual";
+  effectInstanceTargets: EffectInstanceTargetInput[];
+  isMultiInstanceSpell: boolean;
+  manualRoll?: number | null;
+  parsedBonus: number;
+  rollSource?: "manual" | "system";
+  selectedSlotLevel: number | null;
+  spell: CombatSpellOption;
+  spellDamageType: string;
+  spellEffectDice: string;
+  spellMode: CombatSpellMode;
+  spellSaveAbility: AbilityName | "";
+  targetRefId?: string | null;
+};
+
+export const buildNonAreaSpellCastPayload = ({
+  actorParticipantId,
+  concentrationManualRoll,
+  concentrationRollMode,
+  effectInstanceTargets,
+  isMultiInstanceSpell,
+  manualRoll = null,
+  parsedBonus,
+  rollSource = "system",
+  selectedSlotLevel,
+  spell,
+  spellDamageType,
+  spellEffectDice,
+  spellMode,
+  spellSaveAbility,
+  targetRefId = null,
+}: BuildNonAreaSpellCastPayloadParams): CombatCastSpellRequest => ({
+  actor_participant_id: actorParticipantId,
+  target_ref_id: isMultiInstanceSpell ? effectInstanceTargets[0]?.target_ref_id ?? targetRefId ?? null : targetRefId,
+  effect_instance_targets: isMultiInstanceSpell ? effectInstanceTargets : null,
+  spell_canonical_key: spell.canonicalKey,
+  spell_id: spell.canonicalKey,
+  campaign_spell_id: spell.campaignSpellId ?? null,
+  spell_mode: spellMode,
+  slot_level:
+    spell.sourceType === "magic_item"
+      ? spell.fixedCastLevel ?? spell.level ?? null
+      : spell.level > 0
+        ? selectedSlotLevel ?? spell.level
+        : null,
+  inventory_item_id: spell.sourceType === "magic_item" ? spell.inventoryItemId ?? null : null,
+  roll_source: rollSource,
+  manual_roll: manualRoll,
+  damage_dice: spellMode === "heal" ? null : spellEffectDice || null,
+  damage_bonus: spellMode === "heal" ? null : parsedBonus,
+  heal_dice: spellMode === "heal" ? spellEffectDice || null : null,
+  heal_bonus: spellMode === "heal" ? parsedBonus : null,
+  damage_type: spellMode === "heal" ? null : spellDamageType || null,
+  save_ability: spellMode === "saving_throw" ? spellSaveAbility || null : null,
+  concentration_roll_source: concentrationRollMode,
+  concentration_manual_roll: concentrationManualRoll,
+});
 
 export const PlayerSpellCastDialog = ({
   actor,
@@ -62,6 +138,7 @@ export const PlayerSpellCastDialog = ({
   const [selectedSlotLevel, setSelectedSlotLevel] = useState<number | null>(
     spell.fixedCastLevel ?? (spell.level > 0 ? spell.level : null),
   );
+  const [effectInstanceTargets, setEffectInstanceTargets] = useState<EffectInstanceTargetInput[]>([]);
   const [result, setResult] = useState<CombatSpellResult | null>(null);
   const [targetingMode, setTargetingMode] = useState(createInitialTargetingMode(spell.areaShape, spell.selectionType));
   const handledSaveResolutionKeyRef = useRef<string | null>(null);
@@ -88,6 +165,17 @@ export const PlayerSpellCastDialog = ({
     spell,
     spellMode,
   });
+  const effectInstanceContext = resolveEffectInstanceContext(spell, selectedSlotLevel);
+  const isMultiInstanceSpell = !isAreaSpell && effectInstanceContext.instanceCount > 1;
+  const selectableParticipants = participants.filter((participant) => participant.id !== actor.id);
+  const normalizedEffectInstanceTargets = normalizeEffectInstanceTargets(
+    effectInstanceTargets,
+    effectInstanceContext.instanceCount,
+  );
+  const effectInstanceTargetsComplete = hasCompleteEffectInstanceTargets(
+    effectInstanceTargets,
+    effectInstanceContext.instanceCount,
+  );
   const rangePreview = useTargetingPreview({
     sessionId,
     actorRefId: actor.ref_id,
@@ -95,9 +183,9 @@ export const PlayerSpellCastDialog = ({
     actionType: "spell",
     normalRangeMeters: spell.rangeMeters ?? null,
     longRangeMeters: null,
-    enabled: !isAreaSpell && !!target,
+    enabled: !isAreaSpell && !isMultiInstanceSpell && !!target,
   });
-  const spellOutOfRange = !isAreaSpell && rangePreview.rangeStatus === "out";
+  const spellOutOfRange = !isAreaSpell && !isMultiInstanceSpell && rangePreview.rangeStatus === "out";
   const targetHasConcentration = target ? participantHasActiveConcentration(target) : false;
   const shouldShowConcentrationControl = targetHasConcentration && spellMode !== "heal" && spellMode !== "utility";
   const slotOptions =
@@ -132,9 +220,21 @@ export const PlayerSpellCastDialog = ({
   useEffect(() => {
     setSelectedSlotLevel(spell.fixedCastLevel ?? (spell.level > 0 ? spell.level : null));
     setTargetingMode(createInitialTargetingMode(spell.areaShape, spell.selectionType));
+    setEffectInstanceTargets([]);
     setError(null);
     handledSaveResolutionKeyRef.current = null;
   }, [spell.fixedCastLevel, spell.id, spell.level, spell.areaShape, spell.selectionType]);
+
+  useEffect(() => {
+    if (!isMultiInstanceSpell) {
+      setEffectInstanceTargets([]);
+      return;
+    }
+
+    setEffectInstanceTargets((current) =>
+      reconcileEffectInstanceTargets(current, effectInstanceContext.instanceCount, target?.ref_id),
+    );
+  }, [effectInstanceContext.instanceCount, isMultiInstanceSpell, target?.ref_id]);
 
   useEffect(() => {
     if (!result?.pending_save_id || !actor.last_save_resolution) {
@@ -195,6 +295,11 @@ export const PlayerSpellCastDialog = ({
       : null;
 
   const submitCast = async (payload?: { manual_roll?: number; roll_source?: "manual" | "system" }) => {
+    if (isMultiInstanceSpell && !effectInstanceTargetsComplete) {
+      setError(MULTI_INSTANCE_TARGET_ERROR);
+      return;
+    }
+
     setLoading(true);
     setError(null);
     try {
@@ -225,31 +330,23 @@ export const PlayerSpellCastDialog = ({
                 manual_roll: payload?.manual_roll ?? null,
               };
             })()
-          : {
-              actor_participant_id: actorParticipantId,
-              target_ref_id: target?.ref_id,
-              spell_canonical_key: spell.canonicalKey,
-              spell_id: spell.canonicalKey,
-              campaign_spell_id: spell.campaignSpellId ?? null,
-              spell_mode: spellMode,
-              slot_level:
-                spell.sourceType === "magic_item"
-                  ? spell.fixedCastLevel ?? spell.level ?? null
-                  : spell.level > 0
-                    ? selectedSlotLevel ?? spell.level
-                    : null,
-              inventory_item_id: spell.sourceType === "magic_item" ? spell.inventoryItemId ?? null : null,
-              roll_source: payload?.roll_source ?? "system",
-              manual_roll: payload?.manual_roll ?? null,
-              damage_dice: spellMode === "heal" ? null : spellEffectDice || null,
-              damage_bonus: spellMode === "heal" ? null : parsedBonus,
-              heal_dice: spellMode === "heal" ? spellEffectDice || null : null,
-              heal_bonus: spellMode === "heal" ? parsedBonus : null,
-              damage_type: spellMode === "heal" ? null : spellDamageType || null,
-              save_ability: spellMode === "saving_throw" ? spellSaveAbility || null : null,
-              concentration_roll_source: concentrationRollMode,
-              concentration_manual_roll: resolveConcentrationManualRoll(),
-            },
+          : buildNonAreaSpellCastPayload({
+              actorParticipantId,
+              concentrationManualRoll: resolveConcentrationManualRoll(),
+              concentrationRollMode,
+              effectInstanceTargets: normalizedEffectInstanceTargets,
+              isMultiInstanceSpell,
+              manualRoll: payload?.manual_roll ?? null,
+              parsedBonus,
+              rollSource: payload?.roll_source ?? "system",
+              selectedSlotLevel,
+              spell,
+              spellDamageType,
+              spellEffectDice,
+              spellMode,
+              spellSaveAbility,
+              targetRefId: target?.ref_id ?? null,
+            }),
       );
       setResult(resolved);
       setManualEffectRolls([]);
@@ -311,9 +408,24 @@ export const PlayerSpellCastDialog = ({
           spellDamageType={spellDamageType}
           spellMode={spellMode}
           spellSaveAbility={spellSaveAbility}
-          targetDisplayName={target?.display_name ?? null}
+          targetDisplayName={isMultiInstanceSpell ? "Múltiplos alvos" : target?.display_name ?? null}
           targetPreview={rangePreview}
         />
+
+        {!result && isMultiInstanceSpell ? (
+          <InstanceTargetSelector
+            disabled={loading}
+            instanceCount={effectInstanceContext.instanceCount}
+            instanceDice={effectInstanceContext.instanceDice}
+            participants={selectableParticipants}
+            spellCanonicalKey={spell.canonicalKey}
+            value={normalizedEffectInstanceTargets}
+            onChange={(nextValue) => {
+              setEffectInstanceTargets(nextValue);
+              setError(null);
+            }}
+          />
+        ) : null}
 
         {!result && isAreaSpell ? (
           <AreaTargetingGrid
@@ -395,6 +507,8 @@ export const PlayerSpellCastDialog = ({
             }}
             spellMode={spellMode}
             spellOutOfRange={spellOutOfRange}
+            submitDisabled={isMultiInstanceSpell && !effectInstanceTargetsComplete}
+            validationMessage={isMultiInstanceSpell && !effectInstanceTargetsComplete ? MULTI_INSTANCE_TARGET_ERROR : null}
           />
         ) : null}
       </div>

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastDialogActions.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastDialogActions.tsx
@@ -12,6 +12,8 @@ type Props = {
   onSubmitCast: (payload?: { manual_roll?: number; roll_source?: "manual" | "system" }) => void;
   spellMode: string;
   spellOutOfRange: boolean;
+  submitDisabled?: boolean;
+  validationMessage?: string | null;
 };
 
 export const SpellCastDialogActions = ({
@@ -26,13 +28,15 @@ export const SpellCastDialogActions = ({
   onSubmitCast,
   spellMode,
   spellOutOfRange,
+  submitDisabled = false,
+  validationMessage = null,
 }: Props) => (
   <>
     {spellMode === "spell_attack" && !isAreaSpell && attackMode === "choose" ? (
       <div className="mt-5 grid grid-cols-2 gap-3">
         <button
           type="button"
-          disabled={spellOutOfRange}
+          disabled={spellOutOfRange || submitDisabled}
           onClick={() => onAttackModeChange("virtual")}
           className="rounded-2xl bg-fuchsia-600 px-4 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-white hover:bg-fuchsia-500 disabled:opacity-40"
         >
@@ -40,7 +44,7 @@ export const SpellCastDialogActions = ({
         </button>
         <button
           type="button"
-          disabled={spellOutOfRange}
+          disabled={spellOutOfRange || submitDisabled}
           onClick={() => onAttackModeChange("manual")}
           className="rounded-2xl border border-slate-600 bg-slate-800 px-4 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-slate-200 hover:bg-slate-700 disabled:opacity-40"
         >
@@ -53,7 +57,7 @@ export const SpellCastDialogActions = ({
       <div className="mt-5 flex gap-3">
         <button
           type="button"
-          disabled={loading}
+          disabled={loading || submitDisabled}
           onClick={() => onSubmitCast({ roll_source: "system" })}
           className="flex-1 rounded-full bg-fuchsia-600 px-4 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-white disabled:opacity-50"
         >
@@ -77,7 +81,7 @@ export const SpellCastDialogActions = ({
             <button
               key={value}
               type="button"
-              disabled={loading}
+              disabled={loading || submitDisabled}
               onClick={() => onSubmitCast({ roll_source: "manual", manual_roll: value })}
               className="rounded-xl border border-slate-700 bg-slate-900 px-2 py-3 text-center text-lg font-bold text-white transition-colors hover:border-fuchsia-500/50 hover:bg-slate-800 disabled:opacity-50"
             >
@@ -99,7 +103,7 @@ export const SpellCastDialogActions = ({
       <div className="mt-5 flex gap-3">
         <button
           type="button"
-          disabled={isAreaSpell ? !canSubmitArea || loading : loading || spellOutOfRange}
+          disabled={isAreaSpell ? !canSubmitArea || loading : loading || spellOutOfRange || submitDisabled}
           onClick={() => onSubmitCast()}
           className="flex-1 rounded-full bg-fuchsia-600 px-4 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-white disabled:opacity-50"
         >
@@ -122,6 +126,10 @@ export const SpellCastDialogActions = ({
           Cancelar
         </button>
       </div>
+    ) : null}
+
+    {!isAreaSpell && validationMessage ? (
+      <p className="mt-3 text-xs text-rose-300">{validationMessage}</p>
     ) : null}
 
     {onShowAreaHint ? (

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastResultPanel.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastResultPanel.tsx
@@ -1,6 +1,10 @@
 import { RollResultCard } from "../../../features/rolls/components/RollResultCard";
 import type { CombatSpellResult } from "../../../shared/api/combatRepo";
-import { formatSpellEffectBreakdown, getOutcomeLabel } from "./spellCastHelpers";
+import {
+  formatEffectInstanceOutcome,
+  formatSpellEffectBreakdown,
+  getOutcomeLabel,
+} from "./spellCastHelpers";
 
 type EffectMode = "choose" | "manual" | "virtual";
 
@@ -38,6 +42,7 @@ export const SpellCastResultPanel = ({
 }: Props) => {
   const pendingEffect = Boolean(result.effect_roll_required && result.pending_spell_id);
   const outcomeLabel = getOutcomeLabel(result);
+  const hasEffectInstanceOutcomes = Boolean(result.effect_instance_outcomes?.length);
 
   return (
     <div className="mt-5 space-y-4">
@@ -73,7 +78,16 @@ export const SpellCastResultPanel = ({
                   : `${result.spell_name} causou ${result.damage} de dano em ${result.target_display_name}.`}
         </p>
 
-        {!pendingEffect && (result.damage > 0 || result.healing > 0) ? (
+        {!pendingEffect && hasEffectInstanceOutcomes ? (
+          <div className="mt-3 space-y-2 text-xs text-slate-300">
+            {result.effect_instance_outcomes?.map((outcome) => (
+              <p key={`${outcome.instance_index}:${outcome.target_ref_id}`}>
+                {formatEffectInstanceOutcome(result, outcome)}
+              </p>
+            ))}
+          </div>
+        ) : null}
+        {!pendingEffect && !hasEffectInstanceOutcomes && (result.damage > 0 || result.healing > 0) ? (
           <p className="mt-2 text-xs text-slate-300">{formatSpellEffectBreakdown(result)}</p>
         ) : null}
         {result.area_shape ? (
@@ -89,7 +103,7 @@ export const SpellCastResultPanel = ({
         {!pendingEffect && result.concentration_check?.summary_text ? (
           <p className="mt-2 text-xs text-amber-100">{result.concentration_check.summary_text}</p>
         ) : null}
-        {!pendingEffect && result.new_hp != null ? (
+        {!pendingEffect && !hasEffectInstanceOutcomes && result.new_hp != null ? (
           <p className="mt-2 text-xs text-slate-400">PV atuais do alvo: {result.new_hp}</p>
         ) : null}
       </div>

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/instanceTargetSelector.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/instanceTargetSelector.test.tsx
@@ -1,0 +1,219 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  getInstanceLabel,
+  hasCompleteEffectInstanceTargets,
+  InstanceTargetSelector,
+  reconcileEffectInstanceTargets,
+  type EffectInstanceTargetInput,
+} from "./InstanceTargetSelector";
+
+type ReactTestNode = {
+  props?: {
+    "aria-label"?: string;
+    children?: unknown;
+    onChange?: (event: { target: { value: string } }) => void;
+  };
+};
+
+const participants = [
+  {
+    id: "enemy-1",
+    kind: "session_entity" as const,
+    ref_id: "session_entity:goblin-a",
+    display_name: "Goblin A",
+    initiative: 12,
+    status: "active" as const,
+    team: "enemies" as const,
+    visible: true,
+    actor_user_id: null,
+  },
+  {
+    id: "enemy-2",
+    kind: "session_entity" as const,
+    ref_id: "session_entity:goblin-b",
+    display_name: "Goblin B",
+    initiative: 10,
+    status: "active" as const,
+    team: "enemies" as const,
+    visible: true,
+    actor_user_id: null,
+  },
+];
+
+const findSelectByLabel = (node: unknown, label: string): ReactTestNode | null => {
+  if (!node || typeof node !== "object") {
+    return null;
+  }
+
+  const typedNode = node as ReactTestNode;
+  if (typedNode.props?.["aria-label"] === label) {
+    return typedNode;
+  }
+
+  const children = typedNode.props?.children;
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      const found = findSelectByLabel(child, label);
+      if (found) {
+        return found;
+      }
+    }
+    return null;
+  }
+
+  return findSelectByLabel(children, label);
+};
+
+describe("InstanceTargetSelector", () => {
+  it("renderiza o numero correto de linhas para instanceCount = 5", () => {
+    const markup = renderToStaticMarkup(
+      <InstanceTargetSelector
+        instanceCount={5}
+        participants={participants}
+        value={[]}
+        onChange={() => undefined}
+      />,
+    );
+
+    expect(markup.match(/<select/g)?.length).toBe(5);
+  });
+
+  it("usa labels Míssil N para magic_missile", () => {
+    expect(getInstanceLabel("magic_missile", 3)).toBe("Míssil 3");
+  });
+
+  it("usa labels Feixe N para eldritch_blast", () => {
+    expect(getInstanceLabel("eldritch_blast", 2)).toBe("Feixe 2");
+  });
+
+  it("usa labels Instância N como fallback", () => {
+    expect(getInstanceLabel("acid_splash", 4)).toBe("Instância 4");
+  });
+
+  it("chama onChange com instance_index e target_ref_id corretos", () => {
+    let nextValue: EffectInstanceTargetInput[] = [];
+    const tree = InstanceTargetSelector({
+      instanceCount: 3,
+      participants,
+      spellCanonicalKey: "magic_missile",
+      value: [],
+      onChange: (value) => {
+        nextValue = value;
+      },
+    });
+
+    const select = findSelectByLabel(tree, "Míssil 2");
+    expect(select?.props?.onChange).toBeTypeOf("function");
+
+    select?.props?.onChange?.({
+      target: { value: "session_entity:goblin-b" },
+    });
+
+    expect(nextValue).toEqual([
+      {
+        instance_index: 2,
+        target_ref_id: "session_entity:goblin-b",
+      },
+    ]);
+  });
+
+  it("permite multiplas instancias no mesmo alvo", () => {
+    let nextValue: EffectInstanceTargetInput[] = [];
+    const firstTree = InstanceTargetSelector({
+      instanceCount: 2,
+      participants,
+      spellCanonicalKey: "magic_missile",
+      value: [],
+      onChange: (value) => {
+        nextValue = value;
+      },
+    });
+
+    findSelectByLabel(firstTree, "Míssil 1")?.props?.onChange?.({
+      target: { value: "session_entity:goblin-a" },
+    });
+
+    const secondTree = InstanceTargetSelector({
+      instanceCount: 2,
+      participants,
+      spellCanonicalKey: "magic_missile",
+      value: nextValue,
+      onChange: (value) => {
+        nextValue = value;
+      },
+    });
+
+    findSelectByLabel(secondTree, "Míssil 2")?.props?.onChange?.({
+      target: { value: "session_entity:goblin-a" },
+    });
+
+    expect(nextValue).toEqual([
+      {
+        instance_index: 1,
+        target_ref_id: "session_entity:goblin-a",
+      },
+      {
+        instance_index: 2,
+        target_ref_id: "session_entity:goblin-a",
+      },
+    ]);
+  });
+
+  it("permite ao pai identificar assignments incompletos", () => {
+    expect(
+      hasCompleteEffectInstanceTargets(
+        [{ instance_index: 1, target_ref_id: "session_entity:goblin-a" }],
+        2,
+      ),
+    ).toBe(false);
+    expect(
+      hasCompleteEffectInstanceTargets(
+        [
+          { instance_index: 1, target_ref_id: "session_entity:goblin-a" },
+          { instance_index: 2, target_ref_id: "session_entity:goblin-b" },
+        ],
+        2,
+      ),
+    ).toBe(true);
+  });
+
+  it("reduzir slot remove instancias excedentes e preserva as restantes", () => {
+    expect(
+      reconcileEffectInstanceTargets(
+        [
+          { instance_index: 1, target_ref_id: "session_entity:goblin-a" },
+          { instance_index: 2, target_ref_id: "session_entity:goblin-a" },
+          { instance_index: 3, target_ref_id: "session_entity:goblin-b" },
+          { instance_index: 4, target_ref_id: "session_entity:goblin-b" },
+          { instance_index: 5, target_ref_id: "session_entity:goblin-c" },
+        ],
+        3,
+      ),
+    ).toEqual([
+      { instance_index: 1, target_ref_id: "session_entity:goblin-a" },
+      { instance_index: 2, target_ref_id: "session_entity:goblin-a" },
+      { instance_index: 3, target_ref_id: "session_entity:goblin-b" },
+    ]);
+  });
+
+  it("aumentar slot adiciona novas instancias usando fallback do alvo atual quando existir", () => {
+    expect(
+      reconcileEffectInstanceTargets(
+        [
+          { instance_index: 1, target_ref_id: "session_entity:goblin-a" },
+          { instance_index: 2, target_ref_id: "session_entity:goblin-b" },
+          { instance_index: 3, target_ref_id: "session_entity:goblin-c" },
+        ],
+        5,
+        "session_entity:goblin-a",
+      ),
+    ).toEqual([
+      { instance_index: 1, target_ref_id: "session_entity:goblin-a" },
+      { instance_index: 2, target_ref_id: "session_entity:goblin-b" },
+      { instance_index: 3, target_ref_id: "session_entity:goblin-c" },
+      { instance_index: 4, target_ref_id: "session_entity:goblin-a" },
+      { instance_index: 5, target_ref_id: "session_entity:goblin-a" },
+    ]);
+  });
+});

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/playerSpellCastDialog.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/playerSpellCastDialog.test.tsx
@@ -1,0 +1,372 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PlayerSpellCastDialog, buildNonAreaSpellCastPayload } from "./PlayerSpellCastDialog";
+import { reconcileEffectInstanceTargets, resolveEffectInstanceContext } from "./InstanceTargetSelector";
+
+let lastActionsProps: Record<string, unknown> | null = null;
+
+vi.mock("../../../shared/api/combatRepo", () => ({
+  combatRepo: {
+    castSpell: vi.fn(),
+    castSpellEffect: vi.fn(),
+  },
+}));
+
+vi.mock("../../../features/combat-ui/hooks/useTargetingPreview", () => ({
+  useTargetingPreview: () => ({
+    loading: false,
+    error: null,
+    diagnostics: null,
+    distanceMeters: null,
+    normalRangeMeters: null,
+    maxRangeMeters: null,
+    rangeStatus: "unknown",
+    hasDisadvantage: false,
+    failureReasons: [],
+  }),
+}));
+
+vi.mock("./useAreaTargeting", () => ({
+  useAreaTargeting: () => ({
+    anchorCell: null,
+    canSubmitArea: false,
+    clearAreaSelection: vi.fn(),
+    isAreaSpell: false,
+    mapError: null,
+    mapLoading: false,
+    mapState: null,
+    originCell: null,
+    preview: null,
+    previewError: null,
+    previewLoading: false,
+    setAnchorCell: vi.fn(),
+  }),
+}));
+
+vi.mock("./SpellCastDialogHeader", () => ({
+  SpellCastDialogHeader: () => <div>header</div>,
+}));
+
+vi.mock("./SpellCastDialogActions", () => ({
+  SpellCastDialogActions: (props: Record<string, unknown>) => {
+    lastActionsProps = props;
+    return <div>actions</div>;
+  },
+}));
+
+vi.mock("./SpellCastResultPanel", () => ({
+  SpellCastResultPanel: () => <div>result</div>,
+}));
+
+vi.mock("./AreaTargetingGrid", () => ({
+  AreaTargetingGrid: () => <div>area</div>,
+}));
+
+const actor = {
+  id: "player-1",
+  kind: "player" as const,
+  ref_id: "player:1",
+  display_name: "Mage",
+  initiative: 15,
+  status: "active" as const,
+  team: "players" as const,
+  visible: true,
+  actor_user_id: "user-1",
+};
+
+const target = {
+  id: "enemy-1",
+  kind: "session_entity" as const,
+  ref_id: "session_entity:goblin-a",
+  display_name: "Goblin A",
+  initiative: 10,
+  status: "active" as const,
+  team: "enemies" as const,
+  visible: true,
+  actor_user_id: null,
+};
+
+const participants = [
+  actor,
+  target,
+  {
+    id: "enemy-2",
+    kind: "session_entity" as const,
+    ref_id: "session_entity:goblin-b",
+    display_name: "Goblin B",
+    initiative: 8,
+    status: "active" as const,
+    team: "enemies" as const,
+    visible: true,
+    actor_user_id: null,
+  },
+];
+
+const baseProps = {
+  actor,
+  actorParticipantId: actor.id,
+  onClose: () => undefined,
+  onResolved: () => undefined,
+  participants,
+  sessionId: "session-1",
+  spellDamageType: "Force",
+  spellEffectBonus: "0",
+  spellEffectDice: "1d10",
+  spellMode: "spell_attack" as const,
+  spellSaveAbility: "",
+  target,
+};
+
+describe("PlayerSpellCastDialog", () => {
+  beforeEach(() => {
+    lastActionsProps = null;
+  });
+
+  it("magia multi-instancia mostra InstanceTargetSelector", () => {
+    const markup = renderToStaticMarkup(
+      <PlayerSpellCastDialog
+        {...baseProps}
+        spell={{
+          id: "spell-1",
+          name: "Magic Missile",
+          canonicalKey: "magic_missile",
+          campaignSpellId: null,
+          level: 1,
+          prepared: true,
+          actionCost: "action",
+          suggestedMode: "direct_damage",
+          damageType: "Force",
+          savingThrow: null,
+          availableSlotLevels: [1, 2, 3],
+          upcast: {
+            mode: "additional_effect_instances",
+            dice: "1d4+1",
+            perLevel: 1,
+            baseEffectInstances: 3,
+          },
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Alvos por instância");
+    expect(markup).toContain("Míssil 1");
+  });
+
+  it("magia single-instance nao mostra InstanceTargetSelector", () => {
+    const markup = renderToStaticMarkup(
+      <PlayerSpellCastDialog
+        {...baseProps}
+        spell={{
+          id: "spell-2",
+          name: "Acid Splash",
+          canonicalKey: "acid_splash",
+          campaignSpellId: null,
+          level: 0,
+          prepared: true,
+          actionCost: "action",
+          suggestedMode: "saving_throw",
+          damageType: "Acid",
+          savingThrow: "DEX",
+          availableSlotLevels: [],
+        }}
+      />,
+    );
+
+    expect(markup).not.toContain("Alvos por instância");
+  });
+
+  it("resolve Magic Missile slot 3 com 5 instancias e Eldritch Blast nivel 5 com 2", () => {
+    expect(
+      resolveEffectInstanceContext(
+        {
+          level: 1,
+          characterLevel: 5,
+          cantripScaling: null,
+          upcast: {
+            mode: "additional_effect_instances",
+            dice: "1d4+1",
+            perLevel: 1,
+            baseEffectInstances: 3,
+          },
+        },
+        3,
+      ),
+    ).toEqual({
+      instanceCount: 5,
+      instanceDice: "1d4+1",
+    });
+
+    expect(
+      resolveEffectInstanceContext(
+        {
+          level: 0,
+          characterLevel: 5,
+          upcast: null,
+          cantripScaling: {
+            scalingMode: "character_level",
+            scalingEffectType: "effect_instances",
+            thresholds: [
+              { characterLevel: 1, instances: 1, instanceDamage: { dice: "1d10" } },
+              { characterLevel: 5, instances: 2, instanceDamage: { dice: "1d10" } },
+            ],
+          },
+        },
+        null,
+      ),
+    ).toEqual({
+      instanceCount: 2,
+      instanceDice: "1d10",
+    });
+  });
+
+  it("trocar slot de Magic Missile recalcula a quantidade de linhas e remove excedentes", () => {
+    const slot1 = resolveEffectInstanceContext(
+      {
+        level: 1,
+        characterLevel: 5,
+        cantripScaling: null,
+        upcast: {
+          mode: "additional_effect_instances",
+          dice: "1d4+1",
+          perLevel: 1,
+          baseEffectInstances: 3,
+        },
+      },
+      1,
+    );
+    const slot3 = resolveEffectInstanceContext(
+      {
+        level: 1,
+        characterLevel: 5,
+        cantripScaling: null,
+        upcast: {
+          mode: "additional_effect_instances",
+          dice: "1d4+1",
+          perLevel: 1,
+          baseEffectInstances: 3,
+        },
+      },
+      3,
+    );
+
+    expect(slot1.instanceCount).toBe(3);
+    expect(slot3.instanceCount).toBe(5);
+    expect(
+      reconcileEffectInstanceTargets(
+        [
+          { instance_index: 1, target_ref_id: "session_entity:goblin-a" },
+          { instance_index: 2, target_ref_id: "session_entity:goblin-a" },
+          { instance_index: 3, target_ref_id: "session_entity:goblin-b" },
+          { instance_index: 4, target_ref_id: "session_entity:goblin-b" },
+          { instance_index: 5, target_ref_id: "session_entity:goblin-c" },
+        ],
+        slot1.instanceCount,
+      ),
+    ).toEqual([
+      { instance_index: 1, target_ref_id: "session_entity:goblin-a" },
+      { instance_index: 2, target_ref_id: "session_entity:goblin-a" },
+      { instance_index: 3, target_ref_id: "session_entity:goblin-b" },
+    ]);
+  });
+
+  it("submit de Magic Missile e Eldritch Blast inclui effect_instance_targets", () => {
+    const multiPayload = buildNonAreaSpellCastPayload({
+      actorParticipantId: actor.id,
+      concentrationManualRoll: null,
+      concentrationRollMode: "system",
+      effectInstanceTargets: [
+        { instance_index: 1, target_ref_id: "session_entity:goblin-a" },
+        { instance_index: 2, target_ref_id: "session_entity:goblin-a" },
+        { instance_index: 3, target_ref_id: "session_entity:goblin-b" },
+        { instance_index: 4, target_ref_id: "session_entity:goblin-b" },
+        { instance_index: 5, target_ref_id: "session_entity:goblin-c" },
+      ],
+      isMultiInstanceSpell: true,
+      parsedBonus: 0,
+      selectedSlotLevel: 3,
+      spell: {
+        id: "spell-1",
+        name: "Magic Missile",
+        canonicalKey: "magic_missile",
+        campaignSpellId: null,
+        level: 1,
+        prepared: true,
+        actionCost: "action",
+        suggestedMode: "direct_damage",
+        damageType: "Force",
+        savingThrow: null,
+        availableSlotLevels: [1, 2, 3],
+      },
+      spellDamageType: "Force",
+      spellEffectDice: "5d4+5",
+      spellMode: "direct_damage",
+      spellSaveAbility: "",
+      targetRefId: "session_entity:goblin-a",
+    });
+
+    expect(multiPayload.effect_instance_targets).toHaveLength(5);
+    expect(multiPayload.target_ref_id).toBe("session_entity:goblin-a");
+  });
+
+  it("submit de Acid Splash single-instance nao inclui effect_instance_targets", () => {
+    const payload = buildNonAreaSpellCastPayload({
+      actorParticipantId: actor.id,
+      concentrationManualRoll: null,
+      concentrationRollMode: "system",
+      effectInstanceTargets: [],
+      isMultiInstanceSpell: false,
+      parsedBonus: 0,
+      selectedSlotLevel: null,
+      spell: {
+        id: "spell-2",
+        name: "Acid Splash",
+        canonicalKey: "acid_splash",
+        campaignSpellId: null,
+        level: 0,
+        prepared: true,
+        actionCost: "action",
+        suggestedMode: "saving_throw",
+        damageType: "Acid",
+        savingThrow: "DEX",
+        availableSlotLevels: [],
+      },
+      spellDamageType: "Acid",
+      spellEffectDice: "1d6",
+      spellMode: "saving_throw",
+      spellSaveAbility: "dexterity",
+      targetRefId: "session_entity:goblin-a",
+    });
+
+    expect(payload.effect_instance_targets).toBeNull();
+  });
+
+  it("submit fica invalido quando ha instancias sem alvo", () => {
+    renderToStaticMarkup(
+      <PlayerSpellCastDialog
+        {...baseProps}
+        spell={{
+          id: "spell-1",
+          name: "Magic Missile",
+          canonicalKey: "magic_missile",
+          campaignSpellId: null,
+          level: 1,
+          prepared: true,
+          actionCost: "action",
+          suggestedMode: "direct_damage",
+          damageType: "Force",
+          savingThrow: null,
+          availableSlotLevels: [1, 2, 3],
+          upcast: {
+            mode: "additional_effect_instances",
+            dice: "1d4+1",
+            perLevel: 1,
+            baseEffectInstances: 3,
+          },
+        }}
+      />,
+    );
+
+    expect(lastActionsProps?.submitDisabled).toBe(true);
+    expect(lastActionsProps?.validationMessage).toBe("Escolha um alvo para cada instância da magia.");
+  });
+});

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastHelpers.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastHelpers.ts
@@ -1,5 +1,6 @@
 import type { CombatSpellResult } from "../../../shared/api/combatRepo";
 import { formatDamageDiceExpression } from "../../../shared/utils/diceExpression";
+import { getInstanceLabel } from "./InstanceTargetSelector";
 
 export const D20_VALUES = Array.from({ length: 20 }, (_, i) => i + 1);
 
@@ -50,3 +51,37 @@ export const getOutcomeLabel = (result: CombatSpellResult) =>
           : result.effect_kind === "healing"
             ? "Cura"
             : "Resultado";
+
+export const formatEffectInstanceOutcome = (
+  result: CombatSpellResult,
+  outcome: NonNullable<CombatSpellResult["effect_instance_outcomes"]>[number],
+) => {
+  const label = getInstanceLabel(result.spell_canonical_key, outcome.instance_index);
+  const details: string[] = [];
+
+  if (outcome.is_hit === true) {
+    details.push(outcome.is_critical ? "acerto critico" : "acerto");
+  } else if (outcome.is_hit === false) {
+    details.push("erro");
+  }
+
+  if (outcome.is_saved === true) {
+    details.push("save passou");
+  } else if (outcome.is_saved === false) {
+    details.push("save falhou");
+  }
+
+  if (typeof outcome.damage === "number" && outcome.damage > 0) {
+    details.push(`${outcome.damage} dano`);
+  }
+
+  if (typeof outcome.healing === "number" && outcome.healing > 0) {
+    details.push(`${outcome.healing} cura`);
+  }
+
+  if (typeof outcome.new_hp === "number") {
+    details.push(`PV ${outcome.new_hp}`);
+  }
+
+  return `${label} -> ${outcome.target_display_name}: ${details.length > 0 ? details.join(", ") : "sem efeito"}`;
+};

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx
@@ -1,0 +1,148 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { SpellCastResultPanel } from "./SpellCastResultPanel";
+
+const baseProps = {
+  effectDiceLabel: "1d10",
+  effectKindLabel: "dano",
+  effectMode: "choose" as const,
+  effectRollCount: 1,
+  effectRollValues: [1, 2, 3],
+  loading: false,
+  manualEffectRolls: [],
+  onClose: () => undefined,
+  onEffectModeChange: () => undefined,
+  onManualEffectRollsChange: () => undefined,
+  onSubmitEffect: () => undefined,
+};
+
+describe("SpellCastResultPanel", () => {
+  it("exibe effect_instance_outcomes quando presente", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastResultPanel
+        {...baseProps}
+        result={{
+          spell_name: "Magic Missile",
+          spell_canonical_key: "magic_missile",
+          action_kind: "direct_damage",
+          effect_kind: "damage",
+          damage: 18,
+          healing: 0,
+          target_display_name: "Goblin A",
+          target_kind: "session_entity",
+          effect_instance_outcomes: [
+            {
+              instance_index: 1,
+              target_ref_id: "session_entity:goblin-a",
+              target_display_name: "Goblin A",
+              target_kind: "session_entity",
+              damage: 4,
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Míssil 1 -&gt; Goblin A: 4 dano");
+  });
+
+  it("exibe dano por missil para Magic Missile", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastResultPanel
+        {...baseProps}
+        result={{
+          spell_name: "Magic Missile",
+          spell_canonical_key: "magic_missile",
+          action_kind: "direct_damage",
+          effect_kind: "damage",
+          damage: 9,
+          healing: 0,
+          target_display_name: "Goblin A",
+          target_kind: "session_entity",
+          effect_instance_outcomes: [
+            {
+              instance_index: 1,
+              target_ref_id: "session_entity:goblin-a",
+              target_display_name: "Goblin A",
+              target_kind: "session_entity",
+              damage: 4,
+            },
+            {
+              instance_index: 2,
+              target_ref_id: "session_entity:goblin-b",
+              target_display_name: "Goblin B",
+              target_kind: "session_entity",
+              damage: 5,
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Míssil 1 -&gt; Goblin A: 4 dano");
+    expect(markup).toContain("Míssil 2 -&gt; Goblin B: 5 dano");
+  });
+
+  it("exibe hit/miss e dano para Eldritch Blast", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastResultPanel
+        {...baseProps}
+        result={{
+          spell_name: "Eldritch Blast",
+          spell_canonical_key: "eldritch_blast",
+          action_kind: "spell_attack",
+          effect_kind: "damage",
+          damage: 7,
+          healing: 0,
+          target_display_name: "Goblin A",
+          target_kind: "session_entity",
+          effect_instance_outcomes: [
+            {
+              instance_index: 1,
+              target_ref_id: "session_entity:goblin-a",
+              target_display_name: "Goblin A",
+              target_kind: "session_entity",
+              is_hit: true,
+              damage: 7,
+            },
+            {
+              instance_index: 2,
+              target_ref_id: "session_entity:orc-b",
+              target_display_name: "Orc B",
+              target_kind: "session_entity",
+              is_hit: false,
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Feixe 1 -&gt; Goblin A: acerto, 7 dano");
+    expect(markup).toContain("Feixe 2 -&gt; Orc B: erro");
+  });
+
+  it("nao quebra resultados antigos sem effect_instance_outcomes", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastResultPanel
+        {...baseProps}
+        result={{
+          spell_name: "Acid Splash",
+          spell_canonical_key: "acid_splash",
+          action_kind: "saving_throw",
+          effect_kind: "damage",
+          damage: 6,
+          healing: 0,
+          is_saved: false,
+          target_display_name: "Goblin A",
+          target_kind: "session_entity",
+          effect_dice: "1d6",
+          effect_rolls: [6],
+          base_effect: 6,
+          effect_bonus: 0,
+        }}
+      />,
+    );
+
+    expect(markup).toContain("1d6: [6] = 6");
+  });
+});

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/types.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/types.ts
@@ -1,4 +1,4 @@
-import type { SpellUpcast } from "../../../entities/base-spell";
+import type { SpellCantripScaling, SpellUpcast } from "../../../entities/base-spell";
 import type {
   SpellAttackType,
   SpellEffectTiming,
@@ -58,6 +58,8 @@ export type CombatSpellOption = {
   rangeMeters?: number | null;
   availableSlotLevels: number[];
   upcast?: SpellUpcast | null;
+  cantripScaling?: SpellCantripScaling | null;
+  characterLevel?: number | null;
   chargesCurrent?: number | null;
   chargesMax?: number | null;
 };

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/usePlayerCombatDebugState.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/usePlayerCombatDebugState.ts
@@ -129,6 +129,8 @@ const buildSpellOptions = (
         areaShape: catalogSpell?.areaShape ?? null,
         savingThrow: catalogSpell?.savingThrow ?? null,
         saveSuccessOutcome: catalogSpell?.saveSuccessOutcome ?? null,
+        cantripScaling: catalogSpell?.cantripScaling ?? null,
+        characterLevel: playerSheet?.level ?? null,
         availableSlotLevels:
           spell.level > 0
             ? availableSlotLevels.filter(

--- a/apps/control-web/src/shared/api/combatRepo.ts
+++ b/apps/control-web/src/shared/api/combatRepo.ts
@@ -207,6 +207,10 @@ export type CombatAttackResult = {
 export type CombatCastSpellRequest = {
   actor_participant_id?: string | null;
   target_ref_id?: string | null;
+  effect_instance_targets?: Array<{
+    instance_index: number;
+    target_ref_id: string;
+  }> | null;
   origin_cell?: { x: number; y: number } | null;
   anchor_cell?: { x: number; y: number } | null;
   inventory_item_id?: string | null;
@@ -281,6 +285,20 @@ export type CombatSpellResult = {
     roll_result?: RollResult | null;
     damage_applied?: number | null;
     healing_applied?: number | null;
+    new_hp?: number | null;
+  }>;
+  effect_instance_outcomes?: Array<{
+    instance_index: number;
+    target_ref_id: string;
+    target_display_name: string;
+    target_kind: CombatParticipantKind;
+    damage?: number;
+    healing?: number;
+    is_hit?: boolean | null;
+    is_saved?: boolean | null;
+    is_critical?: boolean;
+    roll?: number | null;
+    roll_result?: RollResult | null;
     new_hp?: number | null;
   }>;
   target_count?: number;


### PR DESCRIPTION
## Summary
- add frontend API support for `effect_instance_targets` and `effect_instance_outcomes`
- add per-instance target selection UI and wire it into `PlayerSpellCastDialog`
- render per-instance cast result breakdowns and add focused frontend tests

## Details
- `effect_instance_targets` is the source of truth for multi-instance spells in the client payload
- single-instance spells keep the existing target flow and do not send `effect_instance_targets`
- submit is blocked until every instance has a target
- slot changes reconcile instance assignments and drop stale excess entries
- changing spells clears stale per-instance state
- frontend derives pre-cast instance count only for UI preflight; backend remains authoritative at cast/runtime

## Validation
- `npm test -- --run src/pages/PlayerBoardPage/player-combat-debug/instanceTargetSelector.test.tsx src/pages/PlayerBoardPage/player-combat-debug/playerSpellCastDialog.test.tsx src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx`
- `npm run build`
