### PR TITLE
feat(catalog): dedicated spell edit pages and form architecture refactor

### DIFF
--- a/apps/control-web/src/app/routes/AppRoutes.tsx
+++ b/apps/control-web/src/app/routes/AppRoutes.tsx
@@ -33,6 +33,14 @@ const CatalogSpellsPage = lazy(async () => {
   const module = await import("../../pages/CatalogPage");
   return { default: module.CatalogSpellsPage };
 });
+const CatalogSpellNewPage = lazy(async () => {
+  const module = await import("../../pages/CatalogPage/CatalogSpellNewPage");
+  return { default: module.CatalogSpellNewPage };
+});
+const CatalogSpellEditPage = lazy(async () => {
+  const module = await import("../../pages/CatalogPage/CatalogSpellEditPage");
+  return { default: module.CatalogSpellEditPage };
+});
 const SystemCatalogPage = lazy(async () => {
   const module = await import("../../pages/SystemCatalogPage");
   return { default: module.SystemCatalogPage };
@@ -289,6 +297,26 @@ export const AppRoutes = () => {
             <RequireAuth>
               <RequireGmRole>
                 {renderRoute(<CatalogSpellsPage />)}
+              </RequireGmRole>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path={routes.catalogSpellNew}
+          element={
+            <RequireAuth>
+              <RequireGmRole>
+                {renderRoute(<CatalogSpellNewPage />)}
+              </RequireGmRole>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path={routes.catalogSpellEdit}
+          element={
+            <RequireAuth>
+              <RequireGmRole>
+                {renderRoute(<CatalogSpellEditPage />)}
               </RequireGmRole>
             </RequireAuth>
           }

--- a/apps/control-web/src/app/routes/routes.ts
+++ b/apps/control-web/src/app/routes/routes.ts
@@ -23,6 +23,8 @@ export const routes = {
   catalog: "/catalog",
   catalogItems: "/catalog/items",
   catalogSpells: "/catalog/spells",
+  catalogSpellNew: "/catalog/spells/new",
+  catalogSpellEdit: "/catalog/spells/:spellId/edit",
   adminHome: "/admin",
   adminCatalogItems: "/admin/catalog/items",
   adminCatalogSpells: "/admin/catalog/spells",
@@ -47,4 +49,8 @@ export function buildCampaignDashboardPath(
   }
   const search = new URLSearchParams({ partyId });
   return `${path}?${search.toString()}`;
+}
+
+export function buildCatalogSpellEditPath(spellId: string): string {
+  return routes.catalogSpellEdit.replace(":spellId", spellId);
 }

--- a/apps/control-web/src/entities/base-spell/baseSpell.types.ts
+++ b/apps/control-web/src/entities/base-spell/baseSpell.types.ts
@@ -273,6 +273,7 @@ export type BaseSpell = {
   resolutionType?: ResolutionType | null;
   savingThrow?: SpellSavingThrow | null;
   saveSuccessOutcome?: SaveSuccessOutcome | null;
+  coverAppliesToSave?: "physical" | "none" | null;
 
   // Effect
   damageDice?: string | null;
@@ -348,6 +349,7 @@ export type BaseSpellWritePayload = {
   resolutionType?: ResolutionType | null;
   savingThrow?: SpellSavingThrow | null;
   saveSuccessOutcome?: SaveSuccessOutcome | null;
+  coverAppliesToSave?: "physical" | "none" | null;
   damageDice?: string | null;
   damageType?: SpellDamageType | null;
   healDice?: string | null;

--- a/apps/control-web/src/features/shop/components/SpellCatalogCard.tsx
+++ b/apps/control-web/src/features/shop/components/SpellCatalogCard.tsx
@@ -1,16 +1,12 @@
-import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { buildCatalogSpellEditPath } from "../../../app/routes/routes";
 import type { BaseSpell } from "../../../entities/base-spell";
-import type { BaseSpellUpdatePayload } from "../../../shared/api/baseSpellsRepo";
 import { useLocale } from "../../../shared/hooks/useLocale";
 import type { LocaleKey } from "../../../shared/i18n";
-import { SpellCatalogEditor } from "./SpellCatalogEditor";
 
 type Props = {
   spell: BaseSpell;
-  onUpdate?: (
-    spellId: string,
-    payload: BaseSpellUpdatePayload,
-  ) => boolean | Promise<boolean>;
+  canEdit?: boolean;
 };
 
 const SCHOOL_COLORS: Record<string, { chip: string; accent: string }> = {
@@ -30,31 +26,19 @@ const schoolKey = (school: string): LocaleKey =>
 const levelLabel = (level: number, t: (key: LocaleKey) => string) =>
   level === 0 ? t("catalog.spells.cantrip") : `${t("catalog.spells.levelLabel")} ${level}`;
 
-export const SpellCatalogCard = ({ spell, onUpdate }: Props) => {
+export const SpellCatalogCard = ({ spell, canEdit = true }: Props) => {
   const { t, locale } = useLocale();
-  const [expanded, setExpanded] = useState(false);
-  const [isEditing, setIsEditing] = useState(false);
+  const navigate = useNavigate();
 
   const displayName = (locale === "pt" && spell.namePt) ? spell.namePt : spell.nameEn;
   const colors = SCHOOL_COLORS[spell.school] ?? SCHOOL_COLORS.evocation;
   const components = spell.componentsJson?.join(", ") ?? "";
-
-  if (isEditing && onUpdate) {
-    return (
-      <SpellCatalogEditor
-        spell={spell}
-        onSave={onUpdate}
-        onCancel={() => setIsEditing(false)}
-      />
-    );
-  }
 
   return (
     <div className="group relative overflow-hidden rounded-[22px] border border-white/8 bg-[linear-gradient(180deg,rgba(8,12,28,0.92),rgba(2,6,23,0.96))] shadow-[0_12px_40px_rgba(2,6,23,0.22)] transition-all hover:border-white/14 hover:shadow-[0_16px_50px_rgba(2,6,23,0.32)]">
       <div className={`pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,var(--tw-gradient-stops))] ${colors.accent} to-transparent opacity-60`} />
 
       <div className="relative space-y-3 p-4">
-        {/* Header */}
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0 flex-1">
             <h3 className="truncate text-sm font-bold text-slate-100">{displayName}</h3>
@@ -67,7 +51,6 @@ export const SpellCatalogCard = ({ spell, onUpdate }: Props) => {
           </span>
         </div>
 
-        {/* Level + badges */}
         <div className="flex flex-wrap items-center gap-1.5">
           <span className="rounded-full border border-violet-500/30 bg-violet-500/10 px-2 py-0.5 text-[10px] font-semibold text-violet-200">
             {levelLabel(spell.level, t)}
@@ -84,7 +67,6 @@ export const SpellCatalogCard = ({ spell, onUpdate }: Props) => {
           )}
         </div>
 
-        {/* Stats row */}
         <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-slate-400">
           {spell.castingTime && (
             <span>
@@ -118,7 +100,6 @@ export const SpellCatalogCard = ({ spell, onUpdate }: Props) => {
           )}
         </div>
 
-        {/* Classes */}
         {spell.classesJson && spell.classesJson.length > 0 && (
           <div className="flex flex-wrap gap-1">
             {spell.classesJson.map((cls) => (
@@ -132,28 +113,15 @@ export const SpellCatalogCard = ({ spell, onUpdate }: Props) => {
           </div>
         )}
 
-        {/* Description (expandable) */}
-        <button
-          type="button"
-          onClick={() => setExpanded(!expanded)}
-          className="w-full text-left text-[11px] text-slate-500 hover:text-slate-300 transition-colors"
-        >
-          {expanded ? (
-            <p className="whitespace-pre-wrap leading-relaxed text-slate-400">
-              {(locale === "pt" && spell.descriptionPt) ? spell.descriptionPt : spell.descriptionEn}
-            </p>
-          ) : (
-            <p className="line-clamp-2 leading-relaxed">
-              {(locale === "pt" && spell.descriptionPt) ? spell.descriptionPt : spell.descriptionEn}
-            </p>
-          )}
-        </button>
+        <p className="line-clamp-2 text-[11px] leading-relaxed text-slate-500">
+          {(locale === "pt" && spell.descriptionPt) ? spell.descriptionPt : spell.descriptionEn}
+        </p>
 
-        {onUpdate ? (
+        {canEdit ? (
           <div className="pt-1">
             <button
               type="button"
-              onClick={() => setIsEditing(true)}
+              onClick={() => navigate(buildCatalogSpellEditPath(spell.id))}
               className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-100 transition hover:border-white/20 hover:bg-white/9"
             >
               {t("catalog.edit")}

--- a/apps/control-web/src/features/shop/components/SpellCatalogFormFields.tsx
+++ b/apps/control-web/src/features/shop/components/SpellCatalogFormFields.tsx
@@ -25,8 +25,6 @@ import {
     SPELL_ATTACK_TYPE_OPTIONS,
     SPELL_TARGET_TYPE_OPTIONS,
     SPELL_EFFECT_TIMING_OPTIONS,
-    SPELL_DICE_COUNT_OPTIONS,
-    SPELL_DIE_SIZE_OPTIONS,
     SPELL_ORIGIN_TYPE_OPTIONS,
     SPELL_RANGE_KIND_OPTIONS,
     SPELL_SELECTION_TYPE_OPTIONS,
@@ -47,6 +45,15 @@ const schoolLabelKey = (school: string): LocaleKey =>
 
 const fieldClassName =
   "w-full rounded-2xl border border-white/8 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-violet-400/60 focus:outline-none";
+
+const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
+  <div className="space-y-4 rounded-2xl border border-white/8 bg-slate-950/35 p-4">
+    <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+      {title}
+    </p>
+    <div className="space-y-4">{children}</div>
+  </div>
+);
 
 export const SpellCatalogFormFields = ({
   state,
@@ -86,7 +93,7 @@ export const SpellCatalogFormFields = ({
   const showSideField = state.areaShape === "cube";
 
   return (
-    <>
+    <div className="space-y-5">
       {showCanonicalKey ? (
         <SpellCatalogField label={t("catalog.spells.form.canonicalKey")}>
           <input
@@ -99,342 +106,342 @@ export const SpellCatalogFormFields = ({
         </SpellCatalogField>
       ) : null}
 
-      <div className="grid gap-4 sm:grid-cols-2">
-        <SpellCatalogField label={t("catalog.spells.form.nameEn")}>
-          <input
-            value={state.nameEn}
-            onChange={(event) => setState((current) => ({ ...current, nameEn: event.target.value }))}
-            className={fieldClassName}
+      <Section title={t("catalog.spells.form.classes")}>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <SpellCatalogField label={t("catalog.spells.form.nameEn")}>
+            <input
+              value={state.nameEn}
+              onChange={(event) => setState((current) => ({ ...current, nameEn: event.target.value }))}
+              className={fieldClassName}
+            />
+          </SpellCatalogField>
+          <SpellCatalogField label={t("catalog.spells.form.namePt")}>
+            <input
+              value={state.namePt}
+              onChange={(event) => setState((current) => ({ ...current, namePt: event.target.value }))}
+              className={fieldClassName}
+            />
+          </SpellCatalogField>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <SpellCatalogField label={t("catalog.spells.form.level")}>
+            <select
+              value={state.level}
+              onChange={(event) =>
+                setState((current) => ({ ...current, level: Number(event.target.value) }))
+              }
+              className={fieldClassName}
+            >
+              {SPELL_LEVEL_OPTIONS.map((level) => (
+                <option key={level} value={level}>
+                  {level === 0 ? t("catalog.spells.cantrip") : `${t("catalog.spells.levelLabel")} ${level}`}
+                </option>
+              ))}
+            </select>
+          </SpellCatalogField>
+          <SpellCatalogField label={t("catalog.spells.form.school")}>
+            <select
+              value={state.school}
+              onChange={(event) =>
+                setState((current) => ({ ...current, school: event.target.value as BaseSpell["school"] }))
+              }
+              className={fieldClassName}
+            >
+              {SPELL_SCHOOL_OPTIONS.map((school) => (
+                <option key={school} value={school}>
+                  {t(schoolLabelKey(school))}
+                </option>
+              ))}
+            </select>
+          </SpellCatalogField>
+        </div>
+
+        {unsupportedValues.length > 0 ? (
+          <SpellCatalogLegacyWarning
+            title={t("catalog.spells.form.legacyWarningTitle")}
+            description={t("catalog.spells.form.legacyWarningDescription")}
+            values={unsupportedValues}
           />
-        </SpellCatalogField>
-        <SpellCatalogField label={t("catalog.spells.form.namePt")}>
-          <input
-            value={state.namePt}
-            onChange={(event) => setState((current) => ({ ...current, namePt: event.target.value }))}
-            className={fieldClassName}
-          />
-        </SpellCatalogField>
-      </div>
+        ) : null}
 
-      <div className="grid gap-4 sm:grid-cols-2">
-        <SpellCatalogField label={t("catalog.spells.form.level")}>
-          <select
-            value={state.level}
-            onChange={(event) =>
-              setState((current) => ({ ...current, level: Number(event.target.value) }))
-            }
-            className={fieldClassName}
-          >
-            {SPELL_LEVEL_OPTIONS.map((level) => (
-              <option key={level} value={level}>
-                {level === 0 ? t("catalog.spells.cantrip") : `${t("catalog.spells.levelLabel")} ${level}`}
-              </option>
+        <SpellCatalogField label={t("catalog.spells.form.classes")}>
+          <div className="flex flex-wrap gap-2">
+            {SPELL_CLASS_OPTIONS.map((className) => (
+              <SpellCatalogToggleChip
+                key={className}
+                active={state.classesJson.includes(className)}
+                label={localizeSpellClass(className, locale)}
+                onClick={() =>
+                  setState((current) => ({
+                    ...current,
+                    classesJson: toggleSpellListValue(current.classesJson, className),
+                  }))
+                }
+              />
             ))}
-          </select>
+          </div>
         </SpellCatalogField>
-        <SpellCatalogField label={t("catalog.spells.form.school")}>
-          <select
-            value={state.school}
-            onChange={(event) =>
-              setState((current) => ({ ...current, school: event.target.value as BaseSpell["school"] }))
-            }
-            className={fieldClassName}
-          >
-            {SPELL_SCHOOL_OPTIONS.map((school) => (
-              <option key={school} value={school}>
-                {t(schoolLabelKey(school))}
-              </option>
-            ))}
-          </select>
-        </SpellCatalogField>
-      </div>
+      </Section>
 
-      {unsupportedValues.length > 0 ? (
-        <SpellCatalogLegacyWarning
-          title={t("catalog.spells.form.legacyWarningTitle")}
-          description={t("catalog.spells.form.legacyWarningDescription")}
-          values={unsupportedValues}
-        />
-      ) : null}
-
-      <SpellCatalogField label={t("catalog.spells.form.classes")}>
-        <div className="flex flex-wrap gap-2">
-          {SPELL_CLASS_OPTIONS.map((className) => (
-            <SpellCatalogToggleChip
-              key={className}
-              active={state.classesJson.includes(className)}
-              label={localizeSpellClass(className, locale)}
-              onClick={() =>
+      <Section title={t("catalog.spells.castingTime")}>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <SpellCatalogField label={t("catalog.spells.form.castingTimeType")}>
+            <select
+              value={state.castingTimeType}
+              onChange={(event) =>
                 setState((current) => ({
                   ...current,
-                  classesJson: toggleSpellListValue(current.classesJson, className),
+                  castingTimeType: event.target.value as SpellCatalogEditorState["castingTimeType"],
                 }))
               }
+              className={fieldClassName}
+            >
+              <option value="">{selectPlaceholder}</option>
+              {SPELL_CASTING_TIME_TYPE_OPTIONS.map((castingTimeType) => (
+                <option key={castingTimeType} value={castingTimeType}>
+                  {localizeSpellAdminValue(castingTimeType, locale)}
+                </option>
+              ))}
+            </select>
+          </SpellCatalogField>
+          <SpellCatalogField label={t("catalog.spells.form.castingTimeText")}>
+            <input
+              value={state.castingTime}
+              onChange={(event) =>
+                setState((current) => ({ ...current, castingTime: event.target.value }))
+              }
+              className={fieldClassName}
             />
-          ))}
+          </SpellCatalogField>
         </div>
-      </SpellCatalogField>
 
-      <div className="grid gap-4 sm:grid-cols-4">
-        <SpellCatalogField label={t("catalog.spells.form.castingTimeType")}>
-          <select
-            value={state.castingTimeType}
-            onChange={(event) =>
-              setState((current) => ({
-                ...current,
-                castingTimeType: event.target.value as SpellCatalogEditorState["castingTimeType"],
-              }))
-            }
-            className={fieldClassName}
-          >
-            <option value="">{selectPlaceholder}</option>
-            {SPELL_CASTING_TIME_TYPE_OPTIONS.map((castingTimeType) => (
-              <option key={castingTimeType} value={castingTimeType}>
-                {localizeSpellAdminValue(castingTimeType, locale)}
-              </option>
-            ))}
-          </select>
-        </SpellCatalogField>
-        <SpellCatalogField label={t("catalog.spells.form.castingTimeText")}>
-          <input
-            value={state.castingTime}
-            onChange={(event) =>
-              setState((current) => ({ ...current, castingTime: event.target.value }))
-            }
-            className={fieldClassName}
-          />
-        </SpellCatalogField>
-        <SpellCatalogField label={`${t("catalog.spells.range")} (m)`}>
-          <input
-            type="number"
-            min={0}
-            value={state.rangeMeters}
-            onChange={(event) =>
-              setState((current) => ({ ...current, rangeMeters: event.target.value }))
-            }
-            className={fieldClassName}
-          />
-        </SpellCatalogField>
-        <SpellCatalogField label={t("catalog.spells.form.targetType")}>
-          <select
-            value={state.targetType}
-            onChange={(event) =>
-              setState((current) => ({
-                ...current,
-                targetType: event.target.value as SpellCatalogEditorState["targetType"],
-              }))
-            }
-            className={fieldClassName}
-          >
-            <option value="">{selectPlaceholder}</option>
-            {SPELL_TARGET_TYPE_OPTIONS.map((targetType) => (
-              <option key={targetType} value={targetType}>
-                {localizeSpellAdminValue(targetType, locale)}
-              </option>
-            ))}
-          </select>
-        </SpellCatalogField>
-        <SpellCatalogField label={t("catalog.spells.form.maxTargets")}>
-          <input
-            type="number"
-            min={1}
-            step={1}
-            value={state.maxTargets}
-            onChange={(event) =>
-              setState((current) => ({ ...current, maxTargets: event.target.value }))
-            }
-            className={fieldClassName}
-          />
-        </SpellCatalogField>
-      </div>
-
-      <div className="grid gap-4 sm:grid-cols-3">
-        <SpellCatalogField label={t("catalog.spells.form.selectionType")}>
-          <select
-            value={state.selectionType}
-            onChange={(event) =>
-              setState((current) => ({
-                ...current,
-                selectionType: event.target.value as SpellCatalogEditorState["selectionType"],
-              }))
-            }
-            className={fieldClassName}
-          >
-            <option value="">{selectPlaceholder}</option>
-            {SPELL_SELECTION_TYPE_OPTIONS.map((value) => (
-              <option key={value} value={value}>
-                {localizeSpellAdminValue(value, locale)}
-              </option>
-            ))}
-          </select>
-        </SpellCatalogField>
-        <SpellCatalogField label={t("catalog.spells.form.originType")}>
-          <select
-            value={state.originType}
-            onChange={(event) =>
-              setState((current) => ({
-                ...current,
-                originType: event.target.value as SpellCatalogEditorState["originType"],
-              }))
-            }
-            className={fieldClassName}
-          >
-            <option value="">{selectPlaceholder}</option>
-            {SPELL_ORIGIN_TYPE_OPTIONS.map((value) => (
-              <option key={value} value={value}>
-                {localizeSpellAdminValue(value, locale)}
-              </option>
-            ))}
-          </select>
-        </SpellCatalogField>
-        <SpellCatalogField label={t("catalog.spells.form.targetAnchor")}>
-          <select
-            value={state.targetAnchor}
-            onChange={(event) =>
-              setState((current) => ({
-                ...current,
-                targetAnchor: event.target.value as SpellCatalogEditorState["targetAnchor"],
-              }))
-            }
-            className={fieldClassName}
-          >
-            <option value="">{selectPlaceholder}</option>
-            {SPELL_TARGET_ANCHOR_OPTIONS.map((value) => (
-              <option key={value} value={value}>
-                {localizeSpellAdminValue(value, locale)}
-              </option>
-            ))}
-          </select>
-        </SpellCatalogField>
-        <SpellCatalogField label={t("catalog.spells.form.attackType")}>
-          <select
-            value={state.attackType}
-            onChange={(event) =>
-              setState((current) => ({
-                ...current,
-                attackType: event.target.value as SpellCatalogEditorState["attackType"],
-              }))
-            }
-            className={fieldClassName}
-          >
-            <option value="">{selectPlaceholder}</option>
-            {SPELL_ATTACK_TYPE_OPTIONS.map((value) => (
-              <option key={value} value={value}>
-                {localizeSpellAdminValue(value, locale)}
-              </option>
-            ))}
-          </select>
-        </SpellCatalogField>
-        <SpellCatalogField label={t("catalog.spells.form.rangeKind")}>
-          <select
-            value={state.rangeKind}
-            onChange={(event) =>
-              setState((current) => ({
-                ...current,
-                rangeKind: event.target.value as SpellCatalogEditorState["rangeKind"],
-              }))
-            }
-            className={fieldClassName}
-          >
-            <option value="">{selectPlaceholder}</option>
-            {SPELL_RANGE_KIND_OPTIONS.map((value) => (
-              <option key={value} value={value}>
-                {localizeSpellAdminValue(value, locale)}
-              </option>
-            ))}
-          </select>
-        </SpellCatalogField>
-        <SpellCatalogField label={t("catalog.spells.form.effectTiming")}>
-          <select
-            value={state.effectTiming}
-            onChange={(event) =>
-              setState((current) => ({
-                ...current,
-                effectTiming: event.target.value as SpellCatalogEditorState["effectTiming"],
-              }))
-            }
-            className={fieldClassName}
-          >
-            <option value="">{selectPlaceholder}</option>
-            {SPELL_EFFECT_TIMING_OPTIONS.map((value) => (
-              <option key={value} value={value}>
-                {localizeSpellAdminValue(value, locale)}
-              </option>
-            ))}
-          </select>
-        </SpellCatalogField>
-      </div>
-
-      <div className="grid gap-4 sm:grid-cols-2">
-        <SpellCatalogField label={t("catalog.spells.form.areaShape")}>
-          <select
-            value={state.areaShape}
-            onChange={(event) =>
-              setState((current) => ({
-                ...current,
-                areaShape: event.target.value as SpellCatalogEditorState["areaShape"],
-              }))
-            }
-            className={fieldClassName}
-          >
-            <option value="">{selectPlaceholder}</option>
-            {SPELL_AREA_SHAPE_OPTIONS.map((shape) => (
-              <option key={shape} value={shape}>
-                {localizeSpellAdminValue(shape, locale)}
-              </option>
-            ))}
-          </select>
-        </SpellCatalogField>
-      </div>
-
-      {(showRadiusField || showLengthField || showSideField) ? (
         <div className="grid gap-4 sm:grid-cols-2">
-          {showRadiusField && (
-            <SpellCatalogField label={t("catalog.spells.form.radiusMeters")}>
-              <input
-                type="number"
-                min={0.5}
-                step={0.5}
-                value={state.radiusMeters}
-                onChange={(event) =>
-                  setState((current) => ({ ...current, radiusMeters: event.target.value }))
-                }
-                className={fieldClassName}
-              />
-            </SpellCatalogField>
-          )}
-          {showLengthField && (
-            <SpellCatalogField label={t("catalog.spells.form.lengthMeters")}>
-              <input
-                type="number"
-                min={0.5}
-                step={0.5}
-                value={state.lengthMeters}
-                onChange={(event) =>
-                  setState((current) => ({ ...current, lengthMeters: event.target.value }))
-                }
-                className={fieldClassName}
-              />
-            </SpellCatalogField>
-          )}
-          {showSideField && (
-            <SpellCatalogField label={t("catalog.spells.form.sideMeters")}>
-              <input
-                type="number"
-                min={0.5}
-                step={0.5}
-                value={state.sideMeters}
-                onChange={(event) =>
-                  setState((current) => ({ ...current, sideMeters: event.target.value }))
-                }
-                className={fieldClassName}
-              />
-            </SpellCatalogField>
-          )}
+          <SpellCatalogField label={`${t("catalog.spells.range")} (m)`}>
+            <input
+              type="number"
+              min={0}
+              value={state.rangeMeters}
+              onChange={(event) =>
+                setState((current) => ({ ...current, rangeMeters: event.target.value }))
+              }
+              className={fieldClassName}
+            />
+          </SpellCatalogField>
+          <SpellCatalogField label={t("catalog.spells.form.targetType")}>
+            <select
+              value={state.targetType}
+              onChange={(event) =>
+                setState((current) => ({
+                  ...current,
+                  targetType: event.target.value as SpellCatalogEditorState["targetType"],
+                }))
+              }
+              className={fieldClassName}
+            >
+              <option value="">{selectPlaceholder}</option>
+              {SPELL_TARGET_TYPE_OPTIONS.map((targetType) => (
+                <option key={targetType} value={targetType}>
+                  {localizeSpellAdminValue(targetType, locale)}
+                </option>
+              ))}
+            </select>
+          </SpellCatalogField>
         </div>
-      ) : null}
 
-      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <SpellCatalogField label={t("catalog.spells.form.maxTargets")}>
+            <input
+              type="number"
+              min={1}
+              step={1}
+              value={state.maxTargets}
+              onChange={(event) =>
+                setState((current) => ({ ...current, maxTargets: event.target.value }))
+              }
+              className={fieldClassName}
+            />
+          </SpellCatalogField>
+          <SpellCatalogField label={t("catalog.spells.duration")}>
+            <input
+              value={state.duration}
+              onChange={(event) => setState((current) => ({ ...current, duration: event.target.value }))}
+              className={fieldClassName}
+            />
+          </SpellCatalogField>
+        </div>
+      </Section>
+
+      <Section title="Componentes">
+        <SpellCatalogField label={t("catalog.spells.form.components")}>
+          <div className="flex flex-wrap gap-2">
+            {SPELL_COMPONENT_OPTIONS.map((component) => (
+              <SpellCatalogToggleChip
+                key={component}
+                active={state.componentsJson.includes(component)}
+                label={component}
+                onClick={() =>
+                  setState((current) => ({
+                    ...current,
+                    componentsJson: toggleSpellListValue(current.componentsJson, component),
+                  }))
+                }
+              />
+            ))}
+          </div>
+        </SpellCatalogField>
+
+        {state.componentsJson.includes("M") ? (
+          <SpellCatalogField label={t("catalog.spells.form.material")}>
+            <input
+              value={state.materialComponentText}
+              onChange={(event) =>
+                setState((current) => ({ ...current, materialComponentText: event.target.value }))
+              }
+              className={fieldClassName}
+            />
+          </SpellCatalogField>
+        ) : null}
+      </Section>
+
+      <Section title="Propriedades">
+        <div className="flex flex-wrap gap-3">
+          <SpellCatalogToggleChip
+            active={state.concentration}
+            label={t("catalog.spells.concentration")}
+            onClick={() =>
+              setState((current) => ({ ...current, concentration: !current.concentration }))
+            }
+          />
+          <SpellCatalogToggleChip
+            active={state.ritual}
+            label={t("catalog.spells.ritual")}
+            onClick={() => setState((current) => ({ ...current, ritual: !current.ritual }))}
+          />
+        </div>
+      </Section>
+
+      <Section title="Targeting">
+        <div className="grid gap-4 sm:grid-cols-3">
+          <SpellCatalogField label={t("catalog.spells.form.selectionType")}>
+            <select
+              value={state.selectionType}
+              onChange={(event) =>
+                setState((current) => ({
+                  ...current,
+                  selectionType: event.target.value as SpellCatalogEditorState["selectionType"],
+                }))
+              }
+              className={fieldClassName}
+            >
+              <option value="">{selectPlaceholder}</option>
+              {SPELL_SELECTION_TYPE_OPTIONS.map((value) => (
+                <option key={value} value={value}>
+                  {localizeSpellAdminValue(value, locale)}
+                </option>
+              ))}
+            </select>
+          </SpellCatalogField>
+          <SpellCatalogField label={t("catalog.spells.form.originType")}>
+            <select
+              value={state.originType}
+              onChange={(event) =>
+                setState((current) => ({
+                  ...current,
+                  originType: event.target.value as SpellCatalogEditorState["originType"],
+                }))
+              }
+              className={fieldClassName}
+            >
+              <option value="">{selectPlaceholder}</option>
+              {SPELL_ORIGIN_TYPE_OPTIONS.map((value) => (
+                <option key={value} value={value}>
+                  {localizeSpellAdminValue(value, locale)}
+                </option>
+              ))}
+            </select>
+          </SpellCatalogField>
+          <SpellCatalogField label={t("catalog.spells.form.targetAnchor")}>
+            <select
+              value={state.targetAnchor}
+              onChange={(event) =>
+                setState((current) => ({
+                  ...current,
+                  targetAnchor: event.target.value as SpellCatalogEditorState["targetAnchor"],
+                }))
+              }
+              className={fieldClassName}
+            >
+              <option value="">{selectPlaceholder}</option>
+              {SPELL_TARGET_ANCHOR_OPTIONS.map((value) => (
+                <option key={value} value={value}>
+                  {localizeSpellAdminValue(value, locale)}
+                </option>
+              ))}
+            </select>
+          </SpellCatalogField>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-3">
+          <SpellCatalogField label={t("catalog.spells.form.attackType")}>
+            <select
+              value={state.attackType}
+              onChange={(event) =>
+                setState((current) => ({
+                  ...current,
+                  attackType: event.target.value as SpellCatalogEditorState["attackType"],
+                }))
+              }
+              className={fieldClassName}
+            >
+              <option value="">{selectPlaceholder}</option>
+              {SPELL_ATTACK_TYPE_OPTIONS.map((value) => (
+                <option key={value} value={value}>
+                  {localizeSpellAdminValue(value, locale)}
+                </option>
+              ))}
+            </select>
+          </SpellCatalogField>
+          <SpellCatalogField label={t("catalog.spells.form.rangeKind")}>
+            <select
+              value={state.rangeKind}
+              onChange={(event) =>
+                setState((current) => ({
+                  ...current,
+                  rangeKind: event.target.value as SpellCatalogEditorState["rangeKind"],
+                }))
+              }
+              className={fieldClassName}
+            >
+              <option value="">{selectPlaceholder}</option>
+              {SPELL_RANGE_KIND_OPTIONS.map((value) => (
+                <option key={value} value={value}>
+                  {localizeSpellAdminValue(value, locale)}
+                </option>
+              ))}
+            </select>
+          </SpellCatalogField>
+          <SpellCatalogField label={t("catalog.spells.form.effectTiming")}>
+            <select
+              value={state.effectTiming}
+              onChange={(event) =>
+                setState((current) => ({
+                  ...current,
+                  effectTiming: event.target.value as SpellCatalogEditorState["effectTiming"],
+                }))
+              }
+              className={fieldClassName}
+            >
+              <option value="">{selectPlaceholder}</option>
+              {SPELL_EFFECT_TIMING_OPTIONS.map((value) => (
+                <option key={value} value={value}>
+                  {localizeSpellAdminValue(value, locale)}
+                </option>
+              ))}
+            </select>
+          </SpellCatalogField>
+        </div>
+
         <SpellCatalogField label={t("catalog.spells.rangeText")}>
           <input
             value={state.rangeText}
@@ -444,44 +451,78 @@ export const SpellCatalogFormFields = ({
             className={fieldClassName}
           />
         </SpellCatalogField>
-        <SpellCatalogField label={t("catalog.spells.duration")}>
-          <input
-            value={state.duration}
-            onChange={(event) => setState((current) => ({ ...current, duration: event.target.value }))}
-            className={fieldClassName}
-          />
-        </SpellCatalogField>
-      </div>
+      </Section>
 
-      <SpellCatalogField label={t("catalog.spells.form.components")}>
-        <div className="flex flex-wrap gap-2">
-          {SPELL_COMPONENT_OPTIONS.map((component) => (
-            <SpellCatalogToggleChip
-              key={component}
-              active={state.componentsJson.includes(component)}
-              label={component}
-              onClick={() =>
+      <Section title="Área">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <SpellCatalogField label={t("catalog.spells.form.areaShape")}>
+            <select
+              value={state.areaShape}
+              onChange={(event) =>
                 setState((current) => ({
                   ...current,
-                  componentsJson: toggleSpellListValue(current.componentsJson, component),
+                  areaShape: event.target.value as SpellCatalogEditorState["areaShape"],
                 }))
               }
-            />
-          ))}
+              className={fieldClassName}
+            >
+              <option value="">{selectPlaceholder}</option>
+              {SPELL_AREA_SHAPE_OPTIONS.map((shape) => (
+                <option key={shape} value={shape}>
+                  {localizeSpellAdminValue(shape, locale)}
+                </option>
+              ))}
+            </select>
+          </SpellCatalogField>
         </div>
-      </SpellCatalogField>
 
-      {state.componentsJson.includes("M") ? (
-        <SpellCatalogField label={t("catalog.spells.form.material")}>
-          <input
-            value={state.materialComponentText}
-            onChange={(event) =>
-              setState((current) => ({ ...current, materialComponentText: event.target.value }))
-            }
-            className={fieldClassName}
-          />
-        </SpellCatalogField>
-      ) : null}
+        {(showRadiusField || showLengthField || showSideField) ? (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {showRadiusField && (
+              <SpellCatalogField label={t("catalog.spells.form.radiusMeters")}>
+                <input
+                  type="number"
+                  min={0.5}
+                  step={0.5}
+                  value={state.radiusMeters}
+                  onChange={(event) =>
+                    setState((current) => ({ ...current, radiusMeters: event.target.value }))
+                  }
+                  className={fieldClassName}
+                />
+              </SpellCatalogField>
+            )}
+            {showLengthField && (
+              <SpellCatalogField label={t("catalog.spells.form.lengthMeters")}>
+                <input
+                  type="number"
+                  min={0.5}
+                  step={0.5}
+                  value={state.lengthMeters}
+                  onChange={(event) =>
+                    setState((current) => ({ ...current, lengthMeters: event.target.value }))
+                  }
+                  className={fieldClassName}
+                />
+              </SpellCatalogField>
+            )}
+            {showSideField && (
+              <SpellCatalogField label={t("catalog.spells.form.sideMeters")}>
+                <input
+                  type="number"
+                  min={0.5}
+                  step={0.5}
+                  value={state.sideMeters}
+                  onChange={(event) =>
+                    setState((current) => ({ ...current, sideMeters: event.target.value }))
+                  }
+                  className={fieldClassName}
+                />
+              </SpellCatalogField>
+            )}
+          </div>
+        ) : null}
+      </Section>
 
       <SpellCatalogResolutionFields
         state={state}
@@ -526,43 +567,30 @@ export const SpellCatalogFormFields = ({
         />
       )}
 
-      <div className="grid gap-4 sm:grid-cols-2">
-        <SpellCatalogField label={t("catalog.spells.form.descriptionEn")}>
-          <textarea
-            value={state.descriptionEn}
-            onChange={(event) =>
-              setState((current) => ({ ...current, descriptionEn: event.target.value }))
-            }
-            rows={5}
-            className={fieldClassName}
-          />
-        </SpellCatalogField>
-        <SpellCatalogField label={t("catalog.spells.form.descriptionPt")}>
-          <textarea
-            value={state.descriptionPt}
-            onChange={(event) =>
-              setState((current) => ({ ...current, descriptionPt: event.target.value }))
-            }
-            rows={5}
-            className={fieldClassName}
-          />
-        </SpellCatalogField>
-      </div>
-
-      <div className="flex flex-wrap gap-2">
-        <SpellCatalogToggleChip
-          active={state.concentration}
-          label={t("catalog.spells.concentration")}
-          onClick={() =>
-            setState((current) => ({ ...current, concentration: !current.concentration }))
-          }
-        />
-        <SpellCatalogToggleChip
-          active={state.ritual}
-          label={t("catalog.spells.ritual")}
-          onClick={() => setState((current) => ({ ...current, ritual: !current.ritual }))}
-        />
-      </div>
-    </>
+      <Section title="Descrição">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <SpellCatalogField label={t("catalog.spells.form.descriptionEn")}>
+            <textarea
+              value={state.descriptionEn}
+              onChange={(event) =>
+                setState((current) => ({ ...current, descriptionEn: event.target.value }))
+              }
+              rows={5}
+              className={fieldClassName}
+            />
+          </SpellCatalogField>
+          <SpellCatalogField label={t("catalog.spells.form.descriptionPt")}>
+            <textarea
+              value={state.descriptionPt}
+              onChange={(event) =>
+                setState((current) => ({ ...current, descriptionPt: event.target.value }))
+              }
+              rows={5}
+              className={fieldClassName}
+            />
+          </SpellCatalogField>
+        </div>
+      </Section>
+    </div>
   );
 };

--- a/apps/control-web/src/features/shop/components/SpellCatalogList.tsx
+++ b/apps/control-web/src/features/shop/components/SpellCatalogList.tsx
@@ -1,17 +1,13 @@
 import type { BaseSpell } from "../../../entities/base-spell";
-import type { BaseSpellUpdatePayload } from "../../../shared/api/baseSpellsRepo";
 import { useLocale } from "../../../shared/hooks/useLocale";
 import { SpellCatalogCard } from "./SpellCatalogCard";
 
 type Props = {
   spells: BaseSpell[];
-  onUpdate?: (
-    spellId: string,
-    payload: BaseSpellUpdatePayload,
-  ) => boolean | Promise<boolean>;
+  canEdit?: boolean;
 };
 
-export const SpellCatalogList = ({ spells, onUpdate }: Props) => {
+export const SpellCatalogList = ({ spells, canEdit = true }: Props) => {
   const { t } = useLocale();
 
   if (spells.length === 0) {
@@ -23,9 +19,9 @@ export const SpellCatalogList = ({ spells, onUpdate }: Props) => {
   }
 
   return (
-      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
       {spells.map((spell) => (
-        <SpellCatalogCard key={spell.id} spell={spell} onUpdate={onUpdate} />
+        <SpellCatalogCard key={spell.id} spell={spell} canEdit={canEdit} />
       ))}
     </div>
   );

--- a/apps/control-web/src/features/shop/components/SpellCatalogResolutionFields.tsx
+++ b/apps/control-web/src/features/shop/components/SpellCatalogResolutionFields.tsx
@@ -31,6 +31,15 @@ type Props = {
 const fieldClassName =
   "w-full rounded-2xl border border-white/8 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-violet-400/60 focus:outline-none";
 
+const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
+  <div className="space-y-4 rounded-2xl border border-white/8 bg-slate-950/35 p-4">
+    <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+      {title}
+    </p>
+    <div className="space-y-4">{children}</div>
+  </div>
+);
+
 export const SpellCatalogResolutionFields = ({
   state,
   setState,
@@ -43,149 +52,157 @@ export const SpellCatalogResolutionFields = ({
   showHealFields,
 }: Props) => (
   <>
-    <div className="grid gap-4 sm:grid-cols-3">
-      <SpellCatalogField label={t("catalog.spells.form.resolutionType")}>
-        <select
-          value={state.resolutionType}
-          onChange={(event) =>
-            setState((current) => ({
-              ...current,
-              resolutionType: event.target.value as SpellCatalogEditorState["resolutionType"],
-            }))
-          }
-          className={fieldClassName}
-        >
-          <option value="">{selectPlaceholder}</option>
-          {SPELL_RESOLUTION_TYPE_OPTIONS.map((resolutionType) => (
-            <option key={resolutionType} value={resolutionType}>
-              {localizeSpellAdminValue(resolutionType, locale)}
-            </option>
-          ))}
-        </select>
-      </SpellCatalogField>
-      {showSavingThrowFields ? (
-        <SpellCatalogField label={t("catalog.spells.form.savingThrow")}>
+    <Section title="Resolução">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <SpellCatalogField label={t("catalog.spells.form.resolutionType")}>
           <select
-            value={state.savingThrow}
+            value={state.resolutionType}
             onChange={(event) =>
-              setState((current) => ({ ...current, savingThrow: event.target.value }))
+              setState((current) => ({
+                ...current,
+                resolutionType: event.target.value as SpellCatalogEditorState["resolutionType"],
+              }))
             }
             className={fieldClassName}
           >
             <option value="">{selectPlaceholder}</option>
-            {SPELL_SAVING_THROW_OPTIONS.map((savingThrow) => (
-              <option key={savingThrow} value={savingThrow}>
-                {savingThrow}
+            {SPELL_RESOLUTION_TYPE_OPTIONS.map((resolutionType) => (
+              <option key={resolutionType} value={resolutionType}>
+                {localizeSpellAdminValue(resolutionType, locale)}
               </option>
             ))}
           </select>
         </SpellCatalogField>
-      ) : null}
+        {showSavingThrowFields ? (
+          <SpellCatalogField label={t("catalog.spells.form.savingThrow")}>
+            <select
+              value={state.savingThrow}
+              onChange={(event) =>
+                setState((current) => ({ ...current, savingThrow: event.target.value }))
+              }
+              className={fieldClassName}
+            >
+              <option value="">{selectPlaceholder}</option>
+              {SPELL_SAVING_THROW_OPTIONS.map((savingThrow) => (
+                <option key={savingThrow} value={savingThrow}>
+                  {savingThrow}
+                </option>
+              ))}
+            </select>
+          </SpellCatalogField>
+        ) : null}
+      </div>
       {showSaveSuccessOutcome ? (
-        <SpellCatalogField label={t("catalog.spells.form.saveSuccessOutcome")}>
-          <select
-            value={state.saveSuccessOutcome}
-            onChange={(event) =>
-              setState((current) => ({ ...current, saveSuccessOutcome: event.target.value }))
-            }
-            className={fieldClassName}
-          >
-            <option value="">{selectPlaceholder}</option>
-            {SPELL_SAVE_SUCCESS_OUTCOME_OPTIONS.map((outcome) => (
-              <option key={outcome} value={outcome}>
-                {localizeSaveSuccessOutcome(outcome, locale)}
-              </option>
-            ))}
-          </select>
-        </SpellCatalogField>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <SpellCatalogField label={t("catalog.spells.form.saveSuccessOutcome")}>
+            <select
+              value={state.saveSuccessOutcome}
+              onChange={(event) =>
+                setState((current) => ({ ...current, saveSuccessOutcome: event.target.value }))
+              }
+              className={fieldClassName}
+            >
+              <option value="">{selectPlaceholder}</option>
+              {SPELL_SAVE_SUCCESS_OUTCOME_OPTIONS.map((outcome) => (
+                <option key={outcome} value={outcome}>
+                  {localizeSaveSuccessOutcome(outcome, locale)}
+                </option>
+              ))}
+            </select>
+          </SpellCatalogField>
+        </div>
       ) : null}
-    </div>
+    </Section>
 
     {showDamageFields ? (
-      <div className="grid gap-4 sm:grid-cols-4">
-        <SpellCatalogField
-          label={t("catalog.spells.form.damageDiceCount")}
-          help={t("catalog.spells.form.damageDiceCountHelp")}
-        >
-          <select
-            value={state.damageDiceCount}
-            onChange={(event) =>
-              setState((current) => ({ ...current, damageDiceCount: event.target.value }))
-            }
-            className={fieldClassName}
+      <Section title="Dano">
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <SpellCatalogField
+            label={t("catalog.spells.form.damageDiceCount")}
+            help={t("catalog.spells.form.damageDiceCountHelp")}
           >
-            <option value="">{selectPlaceholder}</option>
-            {SPELL_DICE_COUNT_OPTIONS.map((count) => (
-              <option key={count} value={count}>
-                {count}
-              </option>
-            ))}
-          </select>
-        </SpellCatalogField>
-        <SpellCatalogField
-          label={t("catalog.spells.form.damageDieSize")}
-          help={t("catalog.spells.form.damageDieSizeHelp")}
-        >
-          <select
-            value={state.damageDieSize}
-            onChange={(event) =>
-              setState((current) => ({ ...current, damageDieSize: event.target.value }))
-            }
-            className={fieldClassName}
+            <select
+              value={state.damageDiceCount}
+              onChange={(event) =>
+                setState((current) => ({ ...current, damageDiceCount: event.target.value }))
+              }
+              className={fieldClassName}
+            >
+              <option value="">{selectPlaceholder}</option>
+              {SPELL_DICE_COUNT_OPTIONS.map((count) => (
+                <option key={count} value={count}>
+                  {count}
+                </option>
+              ))}
+            </select>
+          </SpellCatalogField>
+          <SpellCatalogField
+            label={t("catalog.spells.form.damageDieSize")}
+            help={t("catalog.spells.form.damageDieSizeHelp")}
           >
-            <option value="">{selectPlaceholder}</option>
-            {SPELL_DIE_SIZE_OPTIONS.map((size) => (
-              <option key={size} value={size}>
-                d{size}
-              </option>
-            ))}
-          </select>
-        </SpellCatalogField>
-        <SpellCatalogField
-          label={t("catalog.spells.form.damageFixedBonus")}
-          help={t("catalog.spells.form.damageFixedBonusHelp")}
-        >
-          <input
-            type="number"
-            step={1}
-            value={state.damageFixedBonus}
-            onChange={(event) =>
-              setState((current) => ({ ...current, damageFixedBonus: event.target.value }))
-            }
-            className={fieldClassName}
-            placeholder="0"
-          />
-        </SpellCatalogField>
-        <SpellCatalogField label={t("catalog.spells.form.damageType")}>
-          <select
-            value={state.damageType}
-            onChange={(event) =>
-              setState((current) => ({ ...current, damageType: event.target.value }))
-            }
-            className={fieldClassName}
+            <select
+              value={state.damageDieSize}
+              onChange={(event) =>
+                setState((current) => ({ ...current, damageDieSize: event.target.value }))
+              }
+              className={fieldClassName}
+            >
+              <option value="">{selectPlaceholder}</option>
+              {SPELL_DIE_SIZE_OPTIONS.map((size) => (
+                <option key={size} value={size}>
+                  d{size}
+                </option>
+              ))}
+            </select>
+          </SpellCatalogField>
+          <SpellCatalogField
+            label={t("catalog.spells.form.damageFixedBonus")}
+            help={t("catalog.spells.form.damageFixedBonusHelp")}
           >
-            <option value="">{selectPlaceholder}</option>
-            {SPELL_DAMAGE_TYPE_OPTIONS.map((damageType) => (
-              <option key={damageType} value={damageType}>
-                {localizeDamageType(damageType, locale)}
-              </option>
-            ))}
-          </select>
-        </SpellCatalogField>
-      </div>
+            <input
+              type="number"
+              step={1}
+              value={state.damageFixedBonus}
+              onChange={(event) =>
+                setState((current) => ({ ...current, damageFixedBonus: event.target.value }))
+              }
+              className={fieldClassName}
+              placeholder="0"
+            />
+          </SpellCatalogField>
+          <SpellCatalogField label={t("catalog.spells.form.damageType")}>
+            <select
+              value={state.damageType}
+              onChange={(event) =>
+                setState((current) => ({ ...current, damageType: event.target.value }))
+              }
+              className={fieldClassName}
+            >
+              <option value="">{selectPlaceholder}</option>
+              {SPELL_DAMAGE_TYPE_OPTIONS.map((damageType) => (
+                <option key={damageType} value={damageType}>
+                  {localizeDamageType(damageType, locale)}
+                </option>
+              ))}
+            </select>
+          </SpellCatalogField>
+        </div>
+      </Section>
     ) : null}
 
     {showHealFields ? (
-      <SpellCatalogField label={t("catalog.spells.form.healDice")}>
-        <input
-          value={state.healDice}
-          onChange={(event) =>
-            setState((current) => ({ ...current, healDice: event.target.value }))
-          }
-          className={fieldClassName}
-          placeholder="1d8"
-        />
-      </SpellCatalogField>
+      <Section title="Cura">
+        <SpellCatalogField label={t("catalog.spells.form.healDice")}>
+          <input
+            value={state.healDice}
+            onChange={(event) =>
+              setState((current) => ({ ...current, healDice: event.target.value }))
+            }
+            className={fieldClassName}
+            placeholder="1d8"
+          />
+        </SpellCatalogField>
+      </Section>
     ) : null}
   </>
 );

--- a/apps/control-web/src/pages/CatalogPage/CatalogSpellEditPage.tsx
+++ b/apps/control-web/src/pages/CatalogPage/CatalogSpellEditPage.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { routes } from "../../app/routes/routes";
+import { useCampaigns } from "../../features/campaign-select";
+import { useCampaignSpells } from "../../features/shop/hooks/useCampaignSpells";
+import { SpellCatalogFormFields } from "../../features/shop/components/SpellCatalogFormFields";
+import {
+  buildSpellUpdatePayload,
+  createSpellEditorState,
+  getUnsupportedSpellEditorValues,
+  type SpellCatalogEditorState,
+} from "../../features/shop/utils/spellCatalogForm";
+import { campaignSpellsRepo } from "../../shared/api/campaignSpellsRepo";
+import { useLocale } from "../../shared/hooks/useLocale";
+import { useToast } from "../../shared/hooks/useToast";
+import { Toast } from "../../shared/ui/Toast";
+
+export const CatalogSpellEditPage = () => {
+  const { spellId } = useParams<{ spellId: string }>();
+  const { selectedCampaignId } = useCampaigns();
+  const navigate = useNavigate();
+  const { t } = useLocale();
+  const { toast, showToast, clearToast } = useToast();
+
+  const {
+    spells,
+    loading: spellsLoading,
+    refetch: refetchSpells,
+  } = useCampaignSpells({ campaignId: selectedCampaignId, auto: true });
+
+  const spell = spells.find((s) => s.id === spellId) ?? null;
+  const [state, setState] = useState(() =>
+    spell ? createSpellEditorState(spell) : null,
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const unsupportedValues = spell ? getUnsupportedSpellEditorValues(spell) : [];
+
+  useEffect(() => {
+    if (spell) {
+      setState(createSpellEditorState(spell));
+    }
+  }, [spell]);
+
+  if (!selectedCampaignId) {
+    return null;
+  }
+
+  if (spellsLoading && !spell) {
+    return (
+      <section className="space-y-6">
+        <div className="mx-auto max-w-4xl rounded-[28px] border border-white/8 bg-[linear-gradient(180deg,rgba(14,17,31,0.92),rgba(3,7,18,0.98))] p-8 text-center">
+          <p className="text-sm text-slate-400">{t("catalog.spells.loading")}</p>
+        </div>
+      </section>
+    );
+  }
+
+  if (!spell || !state) {
+    return (
+      <section className="space-y-6">
+        <div className="mx-auto max-w-4xl rounded-[28px] border border-rose-400/15 bg-rose-500/5 p-8 text-center">
+          <p className="text-sm text-rose-200">{t("catalog.spells.loadErrorDescription")}</p>
+          <button
+            type="button"
+            onClick={() => navigate(routes.catalogSpells)}
+            className="mt-4 rounded-full border border-white/10 bg-white/4 px-4 py-2 text-xs font-semibold text-slate-200 hover:bg-white/8"
+          >
+            {t("catalog.openLibrary")}
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  const formState = state;
+  const setFormState = setState as React.Dispatch<React.SetStateAction<SpellCatalogEditorState>>;
+
+  const canSave =
+    Boolean(formState.nameEn.trim()) &&
+    Boolean(formState.descriptionEn.trim()) &&
+    formState.level >= 0 &&
+    formState.level <= 9;
+
+  const handleSave = async () => {
+    if (!canSave || isSaving) return;
+
+    setIsSaving(true);
+    try {
+      await campaignSpellsRepo.update(
+        selectedCampaignId,
+        spell.id,
+        buildSpellUpdatePayload(formState),
+      );
+      await refetchSpells();
+      showToast({
+        variant: "success",
+        title: t("catalog.spells.updateSuccessTitle"),
+        description: t("catalog.spells.updateSuccessDescription"),
+      });
+      navigate(routes.catalogSpells);
+    } catch (error) {
+      showToast({
+        variant: "error",
+        title: t("catalog.spells.updateErrorTitle"),
+        description:
+          error instanceof Error ? error.message : t("catalog.spells.updateErrorDescription"),
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <section className="space-y-6">
+      <Toast toast={toast} onClose={clearToast} />
+
+      <div className="mx-auto max-w-4xl">
+        <div className="rounded-[28px] border border-white/8 bg-[linear-gradient(180deg,rgba(14,17,31,0.92),rgba(3,7,18,0.98))] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.35)]">
+          <div className="space-y-5">
+            <div className="flex flex-wrap items-start justify-between gap-3 border-b border-white/8 pb-4">
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-500">
+                  {t("catalog.edit")}
+                </p>
+                <h2 className="mt-1 text-2xl font-black tracking-tight text-white">
+                  {spell.nameEn}
+                </h2>
+              </div>
+              <span className="rounded-full border border-white/10 bg-white/4 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-300">
+                {spell.canonicalKey}
+              </span>
+            </div>
+
+            <SpellCatalogFormFields
+              state={formState}
+              setState={setFormState}
+              unsupportedValues={unsupportedValues}
+            />
+
+            <div className="flex flex-wrap gap-3 border-t border-white/8 pt-4">
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={!canSave || isSaving}
+                className={`rounded-full px-5 py-3 text-sm font-semibold ${
+                  !canSave || isSaving
+                    ? "cursor-not-allowed border border-white/8 text-slate-600"
+                    : "border border-violet-300/25 bg-violet-400/12 text-violet-100 hover:bg-violet-400/18"
+                }`}
+              >
+                {isSaving ? t("catalog.saving") : t("catalog.save")}
+              </button>
+              <button
+                type="button"
+                onClick={() => navigate(routes.catalogSpells)}
+                className="rounded-full border border-white/10 bg-white/4 px-5 py-3 text-sm font-semibold text-slate-200 hover:border-white/20 hover:bg-white/8"
+              >
+                {t("catalog.cancel")}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/control-web/src/pages/CatalogPage/CatalogSpellNewPage.tsx
+++ b/apps/control-web/src/pages/CatalogPage/CatalogSpellNewPage.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { routes } from "../../app/routes/routes";
+import { useCampaigns } from "../../features/campaign-select";
+import { SpellCatalogFormFields } from "../../features/shop/components/SpellCatalogFormFields";
+import {
+  buildSpellCreatePayload,
+  createEmptySpellEditorState,
+  normalizeSpellCanonicalKey,
+} from "../../features/shop/utils/spellCatalogForm";
+import type { CampaignSpellCreatePayload } from "../../shared/api/campaignSpellsRepo";
+import { campaignSpellsRepo } from "../../shared/api/campaignSpellsRepo";
+import { useLocale } from "../../shared/hooks/useLocale";
+import { useToast } from "../../shared/hooks/useToast";
+import { Toast } from "../../shared/ui/Toast";
+
+export const CatalogSpellNewPage = () => {
+  const { selectedCampaignId } = useCampaigns();
+  const navigate = useNavigate();
+  const { t } = useLocale();
+  const { toast, showToast, clearToast } = useToast();
+
+  const [state, setState] = useState(createEmptySpellEditorState);
+  const [isSaving, setIsSaving] = useState(false);
+
+  if (!selectedCampaignId) {
+    return null;
+  }
+
+  const canSave =
+    Boolean(normalizeSpellCanonicalKey(state.canonicalKey)) &&
+    Boolean(state.nameEn.trim()) &&
+    Boolean(state.descriptionEn.trim()) &&
+    state.level >= 0 &&
+    state.level <= 9;
+
+  const handleCreate = async () => {
+    if (!canSave || isSaving) return;
+
+    setIsSaving(true);
+    try {
+      await campaignSpellsRepo.create(selectedCampaignId, buildSpellCreatePayload(state) as CampaignSpellCreatePayload);
+      showToast({
+        variant: "success",
+        title: t("catalog.spells.createSuccessTitle"),
+        description: t("catalog.spells.createSuccessDescription"),
+      });
+      navigate(routes.catalogSpells);
+    } catch (error) {
+      showToast({
+        variant: "error",
+        title: t("catalog.spells.createErrorTitle"),
+        description:
+          error instanceof Error ? error.message : t("catalog.spells.createErrorDescription"),
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <section className="space-y-6">
+      <Toast toast={toast} onClose={clearToast} />
+
+      <div className="mx-auto max-w-4xl">
+        <div className="rounded-[28px] border border-violet-300/15 bg-[linear-gradient(180deg,rgba(14,17,31,0.92),rgba(3,7,18,0.98))] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.35)]">
+          <div className="space-y-5">
+            <div className="border-b border-white/8 pb-4">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-violet-200/65">
+                {t("catalog.spells.formTitle")}
+              </p>
+              <h2 className="mt-2 text-2xl font-black tracking-tight text-white">
+                {t("catalog.spells.formHeadline")}
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-slate-300">
+                {t("catalog.spells.formDescription")}
+              </p>
+            </div>
+
+            <SpellCatalogFormFields
+              state={state}
+              setState={setState}
+              showCanonicalKey
+            />
+
+            <div className="flex flex-wrap gap-3 border-t border-white/8 pt-4">
+              <button
+                type="button"
+                onClick={handleCreate}
+                disabled={!canSave || isSaving}
+                className={`rounded-full px-5 py-3 text-sm font-semibold ${
+                  !canSave || isSaving
+                    ? "cursor-not-allowed border border-white/8 text-slate-600"
+                    : "border border-violet-300/25 bg-violet-400/12 text-violet-100 hover:bg-violet-400/18"
+                }`}
+              >
+                {isSaving ? t("catalog.spells.creatingAction") : t("catalog.spells.createAction")}
+              </button>
+              <button
+                type="button"
+                onClick={() => navigate(routes.catalogSpells)}
+                className="rounded-full border border-white/10 bg-white/4 px-5 py-3 text-sm font-semibold text-slate-200 hover:border-white/20 hover:bg-white/8"
+              >
+                {t("catalog.cancel")}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/control-web/src/pages/CatalogPage/CatalogSpellsPage.tsx
+++ b/apps/control-web/src/pages/CatalogPage/CatalogSpellsPage.tsx
@@ -1,22 +1,14 @@
 import { useDeferredValue, useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { routes } from "../../app/routes/routes";
 import { useCampaigns } from "../../features/campaign-select";
 import { useCampaignSpells } from "../../features/shop/hooks/useCampaignSpells";
-import { CreateSpellCatalogForm } from "../../features/shop/components/CreateSpellCatalogForm";
-import type { BaseSpellUpdatePayload } from "../../shared/api/baseSpellsRepo";
-import {
-  campaignSpellsRepo,
-  type CampaignSpellCreatePayload,
-} from "../../shared/api/campaignSpellsRepo";
 import { useLocale } from "../../shared/hooks/useLocale";
 import { useToast } from "../../shared/hooks/useToast";
 import { Toast } from "../../shared/ui/Toast";
 import { CatalogHero } from "./CatalogHero";
-import { CatalogModeSwitch, type CatalogMode } from "./CatalogModeSwitch";
 import { CatalogNoCampaignState } from "./CatalogNoCampaignState";
 import { CatalogSpellsSection } from "./CatalogSpellsSection";
-import { resolveCatalogMessage } from "./catalogPage.utils";
 import { useCatalogPageMetrics } from "./useCatalogPageMetrics";
 
 export const CatalogSpellsPage = () => {
@@ -24,7 +16,7 @@ export const CatalogSpellsPage = () => {
   const { t, locale } = useLocale();
   const { toast, showToast, clearToast } = useToast();
   const location = useLocation();
-  const [mode, setMode] = useState<CatalogMode>("library");
+  const navigate = useNavigate();
   const [spellSearch, setSpellSearch] = useState("");
   const [spellLevelFilter, setSpellLevelFilter] = useState<number | null>(null);
   const [spellSchoolFilter, setSpellSchoolFilter] = useState<string | null>(null);
@@ -35,7 +27,6 @@ export const CatalogSpellsPage = () => {
     spells: allSpells,
     loading: spellsLoading,
     error: spellsError,
-    refetch: refetchSpells,
   } = useCampaignSpells({
     campaignId: selectedCampaignId,
     auto: true,
@@ -50,7 +41,6 @@ export const CatalogSpellsPage = () => {
     setSpellLevelFilter(null);
     setSpellSchoolFilter(null);
     setSpellClassFilter(null);
-    setMode("library");
   }, [selectedCampaignId]);
 
   useEffect(() => {
@@ -89,58 +79,6 @@ export const CatalogSpellsPage = () => {
 
   const campaignPanelRoute = routes.campaignEdit.replace(":campaignId", selectedCampaignId);
 
-  const handleSpellUpdate = async (
-    spellId: string,
-    payload: BaseSpellUpdatePayload,
-  ) => {
-    try {
-      await campaignSpellsRepo.update(selectedCampaignId, spellId, payload);
-      await refetchSpells();
-      showToast({
-        variant: "success",
-        title: t("catalog.spells.updateSuccessTitle"),
-        description: t("catalog.spells.updateSuccessDescription"),
-      });
-      return true;
-    } catch (error) {
-      const message =
-        error instanceof Error && error.message
-          ? error.message
-          : t("catalog.spells.updateErrorDescription");
-      showToast({
-        variant: "error",
-        title: t("catalog.spells.updateErrorTitle"),
-        description: message,
-      });
-      return false;
-    }
-  };
-
-  const handleSpellCreate = async (payload: CampaignSpellCreatePayload) => {
-    try {
-      await campaignSpellsRepo.create(selectedCampaignId, payload);
-      await refetchSpells();
-      showToast({
-        variant: "success",
-        title: t("catalog.spells.createSuccessTitle"),
-        description: t("catalog.spells.createSuccessDescription"),
-      });
-      setMode("library");
-      return true;
-    } catch (error) {
-      showToast({
-        variant: "error",
-        title: t("catalog.spells.createErrorTitle"),
-        description: resolveCatalogMessage(
-          t,
-          error instanceof Error ? error.message : undefined,
-          "catalog.spells.createErrorDescription",
-        ),
-      });
-      return false;
-    }
-  };
-
   return (
     <section className="space-y-6">
       <Toast toast={toast} onClose={clearToast} />
@@ -157,71 +95,48 @@ export const CatalogSpellsPage = () => {
         description={t("catalog.spells.heroDescription")}
       />
 
-      <CatalogModeSwitch
-        mode={mode}
-        createTitle={t("catalog.spells.formHeadline")}
-        libraryTitle={t("catalog.spells.listPanelTitle")}
-        onChange={setMode}
-      />
-
-      {mode === "create" ? (
-        <section className="mx-auto w-full max-w-330 space-y-4">
-          <div className="flex justify-end">
+      <section className="rounded-[34px] border border-white/8 bg-[linear-gradient(180deg,rgba(15,23,42,0.84),rgba(2,6,23,0.96))] p-6 shadow-[0_24px_70px_rgba(2,6,23,0.28)]">
+        <header className="border-b border-white/8 pb-5">
+          <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-400">
+                {t("catalog.spells.listPanelTitle")}
+              </p>
+              <p className="mt-3 text-sm leading-7 text-slate-300">
+                {t("catalog.spells.listPanelDescription")}
+              </p>
+            </div>
             <button
               type="button"
-              onClick={() => setMode("library")}
-              className="rounded-full border border-white/10 bg-white/3 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-200 transition hover:border-white/20 hover:bg-white/8"
+              onClick={() => navigate(routes.catalogSpellNew)}
+              className="rounded-full border border-violet-300/20 bg-violet-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-violet-100 transition hover:bg-violet-400/18"
             >
-              {t("catalog.openLibrary")}
+              {t("catalog.spells.formHeadline")}
             </button>
           </div>
-          <CreateSpellCatalogForm onCreate={handleSpellCreate} />
-        </section>
-      ) : (
-        <section className="rounded-[34px] border border-white/8 bg-[linear-gradient(180deg,rgba(15,23,42,0.84),rgba(2,6,23,0.96))] p-6 shadow-[0_24px_70px_rgba(2,6,23,0.28)]">
-          <header className="border-b border-white/8 pb-5">
-            <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
-              <div>
-                <p className="text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-400">
-                  {t("catalog.spells.listPanelTitle")}
-                </p>
-                <p className="mt-3 text-sm leading-7 text-slate-300">
-                  {t("catalog.spells.listPanelDescription")}
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={() => setMode("create")}
-                className="rounded-full border border-white/10 bg-white/3 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-200 transition hover:border-white/20 hover:bg-white/8"
-              >
-                {t("catalog.openCreate")}
-              </button>
-            </div>
-          </header>
-          <div className="mt-6">
-            <CatalogSpellsSection
-              allSpellsCount={allSpells.length}
-              classFilter={spellClassFilter}
-              filteredSpells={filteredSpells}
-              levelFilter={spellLevelFilter}
-              schoolFilter={spellSchoolFilter}
-              search={spellSearch}
-              spellsLoading={spellsLoading}
-              onClassChange={setSpellClassFilter}
-              onClear={() => {
-                setSpellSearch("");
-                setSpellLevelFilter(null);
-                setSpellSchoolFilter(null);
-                setSpellClassFilter(null);
-              }}
-              onLevelChange={setSpellLevelFilter}
-              onSchoolChange={setSpellSchoolFilter}
-              onSearchChange={setSpellSearch}
-              onUpdate={handleSpellUpdate}
-            />
-          </div>
-        </section>
-      )}
+        </header>
+        <div className="mt-6">
+          <CatalogSpellsSection
+            allSpellsCount={allSpells.length}
+            classFilter={spellClassFilter}
+            filteredSpells={filteredSpells}
+            levelFilter={spellLevelFilter}
+            schoolFilter={spellSchoolFilter}
+            search={spellSearch}
+            spellsLoading={spellsLoading}
+            onClassChange={setSpellClassFilter}
+            onClear={() => {
+              setSpellSearch("");
+              setSpellLevelFilter(null);
+              setSpellSchoolFilter(null);
+              setSpellClassFilter(null);
+            }}
+            onLevelChange={setSpellLevelFilter}
+            onSchoolChange={setSpellSchoolFilter}
+            onSearchChange={setSpellSearch}
+          />
+        </div>
+      </section>
     </section>
   );
 };

--- a/apps/control-web/src/pages/CatalogPage/CatalogSpellsSection.tsx
+++ b/apps/control-web/src/pages/CatalogPage/CatalogSpellsSection.tsx
@@ -1,11 +1,11 @@
 import type { BaseSpell } from "../../entities/base-spell";
-import type { BaseSpellUpdatePayload } from "../../shared/api/baseSpellsRepo";
 import { useLocale } from "../../shared/hooks/useLocale";
 import { SpellCatalogList } from "../../features/shop/components/SpellCatalogList";
 import { SpellCatalogFilters } from "./SpellCatalogFilters";
 
 type Props = {
   allSpellsCount: number;
+  canEdit?: boolean;
   classFilter: string | null;
   filteredSpells: BaseSpell[];
   levelFilter: number | null;
@@ -17,14 +17,11 @@ type Props = {
   onLevelChange: (value: number | null) => void;
   onSchoolChange: (value: string | null) => void;
   onSearchChange: (value: string) => void;
-  onUpdate: (
-    spellId: string,
-    payload: BaseSpellUpdatePayload,
-  ) => boolean | Promise<boolean>;
 };
 
 export const CatalogSpellsSection = ({
   allSpellsCount,
+  canEdit = true,
   classFilter,
   filteredSpells,
   levelFilter,
@@ -36,7 +33,6 @@ export const CatalogSpellsSection = ({
   onLevelChange,
   onSchoolChange,
   onSearchChange,
-  onUpdate,
 }: Props) => {
   const { t } = useLocale();
 
@@ -61,7 +57,7 @@ export const CatalogSpellsSection = ({
           {t("catalog.spells.loading")}
         </div>
       ) : (
-        <SpellCatalogList spells={filteredSpells} onUpdate={onUpdate} />
+        <SpellCatalogList spells={filteredSpells} canEdit={canEdit} />
       )}
     </div>
   );

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/SystemSpellCatalogCastingFields.tsx
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/SystemSpellCatalogCastingFields.tsx
@@ -13,6 +13,7 @@ import type {
 } from "../../entities/base-spell";
 import { useLocale } from "../../shared/hooks/useLocale";
 import { localizeSpellAdminValue } from "../../shared/i18n/domainLabels";
+import { SystemSpellCatalogFormSection } from "./SystemSpellCatalogFormSection";
 import { toggleListValue } from "./systemSpellCatalog.helpers";
 import {
   AREA_SHAPE_OPTIONS,
@@ -45,234 +46,342 @@ export const SystemSpellCatalogCastingFields = ({ form, setForm }: Props) => {
   const showRadiusField = form.areaShape === "sphere" || form.areaShape === "cylinder";
   const showLengthField = form.areaShape === "cone" || form.areaShape === "line";
   const showSideField = form.areaShape === "cube";
+  const showAreaSection = Boolean(form.areaShape);
 
   return (
     <>
-      <div className="grid gap-4 md:grid-cols-3">
-        <label className="block">
+      <SystemSpellCatalogFormSection title="Casting">
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Casting time type
+            </span>
+            <select
+              value={form.castingTimeType}
+              onChange={(event) =>
+                setForm((c) => ({
+                  ...c,
+                  castingTimeType: event.target.value as CastingTimeType | "",
+                }))
+              }
+              className={`${inputClassName} mt-2`}
+            >
+              <option value="">—</option>
+              {CASTING_TIME_TYPE_OPTIONS.map((ctt) => (
+                <option key={ctt} value={ctt}>
+                  {formatSpellChoiceLabel(ctt)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Alcance (m)
+            </span>
+            <input
+              type="number"
+              min={0}
+              value={form.rangeMeters}
+              onChange={(event) =>
+                setForm((c) => ({ ...c, rangeMeters: event.target.value }))
+              }
+              className={`${inputClassName} mt-2`}
+              placeholder="0"
+            />
+          </label>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Duração
+            </span>
+            <select
+              value={form.duration}
+              onChange={(event) =>
+                setForm((c) => ({ ...c, duration: event.target.value }))
+              }
+              className={`${inputClassName} mt-2`}
+            >
+              <option value="">—</option>
+              {DURATION_OPTIONS.map((d) => (
+                <option key={d} value={d}>
+                  {d}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="flex items-end gap-3 pb-1">
+            <button
+              type="button"
+              onClick={() =>
+                setForm((c) => ({ ...c, concentration: !c.concentration }))
+              }
+              className={`rounded-full border px-3 py-2 text-xs font-semibold transition ${
+                form.concentration
+                  ? "border-amber-300/40 bg-amber-400/15 text-amber-100"
+                  : "border-white/10 bg-white/4 text-slate-400 hover:bg-white/8"
+              }`}
+            >
+              Concentration
+            </button>
+            <button
+              type="button"
+              onClick={() => setForm((c) => ({ ...c, ritual: !c.ritual }))}
+              className={`rounded-full border px-3 py-2 text-xs font-semibold transition ${
+                form.ritual
+                  ? "border-teal-300/40 bg-teal-400/15 text-teal-100"
+                  : "border-white/10 bg-white/4 text-slate-400 hover:bg-white/8"
+              }`}
+            >
+              Ritual
+            </button>
+          </div>
+        </div>
+
+        <div>
           <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Casting time type
+            Componentes
           </span>
-          <select
-            value={form.castingTimeType}
-            onChange={(event) =>
-              setForm((c) => ({
-                ...c,
-                castingTimeType: event.target.value as CastingTimeType | "",
-              }))
-            }
-            className={`${inputClassName} mt-2`}
-          >
-            <option value="">—</option>
-            {CASTING_TIME_TYPE_OPTIONS.map((ctt) => (
-              <option key={ctt} value={ctt}>
-                {formatSpellChoiceLabel(ctt)}
-              </option>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {COMPONENT_OPTIONS.map((comp) => (
+              <button
+                key={comp}
+                type="button"
+                onClick={() =>
+                  setForm((c) => ({
+                    ...c,
+                    componentsJson: toggleListValue(c.componentsJson, comp),
+                  }))
+                }
+                className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+                  form.componentsJson.includes(comp)
+                    ? "border-violet-300/40 bg-violet-400/15 text-violet-100"
+                    : "border-white/10 bg-white/4 text-slate-400 hover:bg-white/8"
+                }`}
+              >
+                {comp}
+              </button>
             ))}
-          </select>
-        </label>
+          </div>
+        </div>
 
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Alcance (m)
-          </span>
-          <input
-            type="number"
-            min={0}
-            value={form.rangeMeters}
-            onChange={(event) =>
-              setForm((c) => ({ ...c, rangeMeters: event.target.value }))
-            }
-            className={`${inputClassName} mt-2`}
-            placeholder="0"
-          />
-        </label>
+        {showMaterialComponent && (
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Material component
+            </span>
+            <input
+              value={form.materialComponentText}
+              onChange={(event) =>
+                setForm((c) => ({
+                  ...c,
+                  materialComponentText: event.target.value,
+                }))
+              }
+              className={`${inputClassName} mt-2`}
+              placeholder="a tiny ball of bat guano and sulfur"
+            />
+          </label>
+        )}
+      </SystemSpellCatalogFormSection>
 
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Target type
-          </span>
-          <select
-            value={form.targetType}
-            onChange={(event) =>
-              setForm((c) => ({
-                ...c,
-                targetType: event.target.value as TargetType | "",
-              }))
-            }
-            className={`${inputClassName} mt-2`}
-          >
-            <option value="">—</option>
-            {TARGET_TYPE_OPTIONS.map((tt) => (
-              <option key={tt} value={tt}>
-                {formatSpellChoiceLabel(tt)}
-              </option>
-            ))}
-          </select>
-        </label>
+      <SystemSpellCatalogFormSection
+        title="Targeting"
+        collapsible
+      >
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Target type
+            </span>
+            <select
+              value={form.targetType}
+              onChange={(event) =>
+                setForm((c) => ({
+                  ...c,
+                  targetType: event.target.value as TargetType | "",
+                }))
+              }
+              className={`${inputClassName} mt-2`}
+            >
+              <option value="">—</option>
+              {TARGET_TYPE_OPTIONS.map((tt) => (
+                <option key={tt} value={tt}>
+                  {formatSpellChoiceLabel(tt)}
+                </option>
+              ))}
+            </select>
+          </label>
 
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Max targets
-          </span>
-          <input
-            type="number"
-            min={1}
-            step={1}
-            value={form.maxTargets}
-            onChange={(event) =>
-              setForm((c) => ({ ...c, maxTargets: event.target.value }))
-            }
-            className={`${inputClassName} mt-2`}
-            placeholder="1"
-          />
-        </label>
-      </div>
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Max targets
+            </span>
+            <input
+              type="number"
+              min={1}
+              step={1}
+              value={form.maxTargets}
+              onChange={(event) =>
+                setForm((c) => ({ ...c, maxTargets: event.target.value }))
+              }
+              className={`${inputClassName} mt-2`}
+              placeholder="1"
+            />
+          </label>
+        </div>
 
-      <div className="grid gap-4 md:grid-cols-3">
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Selection type
-          </span>
-          <select
-            value={form.selectionType}
-            onChange={(event) =>
-              setForm((c) => ({
-                ...c,
-                selectionType: event.target.value as SpellSelectionType | "",
-              }))
-            }
-            className={`${inputClassName} mt-2`}
-          >
-            <option value="">—</option>
-            {SELECTION_TYPE_OPTIONS.map((value) => (
-              <option key={value} value={value}>
-                {formatSpellChoiceLabel(value)}
-              </option>
-            ))}
-          </select>
-        </label>
+        <div className="grid gap-4 md:grid-cols-3">
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Selection type
+            </span>
+            <select
+              value={form.selectionType}
+              onChange={(event) =>
+                setForm((c) => ({
+                  ...c,
+                  selectionType: event.target.value as SpellSelectionType | "",
+                }))
+              }
+              className={`${inputClassName} mt-2`}
+            >
+              <option value="">—</option>
+              {SELECTION_TYPE_OPTIONS.map((value) => (
+                <option key={value} value={value}>
+                  {formatSpellChoiceLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
 
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Origin type
-          </span>
-          <select
-            value={form.originType}
-            onChange={(event) =>
-              setForm((c) => ({
-                ...c,
-                originType: event.target.value as SpellOriginType | "",
-              }))
-            }
-            className={`${inputClassName} mt-2`}
-          >
-            <option value="">—</option>
-            {ORIGIN_TYPE_OPTIONS.map((value) => (
-              <option key={value} value={value}>
-                {formatSpellChoiceLabel(value)}
-              </option>
-            ))}
-          </select>
-        </label>
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Origin type
+            </span>
+            <select
+              value={form.originType}
+              onChange={(event) =>
+                setForm((c) => ({
+                  ...c,
+                  originType: event.target.value as SpellOriginType | "",
+                }))
+              }
+              className={`${inputClassName} mt-2`}
+            >
+              <option value="">—</option>
+              {ORIGIN_TYPE_OPTIONS.map((value) => (
+                <option key={value} value={value}>
+                  {formatSpellChoiceLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
 
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Target anchor
-          </span>
-          <select
-            value={form.targetAnchor}
-            onChange={(event) =>
-              setForm((c) => ({
-                ...c,
-                targetAnchor: event.target.value as SpellTargetAnchor | "",
-              }))
-            }
-            className={`${inputClassName} mt-2`}
-          >
-            <option value="">—</option>
-            {TARGET_ANCHOR_OPTIONS.map((value) => (
-              <option key={value} value={value}>
-                {formatSpellChoiceLabel(value)}
-              </option>
-            ))}
-          </select>
-        </label>
-      </div>
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Target anchor
+            </span>
+            <select
+              value={form.targetAnchor}
+              onChange={(event) =>
+                setForm((c) => ({
+                  ...c,
+                  targetAnchor: event.target.value as SpellTargetAnchor | "",
+                }))
+              }
+              className={`${inputClassName} mt-2`}
+            >
+              <option value="">—</option>
+              {TARGET_ANCHOR_OPTIONS.map((value) => (
+                <option key={value} value={value}>
+                  {formatSpellChoiceLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
 
-      <div className="grid gap-4 md:grid-cols-3">
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Attack type
-          </span>
-          <select
-            value={form.attackType}
-            onChange={(event) =>
-              setForm((c) => ({
-                ...c,
-                attackType: event.target.value as SpellAttackType | "",
-              }))
-            }
-            className={`${inputClassName} mt-2`}
-          >
-            <option value="">—</option>
-            {ATTACK_TYPE_OPTIONS.map((value) => (
-              <option key={value} value={value}>
-                {formatSpellChoiceLabel(value)}
-              </option>
-            ))}
-          </select>
-        </label>
+        <div className="grid gap-4 md:grid-cols-3">
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Attack type
+            </span>
+            <select
+              value={form.attackType}
+              onChange={(event) =>
+                setForm((c) => ({
+                  ...c,
+                  attackType: event.target.value as SpellAttackType | "",
+                }))
+              }
+              className={`${inputClassName} mt-2`}
+            >
+              <option value="">—</option>
+              {ATTACK_TYPE_OPTIONS.map((value) => (
+                <option key={value} value={value}>
+                  {formatSpellChoiceLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
 
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Range kind
-          </span>
-          <select
-            value={form.rangeKind}
-            onChange={(event) =>
-              setForm((c) => ({
-                ...c,
-                rangeKind: event.target.value as SpellRangeKind | "",
-              }))
-            }
-            className={`${inputClassName} mt-2`}
-          >
-            <option value="">—</option>
-            {RANGE_KIND_OPTIONS.map((value) => (
-              <option key={value} value={value}>
-                {formatSpellChoiceLabel(value)}
-              </option>
-            ))}
-          </select>
-        </label>
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Range kind
+            </span>
+            <select
+              value={form.rangeKind}
+              onChange={(event) =>
+                setForm((c) => ({
+                  ...c,
+                  rangeKind: event.target.value as SpellRangeKind | "",
+                }))
+              }
+              className={`${inputClassName} mt-2`}
+            >
+              <option value="">—</option>
+              {RANGE_KIND_OPTIONS.map((value) => (
+                <option key={value} value={value}>
+                  {formatSpellChoiceLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
 
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Effect timing
-          </span>
-          <select
-            value={form.effectTiming}
-            onChange={(event) =>
-              setForm((c) => ({
-                ...c,
-                effectTiming: event.target.value as SpellEffectTiming | "",
-              }))
-            }
-            className={`${inputClassName} mt-2`}
-          >
-            <option value="">—</option>
-            {EFFECT_TIMING_OPTIONS.map((value) => (
-              <option key={value} value={value}>
-                {formatSpellChoiceLabel(value)}
-              </option>
-            ))}
-          </select>
-        </label>
-      </div>
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Effect timing
+            </span>
+            <select
+              value={form.effectTiming}
+              onChange={(event) =>
+                setForm((c) => ({
+                  ...c,
+                  effectTiming: event.target.value as SpellEffectTiming | "",
+                }))
+              }
+              className={`${inputClassName} mt-2`}
+            >
+              <option value="">—</option>
+              {EFFECT_TIMING_OPTIONS.map((value) => (
+                <option key={value} value={value}>
+                  {formatSpellChoiceLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </SystemSpellCatalogFormSection>
 
-      <div className="grid gap-4 md:grid-cols-3">
-        <label className="block">
+      <SystemSpellCatalogFormSection
+        title="Área"
+        collapsible
+      >
+        <label className="block min-w-0">
           <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
             Area shape
           </span>
@@ -294,161 +403,66 @@ export const SystemSpellCatalogCastingFields = ({ form, setForm }: Props) => {
             ))}
           </select>
         </label>
-      </div>
 
-      {(showRadiusField || showLengthField || showSideField) && (
-        <div className="grid gap-4 md:grid-cols-3">
-          {showRadiusField && (
-            <label className="block">
-              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-                Raio (m)
-              </span>
-              <input
-                type="number"
-                min={0.5}
-                step={0.5}
-                value={form.radiusMeters}
-                onChange={(event) =>
-                  setForm((c) => ({ ...c, radiusMeters: event.target.value }))
-                }
-                className={`${inputClassName} mt-2`}
-                placeholder="ex: 6"
-              />
-            </label>
-          )}
-          {showLengthField && (
-            <label className="block">
-              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-                Comprimento (m)
-              </span>
-              <input
-                type="number"
-                min={0.5}
-                step={0.5}
-                value={form.lengthMeters}
-                onChange={(event) =>
-                  setForm((c) => ({ ...c, lengthMeters: event.target.value }))
-                }
-                className={`${inputClassName} mt-2`}
-                placeholder="ex: 4.5"
-              />
-            </label>
-          )}
-          {showSideField && (
-            <label className="block">
-              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-                Lado (m)
-              </span>
-              <input
-                type="number"
-                min={0.5}
-                step={0.5}
-                value={form.sideMeters}
-                onChange={(event) =>
-                  setForm((c) => ({ ...c, sideMeters: event.target.value }))
-                }
-                className={`${inputClassName} mt-2`}
-                placeholder="ex: 4.5"
-              />
-            </label>
-          )}
-        </div>
-      )}
-
-      <div className="grid gap-4 md:grid-cols-3">
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Duração
-          </span>
-          <select
-            value={form.duration}
-            onChange={(event) =>
-              setForm((c) => ({ ...c, duration: event.target.value }))
-            }
-            className={`${inputClassName} mt-2`}
-          >
-            <option value="">—</option>
-            {DURATION_OPTIONS.map((d) => (
-              <option key={d} value={d}>
-                {d}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <div className="flex items-end gap-3 pb-1">
-          <button
-            type="button"
-            onClick={() =>
-              setForm((c) => ({ ...c, concentration: !c.concentration }))
-            }
-            className={`rounded-full border px-3 py-2 text-xs font-semibold transition ${
-              form.concentration
-                ? "border-amber-300/40 bg-amber-400/15 text-amber-100"
-                : "border-white/10 bg-white/4 text-slate-400 hover:bg-white/8"
-            }`}
-          >
-            Concentration
-          </button>
-          <button
-            type="button"
-            onClick={() => setForm((c) => ({ ...c, ritual: !c.ritual }))}
-            className={`rounded-full border px-3 py-2 text-xs font-semibold transition ${
-              form.ritual
-                ? "border-teal-300/40 bg-teal-400/15 text-teal-100"
-                : "border-white/10 bg-white/4 text-slate-400 hover:bg-white/8"
-            }`}
-          >
-            Ritual
-          </button>
-        </div>
-      </div>
-
-      <div>
-        <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-          Componentes
-        </span>
-        <div className="mt-2 flex flex-wrap gap-2">
-          {COMPONENT_OPTIONS.map((comp) => (
-            <button
-              key={comp}
-              type="button"
-              onClick={() =>
-                setForm((c) => ({
-                  ...c,
-                  componentsJson: toggleListValue(c.componentsJson, comp),
-                }))
-              }
-              className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
-                form.componentsJson.includes(comp)
-                  ? "border-violet-300/40 bg-violet-400/15 text-violet-100"
-                  : "border-white/10 bg-white/4 text-slate-400 hover:bg-white/8"
-              }`}
-            >
-              {comp}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {showMaterialComponent && (
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Material component
-          </span>
-          <input
-            value={form.materialComponentText}
-            onChange={(event) =>
-              setForm((c) => ({
-                ...c,
-                materialComponentText: event.target.value,
-              }))
-            }
-            className={`${inputClassName} mt-2`}
-            placeholder="a tiny ball of bat guano and sulfur"
-          />
-        </label>
-      )}
+        {showAreaSection && (showRadiusField || showLengthField || showSideField) && (
+          <div className="grid gap-4 md:grid-cols-2">
+            {showRadiusField && (
+              <label className="block min-w-0">
+                <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                  Raio (m)
+                </span>
+                <input
+                  type="number"
+                  min={0.5}
+                  step={0.5}
+                  value={form.radiusMeters}
+                  onChange={(event) =>
+                    setForm((c) => ({ ...c, radiusMeters: event.target.value }))
+                  }
+                  className={`${inputClassName} mt-2`}
+                  placeholder="ex: 6"
+                />
+              </label>
+            )}
+            {showLengthField && (
+              <label className="block min-w-0">
+                <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                  Comprimento (m)
+                </span>
+                <input
+                  type="number"
+                  min={0.5}
+                  step={0.5}
+                  value={form.lengthMeters}
+                  onChange={(event) =>
+                    setForm((c) => ({ ...c, lengthMeters: event.target.value }))
+                  }
+                  className={`${inputClassName} mt-2`}
+                  placeholder="ex: 4.5"
+                />
+              </label>
+            )}
+            {showSideField && (
+              <label className="block min-w-0">
+                <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                  Lado (m)
+                </span>
+                <input
+                  type="number"
+                  min={0.5}
+                  step={0.5}
+                  value={form.sideMeters}
+                  onChange={(event) =>
+                    setForm((c) => ({ ...c, sideMeters: event.target.value }))
+                  }
+                  className={`${inputClassName} mt-2`}
+                  placeholder="ex: 4.5"
+                />
+              </label>
+            )}
+          </div>
+        )}
+      </SystemSpellCatalogFormSection>
     </>
   );
 };

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/SystemSpellCatalogFormSection.tsx
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/SystemSpellCatalogFormSection.tsx
@@ -1,0 +1,49 @@
+import { useState, type ReactNode } from "react";
+
+type Props = {
+  title: string;
+  collapsible?: boolean;
+  defaultCollapsed?: boolean;
+  children: ReactNode;
+};
+
+export const SystemSpellCatalogFormSection = ({
+  title,
+  collapsible = false,
+  defaultCollapsed = false,
+  children,
+}: Props) => {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
+
+  return (
+    <div className="rounded-2xl border border-white/8 bg-slate-950/35 p-4">
+      <button
+        type="button"
+        onClick={collapsible ? () => setCollapsed((c) => !c) : undefined}
+        className={`flex w-full items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400 ${
+          collapsible ? "cursor-pointer hover:text-slate-200" : "cursor-default"
+        }`}
+      >
+        <span>{title}</span>
+        {collapsible && (
+          <svg
+            className={`h-3 w-3 shrink-0 transition-transform duration-200 ${
+              collapsed ? "-rotate-90" : "rotate-0"
+            }`}
+            viewBox="0 0 12 12"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M3 5l3 3 3-3" />
+          </svg>
+        )}
+      </button>
+      {(!collapsible || !collapsed) && (
+        <div className="mt-4 space-y-4">{children}</div>
+      )}
+    </div>
+  );
+};

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/SystemSpellCatalogResolutionFields.tsx
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/SystemSpellCatalogResolutionFields.tsx
@@ -12,7 +12,9 @@ import {
   localizeSaveSuccessOutcome,
   localizeSpellAdminValue,
 } from "../../shared/i18n/domainLabels";
+import { SystemSpellCatalogFormSection } from "./SystemSpellCatalogFormSection";
 import {
+  COVER_APPLIES_TO_SAVE_OPTIONS,
   DAMAGE_TYPE_OPTIONS,
   DICE_COUNT_OPTIONS,
   DIE_SIZE_OPTIONS,
@@ -67,434 +69,522 @@ export const SystemSpellCatalogResolutionFields = ({ form, setForm }: Props) => 
   const showUpcastMaxLevelField = Boolean(form.upcastMode);
   const showEffectScalingFields = form.upcastMode === "effect_scaling";
   const showExtraEffectFields = form.upcastMode === "extra_effect";
+  const showBaseEffectInstances = form.upcastMode === "additional_effect_instances";
 
   return (
     <>
-      <div className="grid gap-4 md:grid-cols-3">
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Resolution type
-          </span>
-          <select
-            value={form.resolutionType}
-            onChange={(event) =>
-              setForm((c) => ({
-                ...c,
-                resolutionType: event.target.value as ResolutionType | "",
-              }))
-            }
-            className={`${inputClassName} mt-2`}
-          >
-            <option value="">—</option>
-            {RESOLUTION_TYPE_OPTIONS.map((rt) => (
-              <option key={rt} value={rt}>
-                {formatSpellChoiceLabel(rt)}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        {showSavingThrowFields && (
-          <label className="block">
+      <SystemSpellCatalogFormSection title="Resolução">
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="block min-w-0">
             <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-              Saving throw ability
+              Resolution type
             </span>
             <select
-              value={form.savingThrow}
+              value={form.resolutionType}
               onChange={(event) =>
                 setForm((c) => ({
                   ...c,
-                  savingThrow: event.target.value as SpellSavingThrow | "",
+                  resolutionType: event.target.value as ResolutionType | "",
                 }))
               }
               className={`${inputClassName} mt-2`}
             >
               <option value="">—</option>
-              {SAVING_THROW_OPTIONS.map((st) => (
-                <option key={st} value={st}>
-                  {st}
+              {RESOLUTION_TYPE_OPTIONS.map((rt) => (
+                <option key={rt} value={rt}>
+                  {formatSpellChoiceLabel(rt)}
                 </option>
               ))}
             </select>
           </label>
-        )}
+
+          {showSavingThrowFields && (
+            <label className="block min-w-0">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                Saving throw ability
+              </span>
+              <select
+                value={form.savingThrow}
+                onChange={(event) =>
+                  setForm((c) => ({
+                    ...c,
+                    savingThrow: event.target.value as SpellSavingThrow | "",
+                  }))
+                }
+                className={`${inputClassName} mt-2`}
+              >
+                <option value="">—</option>
+                {SAVING_THROW_OPTIONS.map((st) => (
+                  <option key={st} value={st}>
+                    {st}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+        </div>
 
         {showSaveSuccessOutcome && (
-          <label className="block">
-            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-              {t("catalog.spells.form.saveSuccessOutcome")}
-            </span>
-            <select
-              value={form.saveSuccessOutcome}
-              onChange={(event) =>
-                setForm((c) => ({
-                  ...c,
-                  saveSuccessOutcome: event.target.value as SaveSuccessOutcome | "",
-                }))
-              }
-              className={`${inputClassName} mt-2`}
-            >
-              <option value="">—</option>
-              {SAVE_SUCCESS_OUTCOME_OPTIONS.map((outcome) => (
-                <option key={outcome} value={outcome}>
-                  {localizeSaveSuccessOutcome(outcome, locale)}
-                </option>
-              ))}
-            </select>
-          </label>
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="block min-w-0">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                {t("catalog.spells.form.saveSuccessOutcome")}
+              </span>
+              <select
+                value={form.saveSuccessOutcome}
+                onChange={(event) =>
+                  setForm((c) => ({
+                    ...c,
+                    saveSuccessOutcome: event.target.value as SaveSuccessOutcome | "",
+                  }))
+                }
+                className={`${inputClassName} mt-2`}
+              >
+                <option value="">—</option>
+                {SAVE_SUCCESS_OUTCOME_OPTIONS.map((outcome) => (
+                  <option key={outcome} value={outcome}>
+                    {localizeSaveSuccessOutcome(outcome, locale)}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block min-w-0">
+              <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                <span>Cover applies to save</span>
+                <FieldHelpIcon text="Se cover físico aplica à saving throw. &quot;physical&quot; = alvo com cover recebe bônus. &quot;none&quot; = cover não aplica." />
+              </span>
+              <select
+                value={form.coverAppliesToSave}
+                onChange={(event) =>
+                  setForm((c) => ({
+                    ...c,
+                    coverAppliesToSave: event.target.value as FormState["coverAppliesToSave"],
+                  }))
+                }
+                className={`${inputClassName} mt-2`}
+              >
+                <option value="">—</option>
+                {COVER_APPLIES_TO_SAVE_OPTIONS.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
         )}
-      </div>
+
+        {showSavingThrowFields && !showSaveSuccessOutcome && (
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="block min-w-0">
+              <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                <span>Cover applies to save</span>
+                <FieldHelpIcon text="Se cover físico aplica à saving throw. &quot;physical&quot; = alvo com cover recebe bônus. &quot;none&quot; = cover não aplica." />
+              </span>
+              <select
+                value={form.coverAppliesToSave}
+                onChange={(event) =>
+                  setForm((c) => ({
+                    ...c,
+                    coverAppliesToSave: event.target.value as FormState["coverAppliesToSave"],
+                  }))
+                }
+                className={`${inputClassName} mt-2`}
+              >
+                <option value="">—</option>
+                {COVER_APPLIES_TO_SAVE_OPTIONS.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        )}
+      </SystemSpellCatalogFormSection>
 
       {showDamageFields && (
-        <div className="grid gap-4 md:grid-cols-4">
-          <label className="block">
-            <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-              <span>Dice count</span>
-              <FieldHelpIcon text="Quantidade de dados do efeito base. Ex.: 3 em 3d4+3." />
-            </span>
-            <select
-              value={form.damageDiceCount}
-              onChange={(event) =>
-                setForm((c) => ({ ...c, damageDiceCount: event.target.value }))
-              }
-              className={`${inputClassName} mt-2`}
-            >
-              <option value="">—</option>
-              {DICE_COUNT_OPTIONS.map((count) => (
-                <option key={count} value={count}>
-                  {count}
-                </option>
-              ))}
-            </select>
-          </label>
+        <SystemSpellCatalogFormSection title="Dano">
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <label className="block min-w-0">
+              <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                <span>Dice count</span>
+                <FieldHelpIcon text="Quantidade de dados do efeito base. Ex.: 3 em 3d4+3." />
+              </span>
+              <select
+                value={form.damageDiceCount}
+                onChange={(event) =>
+                  setForm((c) => ({ ...c, damageDiceCount: event.target.value }))
+                }
+                className={`${inputClassName} mt-2`}
+              >
+                <option value="">—</option>
+                {DICE_COUNT_OPTIONS.map((count) => (
+                  <option key={count} value={count}>
+                    {count}
+                  </option>
+                ))}
+              </select>
+            </label>
 
-          <label className="block">
-            <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-              <span>Die</span>
-              <FieldHelpIcon text="Tipo do dado do efeito base. Ex.: d4." />
-            </span>
-            <select
-              value={form.damageDieSize}
-              onChange={(event) =>
-                setForm((c) => ({ ...c, damageDieSize: event.target.value }))
-              }
-              className={`${inputClassName} mt-2`}
-            >
-              <option value="">—</option>
-              {DIE_SIZE_OPTIONS.map((size) => (
-                <option key={size} value={size}>
-                  d{size}
-                </option>
-              ))}
-            </select>
-          </label>
+            <label className="block min-w-0">
+              <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                <span>Die</span>
+                <FieldHelpIcon text="Tipo do dado do efeito base. Ex.: d4." />
+              </span>
+              <select
+                value={form.damageDieSize}
+                onChange={(event) =>
+                  setForm((c) => ({ ...c, damageDieSize: event.target.value }))
+                }
+                className={`${inputClassName} mt-2`}
+              >
+                <option value="">—</option>
+                {DIE_SIZE_OPTIONS.map((size) => (
+                  <option key={size} value={size}>
+                    d{size}
+                  </option>
+                ))}
+              </select>
+            </label>
 
-          <label className="block">
-            <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-              <span>Fixed bonus</span>
-              <FieldHelpIcon text="Bônus fixo somado ao efeito base. Ex.: +3 em 3d4+3." />
-            </span>
-            <input
-              type="number"
-              step={1}
-              value={form.damageFixedBonus}
-              onChange={(event) =>
-                setForm((c) => ({ ...c, damageFixedBonus: event.target.value }))
-              }
-              className={`${inputClassName} mt-2`}
-              placeholder="0"
-            />
-          </label>
+            <label className="block min-w-0">
+              <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                <span>Fixed bonus</span>
+                <FieldHelpIcon text="Bônus fixo somado ao efeito base. Ex.: +3 em 3d4+3." />
+              </span>
+              <input
+                type="number"
+                step={1}
+                value={form.damageFixedBonus}
+                onChange={(event) =>
+                  setForm((c) => ({ ...c, damageFixedBonus: event.target.value }))
+                }
+                className={`${inputClassName} mt-2`}
+                placeholder="0"
+              />
+            </label>
 
-          <label className="block">
-            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-              Damage type
-            </span>
-            <select
-              value={form.damageType}
-              onChange={(event) =>
-                setForm((c) => ({
-                  ...c,
-                  damageType: event.target.value as SpellDamageType | "",
-                }))
-              }
-              className={`${inputClassName} mt-2`}
-            >
-              <option value="">—</option>
-              {DAMAGE_TYPE_OPTIONS.map((dt) => (
-                <option key={dt} value={dt}>
-                  {dt}
-                </option>
-              ))}
-            </select>
-          </label>
-        </div>
+            <label className="block min-w-0">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                Damage type
+              </span>
+              <select
+                value={form.damageType}
+                onChange={(event) =>
+                  setForm((c) => ({
+                    ...c,
+                    damageType: event.target.value as SpellDamageType | "",
+                  }))
+                }
+                className={`${inputClassName} mt-2`}
+              >
+                <option value="">—</option>
+                {DAMAGE_TYPE_OPTIONS.map((dt) => (
+                  <option key={dt} value={dt}>
+                    {dt}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </SystemSpellCatalogFormSection>
       )}
 
       {showHealFields && (
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Heal dice
-          </span>
-          <input
-            value={form.healDice}
-            onChange={(event) =>
-              setForm((c) => ({ ...c, healDice: event.target.value }))
-            }
-            className={`${inputClassName} mt-2`}
-            placeholder="1d8"
-          />
-        </label>
+        <SystemSpellCatalogFormSection title="Cura">
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Heal dice
+            </span>
+            <input
+              value={form.healDice}
+              onChange={(event) =>
+                setForm((c) => ({ ...c, healDice: event.target.value }))
+              }
+              className={`${inputClassName} mt-2`}
+              placeholder="1d8"
+            />
+          </label>
+        </SystemSpellCatalogFormSection>
       )}
 
-      {form.level > 0 ? (
-      <div className="grid gap-4 md:grid-cols-2">
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Upcast mode
-          </span>
-          <select
-            value={form.upcastMode}
-            onChange={(event) =>
-              setForm((c) => ({
-                ...c,
-                upcastMode: event.target.value as UpcastMode | "",
-              }))
-            }
-            className={`${inputClassName} mt-2`}
-          >
-            <option value="">—</option>
-            {UPCAST_MODE_OPTIONS.map((um) => (
-              <option key={um} value={um}>
-                {formatSpellChoiceLabel(um)}
-              </option>
-            ))}
-          </select>
-        </label>
-
-      </div>
-      ) : null}
-
-      {form.level > 0 && showUpcastDiceField ? (
-        <div className="grid gap-4 md:grid-cols-3">
-          <label className="block">
-            <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-              <span>Upcast dice count</span>
-              <FieldHelpIcon text="Dados por incremento ou instância extra. Ex.: 1 em 1d4+1." />
+      {form.level > 0 && (
+        <SystemSpellCatalogFormSection
+          title="Upcast"
+          collapsible
+        >
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Upcast mode
             </span>
             <select
-              value={form.upcastDiceCount}
+              value={form.upcastMode}
               onChange={(event) =>
-                setForm((c) => ({ ...c, upcastDiceCount: event.target.value }))
+                setForm((c) => ({
+                  ...c,
+                  upcastMode: event.target.value as UpcastMode | "",
+                }))
               }
               className={`${inputClassName} mt-2`}
             >
               <option value="">—</option>
-              {DICE_COUNT_OPTIONS.map((count) => (
-                <option key={count} value={count}>
-                  {count}
+              {UPCAST_MODE_OPTIONS.map((um) => (
+                <option key={um} value={um}>
+                  {formatSpellChoiceLabel(um)}
                 </option>
               ))}
             </select>
           </label>
 
-          <label className="block">
-            <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-              <span>Upcast die</span>
-              <FieldHelpIcon text="Dado do incremento de upcast. Ex.: d4." />
-            </span>
-            <select
-              value={form.upcastDieSize}
-              onChange={(event) =>
-                setForm((c) => ({ ...c, upcastDieSize: event.target.value }))
-              }
-              className={`${inputClassName} mt-2`}
-            >
-              <option value="">—</option>
-              {DIE_SIZE_OPTIONS.map((size) => (
-                <option key={size} value={size}>
-                  d{size}
-                </option>
-              ))}
-            </select>
-          </label>
+          {showUpcastDiceField && (
+            <div className="grid gap-4 md:grid-cols-3">
+              <label className="block min-w-0">
+                <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                  <span>Upcast dice count</span>
+                  <FieldHelpIcon text="Dados por incremento ou instância extra. Ex.: 1 em 1d4+1." />
+                </span>
+                <select
+                  value={form.upcastDiceCount}
+                  onChange={(event) =>
+                    setForm((c) => ({ ...c, upcastDiceCount: event.target.value }))
+                  }
+                  className={`${inputClassName} mt-2`}
+                >
+                  <option value="">—</option>
+                  {DICE_COUNT_OPTIONS.map((count) => (
+                    <option key={count} value={count}>
+                      {count}
+                    </option>
+                  ))}
+                </select>
+              </label>
 
-          <label className="block">
-            <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-              <span>Upcast fixed bonus</span>
-              <FieldHelpIcon text="Bônus por incremento. Ex.: +1 por míssil extra." />
-            </span>
-            <input
-              type="number"
-              step={1}
-              value={form.upcastFixedBonus}
-              onChange={(event) =>
-                setForm((c) => ({ ...c, upcastFixedBonus: event.target.value }))
-              }
-              className={`${inputClassName} mt-2`}
-              placeholder="0"
-            />
-          </label>
-        </div>
-      ) : null}
+              <label className="block min-w-0">
+                <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                  <span>Upcast die</span>
+                  <FieldHelpIcon text="Dado do incremento de upcast. Ex.: d4." />
+                </span>
+                <select
+                  value={form.upcastDieSize}
+                  onChange={(event) =>
+                    setForm((c) => ({ ...c, upcastDieSize: event.target.value }))
+                  }
+                  className={`${inputClassName} mt-2`}
+                >
+                  <option value="">—</option>
+                  {DIE_SIZE_OPTIONS.map((size) => (
+                    <option key={size} value={size}>
+                      d{size}
+                    </option>
+                  ))}
+                </select>
+              </label>
 
-      {form.level > 0 && (showUpcastFlatField || showUpcastPerLevelField || showUpcastMaxLevelField) ? (
-        <div className="grid gap-4 md:grid-cols-3">
-          {showUpcastFlatField ? (
-            <label className="block">
-              <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-                <span>Upcast flat</span>
-                <FieldHelpIcon text="Bônus fixo sem dado; use para escalas numéricas simples." />
-              </span>
-              <input
-                value={form.upcastFlat}
-                onChange={(event) =>
-                  setForm((c) => ({ ...c, upcastFlat: event.target.value }))
-                }
-                className={`${inputClassName} mt-2`}
-                placeholder="1"
-              />
-            </label>
-          ) : null}
+              <label className="block min-w-0">
+                <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                  <span>Upcast fixed bonus</span>
+                  <FieldHelpIcon text="Bônus por incremento. Ex.: +1 por míssil extra." />
+                </span>
+                <input
+                  type="number"
+                  step={1}
+                  value={form.upcastFixedBonus}
+                  onChange={(event) =>
+                    setForm((c) => ({ ...c, upcastFixedBonus: event.target.value }))
+                  }
+                  className={`${inputClassName} mt-2`}
+                  placeholder="0"
+                />
+              </label>
+            </div>
+          )}
 
-          {showUpcastPerLevelField ? (
-            <label className="block">
-              <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-                <span>Upcast por nível</span>
-                <FieldHelpIcon text="Incrementos por slot acima do nível base. Normalmente 1." />
-              </span>
-              <input
-                value={form.upcastPerLevel}
-                onChange={(event) =>
-                  setForm((c) => ({ ...c, upcastPerLevel: event.target.value }))
-                }
-                className={`${inputClassName} mt-2`}
-                placeholder="1"
-              />
-            </label>
-          ) : null}
+          {showBaseEffectInstances && (
+            <div className="grid gap-4 md:grid-cols-2">
+              <label className="block min-w-0">
+                <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                  <span>Base effect instances</span>
+                  <FieldHelpIcon text="Número de instâncias no nível base da magia. Ex.: Magic Missile tem 3." />
+                </span>
+                <input
+                  type="number"
+                  min={1}
+                  step={1}
+                  value={form.upcastBaseEffectInstances}
+                  onChange={(event) =>
+                    setForm((c) => ({ ...c, upcastBaseEffectInstances: event.target.value }))
+                  }
+                  className={`${inputClassName} mt-2`}
+                  placeholder="3"
+                />
+              </label>
+            </div>
+          )}
 
-          {showUpcastMaxLevelField ? (
-            <label className="block">
-              <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-                <span>Nível máximo do slot</span>
-                <FieldHelpIcon text="Limite de escala; vazio usa qualquer slot válido." />
-              </span>
-              <input
-                value={form.upcastMaxLevel}
-                onChange={(event) =>
-                  setForm((c) => ({ ...c, upcastMaxLevel: event.target.value }))
-                }
-                className={`${inputClassName} mt-2`}
-                placeholder="9"
-              />
-            </label>
-          ) : null}
-        </div>
-      ) : null}
+          {(showUpcastFlatField || showUpcastPerLevelField || showUpcastMaxLevelField) && (
+            <div className="grid gap-4 md:grid-cols-3">
+              {showUpcastFlatField ? (
+                <label className="block min-w-0">
+                  <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                    <span>Upcast flat</span>
+                    <FieldHelpIcon text="Bônus fixo sem dado; use para escalas numéricas simples." />
+                  </span>
+                  <input
+                    value={form.upcastFlat}
+                    onChange={(event) =>
+                      setForm((c) => ({ ...c, upcastFlat: event.target.value }))
+                    }
+                    className={`${inputClassName} mt-2`}
+                    placeholder="1"
+                  />
+                </label>
+              ) : null}
 
-      {form.level > 0 && showEffectScalingFields && (
-        <div className="rounded-2xl border border-amber-400/20 bg-amber-400/5 p-4 space-y-3">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-amber-400/70">
-            Effect scaling — o que escala ao upcasting
-          </p>
-          <div className="grid gap-4 md:grid-cols-2">
-            <label className="block">
-              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-                Scaling key <span className="text-red-400">*</span>
-              </span>
-              <input
-                value={form.upcastScalingKey}
-                onChange={(event) =>
-                  setForm((c) => ({ ...c, upcastScalingKey: event.target.value }))
-                }
-                className={`${inputClassName} mt-2`}
-                placeholder="armor_class_bonus"
-              />
-            </label>
-            <label className="block">
-              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-                Scaling summary <span className="text-red-400">*</span>
-              </span>
-              <input
-                value={form.upcastScalingSummary}
-                onChange={(event) =>
-                  setForm((c) => ({ ...c, upcastScalingSummary: event.target.value }))
-                }
-                className={`${inputClassName} mt-2`}
-                placeholder="+1 to AC per slot level above 1st"
-              />
-            </label>
-          </div>
-          <label className="block">
-            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-              Scaling editorial
-            </span>
-            <input
-              value={form.upcastScalingEditorial}
-              onChange={(event) =>
-                setForm((c) => ({ ...c, upcastScalingEditorial: event.target.value }))
-              }
-              className={`${inputClassName} mt-2`}
-              placeholder="Optional editorial note about the scaling behavior"
-            />
-          </label>
-        </div>
+              {showUpcastPerLevelField ? (
+                <label className="block min-w-0">
+                  <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                    <span>Upcast por nível</span>
+                    <FieldHelpIcon text="Incrementos por slot acima do nível base. Normalmente 1." />
+                  </span>
+                  <input
+                    value={form.upcastPerLevel}
+                    onChange={(event) =>
+                      setForm((c) => ({ ...c, upcastPerLevel: event.target.value }))
+                    }
+                    className={`${inputClassName} mt-2`}
+                    placeholder="1"
+                  />
+                </label>
+              ) : null}
+
+              {showUpcastMaxLevelField ? (
+                <label className="block min-w-0">
+                  <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                    <span>Nível máximo do slot</span>
+                    <FieldHelpIcon text="Limite de escala; vazio usa qualquer slot válido." />
+                  </span>
+                  <input
+                    value={form.upcastMaxLevel}
+                    onChange={(event) =>
+                      setForm((c) => ({ ...c, upcastMaxLevel: event.target.value }))
+                    }
+                    className={`${inputClassName} mt-2`}
+                    placeholder="9"
+                  />
+                </label>
+              ) : null}
+            </div>
+          )}
+
+          {showEffectScalingFields && (
+            <div className="rounded-2xl border border-amber-400/20 bg-amber-400/5 p-4 space-y-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-amber-400/70">
+                Effect scaling — o que escala ao upcasting
+              </p>
+              <div className="grid gap-4 md:grid-cols-2">
+                <label className="block min-w-0">
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                    Scaling key <span className="text-red-400">*</span>
+                  </span>
+                  <input
+                    value={form.upcastScalingKey}
+                    onChange={(event) =>
+                      setForm((c) => ({ ...c, upcastScalingKey: event.target.value }))
+                    }
+                    className={`${inputClassName} mt-2`}
+                    placeholder="armor_class_bonus"
+                  />
+                </label>
+                <label className="block min-w-0">
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                    Scaling summary <span className="text-red-400">*</span>
+                  </span>
+                  <input
+                    value={form.upcastScalingSummary}
+                    onChange={(event) =>
+                      setForm((c) => ({ ...c, upcastScalingSummary: event.target.value }))
+                    }
+                    className={`${inputClassName} mt-2`}
+                    placeholder="+1 to AC per slot level above 1st"
+                  />
+                </label>
+              </div>
+              <label className="block min-w-0">
+                <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                  Scaling editorial
+                </span>
+                <input
+                  value={form.upcastScalingEditorial}
+                  onChange={(event) =>
+                    setForm((c) => ({ ...c, upcastScalingEditorial: event.target.value }))
+                  }
+                  className={`${inputClassName} mt-2`}
+                  placeholder="Optional editorial note about the scaling behavior"
+                />
+              </label>
+            </div>
+          )}
+
+          {showExtraEffectFields && (
+            <div className="rounded-2xl border border-violet-400/20 bg-violet-400/5 p-4 space-y-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-violet-400/70">
+                Extra effect — o que é destravado ao upcasting
+              </p>
+              <div className="grid gap-4 md:grid-cols-2">
+                <label className="block min-w-0">
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                    Unlock key <span className="text-red-400">*</span>
+                  </span>
+                  <input
+                    value={form.upcastUnlockKey}
+                    onChange={(event) =>
+                      setForm((c) => ({ ...c, upcastUnlockKey: event.target.value }))
+                    }
+                    className={`${inputClassName} mt-2`}
+                    placeholder="additional_beam"
+                  />
+                </label>
+                <label className="block min-w-0">
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                    Unlock summary <span className="text-red-400">*</span>
+                  </span>
+                  <input
+                    value={form.upcastUnlockSummary}
+                    onChange={(event) =>
+                      setForm((c) => ({ ...c, upcastUnlockSummary: event.target.value }))
+                    }
+                    className={`${inputClassName} mt-2`}
+                    placeholder="Create one additional beam per slot level above 5th"
+                  />
+                </label>
+              </div>
+              <label className="block min-w-0">
+                <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                  Unlock editorial
+                </span>
+                <input
+                  value={form.upcastUnlockEditorial}
+                  onChange={(event) =>
+                    setForm((c) => ({ ...c, upcastUnlockEditorial: event.target.value }))
+                  }
+                  className={`${inputClassName} mt-2`}
+                  placeholder="Optional editorial note about the unlocked effect"
+                />
+              </label>
+            </div>
+          )}
+        </SystemSpellCatalogFormSection>
       )}
 
-      {form.level > 0 && showExtraEffectFields && (
-        <div className="rounded-2xl border border-violet-400/20 bg-violet-400/5 p-4 space-y-3">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-violet-400/70">
-            Extra effect — o que é destravado ao upcasting
-          </p>
+      {form.level === 0 && (
+        <SystemSpellCatalogFormSection
+          title="Cantrip Scaling"
+          collapsible
+        >
           <div className="grid gap-4 md:grid-cols-2">
-            <label className="block">
-              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-                Unlock key <span className="text-red-400">*</span>
-              </span>
-              <input
-                value={form.upcastUnlockKey}
-                onChange={(event) =>
-                  setForm((c) => ({ ...c, upcastUnlockKey: event.target.value }))
-                }
-                className={`${inputClassName} mt-2`}
-                placeholder="additional_beam"
-              />
-            </label>
-            <label className="block">
-              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-                Unlock summary <span className="text-red-400">*</span>
-              </span>
-              <input
-                value={form.upcastUnlockSummary}
-                onChange={(event) =>
-                  setForm((c) => ({ ...c, upcastUnlockSummary: event.target.value }))
-                }
-                className={`${inputClassName} mt-2`}
-                placeholder="Create one additional beam per slot level above 5th"
-              />
-            </label>
-          </div>
-          <label className="block">
-            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-              Unlock editorial
-            </span>
-            <input
-              value={form.upcastUnlockEditorial}
-              onChange={(event) =>
-                setForm((c) => ({ ...c, upcastUnlockEditorial: event.target.value }))
-              }
-              className={`${inputClassName} mt-2`}
-              placeholder="Optional editorial note about the unlocked effect"
-            />
-          </label>
-        </div>
-      )}
-
-      {form.level === 0 ? (
-        <div className="space-y-4 rounded-2xl border border-white/8 bg-slate-950/35 p-4">
-          <div className="grid gap-4 md:grid-cols-2">
-            <label className="block">
+            <label className="block min-w-0">
               <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
                 Scaling mode
               </span>
@@ -524,13 +614,13 @@ export const SystemSpellCatalogResolutionFields = ({ form, setForm }: Props) => 
                 [11, "cantripLevel11DiceCount", "cantripLevel11DieSize", "cantripLevel11FixedBonus"],
                 [17, "cantripLevel17DiceCount", "cantripLevel17DieSize", "cantripLevel17FixedBonus"],
               ].map(([level, countKey, dieKey, bonusKey]) => (
-                <div key={level} className="grid gap-4 md:grid-cols-[90px_repeat(3,minmax(0,1fr))]">
+                <div key={level} className="grid gap-4 md:grid-cols-[80px_1fr_1fr_1fr]">
                   <div className="flex items-end pb-3 text-xs font-semibold text-slate-300">
                     Nível {level}
                   </div>
-                  <label className="block">
+                  <label className="block min-w-0">
                     <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-                      Damage dice count
+                      Dice count
                     </span>
                     <select
                       value={form[countKey as keyof FormState] as string}
@@ -547,9 +637,9 @@ export const SystemSpellCatalogResolutionFields = ({ form, setForm }: Props) => 
                       ))}
                     </select>
                   </label>
-                  <label className="block">
+                  <label className="block min-w-0">
                     <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-                      Damage die
+                      Die size
                     </span>
                     <select
                       value={form[dieKey as keyof FormState] as string}
@@ -566,7 +656,7 @@ export const SystemSpellCatalogResolutionFields = ({ form, setForm }: Props) => 
                       ))}
                     </select>
                   </label>
-                  <label className="block">
+                  <label className="block min-w-0">
                     <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
                       Fixed bonus
                     </span>
@@ -585,8 +675,8 @@ export const SystemSpellCatalogResolutionFields = ({ form, setForm }: Props) => 
               ))}
             </div>
           ) : null}
-        </div>
-      ) : null}
+        </SystemSpellCatalogFormSection>
+      )}
     </>
   );
 };

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/SystemSpellCatalogSpellForm.tsx
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/SystemSpellCatalogSpellForm.tsx
@@ -7,6 +7,7 @@ import {
   localizeSpellSchool,
 } from "../../shared/i18n/domainLabels";
 import { SystemSpellCatalogCastingFields } from "./SystemSpellCatalogCastingFields";
+import { SystemSpellCatalogFormSection } from "./SystemSpellCatalogFormSection";
 import { SystemSpellCatalogResolutionFields } from "./SystemSpellCatalogResolutionFields";
 import { toggleListValue } from "./systemSpellCatalog.helpers";
 import {
@@ -70,229 +71,240 @@ export const SystemSpellCatalogSpellForm = ({
         </div>
       )}
 
-      <div className="grid gap-4 md:grid-cols-3">
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            {t("catalog.admin.table.system")}
-          </span>
-          <select
-            value={form.system}
-            onChange={(event) =>
-              setForm((c) => ({
-                ...c,
-                system: event.target.value as BaseSpell["system"],
-              }))
-            }
-            className={`${inputClassName} mt-2`}
-          >
-            {SYSTEM_OPTIONS.map((s) => (
-              <option key={s} value={s}>
-                {formatSpellChoiceLabel(s)}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            {t("catalog.admin.table.canonicalKey")}
-          </span>
-          <input
-            value={form.canonicalKey}
-            onChange={(event) =>
-              setForm((c) => ({ ...c, canonicalKey: event.target.value }))
-            }
-            className={`${inputClassName} mt-2`}
-            placeholder="fireball"
-          />
-        </label>
-
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            {t("catalog.admin.table.level")}
-          </span>
-          <select
-            value={form.level}
-            onChange={(event) =>
-              setForm((c) => ({ ...c, level: Number(event.target.value) }))
-            }
-            className={`${inputClassName} mt-2`}
-          >
-            {LEVEL_OPTIONS.map((level) => (
-              <option key={level} value={level}>
-                {level === 0
-                  ? t("catalog.spells.cantrip")
-                  : `${t("catalog.spells.levelLabel")} ${level}`}
-              </option>
-            ))}
-          </select>
-        </label>
-      </div>
-
-      <div className="grid gap-4 md:grid-cols-2">
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            {t("catalog.admin.table.nameEn")}
-          </span>
-          <input
-            value={form.nameEn}
-            onChange={(event) =>
-              setForm((c) => ({ ...c, nameEn: event.target.value }))
-            }
-            className={`${inputClassName} mt-2`}
-            placeholder="Fireball"
-          />
-        </label>
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            {t("catalog.admin.table.namePt")}
-          </span>
-          <input
-            value={form.namePt}
-            onChange={(event) =>
-              setForm((c) => ({ ...c, namePt: event.target.value }))
-            }
-            className={`${inputClassName} mt-2`}
-            placeholder="Bola de Fogo"
-          />
-        </label>
-      </div>
-
-      <label className="block">
-        <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-          {t("catalog.admin.table.school")}
-        </span>
-        <select
-          value={form.school}
-          onChange={(event) =>
-            setForm((c) => ({ ...c, school: event.target.value as SpellSchool }))
-          }
-          className={`${inputClassName} mt-2`}
-        >
-          {SCHOOL_OPTIONS.map((school) => (
-            <option key={school} value={school}>
-              {localizeSpellSchool(school, locale)}
-            </option>
-          ))}
-        </select>
-      </label>
-
-      <div>
-        <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-          Classes
-        </span>
-        <div className="mt-2 flex flex-wrap gap-2">
-          {CLASS_OPTIONS.map((cls) => (
-            <button
-              key={cls}
-              type="button"
-              onClick={() =>
+      <SystemSpellCatalogFormSection title="Informações básicas">
+        <div className="grid gap-4 md:grid-cols-3">
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              {t("catalog.admin.table.system")}
+            </span>
+            <select
+              value={form.system}
+              onChange={(event) =>
                 setForm((c) => ({
                   ...c,
-                  classesJson: toggleListValue(c.classesJson, cls),
+                  system: event.target.value as BaseSpell["system"],
                 }))
               }
-              className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
-                form.classesJson.includes(cls)
-                  ? "border-violet-300/40 bg-violet-400/15 text-violet-100"
+              className={`${inputClassName} mt-2`}
+            >
+              {SYSTEM_OPTIONS.map((s) => (
+                <option key={s} value={s}>
+                  {formatSpellChoiceLabel(s)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              {t("catalog.admin.table.canonicalKey")}
+            </span>
+            <input
+              value={form.canonicalKey}
+              onChange={(event) =>
+                setForm((c) => ({ ...c, canonicalKey: event.target.value }))
+              }
+              className={`${inputClassName} mt-2`}
+              placeholder="fireball"
+            />
+          </label>
+
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              {t("catalog.admin.table.level")}
+            </span>
+            <select
+              value={form.level}
+              onChange={(event) =>
+                setForm((c) => ({ ...c, level: Number(event.target.value) }))
+              }
+              className={`${inputClassName} mt-2`}
+            >
+              {LEVEL_OPTIONS.map((level) => (
+                <option key={level} value={level}>
+                  {level === 0
+                    ? t("catalog.spells.cantrip")
+                    : `${t("catalog.spells.levelLabel")} ${level}`}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              {t("catalog.admin.table.nameEn")}
+            </span>
+            <input
+              value={form.nameEn}
+              onChange={(event) =>
+                setForm((c) => ({ ...c, nameEn: event.target.value }))
+              }
+              className={`${inputClassName} mt-2`}
+              placeholder="Fireball"
+            />
+          </label>
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              {t("catalog.admin.table.namePt")}
+            </span>
+            <input
+              value={form.namePt}
+              onChange={(event) =>
+                setForm((c) => ({ ...c, namePt: event.target.value }))
+              }
+              className={`${inputClassName} mt-2`}
+              placeholder="Bola de Fogo"
+            />
+          </label>
+        </div>
+
+        <label className="block">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+            {t("catalog.admin.table.school")}
+          </span>
+          <select
+            value={form.school}
+            onChange={(event) =>
+              setForm((c) => ({ ...c, school: event.target.value as SpellSchool }))
+            }
+            className={`${inputClassName} mt-2`}
+          >
+            {SCHOOL_OPTIONS.map((school) => (
+              <option key={school} value={school}>
+                {localizeSpellSchool(school, locale)}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div>
+          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+            Classes
+          </span>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {CLASS_OPTIONS.map((cls) => (
+              <button
+                key={cls}
+                type="button"
+                onClick={() =>
+                  setForm((c) => ({
+                    ...c,
+                    classesJson: toggleListValue(c.classesJson, cls),
+                  }))
+                }
+                className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+                  form.classesJson.includes(cls)
+                    ? "border-violet-300/40 bg-violet-400/15 text-violet-100"
+                    : "border-white/10 bg-white/4 text-slate-400 hover:bg-white/8"
+                }`}
+              >
+                {cls}
+              </button>
+            ))}
+          </div>
+        </div>
+      </SystemSpellCatalogFormSection>
+
+      <SystemSpellCatalogCastingFields form={form} setForm={setForm} />
+
+      <SystemSpellCatalogResolutionFields form={form} setForm={setForm} />
+
+      <SystemSpellCatalogFormSection title="Descrição">
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Descrição EN
+            </span>
+            <textarea
+              value={form.descriptionEn}
+              onChange={(event) =>
+                setForm((c) => ({ ...c, descriptionEn: event.target.value }))
+              }
+              className={`${inputClassName} mt-2 min-h-28`}
+            />
+          </label>
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Descrição PT
+            </span>
+            <textarea
+              value={form.descriptionPt}
+              onChange={(event) =>
+                setForm((c) => ({ ...c, descriptionPt: event.target.value }))
+              }
+              className={`${inputClassName} mt-2 min-h-28`}
+            />
+          </label>
+        </div>
+      </SystemSpellCatalogFormSection>
+
+      <SystemSpellCatalogFormSection
+        title="Metadados"
+        collapsible
+        defaultCollapsed
+      >
+        <div className="grid gap-4 md:grid-cols-3">
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Source
+            </span>
+            <select
+              value={form.source}
+              onChange={(event) =>
+                setForm((c) => ({ ...c, source: event.target.value as SpellSource }))
+              }
+              className={`${inputClassName} mt-2`}
+            >
+              {SOURCE_OPTIONS.map((s) => (
+                <option key={s} value={s}>
+                  {formatSpellChoiceLabel(s)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block min-w-0">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Source ref
+            </span>
+            <input
+              value={form.sourceRef}
+              onChange={(event) =>
+                setForm((c) => ({ ...c, sourceRef: event.target.value }))
+              }
+              className={`${inputClassName} mt-2`}
+              placeholder="PHB p.241"
+            />
+          </label>
+
+          <div className="flex items-end gap-3 pb-1">
+            <button
+              type="button"
+              onClick={() => setForm((c) => ({ ...c, isSrd: !c.isSrd }))}
+              className={`rounded-full border px-3 py-2 text-xs font-semibold transition ${
+                form.isSrd
+                  ? "border-emerald-300/40 bg-emerald-400/15 text-emerald-100"
                   : "border-white/10 bg-white/4 text-slate-400 hover:bg-white/8"
               }`}
             >
-              {cls}
+              SRD
             </button>
-          ))}
+            <button
+              type="button"
+              onClick={() => setForm((c) => ({ ...c, isActive: !c.isActive }))}
+              className={`rounded-full border px-3 py-2 text-xs font-semibold transition ${
+                form.isActive
+                  ? "border-emerald-300/40 bg-emerald-400/15 text-emerald-100"
+                  : "border-rose-300/40 bg-rose-400/15 text-rose-100"
+              }`}
+            >
+              {form.isActive ? "Ativo" : "Inativo"}
+            </button>
+          </div>
         </div>
-      </div>
-
-      <SystemSpellCatalogCastingFields form={form} setForm={setForm} />
-      <SystemSpellCatalogResolutionFields form={form} setForm={setForm} />
-
-      <div className="grid gap-4 md:grid-cols-2">
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Descrição EN
-          </span>
-          <textarea
-            value={form.descriptionEn}
-            onChange={(event) =>
-              setForm((c) => ({ ...c, descriptionEn: event.target.value }))
-            }
-            className={`${inputClassName} mt-2 min-h-28`}
-          />
-        </label>
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Descrição PT
-          </span>
-          <textarea
-            value={form.descriptionPt}
-            onChange={(event) =>
-              setForm((c) => ({ ...c, descriptionPt: event.target.value }))
-            }
-            className={`${inputClassName} mt-2 min-h-28`}
-          />
-        </label>
-      </div>
-
-      <div className="grid gap-4 md:grid-cols-3">
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Source
-          </span>
-          <select
-            value={form.source}
-            onChange={(event) =>
-              setForm((c) => ({ ...c, source: event.target.value as SpellSource }))
-            }
-            className={`${inputClassName} mt-2`}
-          >
-            {SOURCE_OPTIONS.map((s) => (
-              <option key={s} value={s}>
-                {formatSpellChoiceLabel(s)}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <label className="block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Source ref
-          </span>
-          <input
-            value={form.sourceRef}
-            onChange={(event) =>
-              setForm((c) => ({ ...c, sourceRef: event.target.value }))
-            }
-            className={`${inputClassName} mt-2`}
-            placeholder="PHB p.241"
-          />
-        </label>
-
-        <div className="flex items-end gap-3 pb-1">
-          <button
-            type="button"
-            onClick={() => setForm((c) => ({ ...c, isSrd: !c.isSrd }))}
-            className={`rounded-full border px-3 py-2 text-xs font-semibold transition ${
-              form.isSrd
-                ? "border-emerald-300/40 bg-emerald-400/15 text-emerald-100"
-                : "border-white/10 bg-white/4 text-slate-400 hover:bg-white/8"
-            }`}
-          >
-            SRD
-          </button>
-          <button
-            type="button"
-            onClick={() => setForm((c) => ({ ...c, isActive: !c.isActive }))}
-            className={`rounded-full border px-3 py-2 text-xs font-semibold transition ${
-              form.isActive
-                ? "border-emerald-300/40 bg-emerald-400/15 text-emerald-100"
-                : "border-rose-300/40 bg-rose-400/15 text-rose-100"
-            }`}
-          >
-            {form.isActive ? "Ativo" : "Inativo"}
-          </button>
-        </div>
-      </div>
+      </SystemSpellCatalogFormSection>
 
       <div className="flex flex-wrap gap-3 border-t border-white/8 pt-4">
         <button

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.helpers.test.ts
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.helpers.test.ts
@@ -150,7 +150,8 @@ describe("systemSpellCatalog upcast helpers", () => {
     expect(result.error).toBeUndefined();
     expect(result.payload?.upcast).toBeNull();
     expect(result.payload?.cantripScaling).toEqual({
-      mode: "character_level",
+      scalingMode: "character_level",
+      scalingEffectType: "damage_dice",
       thresholds: [
         { characterLevel: 1, damage: { dice: "1d6" } },
         { characterLevel: 5, damage: { dice: "2d6" } },
@@ -158,5 +159,118 @@ describe("systemSpellCatalog upcast helpers", () => {
         { characterLevel: 17, damage: { dice: "4d6" } },
       ],
     });
+  });
+
+  it("includes coverAppliesToSave in payload when set", () => {
+    const form = createEmptyForm();
+    form.canonicalKey = "fireball";
+    form.nameEn = "Fireball";
+    form.descriptionEn = "A bright streak flashes.";
+    form.level = 3;
+    form.school = "evocation";
+    form.resolutionType = "damage";
+    form.savingThrow = "DEX";
+    form.coverAppliesToSave = "physical";
+    form.damageDiceCount = "8";
+    form.damageDieSize = "6";
+    form.damageType = "Fire";
+
+    const result = buildPayload(form, true);
+
+    expect(result.error).toBeUndefined();
+    expect(result.payload?.coverAppliesToSave).toBe("physical");
+  });
+
+  it("defaults coverAppliesToSave to null when empty", () => {
+    const form = createEmptyForm();
+    form.canonicalKey = "test";
+    form.nameEn = "Test";
+    form.descriptionEn = "Test.";
+
+    const result = buildPayload(form, true);
+
+    expect(result.error).toBeUndefined();
+    expect(result.payload?.coverAppliesToSave).toBeNull();
+  });
+
+  it("includes baseEffectInstances in upcast payload for additional_effect_instances", () => {
+    const form = createEmptyForm();
+    form.canonicalKey = "magic_missile";
+    form.nameEn = "Magic Missile";
+    form.descriptionEn = "Three glowing darts.";
+    form.level = 1;
+    form.school = "evocation";
+    form.resolutionType = "damage";
+    form.damageDiceCount = "3";
+    form.damageDieSize = "4";
+    form.damageFixedBonus = "3";
+    form.damageType = "Force";
+    form.upcastMode = "additional_effect_instances";
+    form.upcastDiceCount = "1";
+    form.upcastDieSize = "4";
+    form.upcastFixedBonus = "1";
+    form.upcastBaseEffectInstances = "3";
+
+    const result = buildPayload(form, true);
+
+    expect(result.error).toBeUndefined();
+    expect(result.payload?.upcast?.baseEffectInstances).toBe(3);
+  });
+
+  it("hydrates coverAppliesToSave and baseEffectInstances from spell", () => {
+    const spell: BaseSpell = {
+      id: "spell-fireball",
+      system: "DND5E",
+      canonicalKey: "fireball",
+      nameEn: "Fireball",
+      namePt: "Bola de Fogo",
+      descriptionEn: "A bright streak flashes to a point.",
+      descriptionPt: null,
+      level: 3,
+      school: "evocation",
+      classesJson: ["Sorcerer", "Wizard"],
+      castingTimeType: "action",
+      castingTime: "1 action",
+      rangeMeters: 45,
+      rangeText: "150 ft",
+      targetType: "ranged",
+      maxTargets: null,
+      selectionType: "point",
+      originType: "selected_point",
+      targetAnchor: "selected_point",
+      attackType: "none",
+      rangeKind: "distance",
+      effectTiming: "immediate",
+      areaShape: "sphere",
+      radiusMeters: 6,
+      lengthMeters: null,
+      sideMeters: null,
+      duration: "Instantaneous",
+      componentsJson: ["V", "S", "M"],
+      materialComponentText: "a tiny ball of bat guano and sulfur",
+      concentration: false,
+      ritual: false,
+      resolutionType: "damage",
+      savingThrow: "DEX",
+      saveSuccessOutcome: "half_damage",
+      coverAppliesToSave: "physical",
+      damageDice: "8d6",
+      damageType: "Fire",
+      healDice: null,
+      upcast: {
+        mode: "extra_damage_dice",
+        dice: "1d6",
+        perLevel: 1,
+      },
+      source: "admin_panel",
+      sourceRef: null,
+      isSrd: true,
+      isActive: true,
+      aliases: [],
+    };
+
+    const form = formFromSpell(spell);
+
+    expect(form.coverAppliesToSave).toBe("physical");
   });
 });

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.helpers.ts
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.helpers.ts
@@ -135,6 +135,7 @@ export const createEmptyForm = (): FormState => ({
   resolutionType: "",
   savingThrow: "",
   saveSuccessOutcome: "",
+  coverAppliesToSave: "",
   damageDice: "",
   damageDiceCount: "",
   damageDieSize: "",
@@ -149,6 +150,7 @@ export const createEmptyForm = (): FormState => ({
   upcastFlat: "",
   upcastPerLevel: "1",
   upcastMaxLevel: "",
+  upcastBaseEffectInstances: "",
   upcastScalingKey: "",
   upcastScalingSummary: "",
   upcastScalingEditorial: "",
@@ -178,9 +180,10 @@ export const formFromSpell = (spell: BaseSpell): FormState => ({
   ...(() => {
     const damageParts = parseDiceParts(spell.damageDice);
     const upcastParts = parseDiceParts(spell.upcast?.dice);
-    const thresholdDice = (level: number) =>
-      spell.cantripScaling?.thresholds.find((entry) => entry.characterLevel === level)
-        ?.damage.dice;
+    const thresholdDice = (level: number) => {
+      const entry = spell.cantripScaling?.thresholds.find((e) => e.characterLevel === level);
+      return entry && "damage" in entry ? entry.damage.dice : undefined;
+    };
     const cantripLevel1Parts = parseDiceParts(thresholdDice(1));
     const cantripLevel5Parts = parseDiceParts(thresholdDice(5));
     const cantripLevel11Parts = parseDiceParts(thresholdDice(11));
@@ -246,6 +249,7 @@ export const formFromSpell = (spell: BaseSpell): FormState => ({
   resolutionType: spell.resolutionType ?? "",
   savingThrow: spell.savingThrow ?? "",
   saveSuccessOutcome: spell.saveSuccessOutcome ?? "",
+  coverAppliesToSave: spell.coverAppliesToSave ?? "",
   damageDice: spell.damageDice ?? "",
   damageType: spell.damageType ?? "",
   healDice: spell.healDice ?? "",
@@ -254,6 +258,7 @@ export const formFromSpell = (spell: BaseSpell): FormState => ({
   upcastFlat: spell.upcast?.flat != null ? String(spell.upcast.flat) : "",
   upcastPerLevel: spell.upcast?.perLevel != null ? String(spell.upcast.perLevel) : "1",
   upcastMaxLevel: spell.upcast?.maxLevel != null ? String(spell.upcast.maxLevel) : "",
+  upcastBaseEffectInstances: spell.upcast?.baseEffectInstances != null ? String(spell.upcast.baseEffectInstances) : "",
   upcastScalingKey: spell.upcast?.scalingKey ?? "",
   upcastScalingSummary: spell.upcast?.scalingSummary ?? "",
   upcastScalingEditorial: spell.upcast?.scalingEditorial ?? "",
@@ -405,6 +410,7 @@ export const buildPayload = (
       resolutionType: form.resolutionType || null,
       savingThrow: showSavingThrow ? form.savingThrow || null : null,
       saveSuccessOutcome: showSaveSuccessOutcome ? form.saveSuccessOutcome || null : null,
+      coverAppliesToSave: form.coverAppliesToSave || null,
       damageDice: showDamage
         ? buildDiceExpression(
             form.damageDiceCount,
@@ -425,6 +431,12 @@ export const buildPayload = (
             flat: upcastFlat.value ?? null,
             perLevel: upcastPerLevel.value ?? 1,
             maxLevel: upcastMaxLevel.value ?? null,
+            ...(form.upcastMode === "additional_effect_instances" ? {
+              baseEffectInstances: (() => {
+                const v = parseOptionalInteger(form.upcastBaseEffectInstances, "Base effect instances");
+                return v.value ?? null;
+              })(),
+            } : {}),
             ...(form.upcastMode === "effect_scaling" ? {
               scalingKey: normalizeOptionalText(form.upcastScalingKey) ?? null,
               scalingSummary: normalizeOptionalText(form.upcastScalingSummary) ?? null,
@@ -440,7 +452,8 @@ export const buildPayload = (
       cantripScaling:
         form.level === 0 && form.cantripScalingMode === "character_level"
           ? {
-              mode: "character_level",
+              scalingMode: "character_level" as const,
+              scalingEffectType: "damage_dice" as const,
               thresholds: [
                 {
                   characterLevel: 1,
@@ -482,7 +495,7 @@ export const buildPayload = (
                     ),
                   },
                 },
-              ].filter((entry) => entry.damage.dice),
+              ].filter((entry): entry is { characterLevel: number; damage: { dice: string } } => Boolean(entry.damage.dice)),
             }
           : null,
       source: form.source,

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.types.ts
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.types.ts
@@ -72,6 +72,7 @@ export type FormState = {
   resolutionType: ResolutionType | "";
   savingThrow: SpellSavingThrow | "";
   saveSuccessOutcome: SaveSuccessOutcome | "";
+  coverAppliesToSave: "" | "physical" | "none";
   damageDice: string;
   damageDiceCount: string;
   damageDieSize: string;
@@ -86,6 +87,7 @@ export type FormState = {
   upcastFlat: string;
   upcastPerLevel: string;
   upcastMaxLevel: string;
+  upcastBaseEffectInstances: string;
   upcastScalingKey: string;
   upcastScalingSummary: string;
   upcastScalingEditorial: string;
@@ -166,6 +168,7 @@ export const CLASS_OPTIONS = [
   "Wizard",
 ] as const;
 export const COMPONENT_OPTIONS = ["V", "S", "M"] as const;
+export const COVER_APPLIES_TO_SAVE_OPTIONS = ["physical", "none"] as const;
 
 export const SCHOOL_COLORS: Record<string, string> = {
   abjuration: "text-blue-300 border-blue-400/30 bg-blue-400/10",


### PR DESCRIPTION
# PR: Refatoração do Sistema de Catálogo de Magias e Novas Páginas de Edição

## Descrição
Esta PR introduz uma mudança estrutural na gestão de magias do catálogo. Removemos o editor *inline* (dentro de modais/cards) em favor de páginas dedicadas de criação e edição, melhorando a experiência do usuário (UX) com layouts mais amplos (`max-w-4xl`). 

Além disso, o formulário de magias foi completamente refatorado em seções colapsáveis e novos campos técnicos foram adicionados ao motor de regras (Cover, Upcast e Cantrip Scaling).

---

## Alterações Principais

### 1. Roteamento e Páginas (GM Only)
- **Novas Páginas:**
  - `CatalogSpellNewPage.tsx`: Página dedicada para criação de novas magias.
  - `CatalogSpellEditPage.tsx`: Página de edição carregando dados por ID via API.
- **Roteamento (`routes.ts` / `AppRoutes.tsx`):**
  - Novas rotas: `/catalog/spells/new` e `/catalog/spells/:spellId/edit`.
  - Proteção de rota via `RequireAuth` e `RequireGmRole`.
  - Implementação de `lazy loading` para as novas páginas.

### 2. UI/UX do Catálogo
- **CatalogSpellsPage.tsx**: Simplificada para ser apenas uma listagem com filtros. O botão "Nova Magia" agora redireciona para a página dedicada.
- **SpellCatalogCard.tsx**: Botão "Editar" agora utiliza `useNavigate` para a página de edição, eliminando o estado interno `isEditing`.
- **SystemSpellCatalogFormSection.tsx**: Novo componente de seção colapsável para organizar formulários extensos.

### 3. Engine de Magias (Tipos e Lógica)
- **Novos Campos (`baseSpell.types.ts`):**
  - Adicionado `coverAppliesToSave` (define se cobertura se aplica ao teste de resistência).
  - Suporte a `upcastBaseEffectInstances`.
- **Helpers (`systemSpellCatalog.helpers.ts`):**
  - Refatorado `createEmptyForm`, `formFromSpell` e `buildPayload`.
  - Correção no `cantripScaling` (ajuste para os novos campos `scalingMode` e `scalingEffectType`).
  - Correção de tipagem no acesso a `.damage` em union types.

### 4. Refatoração do Formulário (`SystemSpellCatalogSpellForm`)
O formulário foi reorganizado em seções lógicas e visuais para melhor legibilidade:
- **Informações Básicas / Descrição / Metadados** (Colapsável).
- **Casting / Targeting** (Colapsável) / **Área** (Colapsável).
- **Resolução / Dano / Cura / Upcast** (Colapsável) / **Cantrip Scaling** (Colapsável).
- Ajustes de Grid: Melhoria na responsividade de 4 colunas para 2 em telas menores para evitar quebra de layout.

---

## Validação e Testes
- **Build**: Sucesso em ~2.9s.
- **TypeScript**: 0 erros nos arquivos modificados.
- **Testes Unitários**:
  - `systemSpellCatalog.helpers.test.ts`: Adicionados 4 novos testes cobrindo hidratação de dados, `coverAppliesToSave` e `baseEffectInstances`.
  - Total: **29/29** testes passando na suíte geral.
  - Total: **8/8** testes de admin helpers e **21/21** de campaign helpers passando.

---

## Fluxo de Trabalho Resultante
1. **Catálogo (`/catalog/spells`)**: Listagem limpa e performática.
2. **Nova Magia (`/catalog/spells/new`)**: Formulário em tela cheia para foco na criação.
3. **Editar Magia (`/catalog/spells/:id/edit`)**: Edição persistente com suporte a todos os novos metadados do sistema.