### PR TITLE
Expose pre-cast resolved spell context for frontend targeting UI

### DIFF
--- a/apps/control-server/app/api/routes/combat_spells.py
+++ b/apps/control-server/app/api/routes/combat_spells.py
@@ -11,6 +11,8 @@ from app.schemas.combat import (
     CombatMapPreviewState,
     CombatMovementPreviewRequest,
     CombatMovementPreviewResponse,
+    CombatResolveSpellContextRequest,
+    CombatResolvedSpellContext,
     CombatResolveSpellEffectRequest,
     CombatSpellResult,
 )
@@ -71,6 +73,25 @@ def action_cast_spell_preview(
     user: User = Depends(get_current_user),
 ):
     return CombatService.preview_area_spell_targeting(
+        db,
+        session_id,
+        req,
+        user.id,
+        _is_session_gm(db, session_id, user),
+    )
+
+
+@router.post(
+    "/sessions/{session_id}/combat/spells/resolve-context",
+    response_model=CombatResolvedSpellContext,
+)
+def resolve_spell_context(
+    session_id: str,
+    req: CombatResolveSpellContextRequest,
+    db: Session = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    return CombatService.resolve_spell_context(
         db,
         session_id,
         req,

--- a/apps/control-server/app/schemas/combat.py
+++ b/apps/control-server/app/schemas/combat.py
@@ -51,6 +51,8 @@ from .combat_spells import (
     CombatMapPreviewToken,
     CombatMovementPreviewRequest,
     CombatMovementPreviewResponse,
+    CombatResolveSpellContextRequest,
+    CombatResolvedSpellContext,
     CombatSpellResult,
 )
 
@@ -99,6 +101,8 @@ __all__ = [
     "CombatResolveDamageRequest",
     "CombatResolveSaveRequest",
     "CombatResolveSpellEffectRequest",
+    "CombatResolveSpellContextRequest",
+    "CombatResolvedSpellContext",
     "CombatReviveRequest",
     "CombatReviveResult",
     "CombatSetInitiativeParticipant",

--- a/apps/control-server/app/schemas/combat_spells.py
+++ b/apps/control-server/app/schemas/combat_spells.py
@@ -86,6 +86,56 @@ class CombatCastSpellRequest(BaseModel):
     effect_instance_targets: list[EffectInstanceTarget] | None = None
 
 
+class CombatResolveSpellContextRequest(BaseModel):
+    actor_participant_id: Optional[str] = None
+    target_ref_id: str | None = None
+    inventory_item_id: str | None = None
+    spell_id: str | None = None
+    spell_canonical_key: str | None = None
+    campaign_spell_id: str | None = None
+    spell_mode: (
+        Literal["spell_attack", "saving_throw", "direct_damage", "heal", "utility"]
+        | None
+    ) = None
+    slot_level: Optional[int] = None
+    dice_expression: Optional[str] = None
+    is_heal: bool = False
+    is_attack: bool = False
+    damage_dice: str | None = None
+    damage_bonus: int | None = None
+    heal_dice: str | None = None
+    heal_bonus: int | None = None
+    damage_type: str | None = None
+    save_ability: AbilityName | None = None
+    save_dc: int | None = Field(default=None, ge=1)
+    spell_attack_bonus: int | None = None
+
+
+class CombatResolvedSpellContext(BaseModel):
+    spell_id: str | None = None
+    spell_canonical_key: str | None = None
+    campaign_spell_id: str | None = None
+    inventory_item_id: str | None = None
+    spell_name: str
+    spell_level: int
+    slot_level: int | None = None
+    target_type: str | None = None
+    selection_type: str | None = None
+    area_shape: Literal["sphere", "cone", "line", "cube", "cylinder"] | None = None
+    resolution_type: Literal[
+        "spell_attack", "saving_throw", "direct_damage", "heal", "utility"
+    ]
+    requires_attack_roll: bool = False
+    requires_saving_throw: bool = False
+    damage_preview: str | None = None
+    effect_instance_count: int = 1
+    effect_instance_dice: str | None = None
+    base_effect_instance_count: int | None = None
+    upcast_applied: bool = False
+    upcast_added_instances: int = 0
+    upcast_instance_effect_dice: str | None = None
+
+
 class CombatGridCell(BaseModel):
     x: int = Field(ge=0)
     y: int = Field(ge=0)

--- a/apps/control-server/app/services/combat_service/spells/cast_target.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target.py
@@ -26,7 +26,16 @@ logger = logging.getLogger(__name__)
 
 class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
     @classmethod
-    def _validate_cast_prerequisites(cls, db, session_id, req, actor_user_id, is_gm):
+    def _validate_cast_prerequisites(
+        cls,
+        db,
+        session_id,
+        req,
+        actor_user_id,
+        is_gm,
+        *,
+        clear_pending_attack: bool = True,
+    ):
         state = cls.get_state(db, session_id)
         cls._require_active(state)
         attacker = cls._resolve_actor_participant(
@@ -48,15 +57,70 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
         if cls._as_dict(attacker_data_check.get("wildShape")).get("active"):
             raise CombatServiceError("Cannot cast spells while in Wild Shape.", 400)
 
-        had_pending = isinstance(attacker.get("pending_attack"), dict)
-        cls._clear_participant_pending_attack(attacker)
-        if had_pending:
-            flag_modified(state, "participants")
+        if clear_pending_attack:
+            had_pending = isinstance(attacker.get("pending_attack"), dict)
+            cls._clear_participant_pending_attack(attacker)
+            if had_pending:
+                flag_modified(state, "participants")
 
         attacker_model, _, _, _, _, _ = cls._get_stats(
             db, attacker["ref_id"], attacker["kind"], session_id
         )
         return state, attacker, attacker_model
+
+    @classmethod
+    def _build_resolved_spell_context_response(cls, req, spell_context: dict) -> dict:
+        resolution_type = spell_context.get("spell_mode")
+        return {
+            "spell_id": req.spell_id or spell_context.get("spell_canonical_key"),
+            "spell_canonical_key": spell_context.get("spell_canonical_key"),
+            "campaign_spell_id": req.campaign_spell_id,
+            "inventory_item_id": spell_context.get("inventory_item_id"),
+            "spell_name": spell_context["spell_name"],
+            "spell_level": cls._safe_int(spell_context.get("spell_level"), 0),
+            "slot_level": spell_context.get("slot_level"),
+            "target_type": spell_context.get("target_type"),
+            "selection_type": spell_context.get("selection_type"),
+            "area_shape": spell_context.get("area_shape"),
+            "resolution_type": resolution_type,
+            "requires_attack_roll": resolution_type == "spell_attack",
+            "requires_saving_throw": resolution_type == "saving_throw",
+            "damage_preview": spell_context.get("effect_dice"),
+            "effect_instance_count": cls._safe_int(
+                spell_context.get("effect_instance_count"),
+                1,
+            ),
+            "effect_instance_dice": spell_context.get("effect_instance_dice"),
+            "base_effect_instance_count": spell_context.get("base_effect_instance_count"),
+            "upcast_applied": bool(spell_context.get("upcast_applied")),
+            "upcast_added_instances": cls._safe_int(
+                spell_context.get("upcast_added_instances"),
+                0,
+            ),
+            "upcast_instance_effect_dice": spell_context.get("upcast_instance_effect_dice"),
+        }
+
+    @classmethod
+    def resolve_spell_context(
+        cls,
+        db,
+        session_id: str,
+        req,
+        actor_user_id: str,
+        is_gm: bool,
+    ) -> dict:
+        _, attacker, attacker_model = cls._validate_cast_prerequisites(
+            db,
+            session_id,
+            req,
+            actor_user_id,
+            is_gm,
+            clear_pending_attack=False,
+        )
+        spell_context = cls._resolve_player_spell_context(
+            db, session_id, attacker, attacker_model, req,
+        )
+        return cls._build_resolved_spell_context_response(req, spell_context)
 
     @classmethod
     def _validate_instance_targets(cls, *, req, spell_context, state):

--- a/apps/control-server/app/services/combat_service/spells/spell_context_resolve.py
+++ b/apps/control-server/app/services/combat_service/spells/spell_context_resolve.py
@@ -91,7 +91,17 @@ class SpellContextResolveMixin:
         }
 
     @classmethod
-    def _resolve_spell_mode_and_targeting(cls, req, catalog_spell, requested_canonical_key: str, spell_level: int, prof_bonus: int, spell_mod: int, source_kind: str) -> dict:
+    def _resolve_spell_mode_and_targeting(
+        cls,
+        req,
+        catalog_spell,
+        requested_canonical_key: str,
+        spell_level: int,
+        prof_bonus: int,
+        spell_mod: int,
+        source_kind: str,
+        attacker_data: dict,
+    ) -> dict:
         catalog_resolution = getattr(catalog_spell, "resolution_type", None)
         catalog_spell_mode = cls._map_resolution_type_to_spell_mode(catalog_resolution)
         targeting_semantics = resolve_spell_targeting_semantics(catalog_spell)
@@ -108,9 +118,9 @@ class SpellContextResolveMixin:
             or ("spell_attack" if targeting_semantics.attack_type in ("melee_spell", "ranged_spell") else None)
             or ("utility" if targeting_semantics.effect_timing in ("persistent", "triggered") else None)
             or automation_default_mode
+            or ("saving_throw" if catalog_save_ability else None)
             or catalog_spell_mode
             or legacy_mode
-            or ("saving_throw" if catalog_save_ability else None)
         )
         if spell_mode not in ("spell_attack", "saving_throw", "direct_damage", "heal", "utility"):
             raise CombatServiceError("Spell cast mode is required for this spell.", 400)
@@ -131,6 +141,14 @@ class SpellContextResolveMixin:
                 slot_level = req.slot_level or spell_level
                 if slot_level < spell_level:
                     raise CombatServiceError("Spell slot level cannot be lower than the spell level.", 400)
+                spellcasting = cls._as_dict(attacker_data.get("spellcasting"))
+                slots = cls._as_dict(spellcasting.get("slots"))
+                slot_data = cls._as_dict(slots.get(str(slot_level)))
+                if cls._safe_int(slot_data.get("max"), 0) <= 0:
+                    raise CombatServiceError(
+                        f"Spell slot level {slot_level} is not available for this caster.",
+                        400,
+                    )
         action_cost = cls._resolve_spell_action_cost(
             getattr(catalog_spell, "casting_time_type", None)
         )
@@ -291,6 +309,7 @@ class SpellContextResolveMixin:
         resolved_mode: dict,
         resolved_math: dict,
         resolved_upcast: dict,
+        spell_level: int,
     ) -> dict:
         upcast_result = resolved_upcast["upcast_result"]
         base_max_targets = getattr(catalog_spell, "max_targets", None)
@@ -318,6 +337,7 @@ class SpellContextResolveMixin:
         return {
             "spell_name": source_context["spell_name"],
             "spell_canonical_key": catalog_spell.canonical_key or source_context["requested_canonical_key"],
+            "spell_level": spell_level,
             "spell_mode": resolved_mode["spell_mode"],
             "target_type": getattr(catalog_spell, "target_type", None),
             "max_targets": effective_max_targets,
@@ -401,6 +421,7 @@ class SpellContextResolveMixin:
             prof_bonus,
             spell_mod,
             source_context["source_kind"],
+            attacker_data,
         )
         resolved_math = cls._resolve_spell_effect_math(
             req,
@@ -426,4 +447,5 @@ class SpellContextResolveMixin:
             resolved_mode=resolved_mode,
             resolved_math=resolved_math,
             resolved_upcast=resolved_upcast,
+            spell_level=catalog_context["spell_level"],
         )

--- a/apps/control-server/tests/test_spell_context_resolve_endpoint.py
+++ b/apps/control-server/tests/test_spell_context_resolve_endpoint.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.models.combat import CombatPhase, CombatState
+from app.models.session_state import SessionState
+from app.schemas.combat import CombatResolveSpellContextRequest
+from app.services.combat import CombatService, CombatServiceError
+
+
+def _build_state() -> CombatState:
+    return CombatState(
+        id="combat-1",
+        session_id="session-1",
+        phase=CombatPhase.active,
+        round=1,
+        current_turn_index=0,
+        participants=[
+          {
+              "id": "p1",
+              "ref_id": "player-1",
+              "kind": "player",
+              "display_name": "Hero",
+              "initiative": 10,
+              "status": "active",
+              "team": "players",
+              "visible": True,
+              "actor_user_id": "user-1",
+          },
+          {
+              "id": "e1",
+              "ref_id": "enemy-1",
+              "kind": "session_entity",
+              "display_name": "Goblin",
+              "initiative": 8,
+              "status": "active",
+              "team": "enemies",
+              "visible": True,
+              "actor_user_id": None,
+          },
+        ],
+    )
+
+
+def _build_attacker_state() -> SessionState:
+    return SessionState(
+        id="state-1",
+        session_id="session-1",
+        player_user_id="user-1",
+        state_json={
+            "level": 5,
+            "abilities": {
+                "intelligence": 18,
+                "charisma": 18,
+            },
+            "spellcasting": {
+                "spells": [
+                    {
+                        "name": "Magic Missile",
+                        "canonicalKey": "magic_missile",
+                        "level": 1,
+                        "prepared": True,
+                    },
+                    {
+                        "name": "Eldritch Blast",
+                        "canonicalKey": "eldritch_blast",
+                        "level": 0,
+                        "prepared": True,
+                    },
+                    {
+                        "name": "Acid Splash",
+                        "canonicalKey": "acid_splash",
+                        "level": 0,
+                        "prepared": True,
+                    },
+                ],
+                "slots": {
+                    "1": {"used": 0, "max": 4},
+                    "2": {"used": 0, "max": 3},
+                    "3": {"used": 0, "max": 2},
+                },
+            },
+        },
+    )
+
+
+def _catalog_spell(**overrides):
+    defaults = {
+        "canonical_key": "magic_missile",
+        "name_en": "Magic Missile",
+        "name_pt": "Mísseis Mágicos",
+        "level": 1,
+        "resolution_type": "damage",
+        "saving_throw": None,
+        "save_success_outcome": None,
+        "damage_type": "Force",
+        "damage_dice": "3d4+3",
+        "heal_dice": None,
+        "upcast_json": {
+            "mode": "additional_effect_instances",
+            "dice": "1d4+1",
+            "perLevel": 1,
+            "baseEffectInstances": 3,
+        },
+        "cantrip_scaling_json": None,
+        "casting_time_type": "action",
+        "target_type": "ranged",
+        "selection_type": "creature",
+        "origin_type": "caster",
+        "target_anchor": "selected_target",
+        "attack_type": "none",
+        "range_kind": "distance",
+        "effect_timing": "immediate",
+        "area_shape": None,
+        "range_meters": 36,
+        "radius_meters": None,
+        "length_meters": None,
+        "side_meters": None,
+        "duration": "Instantaneous",
+        "concentration": False,
+        "cover_applies_to_save": None,
+        "max_targets": 3,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class ResolveSpellContextTests(unittest.TestCase):
+    def setUp(self):
+        self.db = MagicMock()
+        self.state = _build_state()
+        self.attacker_state = _build_attacker_state()
+
+    def _get_stats_side_effect(self, _db, ref_id, kind, _session_id):
+        if ref_id == "player-1" and kind == "player":
+            return (self.attacker_state, 12, 10, 10, 3, 4)
+        raise AssertionError(f"Unexpected _get_stats lookup for {ref_id}/{kind}")
+
+    def _resolve(self, req: CombatResolveSpellContextRequest, catalog_spell):
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state), patch(
+            "app.services.combat.CombatService._get_spell_catalog_entry_for_session",
+            return_value=catalog_spell,
+        ), patch(
+            "app.services.combat.CombatService._get_stats",
+            side_effect=self._get_stats_side_effect,
+        ):
+            return CombatService.resolve_spell_context(
+                self.db,
+                "session-1",
+                req,
+                "user-1",
+                False,
+            )
+
+    def test_resolves_magic_missile_slot_1_effect_instance_count_3(self):
+        result = self._resolve(
+            CombatResolveSpellContextRequest(
+                actor_participant_id="p1",
+                spell_canonical_key="magic_missile",
+                spell_mode="direct_damage",
+                slot_level=1,
+            ),
+            _catalog_spell(),
+        )
+
+        self.assertEqual(result["spell_name"], "Mísseis Mágicos")
+        self.assertEqual(result["spell_level"], 1)
+        self.assertEqual(result["slot_level"], 1)
+        self.assertEqual(result["effect_instance_count"], 3)
+        self.assertEqual(result["effect_instance_dice"], "1d4+1")
+        self.assertEqual(result["damage_preview"], "3d4+3")
+
+    def test_resolves_magic_missile_slot_3_effect_instance_count_5(self):
+        result = self._resolve(
+            CombatResolveSpellContextRequest(
+                actor_participant_id="p1",
+                spell_canonical_key="magic_missile",
+                spell_mode="direct_damage",
+                slot_level=3,
+            ),
+            _catalog_spell(),
+        )
+
+        self.assertEqual(result["slot_level"], 3)
+        self.assertEqual(result["effect_instance_count"], 5)
+        self.assertEqual(result["upcast_added_instances"], 2)
+        self.assertEqual(result["upcast_instance_effect_dice"], "1d4+1")
+        self.assertEqual(result["damage_preview"], "5d4+5")
+
+    def test_resolves_eldritch_blast_level_5_effect_instance_count_2(self):
+        result = self._resolve(
+            CombatResolveSpellContextRequest(
+                actor_participant_id="p1",
+                spell_canonical_key="eldritch_blast",
+            ),
+            _catalog_spell(
+                canonical_key="eldritch_blast",
+                name_en="Eldritch Blast",
+                name_pt="Explosão Eldritch",
+                level=0,
+                damage_dice="1d10",
+                cantrip_scaling_json={
+                    "scalingMode": "character_level",
+                    "scalingEffectType": "effect_instances",
+                    "thresholds": [
+                        {"characterLevel": 1, "instances": 1, "instanceDamage": {"dice": "1d10"}},
+                        {"characterLevel": 5, "instances": 2, "instanceDamage": {"dice": "1d10"}},
+                    ],
+                },
+                upcast_json=None,
+                attack_type="ranged_spell",
+            ),
+        )
+
+        self.assertEqual(result["resolution_type"], "spell_attack")
+        self.assertTrue(result["requires_attack_roll"])
+        self.assertEqual(result["effect_instance_count"], 2)
+        self.assertEqual(result["effect_instance_dice"], "1d10")
+        self.assertEqual(result["damage_preview"], "2d10")
+
+    def test_resolves_acid_splash_level_5_effect_instance_count_1(self):
+        result = self._resolve(
+            CombatResolveSpellContextRequest(
+                actor_participant_id="p1",
+                spell_canonical_key="acid_splash",
+            ),
+            _catalog_spell(
+                canonical_key="acid_splash",
+                name_en="Acid Splash",
+                name_pt="Acid Splash",
+                level=0,
+                damage_dice="1d6",
+                damage_type="Acid",
+                saving_throw="DEX",
+                save_success_outcome="none",
+                cantrip_scaling_json={
+                    "scalingMode": "character_level",
+                    "scalingEffectType": "damage_dice",
+                    "thresholds": [
+                        {"characterLevel": 1, "damage": {"dice": "1d6"}},
+                        {"characterLevel": 5, "damage": {"dice": "2d6"}},
+                    ],
+                },
+                upcast_json=None,
+            ),
+        )
+
+        self.assertEqual(result["resolution_type"], "saving_throw")
+        self.assertTrue(result["requires_saving_throw"])
+        self.assertEqual(result["effect_instance_count"], 1)
+        self.assertIsNone(result["effect_instance_dice"])
+        self.assertEqual(result["damage_preview"], "2d6")
+
+    def test_resolve_spell_context_does_not_alter_combat_state(self):
+        self.state.participants[0]["pending_attack"] = {"id": "pending-1"}
+
+        self._resolve(
+            CombatResolveSpellContextRequest(
+                actor_participant_id="p1",
+                spell_canonical_key="magic_missile",
+                spell_mode="direct_damage",
+                slot_level=3,
+            ),
+            _catalog_spell(),
+        )
+
+        self.assertEqual(
+            self.state.participants[0]["pending_attack"],
+            {"id": "pending-1"},
+        )
+
+    def test_invalid_slot_returns_clear_error(self):
+        with self.assertRaises(CombatServiceError) as context:
+            self._resolve(
+                CombatResolveSpellContextRequest(
+                    actor_participant_id="p1",
+                    spell_canonical_key="magic_missile",
+                    spell_mode="direct_damage",
+                    slot_level=9,
+                ),
+                _catalog_spell(),
+            )
+
+        self.assertIn("Spell slot level 9 is not available", str(context.exception))
+
+    def test_spell_not_available_on_sheet_returns_existing_authorization_error(self):
+        self.attacker_state.state_json["spellcasting"]["spells"] = []
+
+        with self.assertRaises(CombatServiceError) as context:
+            self._resolve(
+                CombatResolveSpellContextRequest(
+                    actor_participant_id="p1",
+                    spell_canonical_key="magic_missile",
+                    spell_mode="direct_damage",
+                    slot_level=1,
+                ),
+                _catalog_spell(),
+            )
+
+        self.assertIn("Spell is not available on the player's sheet.", str(context.exception))

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
@@ -4,6 +4,7 @@ import { participantHasActiveConcentration } from "../../../features/combat-ui/c
 import type {
   CombatCastSpellRequest,
   CombatParticipant,
+  CombatResolvedSpellContext,
   CombatSpellMode,
   CombatSpellResult,
 } from "../../../shared/api/combatRepo";
@@ -31,6 +32,7 @@ import { SpellCastDialogHeader } from "./SpellCastDialogHeader";
 import { SpellCastResultPanel } from "./SpellCastResultPanel";
 import type { CombatSpellOption } from "./types";
 import { useAreaTargeting } from "./useAreaTargeting";
+import { useResolvedSpellContext } from "./useResolvedSpellContext";
 
 type Props = {
   actor: CombatParticipant;
@@ -50,6 +52,11 @@ type Props = {
 };
 
 const MULTI_INSTANCE_TARGET_ERROR = "Escolha um alvo para cada instância da magia.";
+
+type EffectInstanceContext = {
+  instanceCount: number;
+  instanceDice: string | null;
+};
 
 type BuildNonAreaSpellCastPayloadParams = {
   actorParticipantId: string;
@@ -112,6 +119,26 @@ export const buildNonAreaSpellCastPayload = ({
   concentration_manual_roll: concentrationManualRoll,
 });
 
+export const getEffectiveEffectInstanceContext = (
+  resolvedContext: CombatResolvedSpellContext | null,
+  fallbackContext: EffectInstanceContext,
+  allowFallback: boolean,
+): EffectInstanceContext => {
+  if (resolvedContext) {
+    return {
+      instanceCount: Math.max(1, resolvedContext.effect_instance_count),
+      instanceDice: resolvedContext.effect_instance_dice ?? null,
+    };
+  }
+
+  return allowFallback
+    ? fallbackContext
+    : {
+        instanceCount: 1,
+        instanceDice: null,
+      };
+};
+
 export const PlayerSpellCastDialog = ({
   actor,
   actorParticipantId,
@@ -165,7 +192,25 @@ export const PlayerSpellCastDialog = ({
     spell,
     spellMode,
   });
-  const effectInstanceContext = resolveEffectInstanceContext(spell, selectedSlotLevel);
+  const fallbackEffectInstanceContext = resolveEffectInstanceContext(spell, selectedSlotLevel);
+  const resolvedSpellContextState = useResolvedSpellContext({
+    actorParticipantId,
+    selectedSlotLevel,
+    sessionId,
+    spell,
+    spellMode,
+  });
+  // Keep the local derivation only as a temporary defense when the pre-cast
+  // backend contract is unavailable; the resolved backend context is preferred.
+  const allowLocalFallback =
+    Boolean(resolvedSpellContextState.error) ||
+    (!resolvedSpellContextState.loading && !resolvedSpellContextState.context);
+  const spellContextReady = Boolean(resolvedSpellContextState.context) || allowLocalFallback;
+  const effectInstanceContext = getEffectiveEffectInstanceContext(
+    resolvedSpellContextState.context,
+    fallbackEffectInstanceContext,
+    allowLocalFallback,
+  );
   const isMultiInstanceSpell = !isAreaSpell && effectInstanceContext.instanceCount > 1;
   const selectableParticipants = participants.filter((participant) => participant.id !== actor.id);
   const normalizedEffectInstanceTargets = normalizeEffectInstanceTargets(
@@ -203,12 +248,18 @@ export const PlayerSpellCastDialog = ({
     anchorCell && mapState
       ? mapState.tokens.find((token) => token.position.x === anchorCell.x && token.position.y === anchorCell.y)?.combatant_id ?? null
       : null;
-  const effectDiceLabel =
-    formatDamageDiceExpression(result?.effect_dice ?? spellEffectDice, Boolean(result?.is_critical)) ??
+  const effectDiceSource =
     result?.effect_dice ??
+    (spellEffectDice || resolvedSpellContextState.context?.damage_preview || null);
+  const effectDiceLabel =
+    formatDamageDiceExpression(
+      effectDiceSource,
+      Boolean(result?.is_critical),
+    ) ??
+    effectDiceSource ??
     spellEffectDice;
-  const effectRollCount = getDamageRollCount(result?.effect_dice ?? spellEffectDice, Boolean(result?.is_critical));
-  const effectRollSides = getDamageRollSides(result?.effect_dice ?? spellEffectDice);
+  const effectRollCount = getDamageRollCount(effectDiceSource, Boolean(result?.is_critical));
+  const effectRollSides = getDamageRollSides(effectDiceSource);
   const effectRollValues = Array.from({ length: effectRollSides }, (_, i) => i + 1);
   const effectKindLabel =
     result?.effect_kind === "healing" || spellMode === "heal"
@@ -507,8 +558,14 @@ export const PlayerSpellCastDialog = ({
             }}
             spellMode={spellMode}
             spellOutOfRange={spellOutOfRange}
-            submitDisabled={isMultiInstanceSpell && !effectInstanceTargetsComplete}
-            validationMessage={isMultiInstanceSpell && !effectInstanceTargetsComplete ? MULTI_INSTANCE_TARGET_ERROR : null}
+            submitDisabled={!spellContextReady || (isMultiInstanceSpell && !effectInstanceTargetsComplete)}
+            validationMessage={
+              !spellContextReady
+                ? "Resolvendo contexto da magia..."
+                : isMultiInstanceSpell && !effectInstanceTargetsComplete
+                  ? MULTI_INSTANCE_TARGET_ERROR
+                  : null
+            }
           />
         ) : null}
       </div>

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/playerSpellCastDialog.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/playerSpellCastDialog.test.tsx
@@ -1,9 +1,18 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { PlayerSpellCastDialog, buildNonAreaSpellCastPayload } from "./PlayerSpellCastDialog";
+import {
+  PlayerSpellCastDialog,
+  buildNonAreaSpellCastPayload,
+  getEffectiveEffectInstanceContext,
+} from "./PlayerSpellCastDialog";
 import { reconcileEffectInstanceTargets, resolveEffectInstanceContext } from "./InstanceTargetSelector";
 
 let lastActionsProps: Record<string, unknown> | null = null;
+let resolvedSpellContextState = {
+  context: null as Record<string, unknown> | null,
+  error: null as string | null,
+  loading: false,
+};
 
 vi.mock("../../../shared/api/combatRepo", () => ({
   combatRepo: {
@@ -41,6 +50,10 @@ vi.mock("./useAreaTargeting", () => ({
     previewLoading: false,
     setAnchorCell: vi.fn(),
   }),
+}));
+
+vi.mock("./useResolvedSpellContext", () => ({
+  useResolvedSpellContext: () => resolvedSpellContextState,
 }));
 
 vi.mock("./SpellCastDialogHeader", () => ({
@@ -120,9 +133,24 @@ const baseProps = {
 describe("PlayerSpellCastDialog", () => {
   beforeEach(() => {
     lastActionsProps = null;
+    resolvedSpellContextState = {
+      context: null,
+      error: null,
+      loading: false,
+    };
   });
 
-  it("magia multi-instancia mostra InstanceTargetSelector", () => {
+  it("magia multi-instancia usa contexto pre-cast para mostrar InstanceTargetSelector", () => {
+    resolvedSpellContextState = {
+      context: {
+        effect_instance_count: 5,
+        effect_instance_dice: "1d4+1",
+        damage_preview: "5d4+5",
+      },
+      error: null,
+      loading: false,
+    };
+
     const markup = renderToStaticMarkup(
       <PlayerSpellCastDialog
         {...baseProps}
@@ -152,7 +180,17 @@ describe("PlayerSpellCastDialog", () => {
     expect(markup).toContain("Míssil 1");
   });
 
-  it("magia single-instance nao mostra InstanceTargetSelector", () => {
+  it("magia single-instance nao mostra InstanceTargetSelector quando o contexto pre-cast retorna 1 instancia", () => {
+    resolvedSpellContextState = {
+      context: {
+        effect_instance_count: 1,
+        effect_instance_dice: null,
+        damage_preview: "2d6",
+      },
+      error: null,
+      loading: false,
+    };
+
     const markup = renderToStaticMarkup(
       <PlayerSpellCastDialog
         {...baseProps}
@@ -173,6 +211,40 @@ describe("PlayerSpellCastDialog", () => {
     );
 
     expect(markup).not.toContain("Alvos por instância");
+  });
+
+  it("usa contexto pre-cast para renderizar Eldritch Blast nivel 5 com 2 linhas", () => {
+    resolvedSpellContextState = {
+      context: {
+        effect_instance_count: 2,
+        effect_instance_dice: "1d10",
+        damage_preview: "2d10",
+      },
+      error: null,
+      loading: false,
+    };
+
+    const markup = renderToStaticMarkup(
+      <PlayerSpellCastDialog
+        {...baseProps}
+        spell={{
+          id: "spell-3",
+          name: "Eldritch Blast",
+          canonicalKey: "eldritch_blast",
+          campaignSpellId: null,
+          level: 0,
+          prepared: true,
+          actionCost: "action",
+          suggestedMode: "spell_attack",
+          damageType: "Force",
+          savingThrow: null,
+          availableSlotLevels: [],
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Feixe 1");
+    expect(markup).toContain("Feixe 2");
   });
 
   it("resolve Magic Missile slot 3 com 5 instancias e Eldritch Blast nivel 5 com 2", () => {
@@ -269,6 +341,69 @@ describe("PlayerSpellCastDialog", () => {
     ]);
   });
 
+  it("prefere o contexto backend e nao usa fallback local quando ele existe", () => {
+    expect(
+      getEffectiveEffectInstanceContext(
+        {
+          spell_id: "spell-1",
+          spell_name: "Magic Missile",
+          spell_level: 1,
+          resolution_type: "direct_damage",
+          requires_attack_roll: false,
+          requires_saving_throw: false,
+          effect_instance_count: 5,
+          effect_instance_dice: "1d4+1",
+          upcast_applied: true,
+          upcast_added_instances: 2,
+        },
+        {
+          instanceCount: 3,
+          instanceDice: "1d4+1",
+        },
+        true,
+      ),
+    ).toEqual({
+      instanceCount: 5,
+      instanceDice: "1d4+1",
+    });
+  });
+
+  it("queda do resolve-context usa fallback sem quebrar o dialogo", () => {
+    resolvedSpellContextState = {
+      context: null,
+      error: "resolve failed",
+      loading: false,
+    };
+
+    const markup = renderToStaticMarkup(
+      <PlayerSpellCastDialog
+        {...baseProps}
+        spell={{
+          id: "spell-1",
+          name: "Magic Missile",
+          canonicalKey: "magic_missile",
+          campaignSpellId: null,
+          level: 1,
+          prepared: true,
+          actionCost: "action",
+          suggestedMode: "direct_damage",
+          damageType: "Force",
+          savingThrow: null,
+          availableSlotLevels: [1, 2, 3],
+          upcast: {
+            mode: "additional_effect_instances",
+            dice: "1d4+1",
+            perLevel: 1,
+            baseEffectInstances: 3,
+          },
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Alvos por instância");
+    expect(markup).toContain("Míssil 1");
+  });
+
   it("submit de Magic Missile e Eldritch Blast inclui effect_instance_targets", () => {
     const multiPayload = buildNonAreaSpellCastPayload({
       actorParticipantId: actor.id,
@@ -341,6 +476,16 @@ describe("PlayerSpellCastDialog", () => {
   });
 
   it("submit fica invalido quando ha instancias sem alvo", () => {
+    resolvedSpellContextState = {
+      context: {
+        effect_instance_count: 5,
+        effect_instance_dice: "1d4+1",
+        damage_preview: "5d4+5",
+      },
+      error: null,
+      loading: false,
+    };
+
     renderToStaticMarkup(
       <PlayerSpellCastDialog
         {...baseProps}

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/useResolvedSpellContext.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/useResolvedSpellContext.ts
@@ -1,0 +1,101 @@
+import { useEffect, useState } from "react";
+import {
+  combatRepo,
+  type CombatResolvedSpellContext,
+  type CombatSpellMode,
+} from "../../../shared/api/combatRepo";
+import type { CombatSpellOption } from "./types";
+
+type UseResolvedSpellContextParams = {
+  actorParticipantId: string;
+  sessionId: string;
+  spell: CombatSpellOption;
+  spellMode: CombatSpellMode;
+  selectedSlotLevel: number | null;
+};
+
+type UseResolvedSpellContextResult = {
+  context: CombatResolvedSpellContext | null;
+  error: string | null;
+  loading: boolean;
+};
+
+const INITIAL: UseResolvedSpellContextResult = {
+  context: null,
+  error: null,
+  loading: false,
+};
+
+export const useResolvedSpellContext = ({
+  actorParticipantId,
+  sessionId,
+  spell,
+  spellMode,
+  selectedSlotLevel,
+}: UseResolvedSpellContextParams): UseResolvedSpellContextResult => {
+  const [state, setState] = useState<UseResolvedSpellContextResult>(INITIAL);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setState((current) => ({
+      context: current.context,
+      error: null,
+      loading: true,
+    }));
+
+    combatRepo
+      .resolveSpellContext(sessionId, {
+        actor_participant_id: actorParticipantId,
+        inventory_item_id: spell.sourceType === "magic_item" ? spell.inventoryItemId ?? null : null,
+        spell_id: spell.canonicalKey,
+        spell_canonical_key: spell.canonicalKey,
+        campaign_spell_id: spell.campaignSpellId ?? null,
+        spell_mode: spellMode,
+        slot_level:
+          spell.sourceType === "magic_item"
+            ? spell.fixedCastLevel ?? spell.level ?? null
+            : spell.level > 0
+              ? selectedSlotLevel ?? spell.level
+              : null,
+      })
+      .then((context) => {
+        if (cancelled) {
+          return;
+        }
+        setState({
+          context,
+          error: null,
+          loading: false,
+        });
+      })
+      .catch((error: any) => {
+        if (cancelled) {
+          return;
+        }
+        setState({
+          context: null,
+          error: error?.data?.detail || error?.message || "Falha ao resolver contexto da magia.",
+          loading: false,
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    actorParticipantId,
+    selectedSlotLevel,
+    sessionId,
+    spell.campaignSpellId,
+    spell.canonicalKey,
+    spell.fixedCastLevel,
+    spell.id,
+    spell.inventoryItemId,
+    spell.level,
+    spell.sourceType,
+    spellMode,
+  ]);
+
+  return state;
+};

--- a/apps/control-web/src/shared/api/combatRepo.ts
+++ b/apps/control-web/src/shared/api/combatRepo.ts
@@ -240,6 +240,40 @@ export type CombatCastSpellRequest = {
   override_resource_limit?: boolean;
 };
 
+export type CombatResolveSpellContextRequest = {
+  actor_participant_id?: string | null;
+  target_ref_id?: string | null;
+  inventory_item_id?: string | null;
+  spell_id?: string | null;
+  spell_canonical_key?: string | null;
+  campaign_spell_id?: string | null;
+  spell_mode?: CombatSpellMode | null;
+  slot_level?: number | null;
+};
+
+export type CombatResolvedSpellContext = {
+  spell_id?: string | null;
+  spell_canonical_key?: string | null;
+  campaign_spell_id?: string | null;
+  inventory_item_id?: string | null;
+  spell_name: string;
+  spell_level: number;
+  slot_level?: number | null;
+  target_type?: string | null;
+  selection_type?: string | null;
+  area_shape?: "sphere" | "cone" | "line" | "cube" | "cylinder" | null;
+  resolution_type: CombatSpellMode;
+  requires_attack_roll: boolean;
+  requires_saving_throw: boolean;
+  damage_preview?: string | null;
+  effect_instance_count: number;
+  effect_instance_dice?: string | null;
+  base_effect_instance_count?: number | null;
+  upcast_applied: boolean;
+  upcast_added_instances: number;
+  upcast_instance_effect_dice?: string | null;
+};
+
 export type CombatSpellResult = {
   spell_name: string;
   spell_canonical_key?: string | null;
@@ -643,6 +677,11 @@ export const combatRepo = {
     http.post<CombatSpellResult>(
       `/sessions/${sessionId}/combat/action/cast`,
       payload
+    ),
+  resolveSpellContext: (sessionId: string, payload: CombatResolveSpellContextRequest) =>
+    http.post<CombatResolvedSpellContext>(
+      `/sessions/${sessionId}/combat/spells/resolve-context`,
+      payload,
     ),
   ensureMap: (sessionId: string) =>
     http.post<CombatMapEnsureResponse>(


### PR DESCRIPTION
## Summary
- add a read-only pre-cast spell context endpoint for combat spell resolution
- reuse the real backend spell-context pipeline for instance count, dice preview, resolution type, and upcast/cantrip metadata
- switch the player spell dialog to prefer backend-resolved pre-cast context, with documented local fallback only when resolution is unavailable

## What changed
- added `POST /sessions/{session_id}/combat/spells/resolve-context`
- added backend request/response schemas for resolved pre-cast spell context
- reused `_resolve_player_spell_context(...)` instead of duplicating scaling logic
- ensured the endpoint does not clear pending state and does not consume spell slots
- updated frontend `combatRepo` and added `useResolvedSpellContext`
- updated `PlayerSpellCastDialog` to consume backend `effect_instance_count`, `effect_instance_dice`, and `damage_preview`
- kept local frontend derivation only as temporary fallback, with explicit comment

## Final checklist
- [x] Magic Missile slot 1 resolve-context returns 3 instances
- [x] Magic Missile slot 3 resolve-context returns 5 instances
- [x] Eldritch Blast level 5 resolve-context returns 2 instances
- [x] Acid Splash resolve-context returns `resolution_type = saving_throw`
- [x] Acid Splash does not expose `effect_instance_dice` as multi-instance metadata
- [x] endpoint does not mutate pending state
- [x] endpoint does not consume spell slots
- [x] frontend re-resolves pre-cast context when slot changes
- [x] endpoint failure falls back without breaking the dialog
- [x] local fallback does not override valid backend context

## Validation
- `apps/control-server/.venv/bin/python -m pytest apps/control-server/tests/test_spell_context_resolve_endpoint.py`
- `npm test -- --run src/pages/PlayerBoardPage/player-combat-debug/playerSpellCastDialog.test.tsx src/pages/PlayerBoardPage/player-combat-debug/instanceTargetSelector.test.tsx src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx`
- `npm run build`
