### PR TITLE
feat(cover-modifiers): implement cover save DC resolution

### DIFF
--- a/apps/control-server/app/services/combat_service/cover_modifiers.py
+++ b/apps/control-server/app/services/combat_service/cover_modifiers.py
@@ -1,11 +1,10 @@
-"""
-Single source of truth for cover modifier logic.
+"""Single source of truth for cover modifier logic.
 
-Attack-roll cover (Phase 4):
+Attack-roll cover:
   - cover adds to the defender's effective AC
   - half → +2 AC | threeQuarters → +5 AC
 
-Saving throw cover (Phase 5):
+Saving throw cover:
   - cover reduces the effective DC seen by the defender
   - same numeric values as attack cover (half → -2 DC | threeQuarters → -5 DC)
   - only applies when the spell/action explicitly allows it via metadata
@@ -17,12 +16,9 @@ Cover levels:
   full          → blocked before resolution; modifier is irrelevant here
 
 Metadata-driven save cover (coverAppliesToSave field on BaseSpell):
-  "physical" → cover applies  (spatial, projectile, blast, or wave effects)
-  "none"     → cover does not apply (mental, control, self-emanation, etc.)
-  None/unset → use fallback heuristic (see should_cover_apply_to_save)
-
-The fallback heuristic is intentionally conservative and temporary.
-It should be removed once all spell catalog entries carry explicit metadata.
+  "physical" → cover applies
+  "none"     → cover does not apply
+  None/unset/unknown → cover does not apply
 """
 from __future__ import annotations
 
@@ -93,28 +89,32 @@ def should_cover_apply_to_save(
     """Return True if cover should modify the saving throw DC for this effect.
 
     Explicit metadata (coverAppliesToSave on the spell/action) is authoritative.
-    When metadata is absent the fallback heuristic applies.
+    Missing or unknown metadata disables save-cover adjustments.
 
     Args:
         cover_applies_to_save: Value from BaseSpell.cover_applies_to_save.
             "physical" → cover applies.
             "none"     → cover does not apply.
