### PR TITLE
feat(spell-preview): add cover awareness to spell preview

### DIFF
--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastDialogHeader.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastDialogHeader.tsx
@@ -7,8 +7,10 @@ import type { GridCell } from "./areaTargetingUi";
 import type { SpellMapPreviewModel } from "./spellMapPreviewModel";
 import {
   formatAreaOriginPreviewLabel,
+  formatSpellCoverPreview,
   formatSpellMapPreviewReason,
   formatSpellMapPreviewStatus,
+  resolveCoverContext,
 } from "./spellMapPreviewPresentation";
 import type { SpellPreviewModel } from "./spellPreviewModel";
 import type { CombatSpellOption } from "./types";
@@ -117,6 +119,10 @@ export const SpellCastDialogHeader = ({
   const mapPreviewReason = mapPreviewModel
     ? formatSpellMapPreviewReason(mapPreviewModel.reason, mapPreviewModel.status)
     : null;
+  const coverContext = resolveCoverContext(spellMode);
+  const coverLabel = mapPreviewModel?.cover
+    ? formatSpellCoverPreview(mapPreviewModel.cover, coverContext)
+    : null;
 
   return (
     <>
@@ -183,6 +189,9 @@ export const SpellCastDialogHeader = ({
           {mapPreviewModel.rangeMeters != null ? (
             <p className="mt-2 text-xs opacity-90">Alcance: {formatRangeMeters(mapPreviewModel.rangeMeters)}</p>
           ) : null}
+          {coverLabel ? (
+            <p className="mt-1 text-xs opacity-90">{coverLabel}</p>
+          ) : null}
           {mapPreviewModel.areaShape ? (
             <p className="mt-1 text-xs opacity-90">
               Área: {mapPreviewModel.areaShape}
@@ -204,11 +213,15 @@ export const SpellCastDialogHeader = ({
                   instanceStatus.reason,
                   instanceStatus.status,
                 );
+                const instanceCoverLabel = instanceStatus.cover
+                  ? formatSpellCoverPreview(instanceStatus.cover, coverContext)
+                  : null;
                 return (
                   <p key={`${instanceStatus.instanceIndex}:${instanceStatus.targetRefId ?? "none"}`}>
                     {getInstanceLabel(spell.canonicalKey, instanceStatus.instanceIndex)}:{" "}
                     {formatSpellMapPreviewStatus(instanceStatus.status)}
                     {instanceReason ? ` · ${instanceReason}` : ""}
+                    {instanceCoverLabel ? ` · ${instanceCoverLabel}` : ""}
                   </p>
                 );
               })}

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastDialogHeader.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastDialogHeader.test.tsx
@@ -411,6 +411,98 @@ describe("SpellCastDialogHeader tactical preview", () => {
     expect(markup).toContain("Alvos: Goblin A, Goblin B, Orc C");
   });
 
+  it("Eldritch Blast single-target com half cover mostra +2 AC", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        spell={{ ...baseSpell, name: "Eldritch Blast", canonicalKey: "eldritch_blast", level: 0 }}
+        spellMode="spell_attack"
+        mapPreviewModel={buildMapPreviewModel({
+          status: "valid",
+          cover: { rank: "half", bonus: 2 },
+        })}
+        previewModel={buildPreviewModel({ resolutionType: "spell_attack", requiresAttackRoll: true })}
+      />,
+    );
+
+    expect(markup).toContain("Cobertura: meia (+2 AC)");
+  });
+
+  it("Eldritch Blast single-target com three_quarters cover mostra +5 AC", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        spell={{ ...baseSpell, name: "Eldritch Blast", canonicalKey: "eldritch_blast", level: 0 }}
+        spellMode="spell_attack"
+        mapPreviewModel={buildMapPreviewModel({
+          status: "valid",
+          cover: { rank: "three_quarters", bonus: 5 },
+        })}
+        previewModel={buildPreviewModel({ resolutionType: "spell_attack", requiresAttackRoll: true })}
+      />,
+    );
+
+    expect(markup).toContain("Cobertura: três-quartos (+5 AC)");
+  });
+
+  it("Eldritch Blast multi-instância mostra cover por feixe", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        spell={{ ...baseSpell, name: "Eldritch Blast", canonicalKey: "eldritch_blast", level: 0 }}
+        spellMode="spell_attack"
+        mapPreviewModel={buildMapPreviewModel({
+          status: "valid",
+          effectInstanceCount: 2,
+          instanceStatuses: [
+            { instanceIndex: 1, targetRefId: "enemy-1", status: "valid", reason: null, cover: { rank: "half", bonus: 2 } },
+            { instanceIndex: 2, targetRefId: "enemy-2", status: "valid", reason: null, cover: null },
+          ],
+        })}
+        previewModel={buildPreviewModel({ resolutionType: "spell_attack", effectInstanceCount: 2, source: "resolved" })}
+      />,
+    );
+
+    expect(markup).toContain("Feixe 1: válido · Cobertura: meia (+2 AC)");
+    expect(markup).not.toContain("Feixe 2: válido · Cobertura");
+  });
+
+  it("spell inválida por LoS mantém reason e não transforma cover em reason", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        spell={{ ...baseSpell, name: "Eldritch Blast", canonicalKey: "eldritch_blast", level: 0 }}
+        spellMode="spell_attack"
+        mapPreviewModel={buildMapPreviewModel({
+          status: "invalid",
+          reason: "blocked_line_of_sight",
+          cover: { rank: "half", bonus: 2 },
+        })}
+        previewModel={buildPreviewModel({ resolutionType: "spell_attack" })}
+      />,
+    );
+
+    expect(markup).toContain("Motivo: linha de visão bloqueada");
+    // cover is shown even when invalid (it's metadata, not a reason)
+    expect(markup).toContain("Cobertura: meia (+2 AC)");
+  });
+
+  it("Magic Missile não mostra cover como modificador AC/DC (direct_damage)", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        spellMode="direct_damage"
+        mapPreviewModel={buildMapPreviewModel({
+          status: "valid",
+          cover: { rank: "half", bonus: 2 },
+        })}
+        previewModel={buildPreviewModel({ resolutionType: "direct_damage" })}
+      />,
+    );
+
+    expect(markup).not.toContain("Cobertura:");
+  });
+
   it("falls back gracefully when resolve-context is unavailable (preview-source=fallback)", () => {
     const markup = renderToStaticMarkup(
       <SpellCastDialogHeader

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewModel.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewModel.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { METERS_PER_CELL } from "../../../features/combat-ui/hooks/useTargetingPreview";
 import { buildSpellMapPreviewModel } from "./spellMapPreviewModel";
-import type { SpellAreaSpatialValidation } from "./spellMapPreviewModel";
+import type { SpellAreaSpatialValidation, SpellCoverPreview } from "./spellMapPreviewModel";
 import type { SpellPreviewModel } from "./spellPreviewModel";
 
 // Base SpellPreviewModel representing a resolved backend context
@@ -708,5 +708,88 @@ describe("buildSpellMapPreviewModel – área com spatialValidations.area", () =
     });
     expect(model.status).toBe("valid");
     expect(model.affectedTargetCount).toBe(2);
+  });
+});
+
+const halfCover: SpellCoverPreview = { rank: "half", bonus: 2 };
+const threeQuartersCover: SpellCoverPreview = { rank: "three_quarters", bonus: 5 };
+
+describe("buildSpellMapPreviewModel – cover metadata", () => {
+  it("single-target preserva half cover no modelo", () => {
+    const model = buildSpellMapPreviewModel({
+      spellPreviewModel: baseSingleTargetModel,
+      casterPosition: CASTER,
+      selectedTargetRefId: "enemy-1",
+      targetPositions: [{ refId: "enemy-1", cell: TARGET_IN_RANGE }],
+      spatialValidations: {
+        targets: [{ targetRefId: "enemy-1", inRange: true, hasLineOfSight: null, hasLineOfEffect: null, unavailableReason: null, cover: halfCover }],
+      },
+    });
+    expect(model.status).toBe("valid");
+    expect(model.cover).toEqual(halfCover);
+  });
+
+  it("single-target preserva three_quarters cover no modelo", () => {
+    const model = buildSpellMapPreviewModel({
+      spellPreviewModel: baseSingleTargetModel,
+      casterPosition: CASTER,
+      selectedTargetRefId: "enemy-1",
+      targetPositions: [{ refId: "enemy-1", cell: TARGET_IN_RANGE }],
+      spatialValidations: {
+        targets: [{ targetRefId: "enemy-1", inRange: true, hasLineOfSight: null, hasLineOfEffect: null, unavailableReason: null, cover: threeQuartersCover }],
+      },
+    });
+    expect(model.cover).toEqual(threeQuartersCover);
+  });
+
+  it("cover não altera status valid para invalid", () => {
+    const model = buildSpellMapPreviewModel({
+      spellPreviewModel: baseSingleTargetModel,
+      casterPosition: CASTER,
+      selectedTargetRefId: "enemy-1",
+      targetPositions: [{ refId: "enemy-1", cell: TARGET_IN_RANGE }],
+      spatialValidations: {
+        targets: [{ targetRefId: "enemy-1", inRange: true, hasLineOfSight: null, hasLineOfEffect: null, unavailableReason: null, cover: halfCover }],
+      },
+    });
+    expect(model.status).toBe("valid");
+    expect(model.reason).toBeNull();
+  });
+
+  it("cover não sobrescreve reason out_of_range", () => {
+    const model = buildSpellMapPreviewModel({
+      spellPreviewModel: baseSingleTargetModel,
+      casterPosition: CASTER,
+      selectedTargetRefId: "enemy-1",
+      targetPositions: [{ refId: "enemy-1", cell: TARGET_OUT_OF_RANGE }],
+      spatialValidations: {
+        targets: [{ targetRefId: "enemy-1", inRange: false, hasLineOfSight: null, hasLineOfEffect: null, unavailableReason: null, cover: halfCover }],
+      },
+    });
+    expect(model.status).toBe("invalid");
+    expect(model.reason).toBe("out_of_range");
+  });
+
+  it("multi-instância preserva cover por instância", () => {
+    const multiInstanceModel: SpellPreviewModel = { ...baseSingleTargetModel, effectInstanceCount: 2 };
+    const model = buildSpellMapPreviewModel({
+      spellPreviewModel: multiInstanceModel,
+      effectInstanceTargets: [
+        { instance_index: 1, target_ref_id: "enemy-1" },
+        { instance_index: 2, target_ref_id: "enemy-2" },
+      ],
+      targetPositions: [
+        { refId: "enemy-1", cell: TARGET_IN_RANGE },
+        { refId: "enemy-2", cell: TARGET_IN_RANGE },
+      ],
+      spatialValidations: {
+        instances: [
+          { instanceIndex: 1, targetRefId: "enemy-1", inRange: true, hasLineOfSight: null, hasLineOfEffect: null, unavailableReason: null, cover: halfCover },
+          { instanceIndex: 2, targetRefId: "enemy-2", inRange: true, hasLineOfSight: null, hasLineOfEffect: null, unavailableReason: null, cover: threeQuartersCover },
+        ],
+      },
+    });
+    expect(model.instanceStatuses?.[0].cover).toEqual(halfCover);
+    expect(model.instanceStatuses?.[1].cover).toEqual(threeQuartersCover);
   });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewModel.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewModel.ts
@@ -6,6 +6,13 @@ import type { SpellPreviewModel } from "./spellPreviewModel";
 
 export type SpellMapPreviewStatus = "valid" | "invalid" | "partial" | "unknown";
 
+export type SpellCoverRank = "none" | "half" | "three_quarters" | "unknown";
+
+export type SpellCoverPreview = {
+  rank: SpellCoverRank;
+  bonus: number | null;
+};
+
 export type SpellMapPreviewReason =
   | "out_of_range"
   | "blocked_line_of_sight"
@@ -18,6 +25,7 @@ export type SpellInstanceMapStatus = {
   targetRefId: string | null;
   status: SpellMapPreviewStatus;
   reason?: SpellMapPreviewReason | string | null;
+  cover?: SpellCoverPreview | null;
 };
 
 export type SpellMapPreviewModel = {
@@ -30,6 +38,7 @@ export type SpellMapPreviewModel = {
   areaSizeMeters: number | null;
   effectInstanceCount: number;
   instanceStatuses?: SpellInstanceMapStatus[];
+  cover?: SpellCoverPreview | null;
 };
 
 export type SpellMapTargetPosition = {
@@ -48,6 +57,7 @@ type SpellBaseSpatialValidation = {
   hasLineOfSight?: boolean | null;
   hasLineOfEffect?: boolean | null;
   unavailableReason?: SpellSpatialUnavailableReason | null;
+  cover?: SpellCoverPreview | null;
 };
 
 export type SpellTargetSpatialValidation = SpellBaseSpatialValidation & {
@@ -230,6 +240,7 @@ export const buildSpellMapPreviewModel = ({
           targetRefId,
           status: outcome.status,
           reason: outcome.reason,
+          cover: validation?.cover ?? null,
         };
       },
     );
@@ -271,5 +282,6 @@ export const buildSpellMapPreviewModel = ({
     ...base,
     status: outcome.status,
     reason: outcome.reason,
+    cover: validation?.cover ?? null,
   };
 };

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewPresentation.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewPresentation.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   formatAreaOriginPreviewLabel,
+  formatSpellCoverPreview,
   formatSpellMapPreviewReason,
   formatSpellMapPreviewStatus,
+  resolveCoverContext,
 } from "./spellMapPreviewPresentation";
 
 describe("spellMapPreviewPresentation", () => {
@@ -50,6 +52,47 @@ describe("spellMapPreviewPresentation", () => {
   it("preserva reason humana quando já vier formatada", () => {
     expect(formatSpellMapPreviewReason("Fora do alcance", "invalid")).toBe("Fora do alcance");
   });
+});
+
+describe("formatSpellCoverPreview", () => {
+  it("half cover + attack → Cobertura: meia (+2 AC)", () => {
+    expect(formatSpellCoverPreview({ rank: "half", bonus: 2 }, "attack")).toBe("Cobertura: meia (+2 AC)");
+  });
+
+  it("three_quarters cover + attack → Cobertura: três-quartos (+5 AC)", () => {
+    expect(formatSpellCoverPreview({ rank: "three_quarters", bonus: 5 }, "attack")).toBe("Cobertura: três-quartos (+5 AC)");
+  });
+
+  it("half cover + save → Cobertura: meia (-2 DC efetiva)", () => {
+    expect(formatSpellCoverPreview({ rank: "half", bonus: 2 }, "save")).toBe("Cobertura: meia (-2 DC efetiva)");
+  });
+
+  it("three_quarters cover + save → Cobertura: três-quartos (-5 DC efetiva)", () => {
+    expect(formatSpellCoverPreview({ rank: "three_quarters", bonus: 5 }, "save")).toBe("Cobertura: três-quartos (-5 DC efetiva)");
+  });
+
+  it("half cover + other (direct damage) → null", () => {
+    expect(formatSpellCoverPreview({ rank: "half", bonus: 2 }, "other")).toBeNull();
+  });
+
+  it("none cover → null", () => {
+    expect(formatSpellCoverPreview({ rank: "none", bonus: null }, "attack")).toBeNull();
+  });
+
+  it("unknown cover → null", () => {
+    expect(formatSpellCoverPreview({ rank: "unknown", bonus: null }, "attack")).toBeNull();
+  });
+
+  it("null cover → null", () => {
+    expect(formatSpellCoverPreview(null, "attack")).toBeNull();
+  });
+});
+
+describe("resolveCoverContext", () => {
+  it("spell_attack → attack", () => { expect(resolveCoverContext("spell_attack")).toBe("attack"); });
+  it("saving_throw → save", () => { expect(resolveCoverContext("saving_throw")).toBe("save"); });
+  it("direct_damage → other", () => { expect(resolveCoverContext("direct_damage")).toBe("other"); });
+  it("null → other", () => { expect(resolveCoverContext(null)).toBe("other"); });
 });
 
 describe("formatAreaOriginPreviewLabel", () => {

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewPresentation.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewPresentation.ts
@@ -1,4 +1,4 @@
-import type { SpellMapPreviewModel, SpellMapPreviewStatus } from "./spellMapPreviewModel";
+import type { SpellCoverPreview, SpellMapPreviewModel, SpellMapPreviewStatus } from "./spellMapPreviewModel";
 
 const UNKNOWN_MESSAGE = "Dados de posição insuficientes para validar o preview no mapa";
 
@@ -13,6 +13,27 @@ export const formatSpellMapPreviewStatus = (status: SpellMapPreviewStatus): stri
     default:
       return "indisponível";
   }
+};
+
+export type SpellCoverContext = "attack" | "save" | "other";
+
+export const resolveCoverContext = (spellMode: string | null | undefined): SpellCoverContext => {
+  if (spellMode === "spell_attack") return "attack";
+  if (spellMode === "saving_throw") return "save";
+  return "other";
+};
+
+export const formatSpellCoverPreview = (
+  cover: SpellCoverPreview | null | undefined,
+  context: SpellCoverContext,
+): string | null => {
+  if (!cover || cover.rank === "none" || cover.rank === "unknown") return null;
+  if (context === "other") return null;
+  const rankLabel = cover.rank === "half" ? "meia" : "três-quartos";
+  const modifier = cover.bonus ?? 0;
+  if (context === "attack") return `Cobertura: ${rankLabel} (+${modifier} AC)`;
+  if (context === "save") return `Cobertura: ${rankLabel} (-${modifier} DC efetiva)`;
+  return null;
 };
 
 export const formatAreaOriginPreviewLabel = (

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewSpatialValidations.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewSpatialValidations.test.ts
@@ -3,6 +3,7 @@ import {
   buildAreaSpatialValidationFromPreview,
   buildInstanceSpatialValidations,
   buildSingleTargetSpatialValidations,
+  buildSpellCoverPreviewFromDiagnostics,
   buildSpellPreviewFanoutKey,
   buildTargetSpatialValidationFromPreview,
   buildUniqueTargetRefIds,
@@ -75,6 +76,7 @@ describe("spellPreviewSpatialValidations", () => {
         hasLineOfSight: null,
         hasLineOfEffect: null,
         unavailableReason: "missing_map_data",
+        cover: null,
       },
     ]);
   });
@@ -377,5 +379,50 @@ describe("area spatial validation", () => {
     const previewAction = vi.fn().mockRejectedValue(new Error("network error"));
     const result = await fetchAreaSpatialValidation({ actorRefId: "player:1", anchorCell: ANCHOR_CELL, previewAction, rangeMeters: 36, sessionId: "s1" });
     expect(result).toMatchObject({ originCell: ANCHOR_CELL, unavailableReason: "missing_map_data", inRange: null });
+  });
+});
+
+describe("buildSpellCoverPreviewFromDiagnostics", () => {
+  it("half cover → rank half, bonus 2", () => {
+    expect(buildSpellCoverPreviewFromDiagnostics({
+      isValid: true, failureReasons: [], checks: {}, metadata: { cover: "half" },
+    })).toEqual({ rank: "half", bonus: 2 });
+  });
+
+  it("three_quarters cover → rank three_quarters, bonus 5", () => {
+    expect(buildSpellCoverPreviewFromDiagnostics({
+      isValid: true, failureReasons: [], checks: {}, metadata: { cover: "three_quarters" },
+    })).toEqual({ rank: "three_quarters", bonus: 5 });
+  });
+
+  it("none cover → null (não exibir cover)", () => {
+    expect(buildSpellCoverPreviewFromDiagnostics({
+      isValid: true, failureReasons: [], checks: {}, metadata: { cover: "none" },
+    })).toBeNull();
+  });
+
+  it("ausência de cover → null", () => {
+    expect(buildSpellCoverPreviewFromDiagnostics({ isValid: true, failureReasons: [], checks: {}, metadata: {} })).toBeNull();
+  });
+
+  it("diagnostics null → null", () => {
+    expect(buildSpellCoverPreviewFromDiagnostics(null)).toBeNull();
+  });
+
+  it("buildTargetSpatialValidationFromPreview inclui cover quando presente", () => {
+    const result = buildTargetSpatialValidationFromPreview({
+      diagnostics: { isValid: true, failureReasons: [], checks: { in_range: true }, metadata: { cover: "half" } },
+      targetRefId: "enemy-1",
+    });
+    expect(result.cover).toEqual({ rank: "half", bonus: 2 });
+  });
+
+  it("failureReasons continuam mapeando LoS mesmo com cover presente", () => {
+    const result = buildTargetSpatialValidationFromPreview({
+      diagnostics: { isValid: false, failureReasons: ["no_line_of_sight"], checks: { in_range: true }, metadata: { cover: "half" } },
+      targetRefId: "enemy-1",
+    });
+    expect(result.hasLineOfSight).toBe(false);
+    expect(result.cover).toEqual({ rank: "half", bonus: 2 });
   });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewSpatialValidations.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewSpatialValidations.ts
@@ -5,6 +5,7 @@ import type {
 } from "../../../shared/api/combatRepo";
 import type {
   SpellAreaSpatialValidation,
+  SpellCoverPreview,
   SpellInstanceSpatialValidation,
   SpellTargetSpatialValidation,
 } from "./spellMapPreviewModel";
@@ -79,6 +80,16 @@ const deriveRangeCheck = (
   return null;
 };
 
+export const buildSpellCoverPreviewFromDiagnostics = (
+  diagnostics: TacticalDiagnosticsPayload | null,
+): SpellCoverPreview | null => {
+  const coverValue = diagnostics?.metadata?.["cover"];
+  if (!coverValue || typeof coverValue !== "string" || coverValue === "none") return null;
+  if (coverValue === "half") return { rank: "half", bonus: 2 };
+  if (coverValue === "three_quarters") return { rank: "three_quarters", bonus: 5 };
+  return { rank: "unknown", bonus: null };
+};
+
 export const buildTargetSpatialValidationFromPreview = ({
   diagnostics,
   rangeStatus,
@@ -102,6 +113,7 @@ export const buildTargetSpatialValidationFromPreview = ({
         ? false
         : null,
     unavailableReason,
+    cover: buildSpellCoverPreviewFromDiagnostics(diagnostics),
   };
 };
 


### PR DESCRIPTION
## Summary

Adds cover-aware metadata to the spell tactical preview UI.

The preview can now preserve and render cover information for single-target and multi-instance spell previews without changing cast resolution, status/reason calculation, or submit behavior.

## Changes

### Preview model

- Added `SpellCoverRank`
- Added `SpellCoverPreview`
- Added optional `cover` metadata to:
  - `SpellBaseSpatialValidation`
  - `SpellInstanceMapStatus`
  - `SpellMapPreviewModel`
- `buildSpellMapPreviewModel(...)` now propagates cover metadata for:
  - single-target previews
  - multi-instance previews

### Spatial diagnostics mapping

- Added `buildSpellCoverPreviewFromDiagnostics(...)`
- Reads `diagnostics.metadata["cover"]`
- Maps:
  - `half` → `{ rank: "half", bonus: 2 }`
  - `three_quarters` → `{ rank: "three_quarters", bonus: 5 }`
  - `none` → `null`
- Wired into `buildTargetSpatialValidationFromPreview(...)`

### Presentation

- Added `SpellCoverContext`
- Added `resolveCoverContext(spellMode)`
- Added `formatSpellCoverPreview(...)`
- Renders:
  - `Cobertura: meia (+2 AC)`
  - `Cobertura: três-quartos (+5 AC)`
  - `Cobertura: meia (-2 DC efetiva)`
  - `Cobertura: três-quartos (-5 DC efetiva)`
- Returns `null` for:
  - direct damage
  - other/non-applicable modes
  - no cover
  - unknown cover

### Dialog UI

- `SpellCastDialogHeader` now renders cover labels:
  - single-target: after range
  - multi-instance: per instance/beam
- Cover does not replace or override invalid reasons such as LoS/LoE failure.

## Validation

- Full test suite: 469/469 passing
- Frontend build passed
- Added 29 focused tests covering:
  - cover preservation in model
  - cover not changing status/reason
  - diagnostics cover mapping
  - LoS + cover coexistence
  - cover presentation for attack/save contexts
  - header rendering for single-target and multi-instance spells
  - Magic Missile/direct damage not showing cover modifiers