### PR TITLE
feat: add cover applies to save functionality in spell catalog form

### DIFF
--- a/apps/control-web/src/features/shop/components/SpellCatalogResolutionFields.test.tsx
+++ b/apps/control-web/src/features/shop/components/SpellCatalogResolutionFields.test.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { SpellCatalogResolutionFields } from "./SpellCatalogResolutionFields";
+import { createEmptySpellEditorState } from "../utils/spellCatalogForm";
+
+vi.mock("../../../shared/hooks/useLocale", () => ({
+  useLocale: () => ({
+    locale: "pt",
+    t: (key: string) => key,
+  }),
+}));
+
+describe("SpellCatalogResolutionFields", () => {
+  it("renders coverAppliesToSave in the resolution/saving throw section", () => {
+    const state = {
+      ...createEmptySpellEditorState(),
+      resolutionType: "damage" as const,
+      savingThrow: "DEX",
+    };
+
+    const html = renderToStaticMarkup(
+      <SpellCatalogResolutionFields
+        state={state}
+        setState={() => undefined}
+        t={(key) => key}
+        locale="pt"
+        selectPlaceholder="Selecione"
+        showSavingThrowFields
+        showSaveSuccessOutcome
+        showDamageFields
+        showHealFields={false}
+      />,
+    );
+
+    expect(html).toContain("catalog.spells.form.coverAppliesToSave");
+    expect(html).toContain("catalog.spells.form.coverAppliesToSaveHelp");
+    expect(html).toContain(">Física<");
+    expect(html).toContain(">Nenhuma<");
+  });
+});

--- a/apps/control-web/src/features/shop/components/SpellCatalogResolutionFields.tsx
+++ b/apps/control-web/src/features/shop/components/SpellCatalogResolutionFields.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../../shared/i18n/domainLabels";
 import { SpellCatalogField } from "./SpellCatalogEditorControls";
 import {
+  SPELL_COVER_APPLIES_TO_SAVE_OPTIONS,
   SPELL_DICE_COUNT_OPTIONS,
   SPELL_DAMAGE_TYPE_OPTIONS,
   SPELL_DIE_SIZE_OPTIONS,
@@ -106,6 +107,56 @@ export const SpellCatalogResolutionFields = ({
               {SPELL_SAVE_SUCCESS_OUTCOME_OPTIONS.map((outcome) => (
                 <option key={outcome} value={outcome}>
                   {localizeSaveSuccessOutcome(outcome, locale)}
+                </option>
+              ))}
+              </select>
+          </SpellCatalogField>
+
+          <SpellCatalogField
+            label={t("catalog.spells.form.coverAppliesToSave")}
+            help={t("catalog.spells.form.coverAppliesToSaveHelp")}
+          >
+            <select
+              value={state.coverAppliesToSave}
+              onChange={(event) =>
+                setState((current) => ({
+                  ...current,
+                  coverAppliesToSave: event.target.value as SpellCatalogEditorState["coverAppliesToSave"],
+                }))
+              }
+              className={fieldClassName}
+            >
+              <option value="">{selectPlaceholder}</option>
+              {SPELL_COVER_APPLIES_TO_SAVE_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {localizeSpellAdminValue(option, locale)}
+                </option>
+              ))}
+            </select>
+          </SpellCatalogField>
+        </div>
+      ) : null}
+
+      {showSavingThrowFields && !showSaveSuccessOutcome ? (
+        <div className="grid gap-4 sm:grid-cols-2">
+          <SpellCatalogField
+            label={t("catalog.spells.form.coverAppliesToSave")}
+            help={t("catalog.spells.form.coverAppliesToSaveHelp")}
+          >
+            <select
+              value={state.coverAppliesToSave}
+              onChange={(event) =>
+                setState((current) => ({
+                  ...current,
+                  coverAppliesToSave: event.target.value as SpellCatalogEditorState["coverAppliesToSave"],
+                }))
+              }
+              className={fieldClassName}
+            >
+              <option value="">{selectPlaceholder}</option>
+              {SPELL_COVER_APPLIES_TO_SAVE_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {localizeSpellAdminValue(option, locale)}
                 </option>
               ))}
             </select>

