### PR TITLE
feat(cast-area): add per-target cover metadata handling in area savin…

### DIFF
--- a/apps/control-server/app/services/combat_service/spells/cast_area.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_area.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 from uuid import uuid4
 
 from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import Session
 
+from app.core.config import settings
+from app.integrations import LimiarMapClientError
 from app.models.combat import CombatState
 from app.models.inventory import InventoryItem
 from app.schemas.combat import CombatCastSpellRequest
@@ -13,13 +16,64 @@ from app.services.magic_item_effects import consume_inventory_item_charge
 from app.services.roll_resolution import resolve_saving_throw
 
 from ..combat_targeting import get_combat_targeting_service
+from ..cover_modifiers import resolve_cover_save_dc, should_cover_apply_to_save
 from ..exceptions import CombatServiceError
 from ..limiar_map_projection import maybe_sync_active_area_effects_to_limiar_map
 from ..persistent_area_effects import build_persistent_spell_area_effect
 from ..targeting_intent import AreaTargetingIntent
 
+logger = logging.getLogger(__name__)
+
 
 class CastAreaMixin:
+    @classmethod
+    def _get_area_per_target_cover(
+        cls,
+        *,
+        session_id: str,
+        action_id: str,
+        actor_ref_id: str,
+        target_ref_ids: list[str],
+        use_map: bool,
+    ) -> dict[str, str | None]:
+        """Return cover from actor position to each affected area target.
+
+        Used when cover_applies_to_save warrants per-target DC reduction.
+        Any target whose lookup fails maps to None so the cast continues at
+        the base DC (defensive default — cover is a bonus, not a blocker).
+
+        TODO: Replace N individual calls with a batch endpoint once the map
+        API exposes one (follow-up: Batch area target spatial metadata lookup).
+        """
+        if not target_ref_ids:
+            return {}
+        if not use_map or not settings.limiar_map_enabled:
+            return {ref_id: None for ref_id in target_ref_ids}
+        client = cls._build_limiar_map_client()
+        result: dict[str, str | None] = {}
+        for target_ref_id in target_ref_ids:
+            try:
+                response = client.validate_single_target(
+                    session_id=session_id,
+                    action_id=f"{action_id}:cover:{target_ref_id}",
+                    combatant_id=actor_ref_id,
+                    target_combatant_id=target_ref_id,
+                    range_cells=None,
+                    requires_sight=False,
+                    requires_effect=False,
+                )
+                result[target_ref_id] = response.cover
+            except LimiarMapClientError as exc:
+                logger.warning(
+                    "Cover lookup failed for area target session_id=%s "
+                    "target_ref_id=%s (%s); falling back to base DC",
+                    session_id,
+                    target_ref_id,
+                    exc,
+                )
+                result[target_ref_id] = None
+        return result
+
     @classmethod
     async def _cast_area_spell(
         cls,
@@ -133,28 +187,44 @@ class CastAreaMixin:
                 spell_canonical_key=spell_context["spell_canonical_key"],
                 target_participant=target_participant,
             )
+        cover_applies_to_save = spell_context.get("cover_applies_to_save")
+        per_target_cover: dict[str, str | None] = {}
+        if should_cover_apply_to_save(cover_applies_to_save):
+            per_target_cover = cls._get_area_per_target_cover(
+                session_id=session_id,
+                action_id=f"area-cover:{uuid4()}",
+                actor_ref_id=attacker["ref_id"],
+                target_ref_ids=[p["ref_id"] for p in affected_participants],
+                use_map=state.use_map,
+            )
+
+        base_save_dc = cls._safe_int(spell_context.get("save_dc"), 0)
         area_target_outcomes: list[dict[str, Any]] = []
         target_results_for_pending: list[dict[str, Any]] = []
         for target_participant in affected_participants:
