### PR TITLE
feat(spatial-validation): implement area spatial validation logic

### DIFF
--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
@@ -50,10 +50,11 @@ import {
   buildSpellPreviewFanoutKey,
   buildUniqueTargetRefIds,
   createPreviewRequestGate,
+  fetchAreaSpatialValidation,
   fetchPreviewValidationsWithCache,
   type PreviewFanoutCacheEntry,
 } from "./spellPreviewSpatialValidations";
-import type { SpellTargetSpatialValidation } from "./spellMapPreviewModel";
+import type { SpellAreaSpatialValidation, SpellTargetSpatialValidation } from "./spellMapPreviewModel";
 
 type Props = {
   actor: CombatParticipant;
@@ -197,8 +198,10 @@ export const PlayerSpellCastDialog = ({
   const [targetingMode, setTargetingMode] = useState(createInitialTargetingMode(spell.areaShape, spell.selectionType));
   const handledSaveResolutionKeyRef = useRef<string | null>(null);
   const multiPreviewRequestGateRef = useRef(createPreviewRequestGate());
+  const areaPreviewRequestGateRef = useRef(createPreviewRequestGate());
   const previewCacheRef = useRef(new Map<string, PreviewFanoutCacheEntry>());
   const previewInFlightRef = useRef(new Map<string, Promise<SpellTargetSpatialValidation>>());
+  const [areaSpatialValidation, setAreaSpatialValidation] = useState<SpellAreaSpatialValidation | null>(null);
 
   const {
     anchorCell,
@@ -336,7 +339,7 @@ export const PlayerSpellCastDialog = ({
     spatialValidations: {
       targets: singleTargetSpatialValidations,
       instances: multiInstanceSpatialValidations,
-      area: null,
+      area: isAreaSpell ? areaSpatialValidation : null,
     },
   });
 
@@ -375,6 +378,8 @@ export const PlayerSpellCastDialog = ({
     setEffectInstanceTargets([]);
     setError(null);
     handledSaveResolutionKeyRef.current = null;
+    setAreaSpatialValidation(null);
+    areaPreviewRequestGateRef.current.issue();
     previewCacheRef.current.clear();
     previewInFlightRef.current.clear();
   }, [spell.fixedCastLevel, spell.id, spell.level, spell.areaShape, spell.selectionType]);
@@ -440,6 +445,26 @@ export const PlayerSpellCastDialog = ({
     sessionId,
     spell.canonicalKey,
   ]);
+
+  useEffect(() => {
+    if (!isAreaSpell || !anchorCell) {
+      setAreaSpatialValidation(null);
+      return;
+    }
+
+    const requestId = areaPreviewRequestGateRef.current.issue();
+
+    void fetchAreaSpatialValidation({
+      actorRefId: actor.ref_id,
+      anchorCell,
+      previewAction: combatRepo.previewAction,
+      rangeMeters: previewRangeMeters,
+      sessionId,
+    }).then((validation) => {
+      if (!areaPreviewRequestGateRef.current.isCurrent(requestId)) return;
+      setAreaSpatialValidation(validation);
+    });
+  }, [actor.ref_id, anchorCell, isAreaSpell, previewRangeMeters, sessionId]);
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewModel.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewModel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { METERS_PER_CELL } from "../../../features/combat-ui/hooks/useTargetingPreview";
 import { buildSpellMapPreviewModel } from "./spellMapPreviewModel";
+import type { SpellAreaSpatialValidation } from "./spellMapPreviewModel";
 import type { SpellPreviewModel } from "./spellPreviewModel";
 
 // Base SpellPreviewModel representing a resolved backend context
@@ -610,5 +611,102 @@ describe("buildSpellMapPreviewModel – Chebyshev distance boundary", () => {
       targetPositions: [{ refId: "e1", cell: { x: 21, y: 21 } }],
     });
     expect(model.status).toBe("invalid");
+  });
+});
+
+const baseAreaModel: SpellPreviewModel = {
+  resolutionType: "direct_damage",
+  damagePreview: "8d6",
+  damageType: "fire",
+  effectInstanceCount: 1,
+  effectInstanceDice: null,
+  targetType: "area",
+  selectionType: "point",
+  areaShape: "sphere",
+  areaSizeMeters: 6,
+  rangeMeters: 36,
+  requiresAttackRoll: false,
+  requiresSavingThrow: true,
+  saveAbility: "dexterity",
+  source: "resolved",
+};
+
+const ANCHOR = { x: 10, y: 0 };
+
+const areaPreviewResult = {
+  is_valid: true,
+  reason: null,
+  shape: "sphere" as const,
+  affected_cells: [{ x: 9, y: 0 }, { x: 10, y: 0 }, { x: 11, y: 0 }],
+  affected_target_ref_ids: ["goblin-a", "goblin-b"],
+  affected_token_ids: ["t1", "t2"],
+};
+
+describe("buildSpellMapPreviewModel – área com spatialValidations.area", () => {
+  const buildAreaModel = (area: SpellAreaSpatialValidation | null) =>
+    buildSpellMapPreviewModel({
+      spellPreviewModel: baseAreaModel,
+      existingAreaPreviewResult: areaPreviewResult,
+      spatialValidations: { area },
+    });
+
+  it("área totalmente válida retorna valid", () => {
+    const model = buildAreaModel({ originCell: ANCHOR, inRange: true, hasLineOfSight: null, hasLineOfEffect: null, unavailableReason: null });
+    expect(model.status).toBe("valid");
+    expect(model.reason).toBeNull();
+  });
+
+  it("inRange false retorna invalid / out_of_range", () => {
+    const model = buildAreaModel({ originCell: ANCHOR, inRange: false, hasLineOfSight: null, hasLineOfEffect: null, unavailableReason: null });
+    expect(model.status).toBe("invalid");
+    expect(model.reason).toBe("out_of_range");
+  });
+
+  it("hasLineOfSight false retorna invalid / blocked_line_of_sight", () => {
+    const model = buildAreaModel({ originCell: ANCHOR, inRange: true, hasLineOfSight: false, hasLineOfEffect: null, unavailableReason: null });
+    expect(model.status).toBe("invalid");
+    expect(model.reason).toBe("blocked_line_of_sight");
+  });
+
+  it("hasLineOfEffect false retorna invalid / blocked_line_of_effect", () => {
+    const model = buildAreaModel({ originCell: ANCHOR, inRange: true, hasLineOfSight: null, hasLineOfEffect: false, unavailableReason: null });
+    expect(model.status).toBe("invalid");
+    expect(model.reason).toBe("blocked_line_of_effect");
+  });
+
+  it("unavailableReason missing_map_data retorna unknown", () => {
+    const model = buildAreaModel({ originCell: ANCHOR, inRange: null, hasLineOfSight: null, hasLineOfEffect: null, unavailableReason: "missing_map_data" });
+    expect(model.status).toBe("unknown");
+  });
+
+  it("inRange null sem unavailableReason retorna unknown / missing_position", () => {
+    const model = buildAreaModel({ originCell: ANCHOR, inRange: null, hasLineOfSight: null, hasLineOfEffect: null, unavailableReason: null });
+    expect(model.status).toBe("unknown");
+    expect(model.reason).toBe("missing_position");
+  });
+
+  it("spatialValidations.area tem prioridade sobre existingAreaPreviewResult para status", () => {
+    const invalidArea: SpellAreaSpatialValidation = { originCell: ANCHOR, inRange: false, hasLineOfSight: null, hasLineOfEffect: null, unavailableReason: null };
+    const model = buildSpellMapPreviewModel({
+      spellPreviewModel: baseAreaModel,
+      existingAreaPreviewResult: { ...areaPreviewResult, is_valid: true },
+      spatialValidations: { area: invalidArea },
+    });
+    expect(model.status).toBe("invalid");
+    expect(model.reason).toBe("out_of_range");
+  });
+
+  it("existingAreaPreviewResult ainda fornece affectedTargetCount quando spatialValidations.area existe", () => {
+    const model = buildAreaModel({ originCell: ANCHOR, inRange: true, hasLineOfSight: null, hasLineOfEffect: null, unavailableReason: null });
+    expect(model.affectedTargetCount).toBe(2);
+  });
+
+  it("sem spatialValidations.area, existingAreaPreviewResult é usado como fallback", () => {
+    const model = buildSpellMapPreviewModel({
+      spellPreviewModel: baseAreaModel,
+      existingAreaPreviewResult: areaPreviewResult,
+    });
+    expect(model.status).toBe("valid");
+    expect(model.affectedTargetCount).toBe(2);
   });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewSpatialValidations.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewSpatialValidations.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildAreaSpatialValidationFromPreview,
   buildInstanceSpatialValidations,
   buildSingleTargetSpatialValidations,
   buildSpellPreviewFanoutKey,
   buildTargetSpatialValidationFromPreview,
   buildUniqueTargetRefIds,
   createPreviewRequestGate,
+  fetchAreaSpatialValidation,
   fetchPreviewValidationsByTargetRefId,
   fetchPreviewValidationsWithCache,
 } from "./spellPreviewSpatialValidations";
@@ -306,5 +308,74 @@ describe("fetchPreviewValidationsWithCache", () => {
     expect(buildSpellPreviewFanoutKey({ ...base, spellId: "eldritch_blast" })).not.toBe(buildSpellPreviewFanoutKey(base));
     expect(buildSpellPreviewFanoutKey({ ...base, targetRefId: "orc-b" })).not.toBe(buildSpellPreviewFanoutKey(base));
     expect(buildSpellPreviewFanoutKey({ ...base, slotLevel: null })).not.toBe(buildSpellPreviewFanoutKey(base));
+  });
+});
+
+const ANCHOR_CELL = { x: 10, y: 5 };
+
+describe("area spatial validation", () => {
+  it("buildAreaSpatialValidationFromPreview: no_line_of_sight → hasLineOfSight false", () => {
+    const result = buildAreaSpatialValidationFromPreview({
+      diagnostics: { isValid: false, failureReasons: ["no_line_of_sight"], checks: { in_range: true }, metadata: {} },
+      originCell: ANCHOR_CELL,
+    });
+    expect(result).toMatchObject({ originCell: ANCHOR_CELL, inRange: true, hasLineOfSight: false, hasLineOfEffect: null, unavailableReason: null });
+  });
+
+  it("buildAreaSpatialValidationFromPreview: no_line_of_effect → hasLineOfEffect false, hasLineOfSight true", () => {
+    const result = buildAreaSpatialValidationFromPreview({
+      diagnostics: { isValid: false, failureReasons: ["no_line_of_effect"], checks: { in_range: true }, metadata: {} },
+      originCell: ANCHOR_CELL,
+    });
+    expect(result).toMatchObject({ hasLineOfSight: true, hasLineOfEffect: false });
+  });
+
+  it("buildAreaSpatialValidationFromPreview: full_cover → hasLineOfEffect false (não LoS)", () => {
+    const result = buildAreaSpatialValidationFromPreview({
+      diagnostics: { isValid: false, failureReasons: ["full_cover"], checks: { in_range: true }, metadata: {} },
+      originCell: ANCHOR_CELL,
+    });
+    expect(result).toMatchObject({ hasLineOfSight: true, hasLineOfEffect: false });
+  });
+
+  it("buildAreaSpatialValidationFromPreview: unavailableReason passa através e originCell preservado", () => {
+    const result = buildAreaSpatialValidationFromPreview({
+      diagnostics: null,
+      originCell: ANCHOR_CELL,
+      unavailableReason: "missing_map_data",
+    });
+    expect(result).toMatchObject({ originCell: ANCHOR_CELL, unavailableReason: "missing_map_data", inRange: null });
+  });
+
+  it("fetchAreaSpatialValidation: preview válido retorna inRange true com originCell correto", async () => {
+    const previewAction = vi.fn().mockResolvedValue({
+      diagnostics: { isValid: true, failureReasons: [], checks: { in_range: true }, metadata: {} },
+      effectiveReachCells: 24,
+      aoeCells: [],
+    });
+    const result = await fetchAreaSpatialValidation({
+      actorRefId: "player:1",
+      anchorCell: ANCHOR_CELL,
+      previewAction,
+      rangeMeters: 36,
+      sessionId: "session-1",
+    });
+    expect(result).toMatchObject({ originCell: ANCHOR_CELL, inRange: true, unavailableReason: null });
+  });
+
+  it("fetchAreaSpatialValidation: LoS bloqueada → hasLineOfSight false", async () => {
+    const previewAction = vi.fn().mockResolvedValue({
+      diagnostics: { isValid: false, failureReasons: ["no_line_of_sight"], checks: { in_range: true }, metadata: {} },
+      effectiveReachCells: 24,
+      aoeCells: [],
+    });
+    const result = await fetchAreaSpatialValidation({ actorRefId: "player:1", anchorCell: ANCHOR_CELL, previewAction, rangeMeters: 36, sessionId: "s1" });
+    expect(result).toMatchObject({ hasLineOfSight: false, unavailableReason: null });
+  });
+
+  it("fetchAreaSpatialValidation: erro de network → unavailableReason missing_map_data, sem throw", async () => {
+    const previewAction = vi.fn().mockRejectedValue(new Error("network error"));
+    const result = await fetchAreaSpatialValidation({ actorRefId: "player:1", anchorCell: ANCHOR_CELL, previewAction, rangeMeters: 36, sessionId: "s1" });
+    expect(result).toMatchObject({ originCell: ANCHOR_CELL, unavailableReason: "missing_map_data", inRange: null });
   });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewSpatialValidations.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewSpatialValidations.ts
@@ -4,6 +4,7 @@ import type {
   TacticalDiagnosticsPayload,
 } from "../../../shared/api/combatRepo";
 import type {
+  SpellAreaSpatialValidation,
   SpellInstanceSpatialValidation,
   SpellTargetSpatialValidation,
 } from "./spellMapPreviewModel";
@@ -197,6 +198,79 @@ export const fetchPreviewValidationsByTargetRefId = async ({
   );
 
   return new Map(entries);
+};
+
+type PositionalPreviewAction = (
+  sessionId: string,
+  payload: {
+    source_ref_id: string;
+    target_position: { x: number; y: number };
+    action_type: "spell";
+    reach_cells: number;
+  },
+) => Promise<CombatPreviewResponse>;
+
+export const buildAreaSpatialValidationFromPreview = ({
+  diagnostics,
+  rangeStatus,
+  originCell,
+  unavailableReason = null,
+}: {
+  diagnostics: TacticalDiagnosticsPayload | null;
+  rangeStatus?: RangeStatus;
+  originCell: { x: number; y: number };
+  unavailableReason?: "missing_position" | "missing_map_data" | null;
+}): SpellAreaSpatialValidation => {
+  const failureReasons = diagnostics?.failureReasons ?? [];
+  const primaryFailure = resolvePrimaryFailureReason(failureReasons);
+
+  return {
+    originCell,
+    inRange: deriveRangeCheck(diagnostics, rangeStatus),
+    hasLineOfSight:
+      primaryFailure === "no_line_of_sight"
+        ? false
+        : primaryFailure === "no_line_of_effect" || primaryFailure === "full_cover"
+          ? true
+          : null,
+    hasLineOfEffect:
+      primaryFailure === "no_line_of_effect" || primaryFailure === "full_cover" ? false : null,
+    unavailableReason,
+  };
+};
+
+export const fetchAreaSpatialValidation = async ({
+  actorRefId,
+  anchorCell,
+  previewAction,
+  rangeMeters,
+  sessionId,
+}: {
+  actorRefId: string;
+  anchorCell: { x: number; y: number };
+  previewAction: PositionalPreviewAction;
+  rangeMeters: number | null;
+  sessionId: string;
+}): Promise<SpellAreaSpatialValidation> => {
+  const reachCells = rangeMeters != null ? metersToCells(rangeMeters) : 1;
+  try {
+    const response = await previewAction(sessionId, {
+      source_ref_id: actorRefId,
+      target_position: anchorCell,
+      action_type: "spell",
+      reach_cells: reachCells,
+    });
+    return buildAreaSpatialValidationFromPreview({
+      diagnostics: response.diagnostics ?? null,
+      originCell: anchorCell,
+    });
+  } catch {
+    return buildAreaSpatialValidationFromPreview({
+      diagnostics: null,
+      originCell: anchorCell,
+      unavailableReason: "missing_map_data",
+    });
+  }
 };
 
 export type PreviewFanoutCacheEntry = {


### PR DESCRIPTION
## Summary

Adds area LoS/LoE spatial validation transport for spell tactical previews.

Area spells can now validate their selected origin/anchor cell through the existing `/combat/preview` endpoint using `target_position`, then feed the result into `spatialValidations.area` for `SpellMapPreviewModel`.

This is preview-only and does not change cast resolution, damage, saves, or submit behavior.

## Changes

### Spatial validation helpers

- Added `PositionalPreviewAction`
- Added `buildAreaSpatialValidationFromPreview(...)`
- Added `fetchAreaSpatialValidation(...)`
- Area validation now maps preview diagnostics into `SpellAreaSpatialValidation`
- Network/preview failures degrade to `missing_map_data`

### Dialog integration

- Added `areaSpatialValidation` state
- Added `areaPreviewRequestGateRef` to ignore stale area preview responses
- Spell reset clears area spatial validation and invalidates pending area preview requests
- Added area validation effect triggered by `anchorCell` changes
- `spatialValidations.area` now receives real area validation data instead of `null`

### Model behavior

- Area spatial validation can now produce:
  - `valid`
  - `invalid / out_of_range`
  - `invalid / blocked_line_of_sight`
  - `invalid / blocked_line_of_effect`
  - `unknown / missing_position`
  - `unknown / missing_map_data`
- `spatialValidations.area` takes priority over legacy area preview reasons
- Existing area affected target data remains preserved

## Validation

- Full test suite: 426/426 passing
- Frontend build passed

### New/updated tests

`spellMapPreviewModel.test.ts`

- area valid
- area out of range
- area blocked by LoS
- area blocked by LoE
- area unknown
- missing position
- spatial validation priority over fallback
- affected target count preserved
- backwards compatibility without `spatialValidations`

`spellPreviewSpatialValidations.test.ts`

- `buildAreaSpatialValidationFromPreview`
  - LoS blocked
  - LoE blocked
  - `full_cover`
  - unavailable reason
- `fetchAreaSpatialValidation`
  - success
  - LoS blocked
  - network error