### PR TITLE
feat(spell-preview): add cover_applies_to_save handling in spell cont…

### DIFF
--- a/apps/control-server/app/schemas/combat_spells.py
+++ b/apps/control-server/app/schemas/combat_spells.py
@@ -138,6 +138,7 @@ class CombatResolvedSpellContext(BaseModel):
     upcast_applied: bool = False
     upcast_added_instances: int = 0
     upcast_instance_effect_dice: str | None = None
+    cover_applies_to_save: str | None = None
 
 
 class CombatGridCell(BaseModel):

--- a/apps/control-server/app/services/combat_service/spells/cast_target.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target.py
@@ -149,6 +149,7 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
                 0,
             ),
             "upcast_instance_effect_dice": spell_context.get("upcast_instance_effect_dice"),
+            "cover_applies_to_save": spell_context.get("cover_applies_to_save"),
         }
 
     @classmethod

--- a/apps/control-server/tests/test_spell_context_resolve_endpoint.py
+++ b/apps/control-server/tests/test_spell_context_resolve_endpoint.py
@@ -322,6 +322,63 @@ class ResolveSpellContextTests(unittest.TestCase):
             {"id": "pending-1"},
         )
 
+    def test_resolves_cover_applies_to_save_physical_is_exposed(self):
+        result = self._resolve(
+            CombatResolveSpellContextRequest(
+                actor_participant_id="p1",
+                spell_canonical_key="acid_splash",
+                spell_mode="saving_throw",
+            ),
+            _catalog_spell(
+                canonical_key="acid_splash",
+                name_en="Acid Splash",
+                name_pt="Acid Splash",
+                level=0,
+                damage_dice="1d6",
+                damage_type="Acid",
+                saving_throw="DEX",
+                cover_applies_to_save="physical",
+                upcast_json=None,
+            ),
+        )
+
+        self.assertEqual(result["cover_applies_to_save"], "physical")
+
+    def test_resolves_cover_applies_to_save_null_is_exposed_as_none(self):
+        result = self._resolve(
+            CombatResolveSpellContextRequest(
+                actor_participant_id="p1",
+                spell_canonical_key="magic_missile",
+                spell_mode="direct_damage",
+                slot_level=1,
+            ),
+            _catalog_spell(),
+        )
+
+        self.assertIsNone(result["cover_applies_to_save"])
+
+    def test_resolves_cover_applies_to_save_none_rule_is_exposed(self):
+        result = self._resolve(
+            CombatResolveSpellContextRequest(
+                actor_participant_id="p1",
+                spell_canonical_key="acid_splash",
+                spell_mode="saving_throw",
+            ),
+            _catalog_spell(
+                canonical_key="acid_splash",
+                name_en="Acid Splash",
+                name_pt="Acid Splash",
+                level=0,
+                damage_dice="1d6",
+                damage_type="Acid",
+                saving_throw="DEX",
+                cover_applies_to_save="none",
+                upcast_json=None,
+            ),
+        )
+
+        self.assertEqual(result["cover_applies_to_save"], "none")
+
     def test_invalid_slot_returns_clear_error(self):
         with self.assertRaises(CombatServiceError) as context:
             self._resolve(

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastDialogHeader.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastDialogHeader.tsx
@@ -119,7 +119,7 @@ export const SpellCastDialogHeader = ({
   const mapPreviewReason = mapPreviewModel
     ? formatSpellMapPreviewReason(mapPreviewModel.reason, mapPreviewModel.status)
     : null;
-  const coverContext = resolveCoverContext(spellMode);
+  const coverContext = resolveCoverContext(spellMode, previewModel.coverAppliesToSave);
   const coverLabel = mapPreviewModel?.cover
     ? formatSpellCoverPreview(mapPreviewModel.cover, coverContext)
     : null;

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastDialogHeader.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastDialogHeader.test.tsx
@@ -75,6 +75,7 @@ const buildPreviewModel = (overrides: Partial<SpellPreviewModel>): SpellPreviewM
   requiresAttackRoll: false,
   requiresSavingThrow: false,
   saveAbility: null,
+  coverAppliesToSave: null,
   source: "resolved",
   ...overrides,
 });
@@ -497,6 +498,94 @@ describe("SpellCastDialogHeader tactical preview", () => {
           cover: { rank: "half", bonus: 2 },
         })}
         previewModel={buildPreviewModel({ resolutionType: "direct_damage" })}