-            # Area targeting currently exposes only aggregate area metadata, not
-            # per-target cover. Do not invent a shared cover rank for all
-            # affected targets; follow up once targeting can return per-target
-            # spatial metadata for area saves.
+            target_ref_id = target_participant["ref_id"]
+            target_cover = per_target_cover.get(target_ref_id)
+            effective_dc, _ = resolve_cover_save_dc(
+                base_save_dc,
+                target_cover,
+                cover_applies_to_save,
+                spell_context.get("save_ability"),
+            )
             roll_result = resolve_saving_throw(
                 cls._build_roll_actor_stats_for_save(
                     db,
                     session_id,
-                    target_participant["ref_id"],
+                    target_ref_id,
                     target_participant["kind"],
                     target_participant["display_name"],
                 ),
                 ability=spell_context["save_ability"],
-                dc=cls._safe_int(spell_context.get("save_dc"), 0),
+                dc=effective_dc,
             )
             roll_result.is_gm_roll = is_gm
             is_saved = bool(roll_result.success)
             outcome = {
-                "target_ref_id": target_participant["ref_id"],
+                "target_ref_id": target_ref_id,
                 "target_display_name": target_participant["display_name"],
                 "target_kind": target_participant["kind"],
                 "is_saved": is_saved,
@@ -163,6 +233,8 @@ class CastAreaMixin:
                 "damage_applied": None,
                 "healing_applied": None,
                 "new_hp": None,
+                "cover": target_cover,
+                "effective_dc": effective_dc,
             }
             area_target_outcomes.append(outcome)
             target_results_for_pending.append(

--- a/apps/control-server/tests/test_cast_area_cover.py
+++ b/apps/control-server/tests/test_cast_area_cover.py
@@ -1,0 +1,502 @@
+"""Tests for per-target cover metadata in area saving throw spells.
+
+Verifies that _get_area_per_target_cover returns the correct cover per target,
+and that _cast_area_spell applies resolve_cover_save_dc per target when
+cover_applies_to_save permits.
+
+Acceptance criteria:
+- Half cover reduces DC by 2 per target.
+- Three-quarters cover reduces DC by 5 per target.
+- No cover / None metadata keeps base DC.
+- cover_applies_to_save=None/none keeps base DC even with cover.
+- Full cover does not reduce DC.
+- Each target gets its own effective DC independently.
+- Map unavailable or disabled → all targets fall back to None cover.
+- Metadata lookup failure for one target → that target falls back to None.
+- Footprint/affected targets are unchanged.
+"""
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from _combat_test_shared import TestCombatServiceBase
+from app.integrations.limiar_map_client_types import LimiarMapClientError, LimiarMapTargetingResponse
+from app.models.combat import CombatPhase
+from app.models.session_state import SessionState
+from app.schemas.combat import CombatCastSpellRequest, CombatGridCell
+from app.schemas.roll import RollActorStats
+from app.services.combat import CombatService
+from app.services.combat_service.targeting_result import SpatialMetadata, TargetingResult
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _get_area_per_target_cover
+# ---------------------------------------------------------------------------
+
+class GetAreaPerTargetCoverTests(unittest.TestCase):
+    """Unit tests for the _get_area_per_target_cover helper."""
+
+    def _targeting_response(self, cover: str | None) -> LimiarMapTargetingResponse:
+        return LimiarMapTargetingResponse(
+            is_valid=True,
+            reason=None,
+            session_id="s1",
+            action_id="a1",
+            version=1,
+            source_token_id="tok_actor",
+            target_token_id="tok_target",
+            cover=cover,
+        )
+
+    def test_empty_target_list_returns_empty_dict(self):
+        result = CombatService._get_area_per_target_cover(
+            session_id="s1",
+            action_id="a1",
+            actor_ref_id="actor",
+            target_ref_ids=[],
+            use_map=True,
+        )
+        self.assertEqual(result, {})
+
+    def test_use_map_false_returns_all_none(self):
+        result = CombatService._get_area_per_target_cover(
+            session_id="s1",
+            action_id="a1",
+            actor_ref_id="actor",
+            target_ref_ids=["t1", "t2"],
+            use_map=False,
+        )
+        self.assertEqual(result, {"t1": None, "t2": None})
+
+    @patch("app.services.combat_service.spells.cast_area.settings")
+    def test_limiar_map_disabled_returns_all_none(self, mock_settings):
+        mock_settings.limiar_map_enabled = False
+        result = CombatService._get_area_per_target_cover(
+            session_id="s1",
+            action_id="a1",
+            actor_ref_id="actor",
+            target_ref_ids=["t1"],
+            use_map=True,
+        )
+        self.assertEqual(result, {"t1": None})
+
+    @patch("app.services.combat_service.spells.cast_area.settings")
+    def test_returns_cover_per_target_from_map(self, mock_settings):
+        mock_settings.limiar_map_enabled = True
+        mock_client = MagicMock()
+        mock_client.validate_single_target.side_effect = [
+            self._targeting_response("none"),
+            self._targeting_response("half"),
+            self._targeting_response("threeQuarters"),
+        ]
+        with patch.object(CombatService, "_build_limiar_map_client", return_value=mock_client):
+            result = CombatService._get_area_per_target_cover(
+                session_id="s1",
+                action_id="a1",
+                actor_ref_id="actor",
+                target_ref_ids=["t1", "t2", "t3"],
+                use_map=True,
+            )
+        self.assertEqual(result, {"t1": "none", "t2": "half", "t3": "threeQuarters"})
+
+    @patch("app.services.combat_service.spells.cast_area.settings")
+    def test_map_error_for_one_target_falls_back_to_none(self, mock_settings):
+        mock_settings.limiar_map_enabled = True
+        mock_client = MagicMock()
+        mock_client.validate_single_target.side_effect = [
+            self._targeting_response("half"),
+            LimiarMapClientError("timeout", kind="timeout"),
+        ]
+        with patch.object(CombatService, "_build_limiar_map_client", return_value=mock_client):
+            result = CombatService._get_area_per_target_cover(
+                session_id="s1",
+                action_id="a1",
+                actor_ref_id="actor",
+                target_ref_ids=["t1", "t2"],
+                use_map=True,
+            )
+        self.assertEqual(result["t1"], "half")
+        self.assertIsNone(result["t2"])
+
+    @patch("app.services.combat_service.spells.cast_area.settings")
+    def test_response_cover_none_stored_as_none(self, mock_settings):
+        mock_settings.limiar_map_enabled = True
+        mock_client = MagicMock()
+        mock_client.validate_single_target.return_value = self._targeting_response(None)
+        with patch.object(CombatService, "_build_limiar_map_client", return_value=mock_client):
+            result = CombatService._get_area_per_target_cover(
+                session_id="s1",
+                action_id="a1",
+                actor_ref_id="actor",
+                target_ref_ids=["t1"],
+                use_map=True,
+            )
+        self.assertIsNone(result["t1"])
+
+    @patch("app.services.combat_service.spells.cast_area.settings")
+    def test_validate_single_target_called_without_range_or_sight_checks(self, mock_settings):
+        mock_settings.limiar_map_enabled = True
+        mock_client = MagicMock()
+        mock_client.validate_single_target.return_value = self._targeting_response("half")
+        with patch.object(CombatService, "_build_limiar_map_client", return_value=mock_client):
+            CombatService._get_area_per_target_cover(
+                session_id="s1",
+                action_id="a1",
+                actor_ref_id="actor",
+                target_ref_ids=["t1"],
+                use_map=True,
+            )
+        call_kwargs = mock_client.validate_single_target.call_args.kwargs
+        self.assertIsNone(call_kwargs["range_cells"])
+        self.assertFalse(call_kwargs["requires_sight"])
+        self.assertFalse(call_kwargs["requires_effect"])
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: per-target DC in _cast_area_spell
+# ---------------------------------------------------------------------------
+
+def _make_map_targeting_result(affected_ref_ids: list[str]) -> TargetingResult:
+    return TargetingResult(
+        is_valid=True,
+        validated_primary_target_ref_id=affected_ref_ids[0] if affected_ref_ids else "",
+        affected_target_ref_ids=affected_ref_ids,
+        target_kind="session_entity",
+        spatial_metadata=SpatialMetadata(
+            source_token_id="tok_player",
+            affected_token_ids=[f"tok_{r}" for r in affected_ref_ids],
+            affected_cells=[{"x": 10, "y": 10}],
+            area_shape="sphere",
+            map_version=1,
+            targeting_authority="limiar_map",
+        ),
+    )
+
+
+def _make_spell_catalog_entry(cover_applies_to_save: str | None = None):
+    return MagicMock(
+        canonical_key="fireball",
+        name_en="Fireball",
+        name_pt="Bola de Fogo",
+        level=3,
+        resolution_type="saving_throw",
+        saving_throw="dexterity",
+        save_success_outcome="half_damage",
+        damage_type="fire",
+        damage_dice="8d6",
+        heal_dice=None,
+        upcast_json=None,
+        casting_time_type="action",
+        target_type="ranged",
+        area_shape="sphere",
+        range_meters=45,
+        radius_meters=6,
+        cover_applies_to_save=cover_applies_to_save,
+    )
+
+
+def _make_attacker_state() -> SessionState:
+    return SessionState(
+        id="state-player",
+        session_id="session-123",
+        player_user_id="player-123",
+        state_json={
+            "abilities": {"intelligence": 18},
+            "spellcasting": {
+                "spells": [{"name": "Fireball", "canonicalKey": "fireball", "level": 3, "prepared": True}],
+                "slots": {"3": {"used": 0, "max": 2}},
+            },
+        },
+    )
+
+
+def _make_roll_actor_stats(ref_id: str) -> RollActorStats:
+    return RollActorStats(
+        display_name="Target",
+        abilities={"dexterity": 10},
+        actor_kind="session_entity",
+        actor_ref_id=ref_id,
+    )
+
+
+class AreaSaveCoverApplyTests(TestCombatServiceBase):
+    """Integration tests: verify per-target DC reduction in _cast_area_spell."""
+
+    def setUp(self):
+        super().setUp()
+        self.state.phase = CombatPhase.active
+        self.state.current_turn_index = 0
+
+    async def _cast_fireball(self) -> dict:
+        return await CombatService.cast_spell(
+            self.db,
+            "session-123",
+            CombatCastSpellRequest(
+                actor_participant_id="p1",
+                origin_cell=CombatGridCell(x=8, y=8),
+                anchor_cell=CombatGridCell(x=10, y=10),
+                spell_canonical_key="fireball",
+            ),
+            "user-1",
+            False,
+        )
+
+    async def test_no_cover_metadata_uses_base_dc(self):
+        mock_save = MagicMock(side_effect=[MagicMock(total=10, success=False)])
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state), \
+             patch("app.services.combat.CombatService._get_spell_catalog_entry_for_session",
+                   return_value=_make_spell_catalog_entry("physical")), \
+             patch("app.services.combat.CombatService._get_stats",
+                   return_value=(_make_attacker_state(), 12, 10, 10, 3, 4)), \
+             patch("app.services.combat.CombatService._build_roll_actor_stats_for_save",
+                   side_effect=lambda _db, _sid, ref_id, *a, **kw: _make_roll_actor_stats(ref_id)), \
+             patch("app.services.combat_service.spells.cast_area.get_combat_targeting_service",
+                   return_value=SimpleNamespace(validate=MagicMock(
+                       return_value=_make_map_targeting_result(["enemy-123"])))), \
+             patch("app.services.combat.CombatService._get_area_per_target_cover",
+                   return_value={"enemy-123": None}), \
+             patch("app.services.combat_service.spells.cast_area.resolve_saving_throw", mock_save), \
+             patch("app.services.combat.CombatService._emit_player_state_update", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_log", new_callable=AsyncMock):
+            await self._cast_fireball()
+        dc_used = mock_save.call_args.kwargs["dc"]
+        self.assertEqual(dc_used, 15)
+
+    async def test_half_cover_reduces_dc_by_two(self):
+        mock_save = MagicMock(side_effect=[MagicMock(total=10, success=False)])
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state), \
+             patch("app.services.combat.CombatService._get_spell_catalog_entry_for_session",
+                   return_value=_make_spell_catalog_entry("physical")), \
+             patch("app.services.combat.CombatService._get_stats",
+                   return_value=(_make_attacker_state(), 12, 10, 10, 3, 4)), \
+             patch("app.services.combat.CombatService._build_roll_actor_stats_for_save",
+                   side_effect=lambda _db, _sid, ref_id, *a, **kw: _make_roll_actor_stats(ref_id)), \
+             patch("app.services.combat_service.spells.cast_area.get_combat_targeting_service",
+                   return_value=SimpleNamespace(validate=MagicMock(
+                       return_value=_make_map_targeting_result(["enemy-123"])))), \
+             patch("app.services.combat.CombatService._get_area_per_target_cover",
+                   return_value={"enemy-123": "half"}), \
+             patch("app.services.combat_service.spells.cast_area.resolve_saving_throw", mock_save), \
+             patch("app.services.combat.CombatService._emit_player_state_update", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_log", new_callable=AsyncMock):
+            await self._cast_fireball()
+        dc_used = mock_save.call_args.kwargs["dc"]
+        self.assertEqual(dc_used, 13)  # 15 - 2
+
+    async def test_three_quarters_cover_reduces_dc_by_five(self):
+        mock_save = MagicMock(side_effect=[MagicMock(total=10, success=False)])
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state), \
+             patch("app.services.combat.CombatService._get_spell_catalog_entry_for_session",
+                   return_value=_make_spell_catalog_entry("physical")), \
+             patch("app.services.combat.CombatService._get_stats",
+                   return_value=(_make_attacker_state(), 12, 10, 10, 3, 4)), \
+             patch("app.services.combat.CombatService._build_roll_actor_stats_for_save",
+                   side_effect=lambda _db, _sid, ref_id, *a, **kw: _make_roll_actor_stats(ref_id)), \
+             patch("app.services.combat_service.spells.cast_area.get_combat_targeting_service",
+                   return_value=SimpleNamespace(validate=MagicMock(
+                       return_value=_make_map_targeting_result(["enemy-123"])))), \
+             patch("app.services.combat.CombatService._get_area_per_target_cover",
+                   return_value={"enemy-123": "threeQuarters"}), \
+             patch("app.services.combat_service.spells.cast_area.resolve_saving_throw", mock_save), \
+             patch("app.services.combat.CombatService._emit_player_state_update", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_log", new_callable=AsyncMock):
+            await self._cast_fireball()
+        dc_used = mock_save.call_args.kwargs["dc"]
+        self.assertEqual(dc_used, 10)  # 15 - 5
+
+    async def test_cover_applies_to_save_none_string_does_not_reduce_dc(self):
+        mock_save = MagicMock(side_effect=[MagicMock(total=10, success=False)])
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state), \
+             patch("app.services.combat.CombatService._get_spell_catalog_entry_for_session",
+                   return_value=_make_spell_catalog_entry("none")), \
+             patch("app.services.combat.CombatService._get_stats",
+                   return_value=(_make_attacker_state(), 12, 10, 10, 3, 4)), \
+             patch("app.services.combat.CombatService._build_roll_actor_stats_for_save",
+                   side_effect=lambda _db, _sid, ref_id, *a, **kw: _make_roll_actor_stats(ref_id)), \
+             patch("app.services.combat_service.spells.cast_area.get_combat_targeting_service",
+                   return_value=SimpleNamespace(validate=MagicMock(
+                       return_value=_make_map_targeting_result(["enemy-123"])))), \
+             patch("app.services.combat.CombatService._get_area_per_target_cover") as mock_cover_lookup, \
+             patch("app.services.combat_service.spells.cast_area.resolve_saving_throw", mock_save), \
+             patch("app.services.combat.CombatService._emit_player_state_update", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_log", new_callable=AsyncMock):
+            await self._cast_fireball()
+        # Cover lookup skipped since cover_applies_to_save != "physical"
+        mock_cover_lookup.assert_not_called()
+        dc_used = mock_save.call_args.kwargs["dc"]
+        self.assertEqual(dc_used, 15)
+
+    async def test_cover_applies_to_save_null_does_not_reduce_dc(self):
+        mock_save = MagicMock(side_effect=[MagicMock(total=10, success=False)])
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state), \
+             patch("app.services.combat.CombatService._get_spell_catalog_entry_for_session",
+                   return_value=_make_spell_catalog_entry(None)), \
+             patch("app.services.combat.CombatService._get_stats",
+                   return_value=(_make_attacker_state(), 12, 10, 10, 3, 4)), \
+             patch("app.services.combat.CombatService._build_roll_actor_stats_for_save",
+                   side_effect=lambda _db, _sid, ref_id, *a, **kw: _make_roll_actor_stats(ref_id)), \
+             patch("app.services.combat_service.spells.cast_area.get_combat_targeting_service",
+                   return_value=SimpleNamespace(validate=MagicMock(
+                       return_value=_make_map_targeting_result(["enemy-123"])))), \
+             patch("app.services.combat.CombatService._get_area_per_target_cover") as mock_cover_lookup, \
+             patch("app.services.combat_service.spells.cast_area.resolve_saving_throw", mock_save), \
+             patch("app.services.combat.CombatService._emit_player_state_update", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_log", new_callable=AsyncMock):
+            await self._cast_fireball()
+        mock_cover_lookup.assert_not_called()
+        dc_used = mock_save.call_args.kwargs["dc"]
+        self.assertEqual(dc_used, 15)
+
+    async def test_full_cover_does_not_reduce_dc(self):
+        mock_save = MagicMock(side_effect=[MagicMock(total=10, success=False)])
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state), \
+             patch("app.services.combat.CombatService._get_spell_catalog_entry_for_session",
+                   return_value=_make_spell_catalog_entry("physical")), \
+             patch("app.services.combat.CombatService._get_stats",
+                   return_value=(_make_attacker_state(), 12, 10, 10, 3, 4)), \
+             patch("app.services.combat.CombatService._build_roll_actor_stats_for_save",
+                   side_effect=lambda _db, _sid, ref_id, *a, **kw: _make_roll_actor_stats(ref_id)), \
+             patch("app.services.combat_service.spells.cast_area.get_combat_targeting_service",
+                   return_value=SimpleNamespace(validate=MagicMock(
+                       return_value=_make_map_targeting_result(["enemy-123"])))), \
+             patch("app.services.combat.CombatService._get_area_per_target_cover",
+                   return_value={"enemy-123": "full"}), \
+             patch("app.services.combat_service.spells.cast_area.resolve_saving_throw", mock_save), \
+             patch("app.services.combat.CombatService._emit_player_state_update", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_log", new_callable=AsyncMock):
+            await self._cast_fireball()
+        dc_used = mock_save.call_args.kwargs["dc"]
+        # full cover modifier is 0 (blocked upstream, not a DC modifier)
+        self.assertEqual(dc_used, 15)
+
+    async def test_multi_target_each_uses_own_dc(self):
+        """Three targets: no cover, half, three-quarters → three different effective DCs."""
+        self.state.participants.append({
+            "id": "e2",
+            "ref_id": "enemy-456",
+            "kind": "session_entity",
+            "display_name": "Orc",
+            "initiative": None,
+            "status": "active",
+            "team": "enemies",
+            "visible": True,
+            "actor_user_id": None,
+        })
+        self.state.participants.append({
+            "id": "e3",
+            "ref_id": "enemy-789",
+            "kind": "session_entity",
+            "display_name": "Troll",
+            "initiative": None,
+            "status": "active",
+            "team": "enemies",
+            "visible": True,
+            "actor_user_id": None,
+        })
+        affected_ids = ["enemy-123", "enemy-456", "enemy-789"]
+        mock_save = MagicMock(side_effect=[
+            MagicMock(total=10, success=False),
+            MagicMock(total=12, success=True),
+            MagicMock(total=11, success=True),
+        ])
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state), \
+             patch("app.services.combat.CombatService._get_spell_catalog_entry_for_session",
+                   return_value=_make_spell_catalog_entry("physical")), \
+             patch("app.services.combat.CombatService._get_stats",
+                   return_value=(_make_attacker_state(), 12, 10, 10, 3, 4)), \
+             patch("app.services.combat.CombatService._build_roll_actor_stats_for_save",
+                   side_effect=lambda _db, _sid, ref_id, *a, **kw: _make_roll_actor_stats(ref_id)), \
+             patch("app.services.combat_service.spells.cast_area.get_combat_targeting_service",
+                   return_value=SimpleNamespace(validate=MagicMock(
+                       return_value=_make_map_targeting_result(affected_ids)))), \
+             patch("app.services.combat.CombatService._get_area_per_target_cover",
+                   return_value={
+                       "enemy-123": None,          # no cover → DC 15
+                       "enemy-456": "half",         # half cover → DC 13
+                       "enemy-789": "threeQuarters", # 3/4 cover → DC 10
+                   }), \
+             patch("app.services.combat_service.spells.cast_area.resolve_saving_throw", mock_save), \
+             patch("app.services.combat.CombatService._emit_player_state_update", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_log", new_callable=AsyncMock):
+            result = await self._cast_fireball()
+
+        dc_values = [call.kwargs["dc"] for call in mock_save.call_args_list]
+        self.assertEqual(dc_values, [15, 13, 10])
+        self.assertEqual(result["target_count"], 3)
+        self.assertEqual(result["affected_target_ref_ids"], affected_ids)
+
+    async def test_outcomes_include_cover_and_effective_dc(self):
+        mock_save = MagicMock(side_effect=[MagicMock(total=10, success=False)])
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state), \
+             patch("app.services.combat.CombatService._get_spell_catalog_entry_for_session",
+                   return_value=_make_spell_catalog_entry("physical")), \
+             patch("app.services.combat.CombatService._get_stats",
+                   return_value=(_make_attacker_state(), 12, 10, 10, 3, 4)), \
+             patch("app.services.combat.CombatService._build_roll_actor_stats_for_save",
+                   side_effect=lambda _db, _sid, ref_id, *a, **kw: _make_roll_actor_stats(ref_id)), \
+             patch("app.services.combat_service.spells.cast_area.get_combat_targeting_service",
+                   return_value=SimpleNamespace(validate=MagicMock(
+                       return_value=_make_map_targeting_result(["enemy-123"])))), \
+             patch("app.services.combat.CombatService._get_area_per_target_cover",
+                   return_value={"enemy-123": "half"}), \
+             patch("app.services.combat_service.spells.cast_area.resolve_saving_throw", mock_save), \
+             patch("app.services.combat.CombatService._emit_player_state_update", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_log", new_callable=AsyncMock):
+            result = await self._cast_fireball()
+        outcome = result["area_target_outcomes"][0]
+        self.assertEqual(outcome["cover"], "half")
+        self.assertEqual(outcome["effective_dc"], 13)
+
+    async def test_affected_targets_unchanged_by_cover_logic(self):
+        """Cover metadata does not change which targets are affected."""
+        mock_save = MagicMock(side_effect=[MagicMock(total=10, success=False)])
+        target_result = _make_map_targeting_result(["enemy-123"])
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state), \
+             patch("app.services.combat.CombatService._get_spell_catalog_entry_for_session",
+                   return_value=_make_spell_catalog_entry("physical")), \
+             patch("app.services.combat.CombatService._get_stats",
+                   return_value=(_make_attacker_state(), 12, 10, 10, 3, 4)), \
+             patch("app.services.combat.CombatService._build_roll_actor_stats_for_save",
+                   side_effect=lambda _db, _sid, ref_id, *a, **kw: _make_roll_actor_stats(ref_id)), \
+             patch("app.services.combat_service.spells.cast_area.get_combat_targeting_service",
+                   return_value=SimpleNamespace(validate=MagicMock(return_value=target_result))), \
+             patch("app.services.combat.CombatService._get_area_per_target_cover",
+                   return_value={"enemy-123": "threeQuarters"}), \
+             patch("app.services.combat_service.spells.cast_area.resolve_saving_throw", mock_save), \
+             patch("app.services.combat.CombatService._emit_player_state_update", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_log", new_callable=AsyncMock):
+            result = await self._cast_fireball()
+        self.assertEqual(result["affected_target_ref_ids"], ["enemy-123"])
+        self.assertEqual(result["affected_cells"], [{"x": 10, "y": 10}])
+
+    async def test_cover_lookup_not_called_when_cover_does_not_apply(self):
+        """_get_area_per_target_cover must not be called when cover_applies_to_save is absent."""
+        mock_save = MagicMock(side_effect=[MagicMock(total=10, success=False)])
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state), \
+             patch("app.services.combat.CombatService._get_spell_catalog_entry_for_session",
+                   return_value=_make_spell_catalog_entry(None)), \
+             patch("app.services.combat.CombatService._get_stats",
+                   return_value=(_make_attacker_state(), 12, 10, 10, 3, 4)), \
+             patch("app.services.combat.CombatService._build_roll_actor_stats_for_save",
+                   side_effect=lambda _db, _sid, ref_id, *a, **kw: _make_roll_actor_stats(ref_id)), \
+             patch("app.services.combat_service.spells.cast_area.get_combat_targeting_service",
+                   return_value=SimpleNamespace(validate=MagicMock(
+                       return_value=_make_map_targeting_result(["enemy-123"])))), \
+             patch("app.services.combat.CombatService._get_area_per_target_cover") as mock_cover_lookup, \
+             patch("app.services.combat_service.spells.cast_area.resolve_saving_throw", mock_save), \
+             patch("app.services.combat.CombatService._emit_player_state_update", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock), \
+             patch("app.services.combat.CombatService._emit_log", new_callable=AsyncMock):
+            await self._cast_fireball()
+        mock_cover_lookup.assert_not_called()


