### PR TITLE
feat: refactor ability score accounting to use base scores instead of…

### DIFF
--- a/apps/control-web/src/features/character-sheet/components/AbilityScores.tsx
+++ b/apps/control-web/src/features/character-sheet/components/AbilityScores.tsx
@@ -9,8 +9,7 @@ import {
   computeAbilityScoreTotal,
   safeParseInt,
 } from "../utils/calculations";
-import { getRace } from "../data/races";
-import { stripClassLevelAbilityBonuses } from "../data/classFeatures";
+import { computeBaseAbilitiesForPointAccounting } from "../utils/abilityScoreAccounting";
 import { useLocale } from "../../../shared/hooks/useLocale";
 
 type Props = {
@@ -38,19 +37,14 @@ export const AbilityScores = ({
 }: Props) => {
   const { t } = useLocale();
   const isCreation = mode === "creation";
-  const raceData = getRace(race, raceConfig);
-  const baseAbilities = stripClassLevelAbilityBonuses(
-    { ...abilities },
+  const baseAbilities = computeBaseAbilitiesForPointAccounting(
+    abilities,
+    race,
+    raceConfig,
     className ?? "",
     level,
   );
-  if (isCreation && raceData) {
-    for (const [key, bonus] of Object.entries(raceData.abilityBonuses)) {
-      const abilityKey = key as AbilityName;
-      baseAbilities[abilityKey] -= bonus ?? 0;
-    }
-  }
-  const usedPoints = computeAbilityScoreTotal(isCreation ? baseAbilities : abilities);
+  const usedPoints = computeAbilityScoreTotal(baseAbilities);
   const remainingPoints = ABILITY_SCORE_POOL - usedPoints;
 
   return (

--- a/apps/control-web/src/features/character-sheet/hooks/useCharacterSheetSave.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/useCharacterSheetSave.ts
@@ -1,10 +1,8 @@
 import type { CharacterSheetMode } from "../model/characterSheet.types";
 import {
-  ABILITY_SCORE_POOL,
   STANDARD_ARRAY,
 } from "../constants";
 import {
-  computeAbilityScoreTotal,
   isStandardArrayDistribution,
 } from "../utils/calculations";
 import {
@@ -99,19 +97,6 @@ export function useCharacterSheetSave(
           });
           return;
         }
-      }
-    } else {
-      const abilityTotal = computeAbilityScoreTotal(params.state.sheet.abilities);
-      if (abilityTotal !== ABILITY_SCORE_POOL) {
-        const diff = ABILITY_SCORE_POOL - abilityTotal;
-        dispatch({
-          type: "saving_fail",
-          error:
-            diff > 0
-              ? `Ability scores must total ${ABILITY_SCORE_POOL} (remaining: ${diff}).`
-              : `Ability scores must total ${ABILITY_SCORE_POOL} (over by ${Math.abs(diff)}).`,
-        });
-        return;
       }
     }
 

--- a/apps/control-web/src/features/character-sheet/utils/abilityScoreAccounting.ts
+++ b/apps/control-web/src/features/character-sheet/utils/abilityScoreAccounting.ts
@@ -1,0 +1,33 @@
+import type { AbilityName, CharacterSheet } from "../model/characterSheet.types";
+import { stripClassLevelAbilityBonuses } from "../data/classFeatures";
+import { getRace } from "../data/races";
+import { computeAbilityScoreTotal } from "./calculations";
+
+export function computeBaseAbilitiesForPointAccounting(
+  abilities: Record<AbilityName, number>,
+  race: CharacterSheet["race"],
+  raceConfig: CharacterSheet["raceConfig"],
+  className: string,
+  level: number,
+): Record<AbilityName, number> {
+  const base = stripClassLevelAbilityBonuses({ ...abilities }, className, level);
+  const raceData = getRace(race, raceConfig);
+  if (raceData) {
+    for (const [key, bonus] of Object.entries(raceData.abilityBonuses)) {
+      base[key as AbilityName] -= bonus ?? 0;
+    }
+  }
+  return base;
+}
+
+export function computeBaseAbilityScoreTotal(
+  abilities: Record<AbilityName, number>,
+  race: CharacterSheet["race"],
+  raceConfig: CharacterSheet["raceConfig"],
+  className: string,
+  level: number,
+): number {
+  return computeAbilityScoreTotal(
+    computeBaseAbilitiesForPointAccounting(abilities, race, raceConfig, className, level),
+  );
+}

--- a/apps/control-web/src/features/character-sheet/utils/calculations.test.ts
+++ b/apps/control-web/src/features/character-sheet/utils/calculations.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import { computeAbilityScoreTotal } from "./calculations";
+import {
+  computeBaseAbilitiesForPointAccounting,
+  computeBaseAbilityScoreTotal,
+} from "./abilityScoreAccounting";
+import { ABILITY_SCORE_POOL } from "../constants";
+import type { AbilityName } from "../model/characterSheet.types";
+
+// Standard Array: 15+14+13+12+10+8 = 72
+const BASE_ABILITIES: Record<AbilityName, number> = {
+  strength: 15,
+  dexterity: 14,
+  constitution: 13,
+  intelligence: 12,
+  wisdom: 10,
+  charisma: 8,
+};
+
+describe("computeBaseAbilitiesForPointAccounting", () => {
+  it("returns abilities unchanged when no race or class bonuses", () => {
+    const result = computeBaseAbilitiesForPointAccounting(
+      BASE_ABILITIES,
+      null,
+      null,
+      "",
+      1,
+    );
+    expect(result).toEqual(BASE_ABILITIES);
+  });
+
+  it("handles raceConfig = undefined without throwing", () => {
+    const result = computeBaseAbilitiesForPointAccounting(
+      BASE_ABILITIES,
+      null,
+      undefined,
+      "",
+      1,
+    );
+    expect(result).toEqual(BASE_ABILITIES);
+  });
+
+  it("strips race bonuses per attribute — hill-dwarf: constitution −2, wisdom −1, others unchanged", () => {
+    const abilitiesWithRace: Record<AbilityName, number> = {
+      ...BASE_ABILITIES,
+      constitution: BASE_ABILITIES.constitution + 2,
+      wisdom: BASE_ABILITIES.wisdom + 1,
+    };
+    const result = computeBaseAbilitiesForPointAccounting(
+      abilitiesWithRace,
+      "hill-dwarf",
+      null,
+      "",
+      1,
+    );
+    expect(result.strength).toBe(BASE_ABILITIES.strength);
+    expect(result.dexterity).toBe(BASE_ABILITIES.dexterity);
+    expect(result.constitution).toBe(BASE_ABILITIES.constitution);
+    expect(result.intelligence).toBe(BASE_ABILITIES.intelligence);
+    expect(result.wisdom).toBe(BASE_ABILITIES.wisdom);
+    expect(result.charisma).toBe(BASE_ABILITIES.charisma);
+  });
+
+  it("strips Guardian level-4 class bonus per attribute — dexterity −2, others unchanged", () => {
+    const abilitiesWithClass: Record<AbilityName, number> = {
+      ...BASE_ABILITIES,
+      dexterity: BASE_ABILITIES.dexterity + 2,
+    };
+    const result = computeBaseAbilitiesForPointAccounting(
+      abilitiesWithClass,
+      null,
+      null,
+      "Guardian",
+      4,
+    );
+    expect(result.dexterity).toBe(BASE_ABILITIES.dexterity);
+    expect(result.strength).toBe(BASE_ABILITIES.strength);
+    expect(result.constitution).toBe(BASE_ABILITIES.constitution);
+  });
+
+  it("Guardian below level 4 — class bonus not yet active, dexterity unchanged", () => {
+    const abilitiesAtLevel3: Record<AbilityName, number> = { ...BASE_ABILITIES };
+    const result = computeBaseAbilitiesForPointAccounting(
+      abilitiesAtLevel3,
+      null,
+      null,
+      "Guardian",
+      3,
+    );
+    expect(result.dexterity).toBe(BASE_ABILITIES.dexterity);
+  });
+
+  it("strips both race and class bonuses together — each attribute correct", () => {
+    const abilitiesWithBoth: Record<AbilityName, number> = {
+      ...BASE_ABILITIES,
+      dexterity: BASE_ABILITIES.dexterity + 2,
+      constitution: BASE_ABILITIES.constitution + 2,
+      wisdom: BASE_ABILITIES.wisdom + 1,
+    };
+    const result = computeBaseAbilitiesForPointAccounting(
+      abilitiesWithBoth,
+      "hill-dwarf",
+      null,
+      "Guardian",
+      4,
+    );
+    expect(result).toEqual(BASE_ABILITIES);
+  });
+});
+
+describe("computeBaseAbilityScoreTotal", () => {
+  it("valid character — base sums 72, race +3 → usedPoints 72, remaining 0", () => {
+    const abilitiesWithRace: Record<AbilityName, number> = {
+      ...BASE_ABILITIES,
+      constitution: BASE_ABILITIES.constitution + 2,
+      wisdom: BASE_ABILITIES.wisdom + 1,
+    };
+    const usedPoints = computeBaseAbilityScoreTotal(
+      abilitiesWithRace,
+      "hill-dwarf",
+      null,
+      "",
+      1,
+    );
+    expect(usedPoints).toBe(ABILITY_SCORE_POOL);
+    expect(ABILITY_SCORE_POOL - usedPoints).toBe(0);
+  });
+
+  it("valid character — base sums 70, race +3 → usedPoints 70, remaining 2", () => {
+    const lowBase: Record<AbilityName, number> = {
+      ...BASE_ABILITIES,
+      charisma: 6, // 8 → 6: total drops by 2 → 70
+    };
+    const abilitiesWithRace: Record<AbilityName, number> = {
+      ...lowBase,
+      constitution: lowBase.constitution + 2,
+      wisdom: lowBase.wisdom + 1,
+    };
+    const usedPoints = computeBaseAbilityScoreTotal(
+      abilitiesWithRace,
+      "hill-dwarf",
+      null,
+      "",
+      1,
+    );
+    expect(usedPoints).toBe(70);
+    expect(ABILITY_SCORE_POOL - usedPoints).toBe(2);
+  });
+
+  it("valid character — Guardian lv4 +2 DEX does not inflate used points", () => {
+    const abilitiesWithClass: Record<AbilityName, number> = {
+      ...BASE_ABILITIES,
+      dexterity: BASE_ABILITIES.dexterity + 2,
+    };
+    const usedPoints = computeBaseAbilityScoreTotal(
+      abilitiesWithClass,
+      null,
+      null,
+      "Guardian",
+      4,
+    );
+    expect(usedPoints).toBe(ABILITY_SCORE_POOL);
+  });
+
+  it("invalid character — base exceeds 72 → remaining is negative", () => {
+    const overLimit: Record<AbilityName, number> = {
+      ...BASE_ABILITIES,
+      charisma: 12, // 8 → 12: total goes from 72 to 76
+    };
+    const usedPoints = computeBaseAbilityScoreTotal(
+      overLimit,
+      null,
+      null,
+      "",
+      1,
+    );
+    expect(usedPoints).toBeGreaterThan(ABILITY_SCORE_POOL);
+    expect(ABILITY_SCORE_POOL - usedPoints).toBeLessThan(0);
+  });
+
+  it("no race or class — same result as computeAbilityScoreTotal", () => {
+    const usedPoints = computeBaseAbilityScoreTotal(
+      BASE_ABILITIES,
+      null,
+      null,
+      "",
+      1,
+    );
+    expect(usedPoints).toBe(computeAbilityScoreTotal(BASE_ABILITIES));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes incorrect "Used / Remaining Points" calculation in play mode by ensuring ability point accounting is based on **base scores**, not final scores with external bonuses.

Previously, characters with racial/class bonuses could appear as invalid (e.g. `75 / 72`), even when their base allocation was correct.

---

## Problem

The system stores **final ability scores** (base + race + class), but the UI was calculating used points directly from these values in play mode.

Example:
- Base = 72
- Racial bonus = +3
- Final = 75

UI showed:
- Used: 75 / 72
- Remaining: -3 ❌

---

## Solution

Centralized ability point accounting into a single source of truth:

### New helpers

- `computeBaseAbilitiesForPointAccounting(...)`
  - Returns base abilities with **race and class bonuses removed**
  - Used for both:
    - point accounting
    - bonus display per ability

- `computeBaseAbilityScoreTotal(...)`
  - Convenience wrapper over the helper above

---

## Changes

### `utils/abilityScoreAccounting.ts` (new)
- Added:
  - `computeBaseAbilitiesForPointAccounting`
  - `computeBaseAbilityScoreTotal`

---

### `AbilityScores.tsx`
- Removed:
  - inline race bonus stripping
  - `isCreation` conditional logic
  - ternary using final abilities in play mode

- Now:
  - uses `computeBaseAbilitiesForPointAccounting` as the single source
  - guarantees consistency between:
    - "Used points"
    - "Remaining points"
    - per-ability bonus display

---

### `useCharacterSheetSave.ts`
- Removed unreachable `else` block (dead code)
- Cleaned unused imports

---

## Tests

Added `calculations.test.ts` covering:

- Base = 72 + racial bonus → total remains 72
- Base < 72 + racial bonus → remaining calculated correctly
- Guardian level 4 → class bonus correctly removed
- Guardian level 3 → class bonus not applied
- Race + class combined → returns exact base values
- No race / no class → behaves like raw total
- `raceConfig = undefined` handled safely

Also validated **per-ability correctness**:
- Only affected attributes are modified
- All others remain unchanged

---

## Result

- "Used / Remaining Points" now always reflects **base allocation**
- External bonuses no longer invalidate valid characters
- Logic is centralized, consistent, and test-covered

---

## Notes

This change aligns with D&D rules where:
> Point-buy applies to base ability scores; bonuses are applied afterward.
