### PR TITLE
feat(spell-preview): implement caching and deduplication for spell

### DIFF
--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
@@ -47,10 +47,13 @@ import { useResolvedSpellContext } from "./useResolvedSpellContext";
 import {
   buildInstanceSpatialValidations,
   buildSingleTargetSpatialValidations,
+  buildSpellPreviewFanoutKey,
   buildUniqueTargetRefIds,
   createPreviewRequestGate,
-  fetchPreviewValidationsByTargetRefId,
+  fetchPreviewValidationsWithCache,
+  type PreviewFanoutCacheEntry,
 } from "./spellPreviewSpatialValidations";
+import type { SpellTargetSpatialValidation } from "./spellMapPreviewModel";
 
 type Props = {
   actor: CombatParticipant;
@@ -194,6 +197,8 @@ export const PlayerSpellCastDialog = ({
   const [targetingMode, setTargetingMode] = useState(createInitialTargetingMode(spell.areaShape, spell.selectionType));
   const handledSaveResolutionKeyRef = useRef<string | null>(null);
   const multiPreviewRequestGateRef = useRef(createPreviewRequestGate());
+  const previewCacheRef = useRef(new Map<string, PreviewFanoutCacheEntry>());
+  const previewInFlightRef = useRef(new Map<string, Promise<SpellTargetSpatialValidation>>());
 
   const {
     anchorCell,
@@ -370,6 +375,8 @@ export const PlayerSpellCastDialog = ({
     setEffectInstanceTargets([]);
     setError(null);
     handledSaveResolutionKeyRef.current = null;
+    previewCacheRef.current.clear();
+    previewInFlightRef.current.clear();
   }, [spell.fixedCastLevel, spell.id, spell.level, spell.areaShape, spell.selectionType]);
 
   useEffect(() => {
@@ -400,8 +407,18 @@ export const PlayerSpellCastDialog = ({
       return;
     }
 
-    void fetchPreviewValidationsByTargetRefId({
+    void fetchPreviewValidationsWithCache({
       actorRefId: actor.ref_id,
+      buildKey: (targetRefId) =>
+        buildSpellPreviewFanoutKey({
+          sessionId,
+          actorRefId: actor.ref_id,
+          spellId: spell.canonicalKey,
+          slotLevel: selectedSlotLevel,
+          targetRefId,
+        }),
+      cache: previewCacheRef.current,
+      inFlight: previewInFlightRef.current,
       previewAction: combatRepo.previewAction,
       rangeMeters: previewRangeMeters,
       sessionId,
@@ -419,7 +436,9 @@ export const PlayerSpellCastDialog = ({
     isMultiInstanceSpell,
     normalizedEffectInstanceTargetsSignature,
     previewRangeMeters,
+    selectedSlotLevel,
     sessionId,
+    spell.canonicalKey,
   ]);
 
   useEffect(() => {

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewSpatialValidations.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewSpatialValidations.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildInstanceSpatialValidations,
   buildSingleTargetSpatialValidations,
+  buildSpellPreviewFanoutKey,
   buildTargetSpatialValidationFromPreview,
   buildUniqueTargetRefIds,
   createPreviewRequestGate,
   fetchPreviewValidationsByTargetRefId,
+  fetchPreviewValidationsWithCache,
 } from "./spellPreviewSpatialValidations";
 
 describe("spellPreviewSpatialValidations", () => {
@@ -193,5 +195,116 @@ describe("spellPreviewSpatialValidations", () => {
 
     expect(gate.isCurrent(first)).toBe(false);
     expect(gate.isCurrent(second)).toBe(true);
+  });
+});
+
+const okResponse = {
+  diagnostics: { isValid: true, failureReasons: [], checks: { in_range: true }, metadata: {} },
+  effectiveReachCells: 24,
+  aoeCells: [],
+};
+
+const baseArgs = {
+  actorRefId: "player:1",
+  rangeMeters: 36,
+  sessionId: "session-1",
+};
+
+describe("fetchPreviewValidationsWithCache", () => {
+  it("cache hit: segunda chamada com mesma chave não dispara request real", async () => {
+    const cache = new Map();
+    const inFlight = new Map();
+    const previewAction = vi.fn().mockResolvedValue(okResponse);
+    const buildKey = (t: string) => `ctx|${t}`;
+
+    await fetchPreviewValidationsWithCache({ ...baseArgs, buildKey, cache, inFlight, previewAction, targetRefIds: ["enemy-1"] });
+    expect(previewAction).toHaveBeenCalledTimes(1);
+
+    await fetchPreviewValidationsWithCache({ ...baseArgs, buildKey, cache, inFlight, previewAction, targetRefIds: ["enemy-1"] });
+    expect(previewAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("in-flight dedupe: duas chamadas simultâneas com mesma chave disparam apenas uma request", async () => {
+    const cache = new Map();
+    const inFlight = new Map();
+    let resolveRequest!: (v: typeof okResponse) => void;
+    const requestPromise = new Promise<typeof okResponse>((res) => { resolveRequest = res; });
+    const previewAction = vi.fn(() => requestPromise);
+    const buildKey = (t: string) => `ctx|${t}`;
+
+    const p1 = fetchPreviewValidationsWithCache({ ...baseArgs, buildKey, cache, inFlight, previewAction, targetRefIds: ["enemy-1"] });
+    const p2 = fetchPreviewValidationsWithCache({ ...baseArgs, buildKey, cache, inFlight, previewAction, targetRefIds: ["enemy-1"] });
+
+    resolveRequest(okResponse);
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(previewAction).toHaveBeenCalledTimes(1);
+    expect(r1.get("enemy-1")?.inRange).toBe(true);
+    expect(r2.get("enemy-1")?.inRange).toBe(true);
+  });
+
+  it("cache invalidation por slot: chave diferente re-fetcha", async () => {
+    const cache = new Map();
+    const inFlight = new Map();
+    const previewAction = vi.fn().mockResolvedValue(okResponse);
+
+    await fetchPreviewValidationsWithCache({ ...baseArgs, buildKey: (t) => `slot1|${t}`, cache, inFlight, previewAction, targetRefIds: ["enemy-1"] });
+    await fetchPreviewValidationsWithCache({ ...baseArgs, buildKey: (t) => `slot2|${t}`, cache, inFlight, previewAction, targetRefIds: ["enemy-1"] });
+
+    expect(previewAction).toHaveBeenCalledTimes(2);
+  });
+
+  it("cache invalidation por spell: chave diferente re-fetcha", async () => {
+    const cache = new Map();
+    const inFlight = new Map();
+    const previewAction = vi.fn().mockResolvedValue(okResponse);
+
+    await fetchPreviewValidationsWithCache({ ...baseArgs, buildKey: (t) => `spellA|${t}`, cache, inFlight, previewAction, targetRefIds: ["enemy-1"] });
+    await fetchPreviewValidationsWithCache({ ...baseArgs, buildKey: (t) => `spellB|${t}`, cache, inFlight, previewAction, targetRefIds: ["enemy-1"] });
+
+    expect(previewAction).toHaveBeenCalledTimes(2);
+  });
+
+  it("falha não envenena cache: segunda chamada com mesma chave após falha dispara nova request", async () => {
+    const cache = new Map();
+    const inFlight = new Map();
+    const buildKey = (t: string) => `ctx|${t}`;
+    const previewAction = vi.fn()
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockResolvedValueOnce(okResponse);
+
+    const first = await fetchPreviewValidationsWithCache({ ...baseArgs, buildKey, cache, inFlight, previewAction, targetRefIds: ["enemy-1"] });
+    expect(first.get("enemy-1")?.unavailableReason).toBe("missing_map_data");
+    expect(cache.size).toBe(0);
+
+    const second = await fetchPreviewValidationsWithCache({ ...baseArgs, buildKey, cache, inFlight, previewAction, targetRefIds: ["enemy-1"] });
+    expect(second.get("enemy-1")?.unavailableReason).toBeNull();
+    expect(previewAction).toHaveBeenCalledTimes(2);
+  });
+
+  it("falha parcial não afeta outros targets: target ok vai ao cache, target falho não", async () => {
+    const cache = new Map();
+    const inFlight = new Map();
+    const buildKey = (t: string) => `ctx|${t}`;
+    const previewAction = vi.fn(async (_: string, payload: { target_ref_id: string }) => {
+      if (payload.target_ref_id === "enemy-2") throw new Error("fail");
+      return okResponse;
+    });
+
+    const result = await fetchPreviewValidationsWithCache({ ...baseArgs, buildKey, cache, inFlight, previewAction, targetRefIds: ["enemy-1", "enemy-2"] });
+
+    expect(result.get("enemy-1")?.unavailableReason).toBeNull();
+    expect(result.get("enemy-2")?.unavailableReason).toBe("missing_map_data");
+    expect(cache.has("ctx|enemy-1")).toBe(true);
+    expect(cache.has("ctx|enemy-2")).toBe(false);
+  });
+
+  it("buildSpellPreviewFanoutKey gera chaves distintas para slot, spell e target diferentes", () => {
+    const base = { sessionId: "s1", actorRefId: "p1", spellId: "magic_missile", slotLevel: 2, targetRefId: "goblin-a" };
+
+    expect(buildSpellPreviewFanoutKey({ ...base, slotLevel: 3 })).not.toBe(buildSpellPreviewFanoutKey(base));
+    expect(buildSpellPreviewFanoutKey({ ...base, spellId: "eldritch_blast" })).not.toBe(buildSpellPreviewFanoutKey(base));
+    expect(buildSpellPreviewFanoutKey({ ...base, targetRefId: "orc-b" })).not.toBe(buildSpellPreviewFanoutKey(base));
+    expect(buildSpellPreviewFanoutKey({ ...base, slotLevel: null })).not.toBe(buildSpellPreviewFanoutKey(base));
   });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewSpatialValidations.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewSpatialValidations.ts
@@ -199,6 +199,97 @@ export const fetchPreviewValidationsByTargetRefId = async ({
   return new Map(entries);
 };
 
+export type PreviewFanoutCacheEntry = {
+  result: SpellTargetSpatialValidation;
+};
+
+export function buildSpellPreviewFanoutKey(input: {
+  sessionId: string;
+  actorRefId: string;
+  spellId: string;
+  slotLevel: number | null;
+  targetRefId: string;
+}): string {
+  return [
+    input.sessionId,
+    input.actorRefId,
+    input.spellId,
+    input.slotLevel ?? "none",
+    input.targetRefId,
+  ].join("|");
+}
+
+export async function fetchPreviewValidationsWithCache({
+  actorRefId,
+  buildKey,
+  cache,
+  inFlight,
+  previewAction,
+  rangeMeters,
+  sessionId,
+  targetRefIds,
+}: {
+  actorRefId: string;
+  buildKey: (targetRefId: string) => string;
+  cache: Map<string, PreviewFanoutCacheEntry>;
+  inFlight: Map<string, Promise<SpellTargetSpatialValidation>>;
+  previewAction: PreviewAction;
+  rangeMeters: number | null;
+  sessionId: string;
+  targetRefIds: readonly string[];
+}): Promise<Map<string, SpellTargetSpatialValidation>> {
+  const reachCells = rangeMeters != null ? metersToCells(rangeMeters) : 1;
+  const uniqueTargetRefIds = buildUniqueTargetRefIds(targetRefIds);
+
+  const entries = await Promise.all(
+    uniqueTargetRefIds.map(async (targetRefId): Promise<readonly [string, SpellTargetSpatialValidation]> => {
+      const key = buildKey(targetRefId);
+
+      const cached = cache.get(key);
+      if (cached) {
+        return [targetRefId, cached.result] as const;
+      }
+
+      const existing = inFlight.get(key);
+      if (existing) {
+        return [targetRefId, await existing] as const;
+      }
+
+      const promise: Promise<SpellTargetSpatialValidation> = previewAction(sessionId, {
+        source_ref_id: actorRefId,
+        target_ref_id: targetRefId,
+        action_type: "spell",
+        reach_cells: reachCells,
+      })
+        .then((response) => {
+          const result = buildTargetSpatialValidationFromPreview({
+            diagnostics: response.diagnostics ?? null,
+            targetRefId,
+          });
+          if (!result.unavailableReason) {
+            cache.set(key, { result });
+          }
+          return result;
+        })
+        .catch(() =>
+          buildTargetSpatialValidationFromPreview({
+            diagnostics: null,
+            targetRefId,
+            unavailableReason: "missing_map_data",
+          }),
+        )
+        .finally(() => {
+          inFlight.delete(key);
+        });
+
+      inFlight.set(key, promise);
+      return [targetRefId, await promise] as const;
+    }),
+  );
+
+  return new Map(entries);
+}
+
 export const createPreviewRequestGate = () => {
   let currentRequestId = 0;
 


### PR DESCRIPTION
## Summary

Hardens the multi-instance spell preview fanout used for LoS/LoE visual previews.

This adds cache, in-flight request deduplication, stable preview keys, and localized failure handling for multi-instance spells that call `/combat/preview` per unique target.

## Changes

- Added `PreviewFanoutCacheEntry`
- Added `buildSpellPreviewFanoutKey(...)`
- Added `fetchPreviewValidationsWithCache(...)`
- Fanout now follows:
  - cache hit
  - in-flight dedupe
  - new request
- Failed requests are not cached
- Partial failures degrade only affected targets to `unknown`
- `PlayerSpellCastDialog` now keeps:
  - `previewCacheRef`
  - `previewInFlightRef`
- Cache is cleared when the selected spell changes
- Fanout now uses the cached/deduped fetch path
- Added `selectedSlotLevel` and `spell.canonicalKey` to relevant dependencies

## Validation

- Full test suite: 410/410 passing
- Frontend build passed
- Added 7 focused tests covering:
  - cache hits
  - in-flight dedupe
  - slot invalidation
  - spell invalidation
  - failed requests not poisoning cache
  - localized partial failure
  - stable fanout key distinctions