--- a/apps/control-web/src/features/shop/utils/spellCatalogForm.test.ts
+++ b/apps/control-web/src/features/shop/utils/spellCatalogForm.test.ts
@@ -108,6 +108,7 @@ describe("spellCatalogForm", () => {
       damageType: "Lightning",
       savingThrow: "DEX",
       saveSuccessOutcome: "half_damage",
+      coverAppliesToSave: "physical",
       requiresTargetSight: false,
       requiresTargetEffect: true,
       requiresPointSight: true,
@@ -141,6 +142,7 @@ describe("spellCatalogForm", () => {
         damageType: "Lightning",
         savingThrow: "DEX",
         saveSuccessOutcome: "half_damage",
+        coverAppliesToSave: "physical",
         requiresTargetSight: false,
         requiresTargetEffect: true,
         requiresPointSight: true,
@@ -171,6 +173,7 @@ describe("spellCatalogForm", () => {
         maxTargets: 2,
         resolutionType: "heal",
         healDice: "2d4",
+        coverAppliesToSave: "none",
         requiresTargetSight: null,
         requiresTargetEffect: true,
         requiresPointSight: null,
@@ -190,6 +193,7 @@ describe("spellCatalogForm", () => {
     expect(state.maxTargets).toBe("2");
     expect(state.resolutionType).toBe("heal");
     expect(state.healDice).toBe("2d4");
+    expect(state.coverAppliesToSave).toBe("none");
     expect(state.requiresTargetSight).toBeNull();
     expect(state.requiresTargetEffect).toBe(true);
     expect(state.requiresPointSight).toBeNull();
@@ -210,6 +214,7 @@ describe("spellCatalogForm", () => {
           maxTargets: 2,
           resolutionType: "heal",
           healDice: "2d4",
+          coverAppliesToSave: "none",
           requiresTargetSight: null,
           requiresTargetEffect: true,
           requiresPointSight: null,
@@ -229,6 +234,7 @@ describe("spellCatalogForm", () => {
     expect(payload.targetType).toBe("ranged");
     expect(payload.maxTargets).toBe(2);
     expect(payload.resolutionType).toBe("heal");
+    expect(payload.coverAppliesToSave).toBeNull();
     expect(payload.damageDice).toBeNull();
     expect(payload.healDice).toBe("2d4");
     expect(payload.requiresTargetSight).toBeNull();
@@ -361,6 +367,79 @@ describe("spellCatalogForm", () => {
     expect(payload.cantripScaling).toBeNull();
     expect(payload.upcast?.mode).toBe("additional_effect_instances");
     expect(payload.upcast?.dice).toBe("1d4+1");
+  });
+
+  it("preserves coverAppliesToSave as physical in payload", () => {
+    const payload = buildSpellUpdatePayload({
+      ...createEmptySpellEditorState(),
+      resolutionType: "damage",
+      savingThrow: "DEX",
+      saveSuccessOutcome: "half_damage",
+      coverAppliesToSave: "physical",
+      damageDiceCount: "8",
+      damageDieSize: "6",
+      damageType: "Fire",
+    });
+
+    expect(payload.coverAppliesToSave).toBe("physical");
+  });
+
+  it("preserves coverAppliesToSave as none in payload", () => {
+    const payload = buildSpellUpdatePayload({
+      ...createEmptySpellEditorState(),
+      resolutionType: "control",
+      savingThrow: "WIS",
+      coverAppliesToSave: "none",
+    });
+
+    expect(payload.coverAppliesToSave).toBe("none");
+  });
+
+  it("does not default missing coverAppliesToSave to physical", () => {
+    const payload = buildSpellUpdatePayload({
+      ...createEmptySpellEditorState(),
+      canonicalKey: "acid_splash",
+      nameEn: "Acid Splash",
+      descriptionEn: "A bubble of acid.",
+      resolutionType: "damage",
+      savingThrow: "DEX",
+      damageDiceCount: "1",
+      damageDieSize: "6",
+      damageType: "Acid",
+    });
+
+    expect(payload.coverAppliesToSave).toBeNull();
+  });
+
+  it("hydrates coverAppliesToSave as physical from existing spell", () => {
+    const state = createSpellEditorState(
+      createSpell({
+        canonicalKey: "fireball",
+        resolutionType: "damage",
+        savingThrow: "DEX",
+        saveSuccessOutcome: "half_damage",
+        coverAppliesToSave: "physical",
+        damageDice: "8d6",
+        damageType: "Fire",
+      }),
+    );
+
+    expect(state.coverAppliesToSave).toBe("physical");
+  });
+
+  it("hydrates coverAppliesToSave as none from existing spell", () => {
+    const state = createSpellEditorState(
+      createSpell({
+        canonicalKey: "acid_splash",
+        resolutionType: "damage",
+        savingThrow: "DEX",
+        coverAppliesToSave: "none",
+        damageDice: "1d6",
+        damageType: "Acid",
+      }),
+    );
+
+    expect(state.coverAppliesToSave).toBe("none");
   });
 
   it("keeps canonical key normalization deterministic", () => {

--- a/apps/control-web/src/features/shop/utils/spellCatalogForm.ts
+++ b/apps/control-web/src/features/shop/utils/spellCatalogForm.ts
@@ -92,6 +92,7 @@ export const SPELL_SAVING_THROW_OPTIONS = [
 ] as const;
 
 export const SPELL_SAVE_SUCCESS_OUTCOME_OPTIONS = ["none", "half_damage"] as const;
+export const SPELL_COVER_APPLIES_TO_SAVE_OPTIONS = ["none", "physical"] as const;
 export const SPELL_DICE_COUNT_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;
 export const SPELL_DIE_SIZE_OPTIONS = [4, 6, 8, 10, 12] as const;
 
@@ -103,6 +104,7 @@ const SPELL_COMPONENT_OPTION_SET = new Set<string>(SPELL_COMPONENT_OPTIONS);
 const SPELL_DAMAGE_TYPE_OPTION_SET = new Set<string>(SPELL_DAMAGE_TYPE_OPTIONS);
 const SPELL_SAVING_THROW_OPTION_SET = new Set<string>(SPELL_SAVING_THROW_OPTIONS);
 const SPELL_SAVE_SUCCESS_OUTCOME_OPTION_SET = new Set<string>(SPELL_SAVE_SUCCESS_OUTCOME_OPTIONS);
+const SPELL_COVER_APPLIES_TO_SAVE_OPTION_SET = new Set<string>(SPELL_COVER_APPLIES_TO_SAVE_OPTIONS);
 
 const CASTING_TIME_LABELS: Record<CastingTimeType, string> = {
   action: "1 action",
@@ -423,6 +425,9 @@ export const buildSpellUpdatePayload = (
     state.resolutionType === "damage" && state.savingThrow
       ? ((toNullableText(state.saveSuccessOutcome) as SaveSuccessOutcome | null) ?? null)
       : null,
+  coverAppliesToSave: supportsSavingThrow(state.resolutionType)
+    ? ((toNullableText(state.coverAppliesToSave) as "none" | "physical" | null) ?? null)
+    : null,
   requiresTargetSight: toNullableBoolean(state.requiresTargetSight),
   requiresTargetEffect: toNullableBoolean(state.requiresTargetEffect),
   requiresPointSight: toNullableBoolean(state.requiresPointSight),
@@ -478,6 +483,7 @@ export type SpellCatalogEditorState = {
   healDice: string;
   savingThrow: string;
   saveSuccessOutcome: string;
+  coverAppliesToSave: "" | "none" | "physical";
   radiusMeters: string;
   lengthMeters: string;
   sideMeters: string;
@@ -660,6 +666,10 @@ export const createSpellEditorState = (spell: BaseSpell): SpellCatalogEditorStat
     spell.saveSuccessOutcome,
     SPELL_SAVE_SUCCESS_OUTCOME_OPTION_SET,
   ),
+  coverAppliesToSave: normalizeKnownSpellValue(
+    spell.coverAppliesToSave,
+    SPELL_COVER_APPLIES_TO_SAVE_OPTION_SET,
+  ) as SpellCatalogEditorState["coverAppliesToSave"],
   requiresTargetSight: spell.requiresTargetSight ?? null,
   requiresTargetEffect: spell.requiresTargetEffect ?? null,
   requiresPointSight: spell.requiresPointSight ?? null,
@@ -717,6 +727,7 @@ export const createEmptySpellEditorState = (): SpellCatalogEditorState => ({
   healDice: "",
   savingThrow: "",
   saveSuccessOutcome: "",
+  coverAppliesToSave: "",
   requiresTargetSight: null,
   requiresTargetEffect: null,
   requiresPointSight: null,

--- a/apps/control-web/src/shared/i18n/domain/spell.ts
+++ b/apps/control-web/src/shared/i18n/domain/spell.ts
@@ -119,6 +119,7 @@ const SAVE_SUCCESS_OUTCOME_LABELS: Record<SaveSuccessOutcome, LabelEntry> = {
 
 const SPELL_ADMIN_VALUE_LABELS: Record<string, LabelEntry> = {
   saving_throw: label("Saving throw", "Teste de resistência"),
+  physical: label("Physical", "Física"),
 };
 
 const UPCAST_MODE_LABELS: Record<UpcastMode, LabelEntry> = {

--- a/apps/control-web/src/shared/i18n/enUS/catalog.ts
+++ b/apps/control-web/src/shared/i18n/enUS/catalog.ts
@@ -145,6 +145,8 @@ export const catalogEnUSDictionary = {
   "catalog.spells.form.descriptionEn": "Description in English",
   "catalog.spells.form.descriptionPt": "Description in Portuguese",
   "catalog.spells.form.saveSuccessOutcome": "Save success outcome",
+  "catalog.spells.form.coverAppliesToSave": "Cover on saving throw",
+  "catalog.spells.form.coverAppliesToSaveHelp": "Defines whether physical cover reduces the effective saving throw DC. Use \"physical\" for spells where cover should help the target on the save; use \"none\" when cover does not apply.",
   "catalog.spells.form.targetingRequirements": "Targeting requirements",
   "catalog.spells.form.requiresTargetSight": "Needs target line of sight",
   "catalog.spells.form.requiresTargetEffect": "Needs target line of effect",

--- a/apps/control-web/src/shared/i18n/ptBR/catalog.ts
+++ b/apps/control-web/src/shared/i18n/ptBR/catalog.ts
@@ -145,6 +145,8 @@ export const catalogPtBRDictionary = {
   "catalog.spells.form.descriptionEn": "Descrição em inglês",
   "catalog.spells.form.descriptionPt": "Descrição em português",
   "catalog.spells.form.saveSuccessOutcome": "Resultado do save bem-sucedido",
+  "catalog.spells.form.coverAppliesToSave": "Cobertura no saving throw",
+  "catalog.spells.form.coverAppliesToSaveHelp": "Define se cobertura física reduz a DC efetiva do saving throw. Use \"physical\" para magias em que cobertura deve ajudar o alvo no save; use \"none\" quando cobertura não se aplica.",
   "catalog.spells.form.targetingRequirements": "Requisitos de alvo",
   "catalog.spells.form.requiresTargetSight": "Exige linha de visão no alvo",
   "catalog.spells.form.requiresTargetEffect": "Exige linha de efeito no alvo",


### PR DESCRIPTION
## Summary

Adds `coverAppliesToSave` to the reusable GM spell catalog form flow.

The field is now available in the spell editor state, existing spell hydration, create/update payloads, and the Resolution section UI next to `savingThrow` and `saveSuccessOutcome`.

## Changes

- Added `coverAppliesToSave` to the reusable spell catalog form state
- Hydrates `physical`, `none`, and empty/null values from existing spells
- Preserves the field in create/update payloads
- Adds UI in the Resolution section
- Adds PT/EN label and help text
- Adds localization for `physical`
- Keeps empty values safe by submitting `null`, not `physical`

## Validation

```bash
npm test -- apps/control-web/src/features/shop/utils/spellCatalogForm.test.ts apps/control-web/src/features/shop/components/SpellCatalogResolutionFields.test.tsx apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.helpers.test.ts
npm run build -w apps/control-web
```

Closes #105 