### PR TITLE
feat(spatial-metadata): implement per-target effective DC display and…

### DIFF
--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastDialogHeader.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastDialogHeader.tsx
@@ -7,6 +7,7 @@ import type { GridCell } from "./areaTargetingUi";
 import type { SpellMapPreviewModel } from "./spellMapPreviewModel";
 import {
   formatAreaOriginPreviewLabel,
+  formatAreaTargetEffectiveDcLine,
   formatSpellCoverPreview,
   formatSpellMapPreviewReason,
   formatSpellMapPreviewStatus,
@@ -205,6 +206,15 @@ export const SpellCastDialogHeader = ({
           ) : null}
           {mapPreviewModel.affectedTargetNames?.length ? (
             <p className="mt-1 text-xs opacity-90">Alvos: {mapPreviewModel.affectedTargetNames.join(", ")}</p>
+          ) : null}
+          {mapPreviewModel.affectedTargetSpatialMetadata?.length ? (
+            <div className="mt-2 space-y-0.5 text-xs opacity-90">
+              <p className="font-semibold">DC por alvo:</p>
+              {mapPreviewModel.affectedTargetSpatialMetadata.map((item) => {
+                const line = formatAreaTargetEffectiveDcLine(item);
+                return line ? <p key={item.targetRefId}>{line}</p> : null;
+              })}
+            </div>
           ) : null}
           {mapPreviewModel.instanceStatuses?.length ? (
             <div className="mt-2 space-y-1 text-xs">

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastDialogHeader.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastDialogHeader.test.tsx
@@ -87,6 +87,7 @@ const buildMapPreviewModel = (
   reason: null,
   affectedTargetCount: undefined,
   affectedTargetNames: undefined,
+  affectedTargetSpatialMetadata: undefined,
   rangeMeters: 36,
   areaShape: null,
   areaSizeMeters: null,
@@ -611,5 +612,113 @@ describe("SpellCastDialogHeader tactical preview", () => {
     // multi-instance preview must NOT show in fallback mode — fallback path
     // would otherwise re-derive scaling we explicitly want to avoid.
     expect(markup).not.toContain("instâncias");
+  });
+});
+
+describe("SpellCastDialogHeader – DC por alvo (area spatial metadata)", () => {
+  const areaMetadata = [
+    { targetRefId: "goblin-a", targetDisplayName: "Goblin A", cover: null, baseSaveDc: 15, effectiveSaveDc: 15, coverModifier: 0 },
+    { targetRefId: "goblin-b", targetDisplayName: "Goblin B", cover: "half", baseSaveDc: 15, effectiveSaveDc: 13, coverModifier: 2 },
+    { targetRefId: "orc-c", targetDisplayName: "Orc C", cover: "three_quarters", baseSaveDc: 15, effectiveSaveDc: 10, coverModifier: 5 },
+  ];
+
+  const renderAreaWithMetadata = (metadata: typeof areaMetadata | undefined, overrides?: Partial<typeof baseProps>) =>
+    renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        isAreaSpell
+        spell={{ ...baseSpell, name: "Fireball", canonicalKey: "fireball", level: 3, areaShape: "sphere", selectionType: "point" }}
+        spellMode="saving_throw"
+        mapPreviewModel={buildMapPreviewModel({
+          status: "valid",
+          areaShape: "sphere",
+          areaSizeMeters: 6,
+          affectedTargetCount: 3,
+          affectedTargetNames: ["Goblin A", "Goblin B", "Orc C"],
+          affectedTargetSpatialMetadata: metadata,
+        })}
+        previewModel={buildPreviewModel({
+          resolutionType: "saving_throw",
+          requiresSavingThrow: true,
+          saveAbility: "dexterity",
+          areaShape: "sphere",
+          areaSizeMeters: 6,
+          rangeMeters: 45,
+        })}
+        {...overrides}
+      />,
+    );
+
+  it("renders DC por alvo section with metadata", () => {
+    const markup = renderAreaWithMetadata(areaMetadata);
+
+    expect(markup).toContain("DC por alvo:");
+    expect(markup).toContain("Goblin A: DC 15");
+    expect(markup).toContain("Goblin B: meia cobertura, DC efetiva 13");
+    expect(markup).toContain("Orc C: três-quartos, DC efetiva 10");
+  });
+
+  it("target without cover renders plain DC", () => {
+    const markup = renderAreaWithMetadata([
+      { targetRefId: "goblin-a", targetDisplayName: "Goblin A", cover: null, baseSaveDc: 15, effectiveSaveDc: 15, coverModifier: 0 },
+    ]);
+
+    expect(markup).toContain("Goblin A: DC 15");
+    expect(markup).not.toContain("DC efetiva");
+  });
+
+  it("target with half cover renders cover label and effective DC", () => {
+    const markup = renderAreaWithMetadata([
+      { targetRefId: "goblin-b", targetDisplayName: "Goblin B", cover: "half", baseSaveDc: 15, effectiveSaveDc: 13, coverModifier: 2 },
+    ]);
+
+    expect(markup).toContain("Goblin B: meia cobertura, DC efetiva 13");
+  });
+
+  it("affectedTargetCount and affectedTargetNames still visible alongside metadata", () => {
+    const markup = renderAreaWithMetadata(areaMetadata);
+
+    expect(markup).toContain("Afetados: 3");
+    expect(markup).toContain("Alvos: Goblin A, Goblin B, Orc C");
+  });
+
+  it("no DC por alvo section when metadata is undefined", () => {
+    const markup = renderAreaWithMetadata(undefined);
+
+    expect(markup).not.toContain("DC por alvo:");
+  });
+
+  it("no DC por alvo section when metadata is empty array", () => {
+    const markup = renderAreaWithMetadata([]);
+
+    expect(markup).not.toContain("DC por alvo:");
+  });
+
+  it("invalid origin still shows DC per target if metadata exists", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        isAreaSpell
+        spell={{ ...baseSpell, name: "Fireball", canonicalKey: "fireball", level: 3, areaShape: "sphere", selectionType: "point" }}
+        spellMode="saving_throw"
+        mapPreviewModel={buildMapPreviewModel({
+          status: "invalid",
+          reason: "blocked_line_of_sight",
+          areaShape: "sphere",
+          areaSizeMeters: 6,
+          affectedTargetCount: 2,
+          affectedTargetNames: ["Goblin A", "Goblin B"],
+          affectedTargetSpatialMetadata: [
+            { targetRefId: "goblin-a", targetDisplayName: "Goblin A", cover: null, baseSaveDc: 15, effectiveSaveDc: 15, coverModifier: 0 },
+            { targetRefId: "goblin-b", targetDisplayName: "Goblin B", cover: "half", baseSaveDc: 15, effectiveSaveDc: 13, coverModifier: 2 },
+          ],
+        })}
+        previewModel={buildPreviewModel({ areaShape: "sphere" })}
+      />,
+    );
+
+    expect(markup).toContain("Origem da área: linha de visão bloqueada");
+    expect(markup).toContain("DC por alvo:");
+    expect(markup).toContain("Goblin A: DC 15");
   });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewModel.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewModel.test.ts
@@ -799,3 +799,104 @@ describe("buildSpellMapPreviewModel – cover metadata", () => {
     expect(model.instanceStatuses?.[1].cover).toEqual(threeQuartersCover);
   });
 });
