### PR TITLE
feat(combat): render tactical map highlights from SpellMapPreviewModel

### DIFF
--- a/apps/control-web/src/features/combat-ui/map/CombatMapFrame.tsx
+++ b/apps/control-web/src/features/combat-ui/map/CombatMapFrame.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { combatRepo, type CombatActiveAreaEffect } from "../../../shared/api/combatRepo";
+import type { SpellMapHighlight } from "../../../pages/PlayerBoardPage/player-combat-debug/spellMapPreviewHighlights";
 
 export type CombatMapSelectionMode = "none" | "select-token" | "select-cell";
 
@@ -85,6 +86,8 @@ export type CombatMapCellSelection = {
   combatantId: string | null;
 };
 
+export type { SpellMapHighlight };
+
 type Props = {
   sessionId: string;
   title: string;
@@ -96,6 +99,7 @@ type Props = {
   activeAreaEffects?: CombatMapFrameActiveAreaEffect[];
   selectedCell?: Coordinate | null;
   selectedTargetRefId?: string | null;
+  spellHighlights?: SpellMapHighlight[];
   className?: string;
   frameClassName?: string;
   onCellSelected?: (selection: CombatMapCellSelection) => void;
@@ -156,6 +160,7 @@ export const CombatMapFrame = ({
   activeAreaEffects = [],
   selectedCell = null,
   selectedTargetRefId = null,
+  spellHighlights = [],
   className,
   frameClassName,
   onCellSelected,
@@ -190,6 +195,7 @@ export const CombatMapFrame = ({
           selectedCell,
           selectedTargetRefId,
           combatPhase,
+          spellHighlights,
         },
       },
       "*",
@@ -358,6 +364,7 @@ export const CombatMapFrame = ({
     selectedTargetRefId,
     selectionMode,
     sessionId,
+    spellHighlights,
   ]);
 
   return (

--- a/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
+++ b/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AbilityName,
   AdvantageMode,
@@ -28,7 +28,7 @@ import type {
 } from "../../../pages/PlayerBoardPage/playerBoard.types";
 import { usePlayerCombatMode } from "./usePlayerCombatMode";
 import { PlayerTurnPanel } from "./PlayerTurnPanel";
-import { CombatMapFrame, toCombatMapFrameAreaEffects } from "../map/CombatMapFrame";
+import { CombatMapFrame, toCombatMapFrameAreaEffects, type SpellMapHighlight } from "../map/CombatMapFrame";
 import {
   formatMovementMeters,
   getMovementPreviewReasonLabel,
@@ -171,6 +171,10 @@ export const PlayerCombatModeShell = ({
   const myParticipant = combat.myParticipant;
   const selectedSpellIsArea = requiresAreaTargetingSelection(selectedSpell?.selectionType, selectedSpell?.areaShape);
   const selectedSpellNeedsTarget = spellRequiresExternalTarget(selectedSpell?.selectionType, selectedSpell?.areaShape);
+  const [spellMapHighlights, setSpellMapHighlights] = useState<SpellMapHighlight[]>([]);
+  const handleMapPreviewChange = useCallback((highlights: SpellMapHighlight[]) => {
+    setSpellMapHighlights(highlights);
+  }, []);
   const [movementMode, setMovementMode] = useState(false);
   const [movementSelectedCell, setMovementSelectedCell] = useState<{ x: number; y: number } | null>(null);
   const [movementSubmitting, setMovementSubmitting] = useState(false);
@@ -320,6 +324,7 @@ export const PlayerCombatModeShell = ({
           activeAreaEffects={toCombatMapFrameAreaEffects(combat.state?.active_area_effects)}
           selectedCell={movementEnabled ? movementSelectedCell : null}
           selectedTargetRefId={movementEnabled ? null : (targetId || null)}
+          spellHighlights={spellMapHighlights}
           frameClassName="h-[420px] w-full border-0 bg-slate-950 md:h-[560px] xl:h-[720px]"
           onCellSelected={(selection) => {
             if (!movementEnabled) {
@@ -495,6 +500,7 @@ export const PlayerCombatModeShell = ({
           actor={combat.currentParticipant}
           actorParticipantId={combat.currentParticipant.id}
           onClose={closeSpellDialog}
+          onMapPreviewChange={handleMapPreviewChange}
           onResolved={(result) => {
             setLastSpellResult(result);
             if (result.inventory_refresh_required) {

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/AreaTargetingGrid.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/AreaTargetingGrid.tsx
@@ -5,6 +5,7 @@ import {
 } from "../../../features/combat-ui/map/CombatMapFrame";
 import type { CombatMapPreviewState, CombatParticipant } from "../../../shared/api/combatRepo";
 import { formatAffectedTargetNames, resolveAffectedTargetNames, type GridCell } from "./areaTargetingUi";
+import type { SpellMapHighlight } from "../../../features/combat-ui/map/CombatMapFrame";
 
 type Props = {
   actor: CombatParticipant;
@@ -23,6 +24,7 @@ type Props = {
   previewReason: string | null;
   previewValid: boolean;
   sessionId: string;
+  spellHighlights?: SpellMapHighlight[];
   onCellSelected: (cell: GridCell) => void;
 };
 
@@ -43,6 +45,7 @@ export const AreaTargetingGrid = ({
   previewReason,
   previewValid,
   sessionId,
+  spellHighlights,
   onCellSelected,
 }: Props) => {
   const affectedTargetNames = useMemo(
@@ -102,6 +105,7 @@ export const AreaTargetingGrid = ({
         previewCells={previewCells}
         activeAreaEffects={toCombatMapFrameAreaEffects(mapState.active_area_effects)}
         selectedCell={anchorCell}
+        spellHighlights={spellHighlights ?? []}
         className="rounded-2xl border border-white/10 bg-slate-950/70 p-3"
         frameClassName="h-[420px] w-full border-0 bg-slate-950"
         onCellSelected={({ cell }) => onCellSelected(cell)}

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { AbilityName } from "../../../entities/roll/rollResolution.types";
 import { participantHasActiveConcentration } from "../../../features/combat-ui/combatUi.helpers";
 import type {
@@ -35,6 +35,8 @@ import { parseBonus } from "./spellCastHelpers";
 import { SpellCastDialogHeader } from "./SpellCastDialogHeader";
 import { SpellCastResultPanel } from "./SpellCastResultPanel";
 import { buildSpellMapPreviewModel } from "./spellMapPreviewModel";
+import { buildSpellMapPreviewHighlights } from "./spellMapPreviewHighlights";
+import type { SpellMapHighlight } from "../../../features/combat-ui/map/CombatMapFrame";
 import { buildSpellPreviewModel } from "./spellPreviewModel";
 import type { CombatSpellOption } from "./types";
 import { useAreaTargeting } from "./useAreaTargeting";
@@ -45,6 +47,7 @@ type Props = {
   actorParticipantId: string;
   canRevealHiddenTargets?: boolean;
   onClose: () => void;
+  onMapPreviewChange?: (highlights: SpellMapHighlight[]) => void;
   onResolved?: (result: CombatSpellResult) => void | Promise<void>;
   participants: CombatParticipant[];
   sessionId: string;
@@ -150,6 +153,7 @@ export const PlayerSpellCastDialog = ({
   actorParticipantId,
   canRevealHiddenTargets = false,
   onClose,
+  onMapPreviewChange,
   onResolved,
   participants,
   sessionId,
@@ -303,6 +307,22 @@ export const PlayerSpellCastDialog = ({
     existingAreaPreviewResult: preview,
     targetPositions,
   });
+
+  // Derive map highlights from the preview model. Deps are the primitive fields
+  // that drive content changes, plus effectInstanceTargets (state) for per-instance changes.
+  const highlights = useMemo(
+    () => buildSpellMapPreviewHighlights(mapPreviewModel, target?.ref_id ?? null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [mapPreviewModel.status, mapPreviewModel.reason, mapPreviewModel.areaShape, effectInstanceTargets, target?.ref_id],
+  );
+
+  useEffect(() => {
+    onMapPreviewChange?.(highlights);
+  }, [highlights, onMapPreviewChange]);
+
+  useEffect(() => {
+    return () => onMapPreviewChange?.([]);
+  }, [onMapPreviewChange]);
 
   useEffect(() => {
     setSelectedSlotLevel(spell.fixedCastLevel ?? (spell.level > 0 ? spell.level : null));
@@ -559,6 +579,7 @@ export const PlayerSpellCastDialog = ({
             previewReason={preview?.reason ?? null}
             previewValid={Boolean(preview?.is_valid)}
             sessionId={sessionId}
+            spellHighlights={highlights}
             onCellSelected={(cell) => {
               setAnchorCell(cell);
               setTargetingMode("confirming");

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewHighlights.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewHighlights.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import { buildSpellMapPreviewHighlights } from "./spellMapPreviewHighlights";
+import type { SpellMapPreviewModel } from "./spellMapPreviewModel";
+
+const baseSingleTarget: SpellMapPreviewModel = {
+  status: "valid",
+  reason: null,
+  rangeMeters: 36,
+  areaShape: null,
+  areaSizeMeters: null,
+  effectInstanceCount: 1,
+};
+
+const baseMultiInstance: SpellMapPreviewModel = {
+  status: "valid",
+  rangeMeters: 36,
+  areaShape: null,
+  areaSizeMeters: null,
+  effectInstanceCount: 3,
+  instanceStatuses: [
+    { instanceIndex: 1, targetRefId: "goblin-a", status: "valid" },
+    { instanceIndex: 2, targetRefId: "goblin-a", status: "valid" },
+    { instanceIndex: 3, targetRefId: "orc-b", status: "valid" },
+  ],
+};
+
+describe("buildSpellMapPreviewHighlights – single-target", () => {
+  it("emite highlight target valid quando alvo está no alcance", () => {
+    const highlights = buildSpellMapPreviewHighlights(baseSingleTarget, "enemy-1");
+
+    expect(highlights).toHaveLength(1);
+    expect(highlights[0]).toMatchObject({
+      kind: "target",
+      status: "valid",
+      targetRefId: "enemy-1",
+    });
+  });
+
+  it("emite highlight target invalid com reason quando fora de alcance", () => {
+    const model: SpellMapPreviewModel = {
+      ...baseSingleTarget,
+      status: "invalid",
+      reason: "out_of_range",
+    };
+
+    const highlights = buildSpellMapPreviewHighlights(model, "enemy-1");
+
+    expect(highlights).toHaveLength(1);
+    expect(highlights[0]).toMatchObject({
+      kind: "target",
+      status: "invalid",
+      targetRefId: "enemy-1",
+      reason: "out_of_range",
+    });
+  });
+
+  it("retorna lista vazia quando não há targetRefId", () => {
+    const highlights = buildSpellMapPreviewHighlights(baseSingleTarget, null);
+    expect(highlights).toHaveLength(0);
+  });
+
+  it("retorna lista vazia quando status é unknown sem targetRefId", () => {
+    const model: SpellMapPreviewModel = { ...baseSingleTarget, status: "unknown" };
+    const highlights = buildSpellMapPreviewHighlights(model, undefined);
+    expect(highlights).toHaveLength(0);
+  });
+
+  it("emite highlight unknown quando status é unknown com targetRefId", () => {
+    const model: SpellMapPreviewModel = { ...baseSingleTarget, status: "unknown" };
+    const highlights = buildSpellMapPreviewHighlights(model, "enemy-1");
+
+    expect(highlights).toHaveLength(1);
+    expect(highlights[0]).toMatchObject({ kind: "target", status: "unknown", targetRefId: "enemy-1" });
+  });
+});
+
+describe("buildSpellMapPreviewHighlights – multi-instância", () => {
+  it("Magic Missile 5 instâncias todas válidas gera 5 highlights instance-target", () => {
+    const model: SpellMapPreviewModel = {
+      ...baseSingleTarget,
+      status: "valid",
+      effectInstanceCount: 5,
+      instanceStatuses: [
+        { instanceIndex: 1, targetRefId: "goblin-a", status: "valid" },
+        { instanceIndex: 2, targetRefId: "goblin-a", status: "valid" },
+        { instanceIndex: 3, targetRefId: "orc-b", status: "valid" },
+        { instanceIndex: 4, targetRefId: "orc-b", status: "valid" },
+        { instanceIndex: 5, targetRefId: "goblin-a", status: "valid" },
+      ],
+    };
+
+    const highlights = buildSpellMapPreviewHighlights(model);
+
+    expect(highlights).toHaveLength(5);
+    expect(highlights.every((h) => h.kind === "instance-target")).toBe(true);
+    expect(highlights.every((h) => h.status === "valid")).toBe(true);
+  });
+
+  it("Eldritch Blast feixe 1 válido, feixe 2 inválido gera highlights com status diferentes", () => {
+    const model: SpellMapPreviewModel = {
+      ...baseSingleTarget,
+      status: "partial",
+      effectInstanceCount: 2,
+      instanceStatuses: [
+        { instanceIndex: 1, targetRefId: "goblin-a", status: "valid" },
+        { instanceIndex: 2, targetRefId: "orc-b", status: "invalid", reason: "out_of_range" },
+      ],
+    };
+
+    const highlights = buildSpellMapPreviewHighlights(model);
+
+    expect(highlights).toHaveLength(2);
+    expect(highlights[0]).toMatchObject({ kind: "instance-target", status: "valid", targetRefId: "goblin-a", instanceIndex: 1 });
+    expect(highlights[1]).toMatchObject({ kind: "instance-target", status: "invalid", targetRefId: "orc-b", instanceIndex: 2, reason: "out_of_range" });
+  });
+
+  it("instâncias sem targetRefId são omitidas da lista", () => {
+    const model: SpellMapPreviewModel = {
+      ...baseSingleTarget,
+      status: "unknown",
+      effectInstanceCount: 3,
+      instanceStatuses: [
+        { instanceIndex: 1, targetRefId: null, status: "unknown" },
+        { instanceIndex: 2, targetRefId: null, status: "unknown" },
+        { instanceIndex: 3, targetRefId: null, status: "unknown" },
+      ],
+    };
+
+    const highlights = buildSpellMapPreviewHighlights(model);
+    expect(highlights).toHaveLength(0);
+  });
+
+  it("mistura de instâncias atribuídas e não-atribuídas emite apenas as com targetRefId", () => {
+    const model: SpellMapPreviewModel = {
+      ...baseSingleTarget,
+      status: "partial",
+      effectInstanceCount: 3,
+      instanceStatuses: [
+        { instanceIndex: 1, targetRefId: "goblin-a", status: "valid" },
+        { instanceIndex: 2, targetRefId: null, status: "unknown" },
+        { instanceIndex: 3, targetRefId: "orc-b", status: "invalid", reason: "out_of_range" },
+      ],
+    };
+
+    const highlights = buildSpellMapPreviewHighlights(model);
+
+    expect(highlights).toHaveLength(2);
+    expect(highlights.map((h) => h.targetRefId)).toEqual(["goblin-a", "orc-b"]);
+  });
+
+  it("preserva instanceIndex em cada highlight", () => {
+    const highlights = buildSpellMapPreviewHighlights(baseMultiInstance);
+
+    expect(highlights[0].instanceIndex).toBe(1);
+    expect(highlights[1].instanceIndex).toBe(2);
+    expect(highlights[2].instanceIndex).toBe(3);
+  });
+});
+
+describe("buildSpellMapPreviewHighlights – área", () => {
+  it("Fireball com preview válido emite area-cell valid", () => {
+    const model: SpellMapPreviewModel = {
+      status: "valid",
+      rangeMeters: 36,
+      areaShape: "sphere",
+      areaSizeMeters: 6,
+      effectInstanceCount: 1,
+      affectedTargetCount: 3,
+    };
+
+    const highlights = buildSpellMapPreviewHighlights(model);
+
+    expect(highlights).toHaveLength(1);
+    expect(highlights[0]).toMatchObject({ kind: "area-cell", status: "valid" });
+  });
+
+  it("área inválida emite area-cell invalid", () => {
+    const model: SpellMapPreviewModel = {
+      status: "invalid",
+      reason: "out_of_range",
+      rangeMeters: 36,
+      areaShape: "sphere",
+      areaSizeMeters: 6,
+      effectInstanceCount: 1,
+    };
+
+    const highlights = buildSpellMapPreviewHighlights(model);
+
+    expect(highlights).toHaveLength(1);
+    expect(highlights[0]).toMatchObject({ kind: "area-cell", status: "invalid" });
+  });
+
+  it("área unknown (sem preview result) retorna lista vazia", () => {
+    const model: SpellMapPreviewModel = {
+      status: "unknown",
+      rangeMeters: 36,
+      areaShape: "sphere",
+      areaSizeMeters: 6,
+      effectInstanceCount: 1,
+    };
+
+    const highlights = buildSpellMapPreviewHighlights(model);
+    expect(highlights).toHaveLength(0);
+  });
+
+  it("área ignora selectedTargetRefId passado (área não usa target)", () => {
+    const model: SpellMapPreviewModel = {
+      status: "valid",
+      rangeMeters: 36,
+      areaShape: "cone",
+      areaSizeMeters: 9,
+      effectInstanceCount: 1,
+    };
+
+    const highlights = buildSpellMapPreviewHighlights(model, "enemy-1");
+
+    expect(highlights).toHaveLength(1);
+    expect(highlights[0].kind).toBe("area-cell");
+    expect(highlights[0].targetRefId).toBeUndefined();
+  });
+});

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewHighlights.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewHighlights.ts
@@ -1,0 +1,51 @@
+import type { SpellMapPreviewModel } from "./spellMapPreviewModel";
+
+export type SpellMapHighlightKind = "target" | "instance-target" | "area-cell";
+
+export type SpellMapHighlightStatus = "valid" | "invalid" | "partial" | "unknown";
+
+export type SpellMapHighlight = {
+  kind: SpellMapHighlightKind;
+  status: SpellMapHighlightStatus;
+  targetRefId?: string | null;
+  instanceIndex?: number | null;
+  reason?: string | null;
+};
+
+export function buildSpellMapPreviewHighlights(
+  model: SpellMapPreviewModel,
+  selectedTargetRefId?: string | null,
+): SpellMapHighlight[] {
+  // Area spells: emit a single area-cell status signal (no coordinates — cells live in previewCells)
+  if (model.areaShape) {
+    if (model.status === "unknown") return [];
+    return [{ kind: "area-cell", status: model.status }];
+  }
+
+  // Multi-instance spells (Magic Missile, Eldritch Blast, etc.)
+  if (model.instanceStatuses && model.instanceStatuses.length > 0) {
+    const highlights: SpellMapHighlight[] = [];
+    for (const inst of model.instanceStatuses) {
+      if (!inst.targetRefId) continue;
+      highlights.push({
+        kind: "instance-target",
+        status: inst.status,
+        targetRefId: inst.targetRefId,
+        instanceIndex: inst.instanceIndex,
+        reason: inst.reason ?? null,
+      });
+    }
+    return highlights;
+  }
+
+  // Single-target
+  if (!selectedTargetRefId) return [];
+  return [
+    {
+      kind: "target",
+      status: model.status,
+      targetRefId: selectedTargetRefId,
+      reason: model.reason ?? null,
+    },
+  ];
+}

--- a/apps/map-web/src/features/battle-map/battle-map-pixi-runtime.ts
+++ b/apps/map-web/src/features/battle-map/battle-map-pixi-runtime.ts
@@ -10,7 +10,7 @@ import { getEdgeBrushPreset, getObstacleBrushPreset } from "./obstacle-presets";
 import { HttpClient } from "../../services/http-client";
 import { postEmbeddedCellHovered, postEmbeddedCellSelected, postEmbeddedTokenSelected } from "../../services/embedded-map-bridge";
 import { buildFailureExplanation } from "../targeting/diagnostics-to-explanation";
-import { drawCellFills, drawEdgeObstacles, drawEditHandles, drawGrid, drawHUD, drawPreviewHint, drawReachAndAoe, drawTacticalTokenOverlay, drawTokenLayer } from "./canvas-renderers";
+import { drawCellFills, drawEdgeObstacles, drawEditHandles, drawGrid, drawHUD, drawPreviewHint, drawReachAndAoe, drawSpellHighlightRings, drawTacticalTokenOverlay, drawTokenLayer } from "./canvas-renderers";
 import { canControlToken, canInteractWithToken, computePath, getSelectionBlockedMessage, pixelToGrid } from "./utils";
 
 type Snapshot = {
@@ -29,6 +29,7 @@ export type BattleMapPixiRefs = {
   cellFillsGfxRef: MutableRefObject<Graphics | null>;
   edgeObstaclesGfxRef: MutableRefObject<Graphics | null>;
   tokenContainerRef: MutableRefObject<Container | null>;
+  spellHighlightContainerRef: MutableRefObject<Container | null>;
   tacticalOverlayContainerRef: MutableRefObject<Container | null>;
   editHandlesContainerRef: MutableRefObject<Container | null>;
   hudContainerRef: MutableRefObject<Container | null>;
@@ -46,10 +47,12 @@ export function attachPixiLayers(app: Application, refs: BattleMapPixiRefs): voi
   const gridGfx = new Graphics();
   const edgeObstaclesGfx = new Graphics();
   const tokenContainer = new Container();
+  const spellHighlightContainer = new Container();
   const tacticalOverlayContainer = new Container();
   const editHandlesContainer = new Container();
   const hudContainer = new Container();
 
+  spellHighlightContainer.eventMode = "none";
   tacticalOverlayContainer.eventMode = "none";
   editHandlesContainer.eventMode = "passive";
   hudContainer.eventMode = "none";
@@ -59,6 +62,7 @@ export function attachPixiLayers(app: Application, refs: BattleMapPixiRefs): voi
   app.stage.addChild(gridGfx);
   app.stage.addChild(edgeObstaclesGfx);
   app.stage.addChild(tokenContainer);
+  app.stage.addChild(spellHighlightContainer);
   app.stage.addChild(tacticalOverlayContainer);
   app.stage.addChild(editHandlesContainer);
   app.stage.addChild(hudContainer);
@@ -68,6 +72,7 @@ export function attachPixiLayers(app: Application, refs: BattleMapPixiRefs): voi
   refs.gridGfxRef.current = gridGfx;
   refs.edgeObstaclesGfxRef.current = edgeObstaclesGfx;
   refs.tokenContainerRef.current = tokenContainer;
+  refs.spellHighlightContainerRef.current = spellHighlightContainer;
   refs.tacticalOverlayContainerRef.current = tacticalOverlayContainer;
   refs.editHandlesContainerRef.current = editHandlesContainer;
   refs.hudContainerRef.current = hudContainer;
@@ -228,6 +233,7 @@ export function buildDrawFunction(
     }
     if (refs.edgeObstaclesGfxRef.current) drawEdgeObstacles(refs.edgeObstaclesGfxRef.current, calibration, gridWidth, gridHeight, screen.width, screen.height, encounter.edgeObstacles ?? []);
     if (refs.tokenContainerRef.current) drawTokenLayer(refs.tokenContainerRef.current, encounter.tokens, calibration, gridWidth, gridHeight, screen.width, screen.height, selectedTokenId, uiState.embeddedSelectedTargetRefId ?? null, encounter.combatState.activeCombatantId);
+    if (refs.spellHighlightContainerRef.current) drawSpellHighlightRings(refs.spellHighlightContainerRef.current, encounter.tokens, calibration, gridWidth, gridHeight, screen.width, screen.height, uiState.embeddedSpellHighlights);
     if (refs.tacticalOverlayContainerRef.current) drawTacticalTokenOverlay(refs.tacticalOverlayContainerRef.current, encounter.tokens, calibration, gridWidth, gridHeight, screen.width, screen.height, uiState.tacticalPreview);
     if (refs.editHandlesContainerRef.current) {
       drawEditHandles(refs.editHandlesContainerRef.current, calibration, screen.width, screen.height, uiState.isGridEditMode, Boolean(uiState.pendingGridCalibrationActionId), (mode, clientX, clientY) => {
@@ -251,6 +257,7 @@ export function resetPixiRefs(refs: BattleMapPixiRefs): void {
   refs.cellFillsGfxRef.current = null;
   refs.edgeObstaclesGfxRef.current = null;
   refs.tokenContainerRef.current = null;
+  refs.spellHighlightContainerRef.current = null;
   refs.tacticalOverlayContainerRef.current = null;
   refs.editHandlesContainerRef.current = null;
   refs.hudContainerRef.current = null;

--- a/apps/map-web/src/features/battle-map/battle-map-store.ts
+++ b/apps/map-web/src/features/battle-map/battle-map-store.ts
@@ -17,6 +17,7 @@ import type {
   BattleMapUIState,
   EmbeddedCombatPhase,
   EmbeddedSelectionMode,
+  SpellMapHighlight,
   TokenMovementRejectionState
 } from "./battle-map-store.types";
 
@@ -26,7 +27,8 @@ export type {
   TokenMovementRejectionState,
   BattleMapUIState,
   EmbeddedCombatPhase,
-  EmbeddedSelectionMode
+  EmbeddedSelectionMode,
+  SpellMapHighlight
 } from "./battle-map-store.types";
 
 type Listener = () => void;
@@ -39,6 +41,7 @@ class BattleMapStore {
     embeddedSelectionMode: "none",
     embeddedPreview: [],
     embeddedActiveAreaEffects: [],
+    embeddedSpellHighlights: [],
     isGridEditMode: false,
     isObstaclePaintMode: false,
     obstacleBrushRadius: 1,
@@ -108,6 +111,7 @@ class BattleMapStore {
     selectedCell?: Coordinate | null;
     selectedTargetRefId?: string | null;
     combatPhase?: EmbeddedCombatPhase | null;
+    spellHighlights?: SpellMapHighlight[];
   }): void {
     this.set({
       embeddedSelectionMode: ctx.selectionMode,
@@ -115,14 +119,15 @@ class BattleMapStore {
       embeddedActiveAreaEffects: ctx.activeAreaEffects ?? [],
       embeddedSelectedCell: ctx.selectedCell ?? undefined,
       embeddedSelectedTargetRefId: ctx.selectedTargetRefId ?? undefined,
-      embeddedCombatPhase: ctx.combatPhase ?? undefined
+      embeddedCombatPhase: ctx.combatPhase ?? undefined,
+      embeddedSpellHighlights: ctx.spellHighlights ?? [],
     });
   }
 
   setEmbeddedSelectedCell(c?: Coordinate | null): void { this.set({ embeddedSelectedCell: c ?? undefined }); }
 
   clearEmbeddedInteraction(): void {
-    this.set({ embeddedSelectionMode: "none", embeddedPreview: [], embeddedActiveAreaEffects: [], embeddedSelectedCell: undefined, embeddedSelectedTargetRefId: undefined, embeddedCombatPhase: undefined });
+    this.set({ embeddedSelectionMode: "none", embeddedPreview: [], embeddedActiveAreaEffects: [], embeddedSelectedCell: undefined, embeddedSelectedTargetRefId: undefined, embeddedCombatPhase: undefined, embeddedSpellHighlights: [] });
   }
 
   setTokenMovementRejection(rejection: TokenMovementRejectionState): void {

--- a/apps/map-web/src/features/battle-map/battle-map-store.types.ts
+++ b/apps/map-web/src/features/battle-map/battle-map-store.types.ts
@@ -37,6 +37,16 @@ export interface TokenMovementRejectionState {
   exceededBy?: number;
 }
 
+export type SpellMapHighlightKind = "target" | "instance-target" | "area-cell";
+export type SpellMapHighlightStatus = "valid" | "invalid" | "partial" | "unknown";
+export type SpellMapHighlight = {
+  kind: SpellMapHighlightKind;
+  status: SpellMapHighlightStatus;
+  targetRefId?: string | null;
+  instanceIndex?: number | null;
+  reason?: string | null;
+};
+
 export interface BattleMapUIState {
   selectedTokenId?: string;
   placingTokenId: string | null;
@@ -48,6 +58,7 @@ export interface BattleMapUIState {
   embeddedSelectedCell?: Coordinate;
   embeddedSelectedTargetRefId?: string;
   embeddedCombatPhase?: EmbeddedCombatPhase;
+  embeddedSpellHighlights: SpellMapHighlight[];
   message?: string;
   isGridEditMode: boolean;
   isObstaclePaintMode: boolean;

--- a/apps/map-web/src/features/battle-map/canvas-renderers-tactical.ts
+++ b/apps/map-web/src/features/battle-map/canvas-renderers-tactical.ts
@@ -9,7 +9,7 @@ import type {
   GridCalibration,
   Token
 } from "@limiarmap/shared-contracts";
-import type { TacticalPreviewState } from "./battle-map-store";
+import type { TacticalPreviewState, SpellMapHighlight, SpellMapHighlightStatus } from "./battle-map-store";
 import type { FailureExplanation } from "../targeting/diagnostics-to-explanation";
 import { C } from "./constants";
 import { cellRect } from "./utils";
@@ -79,6 +79,69 @@ export function drawTacticalTokenOverlay(
   ring.x = cx;
   ring.y = cy;
   container.addChild(ring);
+}
+
+const STATUS_PRIORITY: Record<SpellMapHighlightStatus, number> = {
+  invalid: 3,
+  partial: 2,
+  valid: 1,
+  unknown: 0,
+};
+
+const resolveRingStyle = (status: SpellMapHighlightStatus): { color: number; alpha: number } | null => {
+  switch (status) {
+    case "valid":
+      return { color: C.previewTargetValid, alpha: C.previewTargetValidAlpha };
+    case "invalid":
+      return { color: C.previewTargetInvalid, alpha: C.previewTargetInvalidAlpha };
+    case "partial":
+      return { color: C.spellHighlightPartial, alpha: C.spellHighlightPartialAlpha };
+    case "unknown":
+      return null;
+  }
+};
+
+export function drawSpellHighlightRings(
+  container: Container,
+  tokens: Token[],
+  cal: GridCalibration,
+  gridW: number,
+  gridH: number,
+  canvasW: number,
+  canvasH: number,
+  highlights: SpellMapHighlight[],
+): void {
+  container.removeChildren();
+
+  // Group highlights by targetRefId, resolving worst status per token
+  const statusByRef = new Map<string, SpellMapHighlightStatus>();
+  for (const h of highlights) {
+    if (!h.targetRefId) continue;
+    const current = statusByRef.get(h.targetRefId);
+    if (!current || STATUS_PRIORITY[h.status] > STATUS_PRIORITY[current]) {
+      statusByRef.set(h.targetRefId, h.status);
+    }
+  }
+
+  for (const [refId, status] of statusByRef) {
+    const style = resolveRingStyle(status);
+    if (!style) continue;
+
+    const token = tokens.find((t) => t.combatantId === refId);
+    if (!token) continue;
+
+    const { x, y, w, h } = cellRect(token.position.x, token.position.y, cal, gridW, gridH, canvasW, canvasH);
+    const cx = x + w / 2;
+    const cy = y + h / 2;
+    const radius = Math.min(w, h) * 0.36;
+
+    const ring = new Graphics();
+    // Slightly larger + thinner than tactical overlay ring to distinguish preview from selection
+    ring.circle(0, 0, radius + 7).stroke({ width: 2, color: style.color, alpha: style.alpha });
+    ring.x = cx;
+    ring.y = cy;
+    container.addChild(ring);
+  }
 }
 
 const SEVERITY_STYLES = {

--- a/apps/map-web/src/features/battle-map/canvas-renderers.ts
+++ b/apps/map-web/src/features/battle-map/canvas-renderers.ts
@@ -1,3 +1,3 @@
 export { drawGrid, drawCellFills, drawEdgeObstacles } from "./canvas-renderers-grid";
 export { drawTokenLayer, drawEditHandles, drawHUD } from "./canvas-renderers-tokens";
-export { drawReachAndAoe, drawTacticalTokenOverlay, drawPreviewHint } from "./canvas-renderers-tactical";
+export { drawReachAndAoe, drawTacticalTokenOverlay, drawPreviewHint, drawSpellHighlightRings } from "./canvas-renderers-tactical";

--- a/apps/map-web/src/features/battle-map/constants.ts
+++ b/apps/map-web/src/features/battle-map/constants.ts
@@ -71,7 +71,13 @@ export const C = {
   previewTargetValid: 0x22dd88,
   previewTargetValidAlpha: 0.9,
   previewTargetInvalid: 0xff4444,
-  previewTargetInvalidAlpha: 0.85
+  previewTargetInvalidAlpha: 0.85,
+
+  // Spell preview highlights — partial (orange) / unknown (slate, skipped by renderers)
+  spellHighlightPartial: 0xf97316,
+  spellHighlightPartialAlpha: 0.75,
+  spellHighlightUnknown: 0x475569,
+  spellHighlightUnknownAlpha: 0.25
 };
 
 export const COVER_RANK: Record<Obstacle["cover"], number> = {

--- a/apps/map-web/src/features/battle-map/use-battle-map-pixi.ts
+++ b/apps/map-web/src/features/battle-map/use-battle-map-pixi.ts
@@ -56,6 +56,7 @@ export function useBattleMapPixi(params: {
     cellFillsGfxRef: useRef<Graphics | null>(null),
     edgeObstaclesGfxRef: useRef<Graphics | null>(null),
     tokenContainerRef: useRef<Container | null>(null),
+    spellHighlightContainerRef: useRef<Container | null>(null),
     tacticalOverlayContainerRef: useRef<Container | null>(null),
     editHandlesContainerRef: useRef<Container | null>(null),
     hudContainerRef: useRef<Container | null>(null)

--- a/apps/map-web/src/services/embedded-map-bridge.ts
+++ b/apps/map-web/src/services/embedded-map-bridge.ts
@@ -3,7 +3,8 @@ import { reconnectAs } from "./centrifugo-client";
 import {
   battleMapStore,
   type EmbeddedCombatPhase,
-  type EmbeddedSelectionMode
+  type EmbeddedSelectionMode,
+  type SpellMapHighlight
 } from "../features/battle-map/battle-map-store";
 
 type MapActorType = "player" | "gm";
@@ -22,6 +23,7 @@ type EmbeddedMapContextMessage = {
     selectedCell?: Coordinate | null;
     selectedTargetRefId?: string | null;
     combatPhase?: EmbeddedCombatPhase | null;
+    spellHighlights?: SpellMapHighlight[];
   };
 };
 
@@ -91,6 +93,7 @@ export const isEmbeddedMapContextMessage = (
     selectedCell?: unknown;
     selectedTargetRefId?: unknown;
     combatPhase?: unknown;
+    spellHighlights?: unknown;
   };
 
   const actorValid =
@@ -161,6 +164,7 @@ export function applyEmbeddedMapContext(message: EmbeddedMapContextMessage["payl
     selectedCell: message.selectedCell ?? null,
     selectedTargetRefId: message.selectedTargetRefId ?? null,
     combatPhase: message.combatPhase ?? null,
+    spellHighlights: message.spellHighlights ?? [],
   });
 }
 


### PR DESCRIPTION
## Summary

- Adiciona highlights visuais no mapa tático baseados no `SpellMapPreviewModel` — visual-only, sem alterar cast, backend ou validação autoritativa
- Novo helper puro `buildSpellMapPreviewHighlights` traduz o modelo em `SpellMapHighlight[]`, coberto por 14 testes (single-target, Magic Missile, Eldritch Blast, Fireball)
- Pipeline completo: `PlayerSpellCastDialog` → `PlayerCombatModeShell` → `CombatMapFrame` → postMessage → `embedded-map-bridge` → `battleMapStore` → `drawSpellHighlightRings` (PixiJS)
- Nova camada `spellHighlightContainer` inserida entre tokens e `tacticalOverlayContainer` (prioridade visual correta — highlights de preview não conflitam com seleção ativa)

## Comportamento por tipo de magia

| Tipo | Comportamento |
|---|---|
| Single-target (Acid Splash) | Anel verde/vermelho no alvo selecionado |
| Multi-instância (Magic Missile, Eldritch Blast) | Anel por token; múltiplas instâncias no mesmo alvo agregam pelo pior status |
| Área (Fireball) | Sinal `area-cell` propagado (coloração de células de área adiada para issue futura) |
| Unknown | Nenhum anel renderizado |

## Status → cor

- `valid` → verde (`previewTargetValid`, reutilizado)
- `invalid` → vermelho (`previewTargetInvalid`, reutilizado)
- `partial` → laranja (nova constante `spellHighlightPartial`)
- `unknown` → skipped

## Arquivos alterados

**control-web** — helper, dialog, grid, shell, map frame  
**map-web** — bridge, store types/state, constants, canvas-renderers-tactical, pixi runtime

## Test plan

- [ ] `npm run --workspace=apps/control-web test` — 376 testes passando
- [ ] `npm run --workspace=apps/control-web build` — build limpo
- [ ] `npm run --workspace=apps/map-web build` — build limpo
- [ ] Acid Splash com alvo no alcance → anel verde no mapa
- [ ] Acid Splash com alvo fora do alcance → anel vermelho
- [ ] Magic Missile slot 3 com instâncias distribuídas → anéis por alvo
- [ ] Fechar o spell dialog → highlights somem do mapa
- [ ] Trocar magia → highlights atualizam

🤖 Generated with [Claude Code](https://claude.com/claude-code)