-            None       → fall back to heuristic.
-        save_ability: Normalized ability name ("dexterity", "strength", etc.).
-            Used only by the fallback when metadata is absent.
+            None       → cover does not apply.
+        save_ability: Unused legacy parameter kept for call-site compatibility.
 
     Returns:
         True if cover should be applied; False otherwise.
     """
-    # Explicit metadata is authoritative — check first.
+    del save_ability
     if cover_applies_to_save == COVER_SAVE_RULE_PHYSICAL:
         return True
-    if cover_applies_to_save == COVER_SAVE_RULE_NONE:
-        return False
+    return False
 
-    # --- Fallback heuristic (legacy safety net) ----------------------------
-    # All base spells and newly created campaign spells carry explicit metadata
-    # after migration 0052/0053.  This path is reached only for campaign spells
-    # that were created before those migrations and have not been updated.
-    # It must not be extended; remove once such records are no longer reachable.
-    return (save_ability or "").lower() in ("dex", "dexterity")
+
+def resolve_cover_save_dc(
+    save_dc: int,
+    cover: str | None,
+    cover_applies_to_save: str | None,
+    save_ability: str | None = None,
+) -> tuple[int, int]:
+    """Return ``(effective_dc, cover_modifier)`` for a saving throw effect."""
+    if not should_cover_apply_to_save(cover_applies_to_save, save_ability):
+        return save_dc, 0
+    modifier = resolve_cover_save_modifier(cover)
+    return max(0, save_dc - modifier), modifier

--- a/apps/control-server/app/services/combat_service/npc_action_resolution.py
+++ b/apps/control-server/app/services/combat_service/npc_action_resolution.py
@@ -14,8 +14,7 @@ from app.services.combat_service.condition_effects import (
 )
 from app.services.combat_service.cover_modifiers import (
     resolve_cover_modifier,
-    resolve_cover_save_modifier,
-    should_cover_apply_to_save,
+    resolve_cover_save_dc,
 )
 from app.services.combat_service.visibility import resolve_target_visibility
 
@@ -225,9 +224,12 @@ class CombatNpcActionResolutionMixin:
             save_success_outcome = cls._normalize_save_success_outcome(resolved_action.get("saveSuccessOutcome")) or "none"
             if not ability_name or save_dc_base <= 0:
                 raise CombatServiceError("Saving throw actions require save ability and save DC.")
-            effective_dc = max(0, save_dc_base - resolve_cover_save_modifier(context["cover"])) if should_cover_apply_to_save(
-                resolved_action.get("coverAppliesToSave"), ability_name
-            ) else save_dc_base
+            effective_dc, _ = resolve_cover_save_dc(
+                save_dc_base,
+                context["cover"],
+                resolved_action.get("coverAppliesToSave"),
+                ability_name,
+            )
             save_mod = modify_saving_throw(target_p, ability_name)
             roll_result = resolve_saving_throw(
                 cls._build_roll_actor_stats_for_save(

--- a/apps/control-server/app/services/combat_service/spells/cast_area.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_area.py
@@ -136,6 +136,10 @@ class CastAreaMixin:
         area_target_outcomes: list[dict[str, Any]] = []
         target_results_for_pending: list[dict[str, Any]] = []
         for target_participant in affected_participants:
+            # Area targeting currently exposes only aggregate area metadata, not
+            # per-target cover. Do not invent a shared cover rank for all
+            # affected targets; follow up once targeting can return per-target
+            # spatial metadata for area saves.
             roll_result = resolve_saving_throw(
                 cls._build_roll_actor_stats_for_save(
                     db,

--- a/apps/control-server/app/services/combat_service/spells/spell_resolution_save.py
+++ b/apps/control-server/app/services/combat_service/spells/spell_resolution_save.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from app.services.combat_service.cover_modifiers import resolve_cover_save_modifier, should_cover_apply_to_save
+from app.services.combat_service.cover_modifiers import resolve_cover_save_dc
 
 from .spell_resolution_common import SpellResolutionCommonMixin, SpellResolutionResult
 
@@ -30,7 +30,12 @@ class SpellResolutionSaveMixin(SpellResolutionCommonMixin):
         result = SpellResolutionResult()
         result.cover = targeting_result.spatial_metadata.cover
         save_dc_base = cls._safe_int(spell_context.get("save_dc"), 0)
-        result.effective_dc = max(0, save_dc_base - resolve_cover_save_modifier(result.cover)) if should_cover_apply_to_save(spell_context.get("cover_applies_to_save"), spell_context.get("save_ability")) else save_dc_base
+        result.effective_dc, _ = resolve_cover_save_dc(
+            save_dc_base,
+            result.cover,
+            spell_context.get("cover_applies_to_save"),
+            spell_context.get("save_ability"),
+        )
 
         result.roll_result = cast_target_module.resolve_saving_throw(
             cls._build_roll_actor_stats_for_save(db, session_id, target_p["ref_id"], target_p["kind"], target_p["display_name"]),

--- a/apps/control-server/app/services/combat_service/spells/spell_response.py
+++ b/apps/control-server/app/services/combat_service/spells/spell_response.py
@@ -186,6 +186,12 @@ class SpellResponseMixin:
             if automation_result is not None
             else effect_bonus
         )
+        if automation_result is not None:
+            response_save_dc = automation_result.get("save_dc")
+        elif spell_mode == "saving_throw":
+            response_save_dc = result.effective_dc
+        else:
+            response_save_dc = spell_context.get("save_dc")
 
         return {
             "spell_name": spell_context["spell_name"],
@@ -205,7 +211,7 @@ class SpellResponseMixin:
             "target_display_name": target_display_name,
             "target_kind": target_kind,
             "save_ability": spell_context.get("save_ability"),
-            "save_dc": spell_context.get("save_dc"),
+            "save_dc": response_save_dc,
             "save_success_outcome": save_success_outcome,
             "effect_dice": effect_dice,
             "effect_bonus": resp_effect_bonus,

--- a/apps/control-server/tests/_combat_test_flow.py
+++ b/apps/control-server/tests/_combat_test_flow.py
@@ -1205,6 +1205,260 @@ class CombatFlowTestsMixin:
     @patch("app.services.combat.CombatService._emit_entity_hp_update")
     @patch("app.services.combat.CombatService._emit_state")
     @patch("app.services.combat.CombatService._emit_log")
+    @patch("app.services.combat_service.spells.cast_target.resolve_saving_throw")
+    async def test_player_saving_throw_spell_uses_cover_adjusted_dc_for_physical_saves(
+        self,
+        mock_resolve_saving_throw,
+        mock_emit_log,
+        mock_emit_state,
+        mock_emit_entity_hp_update,
+        mock_emit_player_state_update,
+    ):
+        self.state.phase = CombatPhase.active
+        self.state.current_turn_index = 0
+        attacker_state = SessionState(
+            id="state-player",
+            session_id="session-123",
+            player_user_id="player-123",
+            state_json={
+                "abilities": {"charisma": 18},
+                "spellcasting": {
+                    "spells": [
+                        {
+                            "name": "Fireball",
+                            "canonicalKey": "fireball",
+                            "level": 3,
+                            "prepared": True,
+                        }
+                    ],
+                    "slots": {"3": {"used": 0, "max": 1}},
+                }
+            },
+        )
+        target_roll_stats = RollActorStats(
+            display_name="Goblin",
+            abilities={"dexterity": 10},
+            actor_kind="session_entity",
+            actor_ref_id="enemy-123",
+        )
+        save_roll = RollResult(
+            event_id="roll-physical-cover",
+            roll_type="save",
+            actor_kind="session_entity",
+            actor_ref_id="enemy-123",
+            actor_display_name="Goblin",
+            rolls=[13],
+            selected_roll=13,
+            advantage_mode="normal",
+            modifier_used=0,
+            override_used=False,
+            formula="1d20 + 0",
+            total=13,
+            ability="dexterity",
+            dc=13,
+            success=True,
+            timestamp=datetime.now(timezone.utc),
+        )
+        mock_resolve_saving_throw.return_value = save_roll
+        targeting_result = TargetingResult(
+            is_valid=True,
+            validated_primary_target_ref_id="enemy-123",
+            affected_target_ref_ids=["enemy-123"],
+            target_kind="session_entity",
+            spatial_metadata=SpatialMetadata(cover="half"),
+        )
+
+        with patch(
+            "app.services.combat.CombatService.get_state", return_value=self.state
+        ), patch(
+            "app.services.combat.CombatService._get_spell_catalog_entry_for_session",
+            return_value=MagicMock(
+                canonical_key="fireball",
+                name_en="Fireball",
+                name_pt="Bola de Fogo",
+                level=3,
+                resolution_type="saving_throw",
+                saving_throw="dexterity",
+                save_success_outcome="half_damage",
+                damage_type="fire",
+                damage_dice="8d6",
+                heal_dice=None,
+                cover_applies_to_save="physical",
+            ),
+        ), patch(
+            "app.services.combat.CombatService._get_stats",
+            return_value=(attacker_state, 12, 10, 10, 3, 4),
+        ), patch(
+            "app.services.combat.CombatService._build_roll_actor_stats_for_save",
+            return_value=target_roll_stats,
+        ), patch(
+            "app.services.combat_service.spells.cast_target.get_combat_targeting_service",
+            return_value=MagicMock(validate=MagicMock(return_value=targeting_result)),
+        ):
+            first_result = await CombatService.cast_spell(
+                self.db,
+                "session-123",
+                CombatCastSpellRequest(
+                    actor_participant_id="p1",
+                    target_ref_id="enemy-123",
+                    spell_canonical_key="fireball",
+                ),
+                "user-1",
+                False,
+            )
+
+            self.assertTrue(first_result["is_saved"])
+            self.assertEqual(first_result["save_dc"], 13)
+            self.assertTrue(first_result["effect_roll_required"])
+            self.assertIsNotNone(first_result["pending_spell_id"])
+            self.assertEqual(mock_resolve_saving_throw.call_args.kwargs["dc"], 13)
+
+            with patch(
+                "app.services.combat.CombatService._apply_damage_to_target",
+                return_value=(8, "", 20, None),
+            ) as mock_apply_damage:
+                second_result = await CombatService.cast_spell_effect(
+                    self.db,
+                    "session-123",
+                    CombatResolveSpellEffectRequest(
+                        actor_participant_id="p1",
+                        pending_spell_id=first_result["pending_spell_id"],
+                        roll_source="manual",
+                        manual_rolls=[6, 6, 6, 6, 6, 6, 6, 6],
+                    ),
+                    "user-1",
+                    False,
+                )
+
+        self.assertTrue(second_result["is_saved"])
+        self.assertEqual(second_result["save_dc"], 13)
+        self.assertEqual(second_result["base_effect"], 48)
+        self.assertEqual(second_result["damage"], 24)
+        mock_apply_damage.assert_called_once_with(
+            self.db,
+            "enemy-123",
+            "session_entity",
+            24,
+            damage_type="fire",
+            is_crit=False,
+            state=self.state,
+        )
+        mock_emit_state.assert_awaited()
+
+    @patch("app.services.combat.CombatService._emit_player_state_update")
+    @patch("app.services.combat.CombatService._emit_entity_hp_update")
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_log")
+    @patch("app.services.combat_service.spells.cast_target.resolve_saving_throw")
+    async def test_player_saving_throw_spell_does_not_apply_cover_without_metadata(
+        self,
+        mock_resolve_saving_throw,
+        mock_emit_log,
+        mock_emit_state,
+        mock_emit_entity_hp_update,
+        mock_emit_player_state_update,
+    ):
+        self.state.phase = CombatPhase.active
+        self.state.current_turn_index = 0
+        attacker_state = SessionState(
+            id="state-player",
+            session_id="session-123",
+            player_user_id="player-123",
+            state_json={
+                "abilities": {"charisma": 18},
+                "spellcasting": {
+                    "spells": [
+                        {
+                            "name": "Acid Splash",
+                            "canonicalKey": "acid_splash",
+                            "level": 0,
+                            "prepared": True,
+                        }
+                    ]
+                }
+            },
+        )
+        target_roll_stats = RollActorStats(
+            display_name="Goblin",
+            abilities={"dexterity": 10},
+            actor_kind="session_entity",
+            actor_ref_id="enemy-123",
+        )
+        save_roll = RollResult(
+            event_id="roll-no-cover-metadata",
+            roll_type="save",
+            actor_kind="session_entity",
+            actor_ref_id="enemy-123",
+            actor_display_name="Goblin",
+            rolls=[13],
+            selected_roll=13,
+            advantage_mode="normal",
+            modifier_used=0,
+            override_used=False,
+            formula="1d20 + 0",
+            total=13,
+            ability="dexterity",
+            dc=15,
+            success=False,
+            timestamp=datetime.now(timezone.utc),
+        )
+        mock_resolve_saving_throw.return_value = save_roll
+        targeting_result = TargetingResult(
+            is_valid=True,
+            validated_primary_target_ref_id="enemy-123",
+            affected_target_ref_ids=["enemy-123"],
+            target_kind="session_entity",
+            spatial_metadata=SpatialMetadata(cover="half"),
+        )
+
+        with patch(
+            "app.services.combat.CombatService.get_state", return_value=self.state
+        ), patch(
+            "app.services.combat.CombatService._get_spell_catalog_entry_for_session",
+            return_value=MagicMock(
+                canonical_key="acid_splash",
+                name_en="Acid Splash",
+                name_pt=None,
+                level=0,
+                resolution_type="saving_throw",
+                saving_throw="dexterity",
+                save_success_outcome="none",
+                damage_type="acid",
+                damage_dice="1d6",
+                heal_dice=None,
+                cover_applies_to_save=None,
+            ),
+        ), patch(
+            "app.services.combat.CombatService._get_stats",
+            return_value=(attacker_state, 12, 10, 10, 3, 4),
+        ), patch(
+            "app.services.combat.CombatService._build_roll_actor_stats_for_save",
+            return_value=target_roll_stats,
+        ), patch(
+            "app.services.combat_service.spells.cast_target.get_combat_targeting_service",
+            return_value=MagicMock(validate=MagicMock(return_value=targeting_result)),
+        ):
+            result = await CombatService.cast_spell(
+                self.db,
+                "session-123",
+                CombatCastSpellRequest(
+                    actor_participant_id="p1",
+                    target_ref_id="enemy-123",
+                    spell_canonical_key="acid_splash",
+                ),
+                "user-1",
+                False,
+            )
+
+        self.assertFalse(result["is_saved"])
+        self.assertEqual(result["save_dc"], 15)
+        self.assertEqual(mock_resolve_saving_throw.call_args.kwargs["dc"], 15)
+        self.assertIsNotNone(result["pending_spell_id"])
+
+    @patch("app.services.combat.CombatService._emit_player_state_update")
+    @patch("app.services.combat.CombatService._emit_entity_hp_update")
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_log")
     @patch(
         "app.services.combat.CombatService._apply_healing_to_target",
         return_value=(5, " (Revived!)", 0),

--- a/apps/control-server/tests/test_combat_area_targeting_integration.py
+++ b/apps/control-server/tests/test_combat_area_targeting_integration.py
@@ -159,6 +159,10 @@ class CombatAreaTargetingIntegrationTests(TestCombatServiceBase):
         self.assertEqual(second_result["affected_target_ref_ids"], ["player-123", "enemy-123"])
         self.assertEqual(second_result["target_count"], 2)
         self.assertEqual(
+            [call.kwargs["dc"] for call in mock_resolve_saving_throw.call_args_list],
+            [15, 15],
+        )
+        self.assertEqual(
             [outcome["damage_applied"] for outcome in second_result["area_target_outcomes"]],
             [24, 48],
         )

--- a/apps/control-server/tests/test_cover_modifiers.py
+++ b/apps/control-server/tests/test_cover_modifiers.py
@@ -1,5 +1,5 @@
 """