+      />,
+    );
+
+    expect(markup).not.toContain("Cobertura:");
+  });
+
+  it("saving throw com coverAppliesToSave true e half cover mostra -2 DC efetiva", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        spell={{ ...baseSpell, name: "Ice Knife Shards", canonicalKey: "ice_knife_shards", level: 1 }}
+        spellMode="saving_throw"
+        mapPreviewModel={buildMapPreviewModel({
+          status: "valid",
+          cover: { rank: "half", bonus: 2 },
+        })}
+        previewModel={buildPreviewModel({
+          resolutionType: "saving_throw",
+          requiresSavingThrow: true,
+          saveAbility: "dexterity",
+          coverAppliesToSave: true,
+        })}
+      />,
+    );
+
+    expect(markup).toContain("Cobertura: meia (-2 DC efetiva)");
+  });
+
+  it("saving throw com coverAppliesToSave true e three_quarters cover mostra -5 DC efetiva", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        spell={{ ...baseSpell, name: "Ice Knife Shards", canonicalKey: "ice_knife_shards", level: 1 }}
+        spellMode="saving_throw"
+        mapPreviewModel={buildMapPreviewModel({
+          status: "valid",
+          cover: { rank: "three_quarters", bonus: 5 },
+        })}
+        previewModel={buildPreviewModel({
+          resolutionType: "saving_throw",
+          requiresSavingThrow: true,
+          saveAbility: "dexterity",
+          coverAppliesToSave: true,
+        })}
+      />,
+    );
+
+    expect(markup).toContain("Cobertura: três-quartos (-5 DC efetiva)");
+  });
+
+  it("saving throw com coverAppliesToSave false não mostra cover", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        spell={{ ...baseSpell, name: "Acid Splash", canonicalKey: "acid_splash", level: 0 }}
+        spellMode="saving_throw"
+        mapPreviewModel={buildMapPreviewModel({
+          status: "valid",
+          cover: { rank: "half", bonus: 2 },
+        })}
+        previewModel={buildPreviewModel({
+          resolutionType: "saving_throw",
+          requiresSavingThrow: true,
+          saveAbility: "dexterity",
+          coverAppliesToSave: false,
+        })}
+      />,
+    );
+
+    expect(markup).not.toContain("Cobertura:");
+  });
+
+  it("Acid Splash sem coverAppliesToSave true não mostra cover", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        spell={{ ...baseSpell, name: "Acid Splash", canonicalKey: "acid_splash", level: 0 }}
+        spellMode="saving_throw"
+        mapPreviewModel={buildMapPreviewModel({
+          status: "valid",
+          cover: { rank: "half", bonus: 2 },
+        })}
+        previewModel={buildPreviewModel({
+          resolutionType: "saving_throw",
+          requiresSavingThrow: true,
+          saveAbility: "dexterity",
+          coverAppliesToSave: null,
+        })}
       />,
     );
 

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewModel.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewModel.test.ts
@@ -19,6 +19,7 @@ const baseSingleTargetModel: SpellPreviewModel = {
   requiresAttackRoll: false,
   requiresSavingThrow: false,
   saveAbility: null,
+  coverAppliesToSave: null,
   source: "resolved",
 };
 
@@ -176,6 +177,7 @@ describe("buildSpellMapPreviewModel – Acid Splash (saving throw, single-instan
     requiresAttackRoll: false,
     requiresSavingThrow: true,
     saveAbility: "dexterity",
+    coverAppliesToSave: null,
     source: "resolved",
   };
 
@@ -213,6 +215,7 @@ describe("buildSpellMapPreviewModel – Magic Missile slot 3 (effectInstanceCoun
     requiresAttackRoll: false,
     requiresSavingThrow: false,
     saveAbility: null,
+    coverAppliesToSave: null,
     source: "resolved",
   };
 