+
+describe("buildSpellMapPreviewModel – area spatial metadata propagation", () => {
+  const metadataPayload = [
+    { target_ref_id: "goblin-a", target_display_name: "Goblin A", cover: "half", base_save_dc: 15, effective_save_dc: 13, cover_modifier: 2 },
+    { target_ref_id: "orc-b", target_display_name: "Orc B", cover: null, base_save_dc: 15, effective_save_dc: 15, cover_modifier: 0 },
+  ];
+
+  it("fallback path: existingAreaPreviewResult com metadata popula affectedTargetSpatialMetadata", () => {
+    const model = buildSpellMapPreviewModel({
+      spellPreviewModel: baseAreaModel,
+      existingAreaPreviewResult: {
+        ...areaPreviewResult,
+        affected_target_spatial_metadata: metadataPayload,
+      },
+    });
+
+    expect(model.affectedTargetSpatialMetadata).toHaveLength(2);
+    expect(model.affectedTargetSpatialMetadata?.[0]).toEqual({
+      targetRefId: "goblin-a",
+      targetDisplayName: "Goblin A",
+      cover: "half",
+      baseSaveDc: 15,
+      effectiveSaveDc: 13,
+      coverModifier: 2,
+    });
+    expect(model.affectedTargetSpatialMetadata?.[1]).toEqual({
+      targetRefId: "orc-b",
+      targetDisplayName: "Orc B",
+      cover: null,
+      baseSaveDc: 15,
+      effectiveSaveDc: 15,
+      coverModifier: 0,
+    });
+  });
+
+  it("spatialValidations.area path: metadata é propagada quando area validation existe", () => {
+    const model = buildSpellMapPreviewModel({
+      spellPreviewModel: baseAreaModel,
+      existingAreaPreviewResult: {
+        ...areaPreviewResult,
+        affected_target_spatial_metadata: metadataPayload,
+      },
+      spatialValidations: {
+        area: { originCell: ANCHOR, inRange: true, hasLineOfSight: null, hasLineOfEffect: null, unavailableReason: null },
+      },
+    });
+
+    expect(model.affectedTargetSpatialMetadata).toHaveLength(2);
+    expect(model.affectedTargetSpatialMetadata?.[0].targetRefId).toBe("goblin-a");
+  });
+
+  it("empty metadata array → affectedTargetSpatialMetadata is undefined", () => {
+    const model = buildSpellMapPreviewModel({
+      spellPreviewModel: baseAreaModel,
+      existingAreaPreviewResult: {
+        ...areaPreviewResult,
+        affected_target_spatial_metadata: [],
+      },
+    });
+
+    expect(model.affectedTargetSpatialMetadata).toBeUndefined();
+  });
+
+  it("missing metadata field → affectedTargetSpatialMetadata is undefined", () => {
+    const model = buildSpellMapPreviewModel({
+      spellPreviewModel: baseAreaModel,
+      existingAreaPreviewResult: areaPreviewResult,
+    });
+
+    expect(model.affectedTargetSpatialMetadata).toBeUndefined();
+  });
+
+  it("metadata does not alter status or reason", () => {
+    const model = buildSpellMapPreviewModel({
+      spellPreviewModel: baseAreaModel,
+      existingAreaPreviewResult: {
+        ...areaPreviewResult,
+        affected_target_spatial_metadata: metadataPayload,
+      },
+    });
+
+    expect(model.status).toBe("valid");
+    expect(model.reason).toBeNull();
+  });
+
+  it("metadata does not alter affectedTargetCount or affectedTargetNames", () => {
+    const model = buildSpellMapPreviewModel({
+      spellPreviewModel: baseAreaModel,
+      existingAreaPreviewResult: {
+        ...areaPreviewResult,
+        affected_target_spatial_metadata: metadataPayload,
+      },
+      targetPositions: [
+        { refId: "goblin-a", cell: { x: 9, y: 0 }, displayName: "Goblin A" },
+      ],
+    });
+
+    expect(model.affectedTargetCount).toBe(2);
+    expect(model.affectedTargetNames).toEqual(["Goblin A"]);
+  });
+});

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewModel.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewModel.ts
@@ -1,5 +1,8 @@
 import { METERS_PER_CELL } from "../../../features/combat-ui/hooks/useTargetingPreview";
