### PR TITLE
Show remaining spell slots in player board and combat mode

### DIFF
--- a/apps/control-web/src/features/combat-ui/player/PlayerActionPanels.tsx
+++ b/apps/control-web/src/features/combat-ui/player/PlayerActionPanels.tsx
@@ -7,6 +7,7 @@ import { isCombatSpellActionCostAvailable } from "../spellAutomation";
 import { requiresAreaTargetingSelection, spellRequiresExternalTarget } from "../../../pages/PlayerBoardPage/player-combat-debug/areaTargetingUi";
 import { RangeStatusBadge } from "../components/RangeStatusBadge";
 import type { TargetingPreviewState } from "../hooks/useTargetingPreview";
+import { SpellSlotSummary } from "../../../shared/ui/SpellSlotSummary";
 import type {
   ConsumableOption,
   DragonbornBreathWeaponOption,
@@ -116,6 +117,14 @@ export const PlayerActionPanels = ({
     dragonbornBreathWeaponAction?.damageType ?? null,
     locale,
   );
+  const selectedSpellHasSlots = (selectedSpell?.availableSlotLevels?.length ?? 0) > 0;
+  const selectedSpellIsCantrip = selectedSpell?.level === 0;
+  const spellCastUnavailableForSlots = Boolean(
+    selectedSpell &&
+      !selectedSpellIsCantrip &&
+      selectedSpell.sourceType !== "magic_item" &&
+      !selectedSpellHasSlots,
+  );
 
   return (
     <div className="space-y-4">
@@ -197,6 +206,17 @@ export const PlayerActionPanels = ({
                   {spellActionCostLabel}
                 </p>
               ) : null}
+              {selectedSpellIsCantrip ? (
+                <p className="mt-2 text-xs text-emerald-200">Truque - sem custo de slot.</p>
+              ) : null}
+              {selectedSpell?.slotSummary?.length ? (
+                <div className="mt-3">
+                  <SpellSlotSummary compact entries={selectedSpell.slotSummary} />
+                </div>
+              ) : null}
+              {spellCastUnavailableForSlots ? (
+                <p className="mt-2 text-xs text-rose-200">Sem slots válidos disponíveis para esta magia.</p>
+              ) : null}
               {selectedSpell && !canSpendSpellActionCost ? (
                 <p className="mt-2 text-xs text-rose-200">
                   {t("combatUi.spellActionUnavailable")}
@@ -205,7 +225,7 @@ export const PlayerActionPanels = ({
             </div>
             <button
               type="button"
-              disabled={!canAct || !canSpendSpellActionCost || (selectedSpellNeedsTarget && !targetId) || !selectedSpell}
+              disabled={!canAct || !canSpendSpellActionCost || spellCastUnavailableForSlots || (selectedSpellNeedsTarget && !targetId) || !selectedSpell}
               onClick={() => {
                 void handleCast();
               }}
@@ -229,6 +249,10 @@ export const PlayerActionPanels = ({
                 spellOptions.map((spell) => (
                   <option key={spell.id} value={spell.id}>
                     {spell.name}
+                    {spell.level === 0 ? " · cantrip" : ""}
+                    {spell.level !== 0 && spell.sourceType !== "magic_item" && (spell.availableSlotLevels?.length ?? 0) === 0
+                      ? " · sem slots"
+                      : ""}
                     {spell.sourceType === "magic_item" && spell.sourceItemName ? ` · ${spell.sourceItemName}` : ""}
                     {typeof spell.chargesCurrent === "number" && typeof spell.chargesMax === "number"
                       ? ` · ${spell.chargesCurrent}/${spell.chargesMax}`

--- a/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
+++ b/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
@@ -7,6 +7,7 @@ import type {
 } from "../../../entities/roll/rollResolution.types";
 import { AuthoritativeRollDialog } from "../../../features/rolls/components/AuthoritativeRollDialog";
 import { useLocale } from "../../../shared/hooks/useLocale";
+import { SpellSlotSummary } from "../../../shared/ui/SpellSlotSummary";
 import { CombatLogPanel } from "../components/CombatLogPanel";
 import { CombatModeBar } from "../components/CombatModeBar";
 import { CombatParticipantRoster } from "../components/CombatParticipantRoster";
@@ -468,6 +469,16 @@ export const PlayerCombatModeShell = ({
                   <p className="mt-3 text-sm text-slate-400">{t("combatUi.noEffects")}</p>
                 )}
               </div>
+
+              {playerSheet?.spellcasting ? (
+                <div className="mt-4 rounded-3xl border border-white/8 bg-white/4 px-4 py-4">
+                  <SpellSlotSummary
+                    slots={playerSheet.spellcasting.slots}
+                    title={t("playerBoard.spellResourcesTitle")}
+                    emptyLabel={t("playerBoard.noSpellSlots")}
+                  />
+                </div>
+              ) : null}
             </section>
 
             <CombatParticipantRoster

--- a/apps/control-web/src/features/combat-ui/player/playerCombatShell.types.ts
+++ b/apps/control-web/src/features/combat-ui/player/playerCombatShell.types.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../../shared/api/combatRepo";
 import type { SpellSelectionType } from "../../../entities/base-spell";
 import type { DragonbornBreathWeaponAction } from "./dragonbornBreathWeapon";
+import type { SpellSlotSummaryEntry } from "../../../shared/ui/SpellSlotSummary";
 
 export type AttackResult = CombatAttackResult;
 export type SpellResult = CombatSpellResult;
@@ -26,6 +27,7 @@ export type CombatShellData = {
 export type SpellOption = {
   id: string;
   name: string;
+  level?: number;
   range?: string | null;
   rangeMeters?: number | null;
   actionCost?: CombatActionCost | null;
@@ -37,6 +39,8 @@ export type SpellOption = {
   inventoryItemId?: string | null;
   chargesCurrent?: number | null;
   chargesMax?: number | null;
+  availableSlotLevels?: number[];
+  slotSummary?: SpellSlotSummaryEntry[];
 };
 export type ConsumableOption = { id: string; label: string };
 export type UseObjectTargetOption = { id: string; display_name: string };

--- a/apps/control-web/src/features/combat-ui/player/usePlayerCombatMode.types.ts
+++ b/apps/control-web/src/features/combat-ui/player/usePlayerCombatMode.types.ts
@@ -47,6 +47,7 @@ export type CombatSpellOption = {
   savingThrow: string | null;
   suggestedMode: CombatSpellMode | null;
   availableSlotLevels: number[];
+  slotSummary?: Array<{ level: number; max: number; used: number; remaining: number }>;
   upcast?: SpellUpcast | null;
   cantripScaling?: SpellCantripScaling | null;
   characterLevel?: number | null;

--- a/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.test.ts
+++ b/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.test.ts
@@ -201,6 +201,102 @@ describe("buildSpellOptions", () => {
         actionCost: "action",
         damageType: "Force",
         availableSlotLevels: [1],
+        slotSummary: [{ level: 1, max: 2, used: 0, remaining: 2 }],
+      }),
+    ]);
+  });
+
+  it("marca magia de slot como indisponível quando não restam slots válidos", () => {
+    seedSpellCatalogCache([
+      {
+        campaignSpellId: null,
+        canonicalKey: "magic_missile",
+        name: "Magic Missile",
+        level: 1,
+        school: "evocation",
+        castingTimeType: "action",
+        castingTime: "1 action",
+        range: "36 m",
+        components: "V, S",
+        duration: "Instantaneous",
+        concentration: false,
+        ritual: false,
+        description: "Test spell.",
+        resolutionType: "damage",
+        damageType: "Force",
+        savingThrow: null,
+        saveSuccessOutcome: null,
+        healDice: null,
+        upcast: null,
+        classes: ["Wizard"],
+      },
+      {
+        campaignSpellId: null,
+        canonicalKey: "ray_of_frost",
+        name: "Ray of Frost",
+        level: 0,
+        school: "evocation",
+        castingTimeType: "action",
+        castingTime: "1 action",
+        range: "18 m",
+        components: "V, S",
+        duration: "Instantaneous",
+        concentration: false,
+        ritual: false,
+        description: "Test cantrip.",
+        resolutionType: "damage",
+        damageType: "Cold",
+        savingThrow: null,
+        saveSuccessOutcome: null,
+        healDice: null,
+        upcast: null,
+        classes: ["Wizard"],
+      },
+    ]);
+
+    const options = buildSpellOptions({
+      level: 3,
+      spellcasting: {
+        ability: "intelligence",
+        mode: "known",
+        slots: { 1: { max: 2, used: 2 } },
+        spells: [
+          {
+            id: "spell-1",
+            name: "Magic Missile",
+            canonicalKey: "magic_missile",
+            campaignSpellId: null,
+            level: 1,
+            school: "evocation",
+            prepared: true,
+            notes: "",
+          },
+          {
+            id: "spell-2",
+            name: "Ray of Frost",
+            canonicalKey: "ray_of_frost",
+            campaignSpellId: null,
+            level: 0,
+            school: "evocation",
+            prepared: true,
+            notes: "",
+          },
+        ],
+      },
+    } as CharacterSheet);
+
+    expect(options).toEqual([
+      expect.objectContaining({
+        id: "spell-2",
+        level: 0,
+        availableSlotLevels: [],
+        slotSummary: [{ level: 1, max: 2, used: 2, remaining: 0 }],
+      }),
+      expect.objectContaining({
+        id: "spell-1",
+        level: 1,
+        availableSlotLevels: [],
+        slotSummary: [{ level: 1, max: 2, used: 2, remaining: 0 }],
       }),
     ]);
   });

--- a/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.ts
+++ b/apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.ts
@@ -13,6 +13,7 @@ import {
   resolveCombatSpellActionCost
 } from "../spellAutomation";
 import type { CombatSpellOption } from "./usePlayerCombatMode.types";
+import { buildSpellSlotSummaryEntries } from "../../../shared/ui/SpellSlotSummary";
 
 export const normalizeSavingThrow = (
   value?: string | null
@@ -50,11 +51,15 @@ export const buildSpellOptions = (
 ): CombatSpellOption[] => {
   const catalog = getBaseSpells(campaignId);
   const spellcasting = playerSheet?.spellcasting;
+  const slotSummary = buildSpellSlotSummaryEntries(spellcasting?.slots);
   const availableSlotLevels = Object.entries(spellcasting?.slots ?? {})
     .map(([level, slot]) => ({ level: Number(level), slot }))
     .filter(
       ({ level, slot }) =>
-        Number.isInteger(level) && level > 0 && Boolean(slot?.max)
+        Number.isInteger(level) &&
+        level > 0 &&
+        Boolean(slot?.max) &&
+        Math.max(0, Number(slot?.max ?? 0) - Number(slot?.used ?? 0)) > 0
     )
     .map(({ level }) => level)
     .sort((left, right) => left - right);
@@ -131,6 +136,10 @@ export const buildSpellOptions = (
                     (slotLevel) => slotLevel >= spell.level
                   )
                 : [],
+            slotSummary:
+              spell.level > 0
+                ? slotSummary.filter((entry) => entry.level >= spell.level)
+                : slotSummary,
             upcast: catalogSpell?.upcast ?? null
           };
         })

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
@@ -265,12 +265,13 @@ export const PlayerBoardPage = () => {
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.08fr)_minmax(320px,0.92fr)]">
         <div className="space-y-6">
-          <PlayerBoardStatusPanel
-            combatActive={combatActive}
-            pendingRoll={pendingRoll}
-            playerStatus={playerStatus}
-            restState={restState}
-            usingHitDie={usingHitDie}
+      <PlayerBoardStatusPanel
+        combatActive={combatActive}
+        pendingRoll={pendingRoll}
+        playerSheet={playerSheet}
+        playerStatus={playerStatus}
+        restState={restState}
+        usingHitDie={usingHitDie}
             onUseHitDie={handleUseHitDie}
           />
           {activeSession?.id && (

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
@@ -1,0 +1,81 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { PlayerBoardStatusPanel } from "./PlayerBoardStatusPanel";
+
+vi.mock("../../shared/hooks/useLocale", () => ({
+  useLocale: () => ({
+    t: (key: string) =>
+      ({
+        "playerBoard.statusPanelTitle": "Base de combate",
+        "playerBoard.statusPanelHeading": "Resumo do aventureiro",
+        "playerBoard.statusPanelDescription": "Descricao",
+        "playerBoard.waitingSheetState": "Aguardando ficha",
+        "sheet.basicInfo.level": "Nível",
+        "playerBoard.currentHpLabel": "Vida atual",
+        "playerBoard.tempHpLabel": "Temp HP",
+        "playerBoard.xpProgressLabel": "XP",
+        "sheet.progress.maxLevel": "Max",
+        "playerBoard.armorClassLabel": "CA",
+        "playerBoard.hpTrackLabel": "HP",
+        "playerBoard.xpTrackLabel": "Progresso",
+        "playerBoard.initiativeLabel": "Iniciativa",
+        "sheet.skills.passivePerception": "Percepção passiva",
+        "playerBoard.spellResourcesTitle": "Slots de magia",
+        "playerBoard.noSpellSlots": "Sem slots de magia ativos.",
+      }[key] ?? key),
+  }),
+}));
+
+vi.mock("./player-board-status/PlayerBoardStatusCards", () => ({
+  DeathSaveCard: () => <div>death</div>,
+  ProgressCard: ({ label, value }: { label: string; value: string }) => <div>{label}:{value}</div>,
+  RestCard: () => <div>rest</div>,
+  StatCard: ({ label, value }: { label: string; value: string }) => <div>{label}:{value}</div>,
+  WeaponCard: () => <div>weapon</div>,
+  getHpBarToneClass: () => "hp-bar",
+  getHpToneClass: () => "hp-tone",
+}));
+
+describe("PlayerBoardStatusPanel", () => {
+  it("mostra resumo persistente de slots de magia quando a ficha tem spellcasting", () => {
+    const markup = renderToStaticMarkup(
+      <PlayerBoardStatusPanel
+        combatActive
+        pendingRoll={null}
+        playerSheet={{
+          spellcasting: {
+            ability: "intelligence",
+            mode: "known",
+            slots: {
+              1: { max: 4, used: 2 },
+              2: { max: 3, used: 3 },
+            },
+            spells: [],
+          },
+        } as any}
+        playerStatus={{
+          level: 5,
+          currentHp: 18,
+          maxHp: 24,
+          hpPercent: 75,
+          tempHp: 0,
+          xpPercent: 40,
+          nextLevelThreshold: 1000,
+          experiencePoints: 400,
+          ac: 15,
+          initiative: 2,
+          passivePerception: 14,
+        } as any}
+        restState="exploration"
+        usingHitDie={false}
+        onUseHitDie={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Slots de magia");
+    expect(markup).toContain("1º círculo");
+    expect(markup).toContain("2/4 restantes");
+    expect(markup).toContain("2º círculo");
+    expect(markup).toContain("0/3 restantes");
+  });
+});

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
@@ -1,4 +1,6 @@
+import type { CharacterSheet } from "../../features/character-sheet/model/characterSheet.types";
 import { useLocale } from "../../shared/hooks/useLocale";
+import { SpellSlotSummary } from "../../shared/ui/SpellSlotSummary";
 import type { PendingRoll, PlayerBoardStatusSummary } from "./playerBoard.types";
 import {
   DeathSaveCard,
@@ -13,6 +15,7 @@ import {
 type Props = {
   combatActive: boolean;
   pendingRoll: PendingRoll | null;
+  playerSheet?: CharacterSheet | null;
   playerStatus: PlayerBoardStatusSummary | null;
   restState: "exploration" | "short_rest" | "long_rest";
   usingHitDie: boolean;
@@ -22,6 +25,7 @@ type Props = {
 export const PlayerBoardStatusPanel = ({
   combatActive,
   pendingRoll,
+  playerSheet,
   playerStatus,
   restState,
   usingHitDie,
@@ -112,6 +116,16 @@ export const PlayerBoardStatusPanel = ({
               playerStatus={playerStatus}
             />
           </div>
+
+          {playerSheet?.spellcasting ? (
+            <div className="mt-5 rounded-3xl border border-white/8 bg-white/4 px-4 py-4">
+              <SpellSlotSummary
+                slots={playerSheet.spellcasting.slots}
+                title={t("playerBoard.spellResourcesTitle")}
+                emptyLabel={t("playerBoard.noSpellSlots")}
+              />
+            </div>
+          ) : null}
 
           <RestCard
             playerStatus={playerStatus}

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastDialogHeader.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastDialogHeader.tsx
@@ -1,5 +1,6 @@
 import { ConcentrationSaveControl } from "../../../features/combat-ui/components/ConcentrationSaveControl";
 import { RangeStatusBadge } from "../../../features/combat-ui/components/RangeStatusBadge";
+import { SpellSlotSummary } from "../../../shared/ui/SpellSlotSummary";
 import type { TargetingPreviewResult } from "../../../features/combat-ui/hooks/useTargetingPreview";
 import type { CombatSpellMode } from "../../../shared/api/combatRepo";
 import { getInstanceLabel } from "./InstanceTargetSelector";
@@ -128,6 +129,11 @@ export const SpellCastDialogHeader = ({
   const coverLabel = mapPreviewModel?.cover
     ? formatSpellCoverPreview(mapPreviewModel.cover, coverContext)
     : null;
+  const selectedSlotSummary =
+    selectedSlotLevel != null
+      ? spell.slotSummary?.find((entry) => entry.level === selectedSlotLevel) ?? null
+      : null;
+  const hasSlotCost = spell.sourceType !== "magic_item" && spell.level > 0;
 
   return (
     <>
@@ -190,6 +196,35 @@ export const SpellCastDialogHeader = ({
           </div>
         ) : null}
       </div>
+
+      {spell.sourceType !== "magic_item" ? (
+        <div className="mb-6 rounded-2xl border border-white/8 bg-white/4 px-4 py-4">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Recursos
+          </p>
+          {spell.level === 0 ? (
+            <p className="mt-2 text-sm font-semibold text-emerald-100">Truque - sem custo de slot</p>
+          ) : hasSlotCost && spell.availableSlotLevels.length === 0 ? (
+            <p className="mt-2 text-sm font-semibold text-rose-200">Sem slots disponíveis</p>
+          ) : (
+            <>
+              {selectedSlotSummary ? (
+                <p className="mt-2 text-sm text-slate-200">
+                  Slot selecionado: {selectedSlotSummary.level}º ({selectedSlotSummary.remaining}/{selectedSlotSummary.max} restantes)
+                </p>
+              ) : null}
+              <div className="mt-3">
+                <SpellSlotSummary
+                  compact
+                  entries={spell.slotSummary}
+                  emptyLabel="Sem slots disponíveis"
+                  highlightLevel={selectedSlotLevel}
+                />
+              </div>
+            </>
+          )}
+        </div>
+      ) : null}
 
       <div
         className="mb-6"

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastDialogHeader.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastDialogHeader.test.tsx
@@ -159,6 +159,53 @@ describe("SpellCastDialogHeader tactical preview", () => {
     expect(markup).toContain("Dados de posição insuficientes para validar o preview no mapa");
   });
 
+  it("mostra resumo de slots e destaca quando a magia não tem slot disponível", () => {
+    const availableMarkup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        selectedSlotLevel={2}
+        previewModel={buildPreviewModel({})}
+        spell={{
+          ...baseSpell,
+          slotSummary: [
+            { level: 1, max: 4, used: 2, remaining: 2 },
+            { level: 2, max: 3, used: 2, remaining: 1 },
+          ],
+        }}
+      />,
+    );
+
+    expect(availableMarkup).toContain("Slot selecionado: 2º");
+    expect(availableMarkup).toContain("1º: 2/4");
+    expect(availableMarkup).toContain("2º: 1/3");
+
+    const unavailableMarkup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        previewModel={buildPreviewModel({})}
+        spell={{
+          ...baseSpell,
+          availableSlotLevels: [],
+          slotSummary: [{ level: 1, max: 4, used: 4, remaining: 0 }],
+        }}
+      />,
+    );
+
+    expect(unavailableMarkup).toContain("Sem slots disponíveis");
+  });
+
+  it("mostra cantrip como sem custo de slot", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        previewModel={buildPreviewModel({})}
+        spell={{ ...baseSpell, level: 0, availableSlotLevels: [] }}
+      />,
+    );
+
+    expect(markup).toContain("Truque - sem custo de slot");
+  });
+
   it("renders Magic Missile slot 3 preview from resolved context (5 instâncias, 5d4+5)", () => {
     const markup = renderToStaticMarkup(
       <SpellCastDialogHeader

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/types.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/types.ts
@@ -57,6 +57,7 @@ export type CombatSpellOption = {
   areaShape?: "sphere" | "cone" | "line" | "cube" | "cylinder" | null;
   rangeMeters?: number | null;
   availableSlotLevels: number[];
+  slotSummary?: Array<{ level: number; max: number; used: number; remaining: number }>;
   upcast?: SpellUpcast | null;
   cantripScaling?: SpellCantripScaling | null;
   characterLevel?: number | null;

--- a/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
@@ -39,6 +39,8 @@ export const playerBoardEnUSDictionary = {
   "playerBoard.statusPanelTitle": "Combat base",
   "playerBoard.statusPanelHeading": "Adventurer summary",
   "playerBoard.statusPanelDescription": "Level, HP, XP, and defense stay visible here to support the next combat and roll flows.",
+  "playerBoard.spellResourcesTitle": "Spell slots",
+  "playerBoard.noSpellSlots": "No active spell slots.",
   "playerBoard.currentHpLabel": "Current HP",
   "playerBoard.tempHpLabel": "Temp HP",
   "playerBoard.xpProgressLabel": "XP",

--- a/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
@@ -39,6 +39,8 @@ export const playerBoardPtBRDictionary = {
   "playerBoard.statusPanelTitle": "Base de combate",
   "playerBoard.statusPanelHeading": "Resumo do aventureiro",
   "playerBoard.statusPanelDescription": "Nivel, vida, XP e defesa ficam visiveis aqui para sustentar as proximas etapas de combate e rolagem.",
+  "playerBoard.spellResourcesTitle": "Slots de magia",
+  "playerBoard.noSpellSlots": "Sem slots de magia ativos.",
   "playerBoard.currentHpLabel": "Vida atual",
   "playerBoard.tempHpLabel": "Temp HP",
   "playerBoard.xpProgressLabel": "XP",

--- a/apps/control-web/src/shared/ui/SpellSlotSummary.test.tsx
+++ b/apps/control-web/src/shared/ui/SpellSlotSummary.test.tsx
@@ -1,0 +1,53 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { SpellSlotSummary, buildSpellSlotSummaryEntries } from "./SpellSlotSummary";
+
+describe("buildSpellSlotSummaryEntries", () => {
+  it("ignora slots com max 0 e calcula remaining corretamente", () => {
+    expect(
+      buildSpellSlotSummaryEntries({
+        1: { max: 4, used: 2 },
+        2: { max: 0, used: 0 },
+        3: { max: 2, used: 3 },
+      }),
+    ).toEqual([
+      { level: 1, max: 4, used: 2, remaining: 2 },
+      { level: 3, max: 2, used: 3, remaining: 0 },
+    ]);
+  });
+});
+
+describe("SpellSlotSummary", () => {
+  it("renderiza slots restantes e esgotados", () => {
+    const markup = renderToStaticMarkup(
+      <SpellSlotSummary
+        slots={{
+          1: { max: 4, used: 2 },
+          2: { max: 0, used: 0 },
+          3: { max: 2, used: 2 },
+        }}
+      />,
+    );
+
+    expect(markup).toContain("1º círculo");
+    expect(markup).toContain("2/4 restantes");
+    expect(markup).not.toContain("2º círculo");
+    expect(markup).toContain("3º círculo");
+    expect(markup).toContain("0/2 restantes");
+  });
+
+  it("renderiza formato compacto", () => {
+    const markup = renderToStaticMarkup(
+      <SpellSlotSummary
+        compact
+        entries={[
+          { level: 1, max: 4, used: 2, remaining: 2 },
+          { level: 2, max: 3, used: 3, remaining: 0 },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("1º: 2/4");
+    expect(markup).toContain("2º: 0/3");
+  });
+});

--- a/apps/control-web/src/shared/ui/SpellSlotSummary.tsx
+++ b/apps/control-web/src/shared/ui/SpellSlotSummary.tsx
@@ -1,0 +1,108 @@
+import type { SpellSlots } from "../../features/character-sheet/model/characterSheet.types";
+
+export type SpellSlotSummaryEntry = {
+  level: number;
+  max: number;
+  used: number;
+  remaining: number;
+};
+
+type Props = {
+  slots?: Record<number, SpellSlots> | null;
+  entries?: SpellSlotSummaryEntry[] | null;
+  compact?: boolean;
+  emptyLabel?: string;
+  highlightLevel?: number | null;
+  title?: string | null;
+};
+
+export const buildSpellSlotSummaryEntries = (
+  slots?: Record<number, SpellSlots> | null,
+): SpellSlotSummaryEntry[] =>
+  Object.entries(slots ?? {})
+    .map(([level, slot]) => ({
+      level: Number(level),
+      max: Math.max(0, Number(slot?.max ?? 0)),
+      used: Math.max(0, Number(slot?.used ?? 0)),
+    }))
+    .filter(({ level, max }) => Number.isInteger(level) && level > 0 && max > 0)
+    .sort((left, right) => left.level - right.level)
+    .map(({ level, max, used }) => ({
+      level,
+      max,
+      used,
+      remaining: Math.max(0, max - used),
+    }));
+
+const formatSlotLabel = (entry: SpellSlotSummaryEntry) =>
+  `${entry.level}º: ${entry.remaining}/${entry.max}`;
+
+export const SpellSlotSummary = ({
+  slots,
+  entries,
+  compact = false,
+  emptyLabel = "Sem slots de magia",
+  highlightLevel = null,
+  title = null,
+}: Props) => {
+  const resolvedEntries = entries?.length ? entries : buildSpellSlotSummaryEntries(slots);
+
+  if (resolvedEntries.length === 0) {
+    return <p className="text-sm text-slate-400">{emptyLabel}</p>;
+  }
+
+  return (
+    <div className="space-y-2" data-testid="spell-slot-summary">
+      {title ? (
+        <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
+          {title}
+        </p>
+      ) : null}
+      <div className={compact ? "flex flex-wrap gap-2" : "space-y-2"}>
+        {resolvedEntries.map((entry) => {
+          const isHighlighted = highlightLevel === entry.level;
+          const isExhausted = entry.remaining <= 0;
+          return (
+            <div
+              key={entry.level}
+              className={
+                compact
+                  ? `rounded-full border px-3 py-1 text-xs font-semibold ${
+                      isHighlighted
+                        ? "border-fuchsia-400/40 bg-fuchsia-500/15 text-fuchsia-100"
+                        : isExhausted
+                          ? "border-rose-500/30 bg-rose-500/10 text-rose-100"
+                          : "border-emerald-500/25 bg-emerald-500/10 text-emerald-100"
+                    }`
+                  : "rounded-2xl border border-white/8 bg-white/4 px-3 py-3"
+              }
+            >
+              {compact ? (
+                <span>{formatSlotLabel(entry)}</span>
+              ) : (
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-white">{entry.level}º círculo</p>
+                    <p className="mt-1 text-xs text-slate-400">
+                      {entry.remaining}/{entry.max} restantes
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-1.5" aria-label={`${entry.level}º círculo: ${entry.remaining}/${entry.max}`}>
+                    {Array.from({ length: entry.max }, (_, index) => (
+                      <span
+                        key={`${entry.level}-${index}`}
+                        className={`h-2.5 w-2.5 rounded-full ${
+                          index < entry.remaining ? "bg-emerald-300" : "bg-slate-700"
+                        }`}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Context
Closes #99.

Esta PR melhora a visibilidade dos recursos de conjuração no player board e no modo combate, sem alterar regras de consumo, upcast ou validação autoritativa. O foco é deixar claro para o jogador quais slots restam, quando uma magia ainda pode ser conjurada e quando um truque não consome slot.

## What changed
- adiciona um componente reutilizável `SpellSlotSummary`
- mostra `Slots de magia` no player board de forma persistente
- mostra `Slots de magia` no painel lateral do modo combate
- mostra resumo de slots no diálogo de conjuração
- explicita cantrips como `Truque - sem custo de slot`
- deixa claro quando uma magia não tem slots válidos restantes
- passa a calcular disponibilidade de cast a partir de `max - used`, sem inventar disponibilidade
- ajusta a nomenclatura da UI para `Slots de magia` e `1º círculo`

## Behavior covered
- slots com `max = 0` não aparecem
- slots esgotados aparecem como `0/x restantes`
- cantrips continuam sem custo de slot
- magias de slot só aparecem como disponíveis quando há slot válido restante
- a UI reflete atualização de `used` ao recalcular o estado atual da ficha

## Non-goals respected
- sem mudança de backend
- sem mudança de regras de consumo de slot
- sem mudança de upcast
- sem mudança de prepared spells
- sem pact magic novo

## Validation
- `npm test -- apps/control-web/src/shared/ui/SpellSlotSummary.test.tsx apps/control-web/src/features/combat-ui/player/usePlayerCombatModeHelpers.test.ts apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastDialogHeader.test.tsx apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx`
- `npm run build -w apps/control-web`