### PR DESCRIPTION
## Summary

Adds per-target cover metadata for area saving throw runtime.

Area saving throw spells can now apply cover-adjusted effective DC per affected target when `cover_applies_to_save = "physical"`.

This closes runtime parity for area save cover without changing area footprint, affected target calculation, origin validation, or cast behavior when cover metadata is unavailable.

## Changes

### `cast_area.py`

- Added `_get_area_per_target_cover(...)`
- Fetches cover metadata per affected target through the LimiarMap client
- Uses `validate_single_target(actor → target)` with:
  - `range_cells = None`
  - `requires_sight = False`
  - `requires_effect = False`
- This intentionally bypasses range/LoS/LoE checks because the area origin was already validated; the call is only used to retrieve cover geometry
- Falls back to `None` per target on `LimiarMapClientError`
- Short-circuits to `{ ref_id: None }` when map is disabled or `use_map = False`
- Includes TODO for replacing N per-target calls with a batch endpoint later

### Area save loop

- Skips cover lookup entirely unless `cover_applies_to_save = "physical"`
- Applies `resolve_cover_save_dc(...)` per affected target
- Passes each target's effective DC into `resolve_saving_throw`
- Adds `cover` and `effective_dc` to `area_target_outcomes` for debugging

## Behavior

- No cover: base DC
- Half cover: DC - 2
- Three-quarters cover: DC - 5
- Full cover: no DC reduction
- `cover_applies_to_save = "none"`: no DC reduction
- Missing/failed cover metadata: base DC fallback
- Each affected target uses its own cover/effective DC

## Validation

Added `tests/test_cast_area_cover.py` with 17 tests covering:

- empty target list
- `use_map = False`
- map disabled
- cover per target from map
- per-target map error fallback
- `None` cover response
- `validate_single_target` called without range/sight/effect flags
- base DC with no cover
- half cover DC reduction
- three-quarters cover DC reduction
- no reduction when cover does not apply
- no reduction for full cover
- multi-target mixed cover
- outcomes include `cover` and `effective_dc`
- footprint unchanged
- no cover lookup when cover does not apply