### PR TITLE
Use resolved spell context for tactical spell preview

### DIFF
--- a/apps/control-server/app/schemas/combat_spells.py
+++ b/apps/control-server/app/schemas/combat_spells.py
@@ -122,11 +122,15 @@ class CombatResolvedSpellContext(BaseModel):
     target_type: str | None = None
     selection_type: str | None = None
     area_shape: Literal["sphere", "cone", "line", "cube", "cylinder"] | None = None
+    area_size_meters: float | None = None
+    range_meters: float | None = None
     resolution_type: Literal[
         "spell_attack", "saving_throw", "direct_damage", "heal", "utility"
     ]
     requires_attack_roll: bool = False
     requires_saving_throw: bool = False
+    save_ability: AbilityName | None = None
+    damage_type: str | None = None
     damage_preview: str | None = None
     effect_instance_count: int = 1
     effect_instance_dice: str | None = None

--- a/apps/control-server/app/services/combat_service/spells/cast_target.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target.py
@@ -69,8 +69,38 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
         return state, attacker, attacker_model
 
     @classmethod
+    def _resolve_area_size_meters(cls, spell_context: dict) -> float | None:
+        area_shape = spell_context.get("area_shape")
+        if not area_shape:
+            return None
+        if area_shape in ("sphere", "cylinder"):
+            value = spell_context.get("radius_meters")
+        elif area_shape == "line":
+            value = spell_context.get("length_meters")
+        elif area_shape == "cube":
+            value = spell_context.get("side_meters")
+        elif area_shape == "cone":
+            value = (
+                spell_context.get("length_meters")
+                or spell_context.get("radius_meters")
+            )
+        else:
+            value = None
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
     def _build_resolved_spell_context_response(cls, req, spell_context: dict) -> dict:
         resolution_type = spell_context.get("spell_mode")