-Tests for cover modifier logic (Phase 4 & 5: mechanical cover effects).
+Tests for cover modifier logic (attack cover + save-cover metadata).
 
 Covers:
 - Core logic: each cover level produces the correct AC modifier (Phase 4)
@@ -7,7 +7,7 @@ Covers:
 - cover_label: human-readable strings for UI feedback
 - Integration: modifier flows into weapon/spell attack resolution via targeting result
 - Save modifier: cover reduces effective DC for physical/spatial saving throw spells (Phase 5)
-- should_cover_apply_to_save: metadata-first with DEX-fallback heuristic
+- should_cover_apply_to_save: metadata-first without heuristic fallback
 """
 from __future__ import annotations
 
@@ -22,6 +22,7 @@ from app.services.combat_service.cover_modifiers import (
     COVER_SAVE_RULE_VALUES,
     cover_label,
     resolve_cover_modifier,
+    resolve_cover_save_dc,
     resolve_cover_save_modifier,
     should_cover_apply_to_save,
 )
@@ -217,17 +218,15 @@ class ShouldCoverApplyToSaveTests(unittest.TestCase):
     def test_none_metadata_does_not_apply_for_dexterity_save(self) -> None:
         self.assertFalse(should_cover_apply_to_save("none", "dexterity"))
 
-    # --- Fallback heuristic (no metadata) ---
+    def test_no_metadata_dex_ability_does_not_apply_cover(self) -> None:
+        self.assertFalse(should_cover_apply_to_save(None, "dex"))
 
-    def test_no_metadata_dex_ability_applies_cover(self) -> None:
-        self.assertTrue(should_cover_apply_to_save(None, "dex"))
+    def test_no_metadata_dexterity_ability_does_not_apply_cover(self) -> None:
+        self.assertFalse(should_cover_apply_to_save(None, "dexterity"))
 
-    def test_no_metadata_dexterity_ability_applies_cover(self) -> None:
-        self.assertTrue(should_cover_apply_to_save(None, "dexterity"))
-
-    def test_no_metadata_dexterity_case_insensitive(self) -> None:
-        self.assertTrue(should_cover_apply_to_save(None, "DEX"))
-        self.assertTrue(should_cover_apply_to_save(None, "Dexterity"))
+    def test_no_metadata_dexterity_case_insensitive_does_not_apply_cover(self) -> None:
+        self.assertFalse(should_cover_apply_to_save(None, "DEX"))
+        self.assertFalse(should_cover_apply_to_save(None, "Dexterity"))
 
     def test_no_metadata_wis_ability_does_not_apply_cover(self) -> None:
         self.assertFalse(should_cover_apply_to_save(None, "wis"))
@@ -255,9 +254,13 @@ class CoverSaveIntegrationTests(unittest.TestCase):
         cover_applies_to_save: str | None,
         save_ability: str | None = None,
     ) -> int:
-        if should_cover_apply_to_save(cover_applies_to_save, save_ability):
-            return max(0, base_dc - resolve_cover_save_modifier(cover))
-        return base_dc
+        effective_dc, _ = resolve_cover_save_dc(
+            base_dc,
+            cover,
+            cover_applies_to_save,
+            save_ability,
+        )
+        return effective_dc
 
     def test_fireball_half_cover_reduces_dc_by_two(self) -> None:
         # fireball → "physical", DEX save; half cover reduces DC 15 to 13
@@ -296,14 +299,27 @@ class CoverSaveIntegrationTests(unittest.TestCase):
         effective = self._effective_dc(14, "half", "physical", "con")
         self.assertEqual(effective, 12)
 
-    def test_fallback_dex_save_no_metadata_gets_cover(self) -> None:
-        # Legacy catalog entry (no metadata); DEX save assumed physical
+    def test_null_metadata_dex_save_does_not_get_cover(self) -> None:
         effective = self._effective_dc(14, "half", None, "dex")
-        self.assertEqual(effective, 12)
+        self.assertEqual(effective, 14)
 
     def test_fallback_wis_save_no_metadata_does_not_get_cover(self) -> None:
         effective = self._effective_dc(14, "half", None, "wis")
         self.assertEqual(effective, 14)
+
+    def test_unknown_metadata_does_not_get_cover(self) -> None:
+        effective = self._effective_dc(14, "half", "unexpected", "dexterity")
+        self.assertEqual(effective, 14)
+
+    def test_resolve_cover_save_dc_returns_modifier_for_half_cover(self) -> None:
+        effective, modifier = resolve_cover_save_dc(15, "half", "physical", "dexterity")
+        self.assertEqual(effective, 13)
+        self.assertEqual(modifier, 2)
+
+    def test_resolve_cover_save_dc_returns_modifier_for_three_quarters_cover(self) -> None:
+        effective, modifier = resolve_cover_save_dc(15, "threeQuarters", "physical", "dexterity")
+        self.assertEqual(effective, 10)
+        self.assertEqual(modifier, 5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Applies cover modifiers to saving throw spell runtime when spell metadata allows it.

Saving throw cover is now metadata-driven through `cover_applies_to_save = "physical"`. When applicable, the runtime reduces the effective save DC by the target's cover modifier from `TargetingResult`.

## Changes

- Added `resolve_cover_save_dc(...)` in `cover_modifiers.py`
- Updated single-target saving throw spell runtime in `spell_resolution_save.py`
- Updated equivalent NPC action resolution path in `npc_action_resolution.py`
- Updated spell cast response so saving throw casts return the effective `save_dc`
- Left area spell cover unchanged until reliable per-target spatial metadata exists
- Added TODO in `cast_area.py` for future per-target area cover support

## Rules

- `cover_applies_to_save = "physical"` applies cover to save DC
- half cover reduces effective DC by 2
- three-quarters cover reduces effective DC by 5
- `none`, `null`, missing, or unknown metadata does not apply cover
- effective DC is clamped with `max(0, ...)`
- area spells remain unchanged without per-target cover metadata

## Validation

```bash
.venv/bin/python -m pytest -q tests/test_cover_modifiers.py tests/test_combat_area_targeting_integration.py
.venv/bin/python -m pytest -q tests -k "cover_adjusted_dc or without_metadata or saving_throw_spell_can_apply_half_damage_on_success"