### PR TITLE
feat(spell-preview): enhance area spell preview status rendering

### DIFF
--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastDialogHeader.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastDialogHeader.tsx
@@ -6,6 +6,7 @@ import { getInstanceLabel } from "./InstanceTargetSelector";
 import type { GridCell } from "./areaTargetingUi";
 import type { SpellMapPreviewModel } from "./spellMapPreviewModel";
 import {
+  formatAreaOriginPreviewLabel,
   formatSpellMapPreviewReason,
   formatSpellMapPreviewStatus,
 } from "./spellMapPreviewPresentation";
@@ -172,9 +173,11 @@ export const SpellCastDialogHeader = ({
           data-testid="spell-map-preview"
         >
           <p className="text-xs font-semibold uppercase tracking-[0.18em]">
-            Preview tático: {formatSpellMapPreviewStatus(mapPreviewModel.status)}
+            {isAreaSpell
+              ? formatAreaOriginPreviewLabel(mapPreviewModel)
+              : `Preview tático: ${formatSpellMapPreviewStatus(mapPreviewModel.status)}`}
           </p>
-          {mapPreviewReason ? (
+          {!isAreaSpell && mapPreviewReason ? (
             <p className="mt-1 text-sm">Motivo: {mapPreviewReason}</p>
           ) : null}
           {mapPreviewModel.rangeMeters != null ? (

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastDialogHeader.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastDialogHeader.test.tsx
@@ -310,6 +310,107 @@ describe("SpellCastDialogHeader tactical preview", () => {
     expect(markup).toContain("Alvos: Goblin A, Goblin B, Orc C");
   });
 
+  it("Fireball válida mostra Origem da área: válida", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        isAreaSpell
+        spell={{ ...baseSpell, name: "Fireball", canonicalKey: "fireball", level: 3, areaShape: "sphere", selectionType: "point" }}
+        spellMode="saving_throw"
+        mapPreviewModel={buildMapPreviewModel({ status: "valid", areaShape: "sphere", areaSizeMeters: 6 })}
+        previewModel={buildPreviewModel({ areaShape: "sphere", areaSizeMeters: 6 })}
+      />,
+    );
+
+    expect(markup).toContain("Origem da área: válida");
+    expect(markup).not.toContain("Preview tático:");
+  });
+
+  it("Fireball fora de alcance mostra Origem da área: fora do alcance", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        isAreaSpell
+        spell={{ ...baseSpell, name: "Fireball", canonicalKey: "fireball", level: 3, areaShape: "sphere", selectionType: "point" }}
+        spellMode="saving_throw"
+        mapPreviewModel={buildMapPreviewModel({ status: "invalid", reason: "out_of_range", areaShape: "sphere" })}
+        previewModel={buildPreviewModel({ areaShape: "sphere", areaSizeMeters: 6 })}
+      />,
+    );
+
+    expect(markup).toContain("Origem da área: fora do alcance");
+    expect(markup).not.toContain("Motivo:");
+  });
+
+  it("Fireball com LoS bloqueada mostra Origem da área: linha de visão bloqueada", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        isAreaSpell
+        spell={{ ...baseSpell, name: "Fireball", canonicalKey: "fireball", level: 3, areaShape: "sphere", selectionType: "point" }}
+        spellMode="saving_throw"
+        mapPreviewModel={buildMapPreviewModel({ status: "invalid", reason: "blocked_line_of_sight", areaShape: "sphere" })}
+        previewModel={buildPreviewModel({ areaShape: "sphere" })}
+      />,
+    );
+
+    expect(markup).toContain("Origem da área: linha de visão bloqueada");
+  });
+
+  it("Fireball com LoE bloqueada mostra Origem da área: linha de efeito bloqueada", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        isAreaSpell
+        spell={{ ...baseSpell, name: "Fireball", canonicalKey: "fireball", level: 3, areaShape: "sphere", selectionType: "point" }}
+        spellMode="saving_throw"
+        mapPreviewModel={buildMapPreviewModel({ status: "invalid", reason: "blocked_line_of_effect", areaShape: "sphere" })}
+        previewModel={buildPreviewModel({ areaShape: "sphere" })}
+      />,
+    );
+
+    expect(markup).toContain("Origem da área: linha de efeito bloqueada");
+  });
+
+  it("Fireball unknown mostra Origem da área: dados insuficientes", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        isAreaSpell
+        spell={{ ...baseSpell, name: "Fireball", canonicalKey: "fireball", level: 3, areaShape: "sphere", selectionType: "point" }}
+        spellMode="saving_throw"
+        mapPreviewModel={buildMapPreviewModel({ status: "unknown", reason: "missing_map_data", areaShape: "sphere" })}
+        previewModel={buildPreviewModel({ areaShape: "sphere" })}
+      />,
+    );
+
+    expect(markup).toContain("Origem da área: dados do mapa insuficientes");
+    expect(markup).not.toContain("Preview tático:");
+  });
+
+  it("Fireball inválida com affected targets mostra reason da origem e lista de alvos", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        isAreaSpell
+        spell={{ ...baseSpell, name: "Fireball", canonicalKey: "fireball", level: 3, areaShape: "sphere", selectionType: "point" }}
+        spellMode="saving_throw"
+        mapPreviewModel={buildMapPreviewModel({
+          status: "invalid",
+          reason: "blocked_line_of_sight",
+          areaShape: "sphere",
+          affectedTargetCount: 3,
+          affectedTargetNames: ["Goblin A", "Goblin B", "Orc C"],
+        })}
+        previewModel={buildPreviewModel({ areaShape: "sphere" })}
+      />,
+    );
+
+    expect(markup).toContain("Origem da área: linha de visão bloqueada");
+    expect(markup).toContain("Afetados: 3");
+    expect(markup).toContain("Alvos: Goblin A, Goblin B, Orc C");
+  });
+
   it("falls back gracefully when resolve-context is unavailable (preview-source=fallback)", () => {
     const markup = renderToStaticMarkup(
       <SpellCastDialogHeader

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewPresentation.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewPresentation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatAreaOriginPreviewLabel,
   formatSpellMapPreviewReason,
   formatSpellMapPreviewStatus,
 } from "./spellMapPreviewPresentation";
@@ -48,5 +49,39 @@ describe("spellMapPreviewPresentation", () => {
 
   it("preserva reason humana quando já vier formatada", () => {
     expect(formatSpellMapPreviewReason("Fora do alcance", "invalid")).toBe("Fora do alcance");
+  });
+});
+
+describe("formatAreaOriginPreviewLabel", () => {
+  it("valid sem reason → Origem da área: válida", () => {
+    expect(formatAreaOriginPreviewLabel({ status: "valid", reason: null })).toBe("Origem da área: válida");
+  });
+
+  it("invalid + out_of_range → Origem da área: fora do alcance", () => {
+    expect(formatAreaOriginPreviewLabel({ status: "invalid", reason: "out_of_range" })).toBe("Origem da área: fora do alcance");
+  });
+
+  it("invalid + blocked_line_of_sight → Origem da área: linha de visão bloqueada", () => {
+    expect(formatAreaOriginPreviewLabel({ status: "invalid", reason: "blocked_line_of_sight" })).toBe("Origem da área: linha de visão bloqueada");
+  });
+
+  it("invalid + blocked_line_of_effect → Origem da área: linha de efeito bloqueada", () => {
+    expect(formatAreaOriginPreviewLabel({ status: "invalid", reason: "blocked_line_of_effect" })).toBe("Origem da área: linha de efeito bloqueada");
+  });
+
+  it("unknown + missing_position → Origem da área: dados de posição insuficientes", () => {
+    expect(formatAreaOriginPreviewLabel({ status: "unknown", reason: "missing_position" })).toBe("Origem da área: dados de posição insuficientes");
+  });
+
+  it("unknown + missing_map_data → Origem da área: dados do mapa insuficientes", () => {
+    expect(formatAreaOriginPreviewLabel({ status: "unknown", reason: "missing_map_data" })).toBe("Origem da área: dados do mapa insuficientes");
+  });
+
+  it("unknown sem reason → Origem da área: dados insuficientes", () => {
+    expect(formatAreaOriginPreviewLabel({ status: "unknown", reason: null })).toBe("Origem da área: dados insuficientes");
+  });
+
+  it("invalid sem reason conhecido → Origem da área: inválida", () => {
+    expect(formatAreaOriginPreviewLabel({ status: "invalid", reason: null })).toBe("Origem da área: inválida");
   });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewPresentation.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewPresentation.ts
@@ -1,4 +1,4 @@
-import type { SpellMapPreviewStatus } from "./spellMapPreviewModel";
+import type { SpellMapPreviewModel, SpellMapPreviewStatus } from "./spellMapPreviewModel";
 
 const UNKNOWN_MESSAGE = "Dados de posição insuficientes para validar o preview no mapa";
 
@@ -12,6 +12,35 @@ export const formatSpellMapPreviewStatus = (status: SpellMapPreviewStatus): stri
       return "parcial";
     default:
       return "indisponível";
+  }
+};
+
+export const formatAreaOriginPreviewLabel = (
+  model: Pick<SpellMapPreviewModel, "status" | "reason">,
+): string => {
+  switch (model.reason) {
+    case "out_of_range":
+      return "Origem da área: fora do alcance";
+    case "blocked_line_of_sight":
+      return "Origem da área: linha de visão bloqueada";
+    case "blocked_line_of_effect":
+      return "Origem da área: linha de efeito bloqueada";
+    case "missing_position":
+      return "Origem da área: dados de posição insuficientes";
+    case "missing_map_data":
+      return "Origem da área: dados do mapa insuficientes";
+    default:
+      break;
+  }
+  switch (model.status) {
+    case "valid":
+      return "Origem da área: válida";
+    case "invalid":
+      return "Origem da área: inválida";
+    case "unknown":
+      return "Origem da área: dados insuficientes";
+    default:
+      return "Origem da área: indisponível";
   }
 };
 


### PR DESCRIPTION
## Summary

Polishes area spell preview status rendering in the cast dialog.

Area spells now render a clearer origin-focused preview label, such as `Origem da área: fora do alcance`, instead of the generic tactical preview status line.

## Changes

- Added `formatAreaOriginPreviewLabel(...)`
- Updated `SpellCastDialogHeader` to use area-origin labels for area spells
- Suppressed the separate `Motivo:` line for area spells because the reason is now included in the origin label
- Preserved affected target count/names regardless of origin status
- Added tests for area origin labels and Fireball preview rendering

## Validation

- Full test suite: 440/440 passing
- Frontend build passed