### PR TITLE
feat(targeting): implement batch targeting endpoint and related schemas

### DIFF
--- a/apps/control-server/app/integrations/limiar_map_client.py
+++ b/apps/control-server/app/integrations/limiar_map_client.py
@@ -6,6 +6,7 @@ import httpx
 
 from .limiar_map_client_types import (
     LimiarMapAreaTargetingResponse,
+    LimiarMapBatchTargetingResponse,
     LimiarMapClientError,
     LimiarMapMovementResponse,
     LimiarMapStateResponse,
@@ -20,6 +21,7 @@ from .limiar_map_client_types import (  # noqa: F401
 )
 from .limiar_map_client_parsers import (
     parse_area_targeting_response,
+    parse_batch_targeting_response,
     parse_movement_response,
     parse_targeting_response,
 )
@@ -114,6 +116,26 @@ class LimiarMapClient:
             json_payload=payload,
         )
         return parse_targeting_response(data)
+
+    def validate_targets_batch(
+        self,
+        *,
+        session_id: str,
+        action_id: str,
+        combatant_id: str,
+        target_combatant_ids: list[str],
+    ) -> LimiarMapBatchTargetingResponse:
+        payload = {
+            "actionId": action_id,
+            "combatantId": combatant_id,
+            "targetCombatantIds": target_combatant_ids,
+        }
+        data = self._request_json(
+            "POST",
+            f"/integration/sessions/{session_id}/targeting/batch",
+            json_payload=payload,
+        )
+        return parse_batch_targeting_response(data)
 
     def resolve_area_targeting(
         self,

--- a/apps/control-server/app/integrations/limiar_map_client_parsers.py
+++ b/apps/control-server/app/integrations/limiar_map_client_parsers.py
@@ -5,6 +5,8 @@ from typing import Any
 from .limiar_map_client_types import (
     LimiarMapAreaCell,
     LimiarMapAreaTargetingResponse,
+    LimiarMapBatchTargetingResponse,
+    LimiarMapBatchTargetingResult,
     LimiarMapClientError,
     LimiarMapMovementCell,
     LimiarMapMovementResponse,
@@ -188,6 +190,63 @@ def parse_area_targeting_response(
         affected_cells=tuple(affected_cells),
         affected_token_ids=tuple(affected_token_ids),
         affected_combatant_ids=tuple(affected_combatant_ids),
+    )
+
+
+def parse_batch_targeting_response(
+    payload: dict[str, Any],
+) -> LimiarMapBatchTargetingResponse:
+    session_id = payload.get("sessionId")
+    action_id = payload.get("actionId")
+    version = payload.get("version")
+    raw_results = payload.get("results")
+
+    if not isinstance(session_id, str) or not session_id.strip():
+        raise LimiarMapClientError(
+            "LimiarMap batch targeting response is missing sessionId",
+            kind="payload",
+        )
+    if not isinstance(action_id, str) or not action_id.strip():
+        raise LimiarMapClientError(
+            "LimiarMap batch targeting response is missing actionId",
+            kind="payload",
+        )
+    if not isinstance(version, int):
+        raise LimiarMapClientError(
+            "LimiarMap batch targeting response is missing version",
+            kind="payload",
+        )
+    if not isinstance(raw_results, list):
+        raise LimiarMapClientError(
+            "LimiarMap batch targeting response is missing results",
+            kind="payload",
+        )
+
+    results: list[LimiarMapBatchTargetingResult] = []
+    for item in raw_results:
+        if not isinstance(item, dict):
+            raise LimiarMapClientError(
+                "LimiarMap batch targeting response has an invalid result entry",
+                kind="payload",
+            )
+        target_combatant_id = item.get("targetCombatantId")
+        if not isinstance(target_combatant_id, str):
+            raise LimiarMapClientError(
+                "LimiarMap batch targeting result is missing targetCombatantId",
+                kind="payload",
+            )
+        cover_raw = item.get("cover")
+        cover = cover_raw if isinstance(cover_raw, str) else None
+        results.append(LimiarMapBatchTargetingResult(
+            target_combatant_id=target_combatant_id,
+            cover=cover,
+        ))
+
+    return LimiarMapBatchTargetingResponse(
+        session_id=session_id,
+        action_id=action_id,
+        version=version,
+        results=tuple(results),
     )
 
 

--- a/apps/control-server/app/integrations/limiar_map_client_types.py
+++ b/apps/control-server/app/integrations/limiar_map_client_types.py
@@ -105,6 +105,20 @@ class LimiarMapMovementResponse:
     remaining_budget: int
 
 
+@dataclass(frozen=True)
+class LimiarMapBatchTargetingResult:
+    target_combatant_id: str
+    cover: str | None
+
+
+@dataclass(frozen=True)
+class LimiarMapBatchTargetingResponse:
+    session_id: str
+    action_id: str
+    version: int
+    results: tuple["LimiarMapBatchTargetingResult", ...]
+
+
 class LimiarMapClientError(RuntimeError):
     def __init__(
         self,

--- a/apps/control-server/app/services/combat_service/spells/area_spatial_metadata.py
+++ b/apps/control-server/app/services/combat_service/spells/area_spatial_metadata.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 
 from app.integrations.limiar_map_client_types import LimiarMapClientError
 
-from ..cover_modifiers import resolve_cover_save_dc, should_cover_apply_to_save
+from ..cover_modifiers import resolve_cover_save_dc
 
 if TYPE_CHECKING:
     from app.integrations.limiar_map_client import LimiarMapClient
@@ -33,14 +33,84 @@ def get_area_per_target_cover(
     fails). Failures are isolated per-target so that one bad lookup never
     blocks the others.
 
+    Prefers a single batch call when the client supports it; falls back to
+    per-target individual calls otherwise or on batch failure.
+
     Callers are responsible for skipping this function when the map is
     unavailable or cover does not apply to the save.
-
-    TODO: Replace N individual calls with a batch endpoint once the map
-    API exposes one (follow-up: Batch area target spatial metadata lookup).
     """
+    if not target_ref_ids:
+        return {}
+
+    unique_ref_ids = list(dict.fromkeys(target_ref_ids))
+
+    if hasattr(client, "validate_targets_batch"):
+        try:
+            return _cover_via_batch(
+                client=client,
+                session_id=session_id,
+                action_id=action_id,
+                actor_ref_id=actor_ref_id,
+                unique_ref_ids=unique_ref_ids,
+            )
+        except LimiarMapClientError as exc:
+            logger.warning(
+                "Batch cover lookup failed for session_id=%s (%s); "
+                "falling back to per-target individual lookups",
+                session_id,
+                exc,
+            )
+
+    return _cover_via_individual(
+        client=client,
+        session_id=session_id,
+        action_id=action_id,
+        actor_ref_id=actor_ref_id,
+        unique_ref_ids=unique_ref_ids,
+    )
+
+
+def _cover_via_batch(
+    *,
+    client: "LimiarMapClient",
+    session_id: str,
+    action_id: str,
+    actor_ref_id: str,
+    unique_ref_ids: list[str],
+) -> dict[str, str | None]:
+    response = client.validate_targets_batch(
+        session_id=session_id,
+        action_id=action_id,
+        combatant_id=actor_ref_id,
+        target_combatant_ids=unique_ref_ids,
+    )
     result: dict[str, str | None] = {}
-    for target_ref_id in target_ref_ids:
+    for item in response.results:
+        result[item.target_combatant_id] = item.cover
+
+    for ref_id in unique_ref_ids:
+        if ref_id not in result:
+            logger.warning(
+                "Batch cover response missing target_ref_id=%s session_id=%s; "
+                "using None (base DC)",
+                ref_id,
+                session_id,
+            )
+            result[ref_id] = None
+
+    return result
+
+
+def _cover_via_individual(
+    *,
+    client: "LimiarMapClient",
+    session_id: str,
+    action_id: str,
+    actor_ref_id: str,
+    unique_ref_ids: list[str],
+) -> dict[str, str | None]:
+    result: dict[str, str | None] = {}
+    for target_ref_id in unique_ref_ids:
         try:
             response = client.validate_single_target(
                 session_id=session_id,

--- a/apps/control-server/tests/test_area_preview_cover.py
+++ b/apps/control-server/tests/test_area_preview_cover.py
@@ -23,9 +23,11 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from app.integrations.limiar_map_client_types import (
-    LimiarMapClientError,
-    LimiarMapAreaTargetingResponse,
     LimiarMapAreaCell,
+    LimiarMapAreaTargetingResponse,
+    LimiarMapBatchTargetingResponse,
+    LimiarMapBatchTargetingResult,
+    LimiarMapClientError,
     LimiarMapTargetingResponse,
 )
 from app.services.combat import CombatService
@@ -72,6 +74,7 @@ class GetAreaPerTargetCoverStandaloneTests(unittest.TestCase):
 
     def test_returns_cover_per_target(self):
         client = MagicMock()
+        client.validate_targets_batch.side_effect = LimiarMapClientError("no batch", kind="network")
         client.validate_single_target.side_effect = [
             self._targeting_response("none"),
             self._targeting_response("half"),
@@ -88,6 +91,7 @@ class GetAreaPerTargetCoverStandaloneTests(unittest.TestCase):
 
     def test_error_for_one_target_falls_back_to_none(self):
         client = MagicMock()
+        client.validate_targets_batch.side_effect = LimiarMapClientError("no batch", kind="network")
         client.validate_single_target.side_effect = [
             self._targeting_response("half"),
             LimiarMapClientError("timeout", kind="timeout"),
@@ -104,6 +108,7 @@ class GetAreaPerTargetCoverStandaloneTests(unittest.TestCase):
 
     def test_null_cover_response_stored_as_none(self):
         client = MagicMock()
+        client.validate_targets_batch.side_effect = LimiarMapClientError("no batch", kind="network")
         client.validate_single_target.return_value = self._targeting_response(None)
         result = get_area_per_target_cover(
             client=client,
@@ -116,6 +121,7 @@ class GetAreaPerTargetCoverStandaloneTests(unittest.TestCase):
 
     def test_called_without_range_or_sight_checks(self):
         client = MagicMock()
+        client.validate_targets_batch.side_effect = LimiarMapClientError("no batch", kind="network")
         client.validate_single_target.return_value = self._targeting_response(None)
         get_area_per_target_cover(
             client=client,
@@ -355,6 +361,7 @@ class AreaPreviewCoverMetadataTests(TestCombatServiceBase):
             ]
         )
         mock_client.preview_area_targeting.return_value = area_preview
+        mock_client.validate_targets_batch.side_effect = LimiarMapClientError("no batch", kind="network")
         mock_client.validate_single_target.side_effect = cover_side_effects
 
         with patch("app.services.combat.CombatService.get_state", return_value=self.state), \

--- a/apps/control-server/tests/test_cast_area_cover.py
+++ b/apps/control-server/tests/test_cast_area_cover.py
@@ -22,7 +22,12 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from _combat_test_shared import TestCombatServiceBase
-from app.integrations.limiar_map_client_types import LimiarMapClientError, LimiarMapTargetingResponse
+from app.integrations.limiar_map_client_types import (
+    LimiarMapBatchTargetingResponse,
+    LimiarMapBatchTargetingResult,
+    LimiarMapClientError,
+    LimiarMapTargetingResponse,
+)
 from app.models.combat import CombatPhase
 from app.models.session_state import SessionState
 from app.schemas.combat import CombatCastSpellRequest, CombatGridCell
@@ -34,6 +39,28 @@ from app.services.combat_service.targeting_result import SpatialMetadata, Target
 # ---------------------------------------------------------------------------
 # Unit tests: _get_area_per_target_cover
 # ---------------------------------------------------------------------------
+
+def _batch_unavailable() -> MagicMock:
+    """Return a side_effect that makes validate_targets_batch raise LimiarMapClientError.
+
+    Use this on mock clients in tests that exercise the individual-fallback path,
+    so the new batch-preferring logic still falls back to validate_single_target.
+    """
+    return MagicMock(side_effect=LimiarMapClientError("batch not available", kind="network"))
+
+
+def _batch_response(*results: tuple[str, str | None]) -> LimiarMapBatchTargetingResponse:
+    """Build a LimiarMapBatchTargetingResponse for test use."""
+    return LimiarMapBatchTargetingResponse(
+        session_id="s1",
+        action_id="a1",
+        version=1,
+        results=tuple(
+            LimiarMapBatchTargetingResult(target_combatant_id=ref_id, cover=cover)
+            for ref_id, cover in results
+        ),
+    )
+
 
 class GetAreaPerTargetCoverTests(unittest.TestCase):
     """Unit tests for the _get_area_per_target_cover helper."""
@@ -86,6 +113,7 @@ class GetAreaPerTargetCoverTests(unittest.TestCase):
     def test_returns_cover_per_target_from_map(self, mock_settings):
         mock_settings.limiar_map_enabled = True
         mock_client = MagicMock()
+        mock_client.validate_targets_batch = _batch_unavailable()
         mock_client.validate_single_target.side_effect = [
             self._targeting_response("none"),
             self._targeting_response("half"),
@@ -105,6 +133,7 @@ class GetAreaPerTargetCoverTests(unittest.TestCase):
     def test_map_error_for_one_target_falls_back_to_none(self, mock_settings):
         mock_settings.limiar_map_enabled = True
         mock_client = MagicMock()
+        mock_client.validate_targets_batch = _batch_unavailable()
         mock_client.validate_single_target.side_effect = [
             self._targeting_response("half"),
             LimiarMapClientError("timeout", kind="timeout"),
@@ -124,6 +153,7 @@ class GetAreaPerTargetCoverTests(unittest.TestCase):
     def test_response_cover_none_stored_as_none(self, mock_settings):
         mock_settings.limiar_map_enabled = True
         mock_client = MagicMock()
+        mock_client.validate_targets_batch = _batch_unavailable()
         mock_client.validate_single_target.return_value = self._targeting_response(None)
         with patch.object(CombatService, "_build_limiar_map_client", return_value=mock_client):
             result = CombatService._get_area_per_target_cover(
@@ -139,6 +169,7 @@ class GetAreaPerTargetCoverTests(unittest.TestCase):
     def test_validate_single_target_called_without_range_or_sight_checks(self, mock_settings):
         mock_settings.limiar_map_enabled = True
         mock_client = MagicMock()
+        mock_client.validate_targets_batch = _batch_unavailable()
         mock_client.validate_single_target.return_value = self._targeting_response("half")
         with patch.object(CombatService, "_build_limiar_map_client", return_value=mock_client):
             CombatService._get_area_per_target_cover(
@@ -152,6 +183,140 @@ class GetAreaPerTargetCoverTests(unittest.TestCase):
         self.assertIsNone(call_kwargs["range_cells"])
         self.assertFalse(call_kwargs["requires_sight"])
         self.assertFalse(call_kwargs["requires_effect"])
+
+
+class GetAreaPerTargetCoverBatchTests(unittest.TestCase):
+    """Unit tests for the batch path in get_area_per_target_cover."""
+
+    @patch("app.services.combat_service.spells.cast_area.settings")
+    def test_batch_called_once_for_all_targets(self, mock_settings):
+        """When batch is available, validate_targets_batch is called once and
+        validate_single_target is never called."""
+        mock_settings.limiar_map_enabled = True
+        mock_client = MagicMock()
+        mock_client.validate_targets_batch.return_value = _batch_response(
+            ("t1", "none"), ("t2", "half"), ("t3", "threeQuarters")
+        )
+        with patch.object(CombatService, "_build_limiar_map_client", return_value=mock_client):
+            result = CombatService._get_area_per_target_cover(
+                session_id="s1",
+                action_id="a1",
+                actor_ref_id="actor",
+                target_ref_ids=["t1", "t2", "t3"],
+                use_map=True,
+            )
+        mock_client.validate_targets_batch.assert_called_once()
+        mock_client.validate_single_target.assert_not_called()
+        self.assertEqual(result, {"t1": "none", "t2": "half", "t3": "threeQuarters"})
+
+    @patch("app.services.combat_service.spells.cast_area.settings")
+    def test_batch_result_missing_target_filled_with_none(self, mock_settings):
+        """If a target ref_id is absent from the batch response, it gets None."""
+        mock_settings.limiar_map_enabled = True
+        mock_client = MagicMock()
+        mock_client.validate_targets_batch.return_value = _batch_response(
+            ("t1", "half"),
+            # t2 deliberately omitted from results
+        )
+        with patch.object(CombatService, "_build_limiar_map_client", return_value=mock_client):
+            result = CombatService._get_area_per_target_cover(
+                session_id="s1",
+                action_id="a1",
+                actor_ref_id="actor",
+                target_ref_ids=["t1", "t2"],
+                use_map=True,
+            )
+        self.assertEqual(result["t1"], "half")
+        self.assertIsNone(result["t2"])
+
+    @patch("app.services.combat_service.spells.cast_area.settings")
+    def test_batch_failure_falls_back_to_individual(self, mock_settings):
+        """A LimiarMapClientError from batch triggers fallback to individual calls."""
+        mock_settings.limiar_map_enabled = True
+        mock_client = MagicMock()
+        mock_client.validate_targets_batch.side_effect = LimiarMapClientError(
+            "service unavailable", kind="http", status_code=503
+        )
+        mock_client.validate_single_target.side_effect = [
+            LimiarMapTargetingResponse(
+                is_valid=True, reason=None, session_id="s1", action_id="a1",
+                version=1, source_token_id=None, target_token_id=None, cover="half",
+            ),
+            LimiarMapTargetingResponse(
+                is_valid=True, reason=None, session_id="s1", action_id="a1",
+                version=1, source_token_id=None, target_token_id=None, cover="none",
+            ),
+        ]
+        with patch.object(CombatService, "_build_limiar_map_client", return_value=mock_client):
+            result = CombatService._get_area_per_target_cover(
+                session_id="s1",
+                action_id="a1",
+                actor_ref_id="actor",
+                target_ref_ids=["t1", "t2"],
+                use_map=True,
+            )
+        mock_client.validate_targets_batch.assert_called_once()
+        self.assertEqual(mock_client.validate_single_target.call_count, 2)
+        self.assertEqual(result, {"t1": "half", "t2": "none"})
+
+    @patch("app.services.combat_service.spells.cast_area.settings")
+    def test_duplicate_target_ref_ids_are_deduped(self, mock_settings):
+        """Duplicate target_ref_ids must be deduped before the batch/individual call."""
+        mock_settings.limiar_map_enabled = True
+        mock_client = MagicMock()
+        mock_client.validate_targets_batch.return_value = _batch_response(
+            ("t1", "half"),
+        )
+        with patch.object(CombatService, "_build_limiar_map_client", return_value=mock_client):
+            result = CombatService._get_area_per_target_cover(
+                session_id="s1",
+                action_id="a1",
+                actor_ref_id="actor",
+                target_ref_ids=["t1", "t1", "t1"],
+                use_map=True,
+            )
+        batch_call = mock_client.validate_targets_batch.call_args.kwargs
+        self.assertEqual(batch_call["target_combatant_ids"], ["t1"],
+                         "Batch must receive deduplicated list")
+        self.assertEqual(result["t1"], "half")
+
+    @patch("app.services.combat_service.spells.cast_area.settings")
+    def test_duplicate_deduplication_with_individual_fallback(self, mock_settings):
+        """Dedupe also applies when falling back to individual calls."""
+        mock_settings.limiar_map_enabled = True
+        mock_client = MagicMock()
+        mock_client.validate_targets_batch = _batch_unavailable()
+        mock_client.validate_single_target.return_value = LimiarMapTargetingResponse(
+            is_valid=True, reason=None, session_id="s1", action_id="a1",
+            version=1, source_token_id=None, target_token_id=None, cover="half",
+        )
+        with patch.object(CombatService, "_build_limiar_map_client", return_value=mock_client):
+            result = CombatService._get_area_per_target_cover(
+                session_id="s1",
+                action_id="a1",
+                actor_ref_id="actor",
+                target_ref_ids=["t1", "t1", "t1"],
+                use_map=True,
+            )
+        self.assertEqual(mock_client.validate_single_target.call_count, 1,
+                         "Individual fallback must call validate_single_target only once per unique ref_id")
+        self.assertEqual(result["t1"], "half")
+
+    @patch("app.services.combat_service.spells.cast_area.settings")
+    def test_batch_cover_null_stored_as_none(self, mock_settings):
+        """cover=null from batch (token not found) is stored as None."""
+        mock_settings.limiar_map_enabled = True
+        mock_client = MagicMock()
+        mock_client.validate_targets_batch.return_value = _batch_response(("t1", None))
+        with patch.object(CombatService, "_build_limiar_map_client", return_value=mock_client):
+            result = CombatService._get_area_per_target_cover(
+                session_id="s1",
+                action_id="a1",
+                actor_ref_id="actor",
+                target_ref_ids=["t1"],
+                use_map=True,
+            )
+        self.assertIsNone(result["t1"])
 
 
 # ---------------------------------------------------------------------------

--- a/apps/map-server/src/routes/integration/targeting.single.routes.ts
+++ b/apps/map-server/src/routes/integration/targeting.single.routes.ts
@@ -7,7 +7,7 @@ import {
   hasLineOfEffect,
   nextEncounterVersion
 } from "@limiarmap/tactical-engine";
-import { singleTargetRequestSchema } from "@limiarmap/shared-contracts";
+import { batchTargetingRequestSchema, singleTargetRequestSchema } from "@limiarmap/shared-contracts";
 import type { InMemoryEncounterRepository } from "../../modules/encounters/encounter-repository";
 import type { BroadcastAdapter } from "../../modules/realtime/broadcast";
 import { broadcastAuthoritativeEvent } from "../../modules/realtime/broadcast";
@@ -215,6 +215,57 @@ export function registerSingleTargetingRoutes(
         targetTokenId: targetToken.id,
         distanceCells: distance,
         cover
+      });
+    }
+  );
+
+  app.post(
+    "/integration/sessions/:sessionId/targeting/batch",
+    async (request, reply) => {
+      const { sessionId } = request.params as { sessionId: string };
+      const encounter = repository.getEncounter(sessionId);
+      if (!encounter) {
+        return err(reply, 404, "session_not_found", "Session not found");
+      }
+
+      const parse = batchTargetingRequestSchema.safeParse(request.body);
+      if (!parse.success) {
+        return reply.status(400).send({
+          message: "Invalid request body",
+          errors: parse.error.errors
+        });
+      }
+
+      const { actionId, combatantId, targetCombatantIds } = parse.data;
+
+      const sourceToken = encounter.tokens.find(
+        (token) => token.combatantId === combatantId
+      );
+
+      const results = targetCombatantIds.map((targetCombatantId) => {
+        if (!sourceToken) {
+          return { targetCombatantId, cover: null };
+        }
+        const targetToken = encounter.tokens.find(
+          (token) => token.combatantId === targetCombatantId
+        );
+        if (!targetToken) {
+          return { targetCombatantId, cover: null };
+        }
+        const cover = evaluateCover(
+          encounter.obstacles,
+          sourceToken.position,
+          targetToken.position,
+          encounter.edgeObstacles
+        );
+        return { targetCombatantId, cover: cover ?? null };
+      });
+
+      return reply.status(200).send({
+        sessionId,
+        actionId,
+        version: encounter.combatState.version,
+        results
       });
     }
   );

--- a/packages/shared-contracts/src/integration.targeting.ts
+++ b/packages/shared-contracts/src/integration.targeting.ts
@@ -51,9 +51,30 @@ export const areaTargetResponseSchema = z.object({
 
 export const areaTargetPreviewResponseSchema = areaTargetResponseSchema;
 
+export const batchTargetingRequestSchema = z.object({
+  actionId: z.string(),
+  combatantId: z.string(),
+  targetCombatantIds: z.array(z.string()),
+});
+
+export const batchTargetingResultSchema = z.object({
+  targetCombatantId: z.string(),
+  cover: obstacleCoverSchema.nullable(),
+});
+
+export const batchTargetingResponseSchema = z.object({
+  sessionId: z.string(),
+  actionId: z.string(),
+  version: z.number().int().nonnegative(),
+  results: z.array(batchTargetingResultSchema),
+});
+
 export type SingleTargetRequest = z.infer<typeof singleTargetRequestSchema>;
 export type AreaTargetShape = z.infer<typeof areaTargetShapeSchema>;
 export type AreaTargetRequest = z.infer<typeof areaTargetRequestSchema>;
 export type SingleTargetResponse = z.infer<typeof singleTargetResponseSchema>;
 export type AreaTargetResponse = z.infer<typeof areaTargetResponseSchema>;
 export type AreaTargetPreviewResponse = z.infer<typeof areaTargetPreviewResponseSchema>;
+export type BatchTargetingRequest = z.infer<typeof batchTargetingRequestSchema>;
+export type BatchTargetingResult = z.infer<typeof batchTargetingResultSchema>;
+export type BatchTargetingResponse = z.infer<typeof batchTargetingResponseSchema>;


### PR DESCRIPTION
## Summary

Adds batch area target spatial metadata lookup for cover.

Area cover metadata now prefers a batch targeting lookup through LimiarMap when available, while preserving the existing per-target fallback path. This reduces repeated map service calls for area spells affecting multiple targets without changing cover semantics, effective DC calculation, preview behavior, or cast resolution.

## Changes

### shared-contracts

- Added batch targeting schemas and types:
  - `batchTargetingRequestSchema`
  - `batchTargetingResultSchema`
  - `batchTargetingResponseSchema`

### map-server

- Added `POST /integration/sessions/:sessionId/targeting/batch`
- Reuses the same `evaluateCover` logic as the single-target endpoint
- Returns per-target cover metadata
- Missing tokens return `cover: null`
- Does not register actions
- Does not broadcast events

### Python client

- Added:
  - `LimiarMapBatchTargetingResult`
  - `LimiarMapBatchTargetingResponse`
- Added `parse_batch_targeting_response(...)`
- Added `validate_targets_batch(...)`

### area spatial metadata

- Refactored `get_area_per_target_cover(...)`
- Deduplicates `target_ref_ids` before lookup
- Prefers batch lookup when `validate_targets_batch(...)` is available
- Falls back to individual `validate_single_target(...)` when:
  - batch method is unavailable
  - batch request fails
- Missing targets in the batch response degrade to `None` with a warning
- `cover: null` remains `None`

## Validation

- Full backend suite: 1542 passing
- Updated existing area cover tests for explicit individual fallback
- Added 6 batch tests covering:
  - batch called once
  - missing target returns `None`
  - batch failure falls back to individual lookup
  - dedupe in batch path
  - dedupe in fallback individual path
  - `cover: null` maps to `None`