+        range_meters = spell_context.get("range_meters")
+        try:
+            range_meters_value = float(range_meters) if range_meters is not None else None
+        except (TypeError, ValueError):
+            range_meters_value = None
         return {
             "spell_id": req.spell_id or spell_context.get("spell_canonical_key"),
             "spell_canonical_key": spell_context.get("spell_canonical_key"),
@@ -82,9 +112,13 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
             "target_type": spell_context.get("target_type"),
             "selection_type": spell_context.get("selection_type"),
             "area_shape": spell_context.get("area_shape"),
+            "area_size_meters": cls._resolve_area_size_meters(spell_context),
+            "range_meters": range_meters_value,
             "resolution_type": resolution_type,
             "requires_attack_roll": resolution_type == "spell_attack",
             "requires_saving_throw": resolution_type == "saving_throw",
+            "save_ability": spell_context.get("save_ability"),
+            "damage_type": spell_context.get("damage_type"),
             "damage_preview": spell_context.get("effect_dice"),
             "effect_instance_count": cls._safe_int(
                 spell_context.get("effect_instance_count"),

--- a/apps/control-server/tests/test_spell_context_resolve_endpoint.py
+++ b/apps/control-server/tests/test_spell_context_resolve_endpoint.py
@@ -171,6 +171,12 @@ class ResolveSpellContextTests(unittest.TestCase):
         self.assertEqual(result["effect_instance_count"], 3)
         self.assertEqual(result["effect_instance_dice"], "1d4+1")
         self.assertEqual(result["damage_preview"], "3d4+3")
+        self.assertEqual(result["target_type"], "ranged")
+        self.assertIsNone(result["area_shape"])
+        self.assertIsNone(result["area_size_meters"])
+        self.assertEqual(result["range_meters"], 36)
+        self.assertEqual(result["damage_type"], "force")
+        self.assertIsNone(result["save_ability"])
 
     def test_resolves_magic_missile_slot_3_effect_instance_count_5(self):
         result = self._resolve(
@@ -252,6 +258,51 @@ class ResolveSpellContextTests(unittest.TestCase):
         self.assertEqual(result["effect_instance_count"], 1)
         self.assertIsNone(result["effect_instance_dice"])
         self.assertEqual(result["damage_preview"], "2d6")
+        self.assertEqual(result["save_ability"], "dexterity")
+        self.assertEqual(result["damage_type"], "acid")
+
+    def test_resolves_fireball_exposes_area_shape_and_area_size_meters(self):
+        self.attacker_state.state_json["spellcasting"]["spells"].append(
+            {
+                "name": "Fireball",
+                "canonicalKey": "fireball",
+                "level": 3,
+                "prepared": True,
+            }
+        )
+
+        result = self._resolve(
+            CombatResolveSpellContextRequest(
+                actor_participant_id="p1",
+                spell_canonical_key="fireball",
+                spell_mode="saving_throw",
+                slot_level=3,
+            ),
+            _catalog_spell(
+                canonical_key="fireball",
+                name_en="Fireball",
+                name_pt="Bola de Fogo",
+                level=3,
+                damage_dice="8d6",
+                damage_type="Fire",
+                saving_throw="DEX",
+                save_success_outcome="half_damage",
+                upcast_json=None,
+                cantrip_scaling_json=None,
+                target_type="ranged",
+                selection_type="point",
+                area_shape="sphere",
+                range_meters=45,
+                radius_meters=6,
+                max_targets=None,
+            ),
+        )
+
+        self.assertEqual(result["area_shape"], "sphere")
+        self.assertEqual(result["area_size_meters"], 6)
+        self.assertEqual(result["range_meters"], 45)
+        self.assertEqual(result["save_ability"], "dexterity")
+        self.assertEqual(result["damage_type"], "fire")
 
     def test_resolve_spell_context_does_not_alter_combat_state(self):
         self.state.participants[0]["pending_attack"] = {"id": "pending-1"}

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
@@ -30,6 +30,7 @@ import { SpellCastDialogActions } from "./SpellCastDialogActions";
 import { parseBonus } from "./spellCastHelpers";
 import { SpellCastDialogHeader } from "./SpellCastDialogHeader";
 import { SpellCastResultPanel } from "./SpellCastResultPanel";
+import { buildSpellPreviewModel } from "./spellPreviewModel";
 import type { CombatSpellOption } from "./types";
 import { useAreaTargeting } from "./useAreaTargeting";
 import { useResolvedSpellContext } from "./useResolvedSpellContext";
@@ -206,6 +207,15 @@ export const PlayerSpellCastDialog = ({
     Boolean(resolvedSpellContextState.error) ||
     (!resolvedSpellContextState.loading && !resolvedSpellContextState.context);
   const spellContextReady = Boolean(resolvedSpellContextState.context) || allowLocalFallback;
+  const previewModel = buildSpellPreviewModel(
+    resolvedSpellContextState.context,
+    {
+      spell,
+      selectedSlotLevel,
+      spellMode,
+      spellEffectDice: spellEffectDice || null,
+    },
+  );
   const effectInstanceContext = getEffectiveEffectInstanceContext(
     resolvedSpellContextState.context,
     fallbackEffectInstanceContext,
@@ -451,14 +461,13 @@ export const PlayerSpellCastDialog = ({
           loading={loading}
           onConcentrationManualRollChange={setConcentrationManualRoll}
           onConcentrationRollModeChange={setConcentrationRollMode}
+          previewModel={previewModel}
           selectedSlotLevel={selectedSlotLevel}
           setSelectedSlotLevel={setSelectedSlotLevel}
           shouldShowConcentrationControl={shouldShowConcentrationControl}
           slotOptions={slotOptions}
           spell={spell}
-          spellDamageType={spellDamageType}
           spellMode={spellMode}
-          spellSaveAbility={spellSaveAbility}
           targetDisplayName={isMultiInstanceSpell ? "Múltiplos alvos" : target?.display_name ?? null}
           targetPreview={rangePreview}
         />

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastDialogHeader.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastDialogHeader.tsx
@@ -3,6 +3,7 @@ import { RangeStatusBadge } from "../../../features/combat-ui/components/RangeSt
 import type { TargetingPreviewResult } from "../../../features/combat-ui/hooks/useTargetingPreview";
 import type { CombatSpellMode } from "../../../shared/api/combatRepo";
 import type { GridCell } from "./areaTargetingUi";
+import type { SpellPreviewModel } from "./spellPreviewModel";
 import type { CombatSpellOption } from "./types";
 
 type Props = {
@@ -16,16 +17,50 @@ type Props = {
   loading: boolean;
   onConcentrationManualRollChange: (value: string) => void;
   onConcentrationRollModeChange: (value: "system" | "manual") => void;
+  previewModel: SpellPreviewModel;
   selectedSlotLevel: number | null;
   setSelectedSlotLevel: (value: number) => void;
   shouldShowConcentrationControl: boolean;
   slotOptions: number[];
   spell: CombatSpellOption;
-  spellDamageType: string;
   spellMode: CombatSpellMode;
-  spellSaveAbility: string;
   targetDisplayName?: string | null;
   targetPreview: TargetingPreviewResult;
+};
+
+const formatRangeMeters = (meters: number | null): string | null =>
+  meters === null ? null : `${Number.isInteger(meters) ? meters : meters.toFixed(1)}m`;
+
+const formatAreaSizeMeters = (
+  shape: SpellPreviewModel["areaShape"],
+  meters: number | null,
+): string | null => {
+  if (!shape || meters === null) return null;
+  const formatted = Number.isInteger(meters) ? `${meters}m` : `${meters.toFixed(1)}m`;
+  if (shape === "sphere" || shape === "cylinder") return `raio ${formatted}`;
+  if (shape === "line") return `comprimento ${formatted}`;
+  if (shape === "cube") return `lado ${formatted}`;
+  if (shape === "cone") return `cone ${formatted}`;
+  return formatted;
+};
+
+const formatResolutionType = (
+  resolutionType: SpellPreviewModel["resolutionType"],
+): string => {
+  switch (resolutionType) {
+    case "spell_attack":
+      return "ataque";
+    case "saving_throw":
+      return "saving throw";
+    case "direct_damage":
+      return "dano direto";
+    case "heal":
+      return "cura";
+    case "utility":
+      return "efeito";
+    default:
+      return "—";
+  }
 };
 
 export const SpellCastDialogHeader = ({
@@ -39,87 +74,125 @@ export const SpellCastDialogHeader = ({
   loading,
   onConcentrationManualRollChange,
   onConcentrationRollModeChange,
+  previewModel,
   selectedSlotLevel,
   setSelectedSlotLevel,
   shouldShowConcentrationControl,
   slotOptions,
   spell,
-  spellDamageType,
   spellMode,
-  spellSaveAbility,
   targetDisplayName,
   targetPreview,
-}: Props) => (
-  <>
-    <p className="text-xs uppercase tracking-[0.3em] text-fuchsia-200">Magia</p>
-    <h2 className="mt-3 text-2xl font-semibold text-white">{spell.name}</h2>
-    <p className="mt-2 text-sm text-slate-300">
-      {isAreaSpell
-        ? `Origem: ${actorDisplayName}${anchorCell ? ` · Ancora: (${anchorCell.x}, ${anchorCell.y})` : ""}`
-        : (
-          <>
-            Alvo: <span className="font-semibold text-white">{targetDisplayName ?? "Nenhum"}</span>
-          </>
-        )}
-    </p>
-    {spell.sourceType === "magic_item" && spell.sourceItemName ? (
+}: Props) => {
+  const flowDamageType =
+    spellMode !== "heal" && spellMode !== "utility" && previewModel.damageType
+      ? previewModel.damageType
+      : null;
+  const flowSaveAbility =
+    previewModel.requiresSavingThrow && previewModel.saveAbility ? previewModel.saveAbility : null;
+  const flowAreaShape = isAreaSpell && previewModel.areaShape ? previewModel.areaShape : null;
+  const showInstanceCount =
+    previewModel.effectInstanceCount > 1 && previewModel.source === "resolved";
+  const rangeLabel = formatRangeMeters(previewModel.rangeMeters);
+  const areaSizeLabel = isAreaSpell
+    ? formatAreaSizeMeters(previewModel.areaShape, previewModel.areaSizeMeters)
+    : null;
+  const resolutionLabel = formatResolutionType(previewModel.resolutionType);
+
+  return (
+    <>
+      <p className="text-xs uppercase tracking-[0.3em] text-fuchsia-200">Magia</p>
+      <h2 className="mt-3 text-2xl font-semibold text-white">{spell.name}</h2>
+      <p className="mt-2 text-sm text-slate-300">
+        {isAreaSpell
+          ? `Origem: ${actorDisplayName}${anchorCell ? ` · Ancora: (${anchorCell.x}, ${anchorCell.y})` : ""}`
+          : (
+            <>
+              Alvo: <span className="font-semibold text-white">{targetDisplayName ?? "Nenhum"}</span>
+            </>
+          )}
+      </p>
+      {spell.sourceType === "magic_item" && spell.sourceItemName ? (
+        <p className="mt-1 text-sm text-slate-400">
+          Item: <span className="font-semibold text-white">{spell.sourceItemName}</span>
+          {typeof spell.chargesCurrent === "number" && typeof spell.chargesMax === "number"
+            ? ` · ${spell.chargesCurrent}/${spell.chargesMax}`
+            : ""}
+        </p>
+      ) : null}
       <p className="mt-1 text-sm text-slate-400">
-        Item: <span className="font-semibold text-white">{spell.sourceItemName}</span>
-        {typeof spell.chargesCurrent === "number" && typeof spell.chargesMax === "number"
-          ? ` · ${spell.chargesCurrent}/${spell.chargesMax}`
-          : ""}
+        Fluxo: {resolutionLabel}
+        {flowDamageType ? ` · ${flowDamageType}` : ""}
+        {flowSaveAbility ? ` · save ${flowSaveAbility}` : ""}
+        {flowAreaShape ? ` · ${flowAreaShape}` : ""}
       </p>
-    ) : null}
-    <p className="mt-1 text-sm text-slate-400">
-      Fluxo: {spellMode.replace(/_/g, " ")}
-      {spellMode !== "heal" && spellMode !== "utility" && spellDamageType ? ` · ${spellDamageType}` : ""}
-      {spellMode === "saving_throw" && spellSaveAbility ? ` · save ${spellSaveAbility}` : ""}
-      {isAreaSpell && spell.areaShape ? ` · ${spell.areaShape}` : ""}
-    </p>
-    <p className="mt-1 text-xs uppercase tracking-[0.2em] text-fuchsia-200/80">{actionCostLabel}</p>
-    {spell.sourceType === "magic_item" && spell.fixedCastLevel ? (
-      <p className="mt-4 text-xs uppercase tracking-[0.18em] text-slate-400">
-        Item cast level: {spell.fixedCastLevel}
-      </p>
-    ) : null}
-    {spell.level > 0 && spell.sourceType !== "magic_item" ? (
-      <label className="mt-4 block">
-        <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
-          Slot level
+      <p
+        className="mt-2 text-xs text-slate-300"
+        data-testid="spell-tactical-preview"
+        data-preview-source={previewModel.source}
+      >
+        <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-fuchsia-200/80">
+          Preview
         </span>
-        <select
-          value={selectedSlotLevel ?? spell.level}
-          onChange={(event) => setSelectedSlotLevel(Number.parseInt(event.target.value, 10))}
-          className="mt-2 w-full rounded-2xl border border-white/10 bg-slate-950/70 px-3 py-2 text-sm text-white outline-none transition focus:border-fuchsia-400"
-        >
-          {slotOptions.map((slotLevel) => (
-            <option key={slotLevel} value={slotLevel}>
-              {slotLevel}
-            </option>
-          ))}
-        </select>
-      </label>
-    ) : null}
-    {shouldShowConcentrationControl ? (
-      <div className="mt-4">
-        <ConcentrationSaveControl
-          disabled={loading}
-          manualValue={concentrationManualRoll}
-          mode={concentrationRollMode}
-          onManualValueChange={onConcentrationManualRollChange}
-          onModeChange={onConcentrationRollModeChange}
-        />
-      </div>
-    ) : null}
-    {!isAreaSpell ? (
-      <div className="mt-4">
-        <RangeStatusBadge preview={targetPreview} />
-      </div>
-    ) : null}
-    {error ? (
-      <div className="mt-4 rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
-        {error}
-      </div>
-    ) : null}
-  </>
-);
+        <span className="ml-2 text-slate-200">
+          {previewModel.damagePreview ? `Dano ${previewModel.damagePreview}` : "Sem dano direto"}
+        </span>
+        {showInstanceCount ? (
+          <span className="ml-2 text-fuchsia-100">
+            · {previewModel.effectInstanceCount} instâncias
+            {previewModel.effectInstanceDice ? ` (${previewModel.effectInstanceDice})` : ""}
+          </span>
+        ) : null}
+        {areaSizeLabel ? <span className="ml-2 text-slate-300">· {areaSizeLabel}</span> : null}
+        {rangeLabel && !isAreaSpell ? (
+          <span className="ml-2 text-slate-300">· alcance {rangeLabel}</span>
+        ) : null}
+      </p>
+      <p className="mt-1 text-xs uppercase tracking-[0.2em] text-fuchsia-200/80">{actionCostLabel}</p>
+      {spell.sourceType === "magic_item" && spell.fixedCastLevel ? (
+        <p className="mt-4 text-xs uppercase tracking-[0.18em] text-slate-400">
+          Item cast level: {spell.fixedCastLevel}
+        </p>
+      ) : null}
+      {spell.level > 0 && spell.sourceType !== "magic_item" ? (
+        <label className="mt-4 block">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+            Slot level
+          </span>
+          <select
+            value={selectedSlotLevel ?? spell.level}
+            onChange={(event) => setSelectedSlotLevel(Number.parseInt(event.target.value, 10))}
+            className="mt-2 w-full rounded-2xl border border-white/10 bg-slate-950/70 px-3 py-2 text-sm text-white outline-none transition focus:border-fuchsia-400"
+          >
+            {slotOptions.map((slotLevel) => (
+              <option key={slotLevel} value={slotLevel}>
+                {slotLevel}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : null}
+      {shouldShowConcentrationControl ? (
+        <div className="mt-4">
+          <ConcentrationSaveControl
+            disabled={loading}
+            manualValue={concentrationManualRoll}
+            mode={concentrationRollMode}
+            onManualValueChange={onConcentrationManualRollChange}
+            onModeChange={onConcentrationRollModeChange}
+          />
+        </div>
+      ) : null}
+      {!isAreaSpell ? (
+        <div className="mt-4">
+          <RangeStatusBadge preview={targetPreview} />
+        </div>
+      ) : null}
+      {error ? (
+        <div className="mt-4 rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+          {error}
+        </div>
+      ) : null}
+    </>
+  );
+};

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastDialogHeader.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastDialogHeader.test.tsx
@@ -1,0 +1,193 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { SpellCastDialogHeader } from "./SpellCastDialogHeader";
+import type { SpellPreviewModel } from "./spellPreviewModel";
+import type { CombatSpellOption } from "./types";
+
+vi.mock("../../../features/combat-ui/components/ConcentrationSaveControl", () => ({
+  ConcentrationSaveControl: () => <div>concentration</div>,
+}));
+
+vi.mock("../../../features/combat-ui/components/RangeStatusBadge", () => ({
+  RangeStatusBadge: () => <div>range badge</div>,
+}));
+
+const baseSpell: CombatSpellOption = {
+  id: "spell-1",
+  name: "Magic Missile",
+  canonicalKey: "magic_missile",
+  campaignSpellId: null,
+  level: 1,
+  prepared: true,
+  actionCost: "action",
+  suggestedMode: "direct_damage",
+  damageType: "Force",
+  savingThrow: null,
+  availableSlotLevels: [1, 2, 3],
+};
+
+const baseTargetingPreview = {
+  loading: false,
+  error: null,
+  diagnostics: null,
+  distanceMeters: null,
+  normalRangeMeters: null,
+  maxRangeMeters: null,
+  rangeStatus: "unknown" as const,
+  hasDisadvantage: false,
+  failureReasons: [],
+};
+
+const baseProps = {
+  actionCostLabel: "Action",
+  actorDisplayName: "Mage",
+  anchorCell: null,
+  concentrationManualRoll: "",
+  concentrationRollMode: "system" as const,
+  error: null,
+  isAreaSpell: false,
+  loading: false,
+  onConcentrationManualRollChange: () => undefined,
+  onConcentrationRollModeChange: () => undefined,
+  selectedSlotLevel: 3,
+  setSelectedSlotLevel: () => undefined,
+  shouldShowConcentrationControl: false,
+  slotOptions: [1, 2, 3],
+  spell: baseSpell,
+  spellMode: "direct_damage" as const,
+  targetDisplayName: "Goblin",
+  targetPreview: baseTargetingPreview,
+};
+
+const buildPreviewModel = (overrides: Partial<SpellPreviewModel>): SpellPreviewModel => ({
+  resolutionType: "direct_damage",
+  damagePreview: null,
+  damageType: null,
+  effectInstanceCount: 1,
+  effectInstanceDice: null,
+  targetType: null,
+  selectionType: null,
+  areaShape: null,
+  areaSizeMeters: null,
+  rangeMeters: null,
+  requiresAttackRoll: false,
+  requiresSavingThrow: false,
+  saveAbility: null,
+  source: "resolved",
+  ...overrides,
+});
+
+describe("SpellCastDialogHeader tactical preview", () => {
+  it("renders Magic Missile slot 3 preview from resolved context (5 instâncias, 5d4+5)", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        previewModel={buildPreviewModel({
+          damagePreview: "5d4+5",
+          damageType: "force",
+          effectInstanceCount: 5,
+          effectInstanceDice: "1d4+1",
+          rangeMeters: 36,
+          source: "resolved",
+        })}
+      />,
+    );
+
+    expect(markup).toContain("Dano 5d4+5");
+    expect(markup).toContain("5 instâncias");
+    expect(markup).toContain("(1d4+1)");
+    expect(markup).toContain("alcance 36m");
+    expect(markup).toContain('data-preview-source="resolved"');
+  });
+
+  it("renders Eldritch Blast caster level 5 with 2 feixes from resolved context", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        spell={{ ...baseSpell, name: "Eldritch Blast", canonicalKey: "eldritch_blast", level: 0 }}
+        spellMode="spell_attack"
+        previewModel={buildPreviewModel({
+          resolutionType: "spell_attack",
+          requiresAttackRoll: true,
+          damagePreview: "2d10",
+          damageType: "force",
+          effectInstanceCount: 2,
+          effectInstanceDice: "1d10",
+        })}
+      />,
+    );
+
+    expect(markup).toContain("Dano 2d10");
+    expect(markup).toContain("2 instâncias");
+    expect(markup).toContain("(1d10)");
+    expect(markup).toContain("ataque");
+  });
+
+  it("renders Acid Splash as saving throw without instâncias", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        spell={{ ...baseSpell, name: "Acid Splash", canonicalKey: "acid_splash", level: 0 }}
+        spellMode="saving_throw"
+        previewModel={buildPreviewModel({
+          resolutionType: "saving_throw",
+          requiresSavingThrow: true,
+          saveAbility: "dexterity",
+          damagePreview: "2d6",
+          damageType: "acid",
+          effectInstanceCount: 1,
+        })}
+      />,
+    );
+
+    expect(markup).toContain("saving throw");
+    expect(markup).toContain("save dexterity");
+    expect(markup).toContain("Dano 2d6");
+    expect(markup).not.toContain("instâncias");
+  });
+
+  it("renders Fireball area shape and area size from resolved context", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        isAreaSpell
+        spell={{ ...baseSpell, name: "Fireball", canonicalKey: "fireball", level: 3, areaShape: "sphere", selectionType: "point" }}
+        spellMode="saving_throw"
+        previewModel={buildPreviewModel({
+          resolutionType: "saving_throw",
+          requiresSavingThrow: true,
+          saveAbility: "dexterity",
+          damagePreview: "8d6",
+          damageType: "fire",
+          areaShape: "sphere",
+          areaSizeMeters: 6,
+          rangeMeters: 45,
+        })}
+      />,
+    );
+
+    expect(markup).toContain("sphere");
+    expect(markup).toContain("raio 6m");
+    expect(markup).toContain("Dano 8d6");
+  });
+
+  it("falls back gracefully when resolve-context is unavailable (preview-source=fallback)", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        previewModel={buildPreviewModel({
+          source: "fallback",
+          damagePreview: "1d10",
+          damageType: "Force",
+          effectInstanceCount: 1,
+        })}
+      />,
+    );
+
+    expect(markup).toContain('data-preview-source="fallback"');
+    expect(markup).toContain("Dano 1d10");
+    // multi-instance preview must NOT show in fallback mode — fallback path
+    // would otherwise re-derive scaling we explicitly want to avoid.
+    expect(markup).not.toContain("instâncias");
+  });
+});

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewModel.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewModel.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+import { buildSpellPreviewModel } from "./spellPreviewModel";
+import type { CombatResolvedSpellContext } from "../../../shared/api/combatRepo";
+
+const baseFallbackSpell = {
+  areaShape: null,
+  cantripScaling: null,
+  characterLevel: 5,
+  damageType: "Force",
+  level: 1,
+  rangeMeters: 36,
+  savingThrow: null,
+  selectionType: "creature" as const,
+  targetType: "ranged" as const,
+  upcast: null,
+};
+
+const resolvedContextDefaults: CombatResolvedSpellContext = {
+  spell_name: "Magic Missile",
+  spell_level: 1,
+  resolution_type: "direct_damage",
+  requires_attack_roll: false,
+  requires_saving_throw: false,
+  effect_instance_count: 1,
+  upcast_applied: false,
+  upcast_added_instances: 0,
+};
+
+describe("buildSpellPreviewModel", () => {
+  it("uses Magic Missile slot 3 effect_instance_count = 5 from resolvedContext", () => {
+    const model = buildSpellPreviewModel(
+      {
+        ...resolvedContextDefaults,
+        slot_level: 3,
+        effect_instance_count: 5,
+        effect_instance_dice: "1d4+1",
+        damage_preview: "5d4+5",
+        damage_type: "force",
+        target_type: "ranged",
+        range_meters: 36,
+        upcast_applied: true,
+        upcast_added_instances: 2,
+      },
+      {
+        spell: {
+          ...baseFallbackSpell,
+          upcast: {
+            mode: "additional_effect_instances",
+            dice: "1d4+1",
+            perLevel: 1,
+            baseEffectInstances: 3,
+          },
+        },
+        selectedSlotLevel: 3,
+        spellMode: "direct_damage",
+        spellEffectDice: "3d4+3",
+      },
+    );
+
+    expect(model.source).toBe("resolved");
+    expect(model.effectInstanceCount).toBe(5);
+    expect(model.effectInstanceDice).toBe("1d4+1");
+    expect(model.damagePreview).toBe("5d4+5");
+    expect(model.rangeMeters).toBe(36);
+  });
+
+  it("uses Eldritch Blast caster level 5 effect_instance_count = 2 from resolvedContext", () => {
+    const model = buildSpellPreviewModel(
+      {
+        ...resolvedContextDefaults,
+        spell_name: "Eldritch Blast",
+        spell_level: 0,
+        slot_level: null,
+        resolution_type: "spell_attack",
+        requires_attack_roll: true,
+        effect_instance_count: 2,
+        effect_instance_dice: "1d10",
+        damage_preview: "2d10",
+        damage_type: "force",
+      },
+      {
+        spell: {
+          ...baseFallbackSpell,
+          level: 0,
+          damageType: "Force",
+          targetType: "ranged",
+          cantripScaling: {
+            scalingMode: "character_level",
+            scalingEffectType: "effect_instances",
+            thresholds: [
+              { characterLevel: 1, instances: 1, instanceDamage: { dice: "1d10" } },
+              { characterLevel: 5, instances: 2, instanceDamage: { dice: "1d10" } },
+            ],
+          },
+        },
+        selectedSlotLevel: null,
+        spellMode: "spell_attack",
+        spellEffectDice: "1d10",
+      },
+    );
+
+    expect(model.effectInstanceCount).toBe(2);
+    expect(model.effectInstanceDice).toBe("1d10");
+    expect(model.damagePreview).toBe("2d10");
+    expect(model.requiresAttackRoll).toBe(true);
+    expect(model.resolutionType).toBe("spell_attack");
+  });
+
+  it("uses Acid Splash resolution_type = saving_throw and effect_instance_count = 1", () => {
+    const model = buildSpellPreviewModel(
+      {
+        ...resolvedContextDefaults,
+        spell_name: "Acid Splash",
+        spell_level: 0,
+        slot_level: null,
+        resolution_type: "saving_throw",
+        requires_attack_roll: false,
+        requires_saving_throw: true,
+        save_ability: "dexterity",
+        damage_preview: "2d6",
+        damage_type: "acid",
+        effect_instance_count: 1,
+        effect_instance_dice: null,
+      },
+      {
+        spell: {
+          ...baseFallbackSpell,
+          level: 0,
+          damageType: "Acid",
+          savingThrow: "DEX",
+        },
+        selectedSlotLevel: null,
+        spellMode: "saving_throw",
+        spellEffectDice: "1d6",
+      },
+    );
+
+    expect(model.resolutionType).toBe("saving_throw");
+    expect(model.requiresSavingThrow).toBe(true);
+    expect(model.requiresAttackRoll).toBe(false);
+    expect(model.saveAbility).toBe("dexterity");
+    expect(model.effectInstanceCount).toBe(1);
+    expect(model.effectInstanceDice).toBeNull();
+    expect(model.damagePreview).toBe("2d6");
+  });
+
+  it("does not let fallback override fields present on resolvedContext", () => {
+    const model = buildSpellPreviewModel(
+      {
+        ...resolvedContextDefaults,
+        effect_instance_count: 3,
+        effect_instance_dice: "1d4+1",
+        damage_preview: "3d4+3",
+        damage_type: "force",
+        target_type: "ranged",
+        range_meters: 30,
+        area_shape: null,
+        area_size_meters: null,
+      },
+      {
+        spell: {
+          ...baseFallbackSpell,
+          rangeMeters: 999,
+          damageType: "ShouldNotWin",
+          areaShape: "sphere",
+          upcast: {
+            mode: "additional_effect_instances",
+            dice: "9d9",
+            perLevel: 9,
+            baseEffectInstances: 9,
+          },
+        },
+        selectedSlotLevel: 9,
+        spellMode: "direct_damage",
+        spellEffectDice: "shouldNotWin",
+      },
+    );
+
+    expect(model.effectInstanceCount).toBe(3);
+    expect(model.effectInstanceDice).toBe("1d4+1");
+    expect(model.damagePreview).toBe("3d4+3");
+    expect(model.damageType).toBe("force");
+    expect(model.rangeMeters).toBe(30);
+    expect(model.areaShape).toBeNull();
+  });
+
+  it("does not recalculate scaling when resolvedContext is provided", () => {
+    const model = buildSpellPreviewModel(
+      {
+        ...resolvedContextDefaults,
+        effect_instance_count: 3,
+        effect_instance_dice: "1d4+1",
+      },
+      {
+        spell: {
+          ...baseFallbackSpell,
+          upcast: {
+            mode: "additional_effect_instances",
+            dice: "1d4+1",
+            perLevel: 1,
+            baseEffectInstances: 3,
+          },
+        },
+        selectedSlotLevel: 9,
+        spellMode: "direct_damage",
+        spellEffectDice: "3d4+3",
+      },
+    );
+
+    expect(model.effectInstanceCount).toBe(3);
+  });
+
+  it("falls back to spell metadata when resolvedContext is null", () => {
+    const model = buildSpellPreviewModel(null, {
+      spell: {
+        ...baseFallbackSpell,
+        upcast: {
+          mode: "additional_effect_instances",
+          dice: "1d4+1",
+          perLevel: 1,
+          baseEffectInstances: 3,
+        },
+      },
+      selectedSlotLevel: 3,
+      spellMode: "direct_damage",
+      spellEffectDice: "3d4+3",
+    });
+
+    expect(model.source).toBe("fallback");
+    expect(model.effectInstanceCount).toBe(5);
+    expect(model.effectInstanceDice).toBe("1d4+1");
+    expect(model.damagePreview).toBe("3d4+3");
+    expect(model.rangeMeters).toBe(36);
+    expect(model.resolutionType).toBe("direct_damage");
+  });
+
+  it("exposes area_shape and area_size_meters from resolvedContext when present", () => {
+    const model = buildSpellPreviewModel(
+      {
+        ...resolvedContextDefaults,
+        spell_name: "Fireball",
+        spell_level: 3,
+        slot_level: 3,
+        resolution_type: "saving_throw",
+        requires_saving_throw: true,
+        save_ability: "dexterity",
+        area_shape: "sphere",
+        area_size_meters: 6,
+        range_meters: 45,
+        damage_preview: "8d6",
+        damage_type: "fire",
+      },
+      {
+        spell: {
+          ...baseFallbackSpell,
+          level: 3,
+          damageType: "Fire",
+          areaShape: "sphere",
+          rangeMeters: 45,
+          savingThrow: "DEX",
+          selectionType: "point",
+        },
+        selectedSlotLevel: 3,
+        spellMode: "saving_throw",
+        spellEffectDice: "8d6",
+      },
+    );
+
+    expect(model.areaShape).toBe("sphere");
+    expect(model.areaSizeMeters).toBe(6);
+    expect(model.rangeMeters).toBe(45);
+    expect(model.saveAbility).toBe("dexterity");
+  });
+});

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewModel.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewModel.ts
@@ -1,0 +1,104 @@
+import type { CombatResolvedSpellContext, CombatSpellMode } from "../../../shared/api/combatRepo";
+import type { CombatSpellOption } from "./types";
+import { resolveEffectInstanceContext } from "./InstanceTargetSelector";
+
+export type SpellPreviewModel = {
+  resolutionType: CombatSpellMode | null;
+  damagePreview: string | null;
+  damageType: string | null;
+  effectInstanceCount: number;
+  effectInstanceDice: string | null;
+  targetType: string | null;
+  selectionType: string | null;
+  areaShape: "sphere" | "cone" | "line" | "cube" | "cylinder" | null;
+  areaSizeMeters: number | null;
+  rangeMeters: number | null;
+  requiresAttackRoll: boolean;
+  requiresSavingThrow: boolean;
+  saveAbility: string | null;
+  source: "resolved" | "fallback";
+};
+
+type FallbackInputs = {
+  spell: Pick<
+    CombatSpellOption,
+    | "areaShape"
+    | "cantripScaling"
+    | "characterLevel"
+    | "damageType"
+    | "level"
+    | "rangeMeters"
+    | "savingThrow"
+    | "selectionType"
+    | "targetType"
+    | "upcast"
+  >;
+  selectedSlotLevel: number | null;
+  spellMode: CombatSpellMode | null;
+  spellEffectDice: string | null;
+};
+
+const normalizeNumber = (value: number | null | undefined): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null;
+
+const normalizeString = (value: string | null | undefined): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+/**
+ * Build a preview model that the tactical/spell preview UI consumes.
+ *
+ * resolvedContext is the source of truth: when present, every mechanical
+ * field is taken from it. fallback only fills gaps (or the whole model
+ * when the backend resolve-context call is unavailable). Fallback never
+ * recalculates upcast/cantripScaling on top of resolvedContext — instance
+ * count derivation is gated on resolvedContext being absent.
+ */
+export const buildSpellPreviewModel = (
+  resolvedContext: CombatResolvedSpellContext | null,
+  fallback: FallbackInputs,
+): SpellPreviewModel => {
+  if (resolvedContext) {
+    return {
+      resolutionType: resolvedContext.resolution_type ?? null,
+      damagePreview: normalizeString(resolvedContext.damage_preview),
+      damageType: normalizeString(resolvedContext.damage_type),
+      effectInstanceCount: Math.max(1, resolvedContext.effect_instance_count ?? 1),
+      effectInstanceDice: normalizeString(resolvedContext.effect_instance_dice),
+      targetType: normalizeString(resolvedContext.target_type),
+      selectionType: normalizeString(resolvedContext.selection_type),
+      areaShape: resolvedContext.area_shape ?? null,
+      areaSizeMeters: normalizeNumber(resolvedContext.area_size_meters ?? null),
+      rangeMeters: normalizeNumber(resolvedContext.range_meters ?? null),
+      requiresAttackRoll: Boolean(resolvedContext.requires_attack_roll),
+      requiresSavingThrow: Boolean(resolvedContext.requires_saving_throw),
+      saveAbility: normalizeString(resolvedContext.save_ability),
+      source: "resolved",
+    };
+  }
+
+  const fallbackInstance = resolveEffectInstanceContext(
+    fallback.spell,
+    fallback.selectedSlotLevel,
+  );
+  return {
+    resolutionType: fallback.spellMode ?? null,
+    damagePreview: normalizeString(fallback.spellEffectDice),
+    damageType: normalizeString(fallback.spell.damageType ?? null),
+    effectInstanceCount: Math.max(1, fallbackInstance.instanceCount),
+    effectInstanceDice: normalizeString(fallbackInstance.instanceDice),
+    targetType: normalizeString(fallback.spell.targetType ?? null),
+    selectionType: normalizeString(fallback.spell.selectionType ?? null),
+    areaShape: fallback.spell.areaShape ?? null,
+    areaSizeMeters: null,
+    rangeMeters: normalizeNumber(fallback.spell.rangeMeters ?? null),
+    requiresAttackRoll: fallback.spellMode === "spell_attack",
+    requiresSavingThrow: fallback.spellMode === "saving_throw",
+    saveAbility: normalizeString(fallback.spell.savingThrow ?? null),
+    source: "fallback",
+  };
+};

--- a/apps/control-web/src/shared/api/combatRepo.ts
+++ b/apps/control-web/src/shared/api/combatRepo.ts
@@ -262,9 +262,13 @@ export type CombatResolvedSpellContext = {
   target_type?: string | null;
   selection_type?: string | null;
   area_shape?: "sphere" | "cone" | "line" | "cube" | "cylinder" | null;
+  area_size_meters?: number | null;
+  range_meters?: number | null;
   resolution_type: CombatSpellMode;
   requires_attack_roll: boolean;
   requires_saving_throw: boolean;
+  save_ability?: string | null;
+  damage_type?: string | null;
   damage_preview?: string | null;
   effect_instance_count: number;
   effect_instance_dice?: string | null;


### PR DESCRIPTION
## Summary

Makes the tactical/spell preview in the cast dialog consume the backend's pre-cast `resolve-context` as the source of truth for mechanical metadata, instead of inferring behavior from raw catalog fields. Builds on PR #81.

## Backend

- Extends `CombatResolvedSpellContext` with mechanical fields already derivable from the existing spell context — **no new endpoint, no scaling logic moved**:
  - `range_meters`
  - `area_size_meters` (derived from `radius_meters` / `length_meters` / `side_meters` per `area_shape`)
  - `save_ability`
  - `damage_type`
- Reuses `_resolve_player_spell_context(...)` and `_build_resolved_spell_context_response(...)` — does not consume slots, does not clear pending state, does not mutate combat state.

## Frontend

- New `SpellPreviewModel` type + `buildSpellPreviewModel(resolvedContext, fallback)` helper:
  - `resolvedContext` is fully authoritative when present.
  - Fallback only kicks in when the backend context is unavailable; it never re-derives scaling on top of a resolved context (gated via the same `resolveEffectInstanceContext` already used for the instance UI).
  - Each model exposes `source: "resolved" | "fallback"` so the UI can document which path it took.
- `PlayerSpellCastDialog` builds the preview model and passes it to `SpellCastDialogHeader`.
- `SpellCastDialogHeader` now shows a tactical preview row driven entirely by the model:
  - resolution type (ataque / saving throw / dano direto / cura / efeito)
  - damage preview
  - instance count + per-instance dice when `effectInstanceCount > 1`
  - area shape + area size (raio/lado/comprimento)
  - range
  - save ability
- The map/dialog never recalculates upcast or cantrip scaling on top of a resolved context.

## Behaviour matches the spec

- **Magic Missile slot 3**: header shows 5 instâncias (1d4+1) + dano 5d4+5, taken straight from `effect_instance_count = 5` and `damage_preview = 5d4+5`.
- **Eldritch Blast caster level 5**: header shows 2 instâncias (1d10) + dano 2d10 + ataque, from `effect_instance_count = 2`.
- **Acid Splash**: header shows saving throw + save dexterity + dano 2d6, no multi-instance UI (`effect_instance_count = 1`).
- **Fireball**: area shape `sphere`, raio 6m, alcance 45m — area_size_meters derived from `radius_meters`.
- **Resolve-context failure**: dialog renders fallback preview with `data-preview-source=\"fallback\"`, no broken screen.

## Non-goals (untouched)

- No changes to spell scaling rules, catalog, upcast/cantripScaling logic.
- No changes to actual cast resolution / damage / save flows.
- No LoS/LoE, cover, or per-instance target validation in the map.
- No drag-and-drop, no UI redesign of the map.

## Validation

```bash
apps/control-server/.venv/bin/python -m pytest apps/control-server/tests/test_spell_context_resolve_endpoint.py
# 8 passed

cd apps/control-web && npm test -- --run \
  src/pages/PlayerBoardPage/player-combat-debug/playerSpellCastDialog.test.tsx \
  src/pages/PlayerBoardPage/player-combat-debug/instanceTargetSelector.test.tsx \
  src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx \
  src/pages/PlayerBoardPage/player-combat-debug/spellPreviewModel.test.ts \
  src/pages/PlayerBoardPage/player-combat-debug/spellCastDialogHeader.test.tsx
# 35 passed

cd apps/control-web && npm test -- --run
# 329 passed (full suite)

cd apps/control-web && npm run build
# OK
```

Note: `tests/test_spell_targeting_semantics.py::test_required_spell_context_modes` has 7 pre-existing failures on `wip/limiar-lab` (unrelated to this change — confirmed by stashing the diff and running on the base branch).

## Test plan

- [ ] Open PlayerSpellCastDialog with Magic Missile, switch slot 1 → 3 → verify preview row updates to `5 instâncias` + `Dano 5d4+5`.
- [ ] Open Eldritch Blast at caster level 5 → verify `2 instâncias` + `ataque`.
- [ ] Open Acid Splash → verify `saving throw` + `save dexterity`, no multi-instance row.
- [ ] Open Fireball → verify `sphere`, `raio 6m`, `alcance 45m`.
- [ ] Force resolve-context to fail → verify dialog still renders with `data-preview-source=\"fallback\"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)