-import type { CombatAreaPreviewResponse } from "../../../shared/api/combatRepo";
+import type {
+  AreaPreviewAffectedTargetSpatialMetadata,
+  CombatAreaPreviewResponse,
+} from "../../../shared/api/combatRepo";
 import type { GridCell } from "./areaTargetingUi";
 import type { EffectInstanceTargetInput } from "./InstanceTargetSelector";
 import type { SpellPreviewModel } from "./spellPreviewModel";
@@ -28,11 +31,21 @@ export type SpellInstanceMapStatus = {
   cover?: SpellCoverPreview | null;
 };
 
+export type AreaTargetSpatialMetadata = {
+  targetRefId: string;
+  targetDisplayName: string | null;
+  cover: string | null;
+  baseSaveDc: number | null;
+  effectiveSaveDc: number | null;
+  coverModifier: number;
+};
+
 export type SpellMapPreviewModel = {
   status: SpellMapPreviewStatus;
   reason?: SpellMapPreviewReason | string | null;
   affectedTargetCount?: number;
   affectedTargetNames?: string[];
+  affectedTargetSpatialMetadata?: AreaTargetSpatialMetadata[];
   rangeMeters: number | null;
   areaShape: string | null;
   areaSizeMeters: number | null;
@@ -91,6 +104,20 @@ export type BuildSpellMapPreviewModelParams = {
 // max(|dx|, |dy|) — king-moves on the grid, same as D&D diagonal-equals-cardinal.
 const chebyshevMeters = (a: GridCell, b: GridCell): number =>
   Math.max(Math.abs(b.x - a.x), Math.abs(b.y - a.y)) * METERS_PER_CELL;
+
+const toAreaTargetSpatialMetadata = (
+  raw?: AreaPreviewAffectedTargetSpatialMetadata[],
+): AreaTargetSpatialMetadata[] | undefined => {
+  if (!raw || raw.length === 0) return undefined;
+  return raw.map((item) => ({
+    targetRefId: item.target_ref_id,
+    targetDisplayName: item.target_display_name ?? null,
+    cover: item.cover ?? null,
+    baseSaveDc: item.base_save_dc ?? null,
+    effectiveSaveDc: item.effective_save_dc ?? null,
+    coverModifier: item.cover_modifier ?? 0,
+  }));
+};
 
 const checkRange = (
   casterPosition: GridCell,
@@ -182,6 +209,9 @@ export const buildSpellMapPreviewModel = ({
               targetPositions?.find((position) => position.refId === targetRefId)?.displayName ?? null,
           )
           .filter((name): name is string => Boolean(name)),
+        affectedTargetSpatialMetadata: toAreaTargetSpatialMetadata(
+          existingAreaPreviewResult?.affected_target_spatial_metadata,
+        ),
       };
     }
 
@@ -197,6 +227,9 @@ export const buildSpellMapPreviewModel = ({
               targetPositions?.find((position) => position.refId === targetRefId)?.displayName ?? null,
           )
           .filter((name): name is string => Boolean(name)),
+        affectedTargetSpatialMetadata: toAreaTargetSpatialMetadata(
+          existingAreaPreviewResult.affected_target_spatial_metadata,
+        ),
       };
     }
     return { ...base, status: "unknown", reason: "missing_map_data" };

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewPresentation.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewPresentation.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
+import type { AreaTargetSpatialMetadata } from "./spellMapPreviewModel";
 import {
   formatAreaOriginPreviewLabel,
+  formatAreaTargetCoverRank,
+  formatAreaTargetEffectiveDcLine,
   formatSpellCoverPreview,
   formatSpellMapPreviewReason,
   formatSpellMapPreviewStatus,
@@ -129,5 +132,107 @@ describe("formatAreaOriginPreviewLabel", () => {
 
   it("invalid sem reason conhecido → Origem da área: inválida", () => {
     expect(formatAreaOriginPreviewLabel({ status: "invalid", reason: null })).toBe("Origem da área: inválida");
+  });
+});
+
+describe("formatAreaTargetCoverRank", () => {
+  it("half → meia cobertura", () => {
+    expect(formatAreaTargetCoverRank("half")).toBe("meia cobertura");
+  });
+
+  it("three_quarters → três-quartos", () => {
+    expect(formatAreaTargetCoverRank("three_quarters")).toBe("três-quartos");
+  });
+
+  it("threeQuarters (camelCase) → três-quartos", () => {
+    expect(formatAreaTargetCoverRank("threeQuarters")).toBe("três-quartos");
+  });
+
+  it("none → null", () => {
+    expect(formatAreaTargetCoverRank("none")).toBeNull();
+  });
+
+  it("full → null", () => {
+    expect(formatAreaTargetCoverRank("full")).toBeNull();
+  });
+
+  it("null → null", () => {
+    expect(formatAreaTargetCoverRank(null)).toBeNull();
+  });
+
+  it("unknown value → null", () => {
+    expect(formatAreaTargetCoverRank("unknown_value")).toBeNull();
+  });
+});
+
+describe("formatAreaTargetEffectiveDcLine", () => {
+  const base = (overrides: Partial<AreaTargetSpatialMetadata>): AreaTargetSpatialMetadata => ({
+    targetRefId: "goblin-a",
+    targetDisplayName: "Goblin A",
+    cover: null,
+    baseSaveDc: null,
+    effectiveSaveDc: null,
+    coverModifier: 0,
+    ...overrides,
+  });
+
+  it("no cover, effective DC 15 → Goblin A: DC 15", () => {
+    expect(formatAreaTargetEffectiveDcLine(base({ effectiveSaveDc: 15 }))).toBe("Goblin A: DC 15");
+  });
+
+  it("half cover, modifier 2, effective DC 13 → Goblin B: meia cobertura, DC efetiva 13", () => {
+    expect(
+      formatAreaTargetEffectiveDcLine(
+        base({ targetRefId: "goblin-b", targetDisplayName: "Goblin B", cover: "half", coverModifier: 2, effectiveSaveDc: 13 }),
+      ),
+    ).toBe("Goblin B: meia cobertura, DC efetiva 13");
+  });
+
+  it("three_quarters cover, modifier 5, effective DC 10 → Orc C: três-quartos, DC efetiva 10", () => {
+    expect(
+      formatAreaTargetEffectiveDcLine(
+        base({ targetRefId: "orc-c", targetDisplayName: "Orc C", cover: "three_quarters", coverModifier: 5, effectiveSaveDc: 10 }),
+      ),
+    ).toBe("Orc C: três-quartos, DC efetiva 10");
+  });
+
+  it("threeQuarters (camel) → same três-quartos label", () => {
+    expect(
+      formatAreaTargetEffectiveDcLine(
+        base({ cover: "threeQuarters", coverModifier: 5, effectiveSaveDc: 10 }),
+      ),
+    ).toBe("Goblin A: três-quartos, DC efetiva 10");
+  });
+
+  it("full cover + modifier 0 → no cover label, plain DC", () => {
+    expect(
+      formatAreaTargetEffectiveDcLine(
+        base({ cover: "full", coverModifier: 0, effectiveSaveDc: 15 }),
+      ),
+    ).toBe("Goblin A: DC 15");
+  });
+
+  it("missing effective DC, base DC 15 → Goblin A: DC 15", () => {
+    expect(formatAreaTargetEffectiveDcLine(base({ baseSaveDc: 15 }))).toBe("Goblin A: DC 15");
+  });
+
+  it("both DCs null → null", () => {
+    expect(formatAreaTargetEffectiveDcLine(base({}))).toBeNull();
+  });
+
+  it("missing display name → fallback to targetRefId", () => {
+    expect(
+      formatAreaTargetEffectiveDcLine(
+        base({ targetDisplayName: null, effectiveSaveDc: 12 }),
+      ),
+    ).toBe("goblin-a: DC 12");
+  });
+
+  it("coverModifier 0 with cover half → no cover label", () => {
+    expect(
+      formatAreaTargetEffectiveDcLine(
+        base({ cover: "half", coverModifier: 0, effectiveSaveDc: 13 }),
+      ),
+    ).toBe("Goblin A: DC 13");
   });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewPresentation.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewPresentation.ts
@@ -1,4 +1,4 @@
-import type { SpellCoverPreview, SpellMapPreviewModel, SpellMapPreviewStatus } from "./spellMapPreviewModel";
+import type { AreaTargetSpatialMetadata, SpellCoverPreview, SpellMapPreviewModel, SpellMapPreviewStatus } from "./spellMapPreviewModel";
 
 const UNKNOWN_MESSAGE = "Dados de posição insuficientes para validar o preview no mapa";
 
@@ -90,4 +90,26 @@ export const formatSpellMapPreviewReason = (
     default:
       return reason;
   }
+};
+
+export const formatAreaTargetCoverRank = (cover: string | null | undefined): string | null => {
+  if (cover === "half") return "meia cobertura";
+  if (cover === "three_quarters" || cover === "threeQuarters") return "três-quartos";
+  return null;
+};
+
+export const formatAreaTargetEffectiveDcLine = (
+  item: AreaTargetSpatialMetadata,
+): string | null => {
+  const dc = item.effectiveSaveDc ?? item.baseSaveDc;
+  if (dc == null) return null;
+
+  const name = item.targetDisplayName ?? item.targetRefId;
+  const coverLabel =
+    item.coverModifier > 0 ? formatAreaTargetCoverRank(item.cover) : null;
+
+  if (coverLabel) {
+    return `${name}: ${coverLabel}, DC efetiva ${dc}`;
+  }
+  return `${name}: DC ${dc}`;
 };


### PR DESCRIPTION
## Summary

Renders per-target area cover metadata in the tactical spell preview.

Area spell previews can now show each affected target's effective save DC and cover information when `affected_target_spatial_metadata` is returned by the backend.

## Changes

### Model

- Added `AreaTargetSpatialMetadata`
- Added `affectedTargetSpatialMetadata` to `SpellMapPreviewModel`
- Added `toAreaTargetSpatialMetadata(...)`
- Propagated area target spatial metadata through both area preview paths

### Presentation

- Added `formatAreaTargetCoverRank(...)`
- Added `formatAreaTargetEffectiveDcLine(...)`

Example output:

- `Goblin A: DC 15`
- `Goblin B: meia cobertura, DC efetiva 13`
- `Orc C: três-quartos, DC efetiva 10`

### UI

- `SpellCastDialogHeader` now renders a `DC por alvo:` block after the affected targets line
- The UI uses backend-provided `effectiveSaveDc` and does not recalculate DC client-side

## Validation

- 135 focused tests passing
- 28 new tests added:
  - 16 presentation tests
  - 6 model tests
  - 7 header tests
- No typecheck regressions