@@ -372,6 +375,7 @@ describe("buildSpellMapPreviewModel – Eldritch Blast level 5 (effectInstanceCo
     requiresAttackRoll: true,
     requiresSavingThrow: false,
     saveAbility: null,
+    coverAppliesToSave: null,
     source: "resolved",
   };
 
@@ -440,6 +444,7 @@ describe("buildSpellMapPreviewModel – Fireball (area spell)", () => {
     requiresAttackRoll: false,
     requiresSavingThrow: true,
     saveAbility: "dexterity",
+    coverAppliesToSave: null,
     source: "resolved",
   };
 
@@ -628,6 +633,7 @@ const baseAreaModel: SpellPreviewModel = {
   requiresAttackRoll: false,
   requiresSavingThrow: true,
   saveAbility: "dexterity",
+  coverAppliesToSave: null,
   source: "resolved",
 };
 

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewPresentation.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewPresentation.test.ts
@@ -90,7 +90,10 @@ describe("formatSpellCoverPreview", () => {
 
 describe("resolveCoverContext", () => {
   it("spell_attack → attack", () => { expect(resolveCoverContext("spell_attack")).toBe("attack"); });
-  it("saving_throw → save", () => { expect(resolveCoverContext("saving_throw")).toBe("save"); });
+  it("saving_throw + coverAppliesToSave true → save", () => { expect(resolveCoverContext("saving_throw", true)).toBe("save"); });
+  it("saving_throw + coverAppliesToSave false → other", () => { expect(resolveCoverContext("saving_throw", false)).toBe("other"); });
+  it("saving_throw + coverAppliesToSave null → other", () => { expect(resolveCoverContext("saving_throw", null)).toBe("other"); });
+  it("saving_throw + coverAppliesToSave undefined → other", () => { expect(resolveCoverContext("saving_throw")).toBe("other"); });
   it("direct_damage → other", () => { expect(resolveCoverContext("direct_damage")).toBe("other"); });
   it("null → other", () => { expect(resolveCoverContext(null)).toBe("other"); });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewPresentation.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewPresentation.ts
@@ -17,9 +17,12 @@ export const formatSpellMapPreviewStatus = (status: SpellMapPreviewStatus): stri
 
 export type SpellCoverContext = "attack" | "save" | "other";
 
-export const resolveCoverContext = (spellMode: string | null | undefined): SpellCoverContext => {
+export const resolveCoverContext = (
+  spellMode: string | null | undefined,
+  coverAppliesToSave?: boolean | null,
+): SpellCoverContext => {
   if (spellMode === "spell_attack") return "attack";
-  if (spellMode === "saving_throw") return "save";
+  if (spellMode === "saving_throw" && coverAppliesToSave === true) return "save";
   return "other";
 };
 

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewModel.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewModel.test.ts
@@ -271,4 +271,57 @@ describe("buildSpellPreviewModel", () => {
     expect(model.rangeMeters).toBe(45);
     expect(model.saveAbility).toBe("dexterity");
   });
+
+  it("normalizes coverAppliesToSave to true when physical", () => {
+    const model = buildSpellPreviewModel(
+      {
+        ...resolvedContextDefaults,
+        resolution_type: "saving_throw",
+        requires_saving_throw: true,
+        cover_applies_to_save: "physical",
+      },
+      { spell: baseFallbackSpell, selectedSlotLevel: 1, spellMode: "saving_throw", spellEffectDice: null },
+    );
+
+    expect(model.coverAppliesToSave).toBe(true);
+  });
+
+  it("normalizes coverAppliesToSave to false when none", () => {
+    const model = buildSpellPreviewModel(
+      {
+        ...resolvedContextDefaults,
+        resolution_type: "saving_throw",
+        requires_saving_throw: true,
+        cover_applies_to_save: "none",
+      },
+      { spell: baseFallbackSpell, selectedSlotLevel: 1, spellMode: "saving_throw", spellEffectDice: null },
+    );
+
+    expect(model.coverAppliesToSave).toBe(false);
+  });
+
+  it("normalizes coverAppliesToSave to null when absent", () => {
+    const model = buildSpellPreviewModel(
+      {
+        ...resolvedContextDefaults,
+        resolution_type: "saving_throw",
+        requires_saving_throw: true,
+      },
+      { spell: baseFallbackSpell, selectedSlotLevel: 1, spellMode: "saving_throw", spellEffectDice: null },
+    );
+
+    expect(model.coverAppliesToSave).toBeNull();
+  });
+
+  it("fallback model has coverAppliesToSave null", () => {
+    const model = buildSpellPreviewModel(null, {
+      spell: baseFallbackSpell,
+      selectedSlotLevel: 1,
+      spellMode: "direct_damage",
+      spellEffectDice: "1d4+1",
+    });
+
+    expect(model.source).toBe("fallback");
+    expect(model.coverAppliesToSave).toBeNull();
+  });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewModel.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellPreviewModel.ts
@@ -16,6 +16,7 @@ export type SpellPreviewModel = {
   requiresAttackRoll: boolean;
   requiresSavingThrow: boolean;
   saveAbility: string | null;
+  coverAppliesToSave: boolean | null;
   source: "resolved" | "fallback";
 };
 
@@ -77,6 +78,7 @@ export const buildSpellPreviewModel = (
       requiresAttackRoll: Boolean(resolvedContext.requires_attack_roll),
       requiresSavingThrow: Boolean(resolvedContext.requires_saving_throw),
       saveAbility: normalizeString(resolvedContext.save_ability),
+      coverAppliesToSave: resolvedContext.cover_applies_to_save === "physical" ? true : resolvedContext.cover_applies_to_save === "none" ? false : null,
       source: "resolved",
     };
   }
@@ -99,6 +101,7 @@ export const buildSpellPreviewModel = (
     requiresAttackRoll: fallback.spellMode === "spell_attack",
     requiresSavingThrow: fallback.spellMode === "saving_throw",
     saveAbility: normalizeString(fallback.spell.savingThrow ?? null),
+    coverAppliesToSave: null,
     source: "fallback",
   };
 };

--- a/apps/control-web/src/shared/api/combatRepo.ts
+++ b/apps/control-web/src/shared/api/combatRepo.ts
@@ -276,6 +276,7 @@ export type CombatResolvedSpellContext = {
   upcast_applied: boolean;
   upcast_added_instances: number;
   upcast_instance_effect_dice?: string | null;
+  cover_applies_to_save?: string | null;
 };
 
 export type CombatSpellResult = {


### PR DESCRIPTION
## Summary

Adds saving-throw cover preview metadata.

The resolve-context endpoint now exposes `cover_applies_to_save`, and the frontend uses it to decide whether cover should be displayed as an effective save DC modifier for saving throw spells.

This is preview-only and does not change cast resolution or runtime DC behavior.

## Backend

- Added `cover_applies_to_save` to `CombatResolvedSpellContext`
- Populates it from `spell_context.get("cover_applies_to_save")`
- Added backend tests for:
  - `"physical"`
  - `"none"`
  - `null`

## Frontend

- Added `cover_applies_to_save` to `CombatResolvedSpellContext` API type
- Added normalized `coverAppliesToSave: boolean | null` to `SpellPreviewModel`
- Normalization:
  - `"physical"` -> `true`
  - `"none"` -> `false`
  - absent/null -> `null`
- Updated `resolveCoverContext(...)` so saving throw spells only use save cover context when `coverAppliesToSave === true`
- Updated `SpellCastDialogHeader` to pass `previewModel.coverAppliesToSave`
- Spell attack cover preview remains unchanged
- Direct damage cover preview remains hidden

## Validation

- 147 frontend tests passed
- 11 backend tests passed
- No new TypeScript errors

## Notes

`cover_applies_to_save` is intentionally kept as the raw backend string in the API layer and normalized into a boolean only for the current frontend preview need.
Runtime saving throw DC behavior is unchanged in this PR.