### PR TITLE
feat(combat): surface AoE mechanical guardrail exclusions

### DIFF
--- a/apps/control-server/app/schemas/combat_spells.py
+++ b/apps/control-server/app/schemas/combat_spells.py
@@ -160,6 +160,16 @@ class CombatAreaTargetOutcome(BaseModel):
     base_save_dc: int | None = None
     effective_save_dc: int | None = None
     cover_modifier: int = 0
+    excluded_by_guardrail: bool = False
+    guardrail_reason: str | None = None
+
+
+class CombatAreaGuardrailOutcome(BaseModel):
+    target_ref_id: str
+    target_display_name: str
+    target_kind: Literal["player", "session_entity"]
+    excluded_by_guardrail: bool = True
+    guardrail_reason: str
 
 
 class CombatMapPreviewToken(BaseModel):
@@ -258,6 +268,9 @@ class CombatAreaPreviewResponse(BaseModel):
     affected_token_ids: list[str] = Field(default_factory=list)
     map_version: int | None = None
     affected_target_spatial_metadata: list[AreaPreviewAffectedTargetSpatialMetadata] = Field(
+        default_factory=list
+    )
+    guardrail_target_outcomes: list[CombatAreaGuardrailOutcome] = Field(
         default_factory=list
     )
 

--- a/apps/control-server/app/services/combat_service/spells/area_guardrails.py
+++ b/apps/control-server/app/services/combat_service/spells/area_guardrails.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from ..exceptions import CombatServiceError
+
+
+def normalize_area_guardrail_reason(error: CombatServiceError) -> str:
+    detail = error.detail if isinstance(error.detail, str) else str(error.detail or error)
+    text = detail.strip()
+    return text or "Target was excluded by a mechanical rule."
+
+
+def evaluate_area_target_guardrail(
+    *,
+    db,
+    session_id: str,
+    attacker: dict[str, Any],
+    target_participant: dict[str, Any],
+    spell_canonical_key: str,
+    assert_hostile_action_allowed: Callable[..., None],
+    validate_spell_automation_target: Callable[..., None],
+) -> str | None:
+    try:
+        assert_hostile_action_allowed(
+            attacker,
+            target_participant,
+            action_label="a hostile spell",
+        )
+        validate_spell_automation_target(
+            db,
+            session_id,
+            spell_canonical_key=spell_canonical_key,
+            target_participant=target_participant,
+        )
+    except CombatServiceError as exc:
+        return normalize_area_guardrail_reason(exc)
+    return None
+
+
+def build_area_guardrail_outcome(
+    *,
+    target_participant: dict[str, Any],
+    reason: str,
+) -> dict[str, Any]:
+    return {
+        "target_ref_id": target_participant["ref_id"],
+        "target_display_name": target_participant.get("display_name") or target_participant["ref_id"],
+        "target_kind": target_participant["kind"],
+        "excluded_by_guardrail": True,
+        "guardrail_reason": reason,
+    }

--- a/apps/control-server/app/services/combat_service/spells/area_targeting.py
+++ b/apps/control-server/app/services/combat_service/spells/area_targeting.py
@@ -67,6 +67,7 @@ from ..targeting_requirements import (
 from ..targeting_intent import AreaTargetingIntent, SpellCastIntent, WeaponAttackIntent
 from ..unit_conversion import meters_to_cells
 from .area_spatial_metadata import build_area_affected_target_spatial_metadata, get_area_per_target_cover
+from .area_guardrails import build_area_guardrail_outcome, evaluate_area_target_guardrail
 
 
 
@@ -326,6 +327,32 @@ class AreaTargetingMixin:
             ) from exc
 
         affected_target_ref_ids = list(preview.affected_combatant_ids)
+        participant_by_ref_id = {
+            p["ref_id"]: p
+            for p in state.participants
+            if isinstance(p.get("ref_id"), str)
+        }
+        guardrail_target_outcomes: list[dict[str, Any]] = []
+        for target_ref_id in affected_target_ref_ids:
+            participant = participant_by_ref_id.get(target_ref_id)
+            if not participant:
+                continue
+            reason = evaluate_area_target_guardrail(
+                db=db,
+                session_id=session_id,
+                attacker=attacker,
+                target_participant=participant,
+                spell_canonical_key=spell_context["spell_canonical_key"],
+                assert_hostile_action_allowed=cls._assert_hostile_action_allowed,
+                validate_spell_automation_target=cls._validate_spell_automation_target,
+            )
+            if reason:
+                guardrail_target_outcomes.append(
+                    build_area_guardrail_outcome(
+                        target_participant=participant,
+                        reason=reason,
+                    )
+                )
 
         cover_applies_to_save = spell_context.get("cover_applies_to_save")
         raw_save_dc = spell_context.get("save_dc")
@@ -372,4 +399,5 @@ class AreaTargetingMixin:
             "affected_token_ids": list(preview.affected_token_ids),
             "map_version": preview.version,
             "affected_target_spatial_metadata": affected_target_spatial_metadata,
+            "guardrail_target_outcomes": guardrail_target_outcomes,
         }

--- a/apps/control-server/app/services/combat_service/spells/cast_area.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_area.py
@@ -21,6 +21,7 @@ from ..limiar_map_projection import maybe_sync_active_area_effects_to_limiar_map
 from ..persistent_area_effects import build_persistent_spell_area_effect
 from ..targeting_intent import AreaTargetingIntent
 from .area_spatial_metadata import get_area_per_target_cover
+from .area_guardrails import build_area_guardrail_outcome, evaluate_area_target_guardrail
 
 logger = logging.getLogger(__name__)
 
@@ -170,18 +171,27 @@ class CastAreaMixin:
             for participant in state.participants
             if participant["ref_id"] in targeting_result.affected_target_ref_ids
         ]
+        eligible_participants: list[dict[str, Any]] = []
+        excluded_target_outcomes: list[dict[str, Any]] = []
         for target_participant in affected_participants:
-            cls._assert_hostile_action_allowed(
-                attacker,
-                target_participant,
-                action_label="a hostile spell",
-            )
-            cls._validate_spell_automation_target(
-                db,
-                session_id,
-                spell_canonical_key=spell_context["spell_canonical_key"],
+            guardrail_reason = evaluate_area_target_guardrail(
+                db=db,
+                session_id=session_id,
+                attacker=attacker,
                 target_participant=target_participant,
+                spell_canonical_key=spell_context["spell_canonical_key"],
+                assert_hostile_action_allowed=cls._assert_hostile_action_allowed,
+                validate_spell_automation_target=cls._validate_spell_automation_target,
             )
+            if guardrail_reason:
+                excluded_target_outcomes.append(
+                    build_area_guardrail_outcome(
+                        target_participant=target_participant,
+                        reason=guardrail_reason,
+                    )
+                )
+                continue
+            eligible_participants.append(target_participant)
         cover_applies_to_save = spell_context.get("cover_applies_to_save")
         per_target_cover: dict[str, str | None] = {}
         if should_cover_apply_to_save(cover_applies_to_save):
@@ -189,14 +199,14 @@ class CastAreaMixin:
                 session_id=session_id,
                 action_id=f"area-cover:{uuid4()}",
                 actor_ref_id=attacker["ref_id"],
-                target_ref_ids=[p["ref_id"] for p in affected_participants],
+                target_ref_ids=[p["ref_id"] for p in eligible_participants],
                 use_map=state.use_map,
             )
 
         base_save_dc = cls._safe_int(spell_context.get("save_dc"), 0)
         area_target_outcomes: list[dict[str, Any]] = []
         target_results_for_pending: list[dict[str, Any]] = []
-        for target_participant in affected_participants:
+        for target_participant in eligible_participants:
             target_ref_id = target_participant["ref_id"]
             target_cover = per_target_cover.get(target_ref_id)
             effective_dc, _ = resolve_cover_save_dc(
@@ -245,9 +255,78 @@ class CastAreaMixin:
                 }
             )
 
+        area_target_outcomes.extend(excluded_target_outcomes)
+
+        if not target_results_for_pending:
+            db.add(state)
+            db.commit()
+            db.refresh(state)
+            if slot_spent:
+                target_state, *_ = cls._get_stats(db, attacker["ref_id"], "player", session_id)
+                await cls._emit_player_state_update(db, session_id, attacker["ref_id"], target_state)
+            await cls._emit_state(session_id, state)
+            log_message = (
+                f"{attacker['display_name']} lancou {spell_context['spell_name']} em area "
+                f"({area_spec['shape']}), mas todos os alvos espaciais foram excluidos por regras mecânicas."
+            )
+            if excluded_target_outcomes:
+                blocked_lines = [
+                    f"  {outcome['target_display_name']}: {outcome['guardrail_reason']}"
+                    for outcome in excluded_target_outcomes
+                ]
+                log_message = "\n".join([log_message, *blocked_lines])
+            if was_overridden:
+                log_message = f"[OVERRIDE: Limit for '{action_cost}' ignored] {log_message}"
+            await cls._emit_log(session_id, {
+                "message": log_message,
+                "actorUserId": actor_user_id,
+                "source": "gm_override" if is_gm else "player_turn",
+                "is_override": was_overridden,
+                "overridden_resource": action_cost if was_overridden else None,
+            })
+            return {
+                "spell_name": spell_context["spell_name"],
+                "spell_canonical_key": spell_context["spell_canonical_key"],
+                "action_kind": spell_context["spell_mode"],
+                "effect_kind": spell_context["effect_kind"],
+                "damage": 0,
+                "healing": 0,
+                "damage_type": spell_context.get("damage_type"),
+                "is_critical": False,
+                "is_hit": None,
+                "is_saved": None,
+                "new_hp": None,
+                "roll": None,
+                "roll_result": None,
+                "target_ac": None,
+                "target_display_name": "Area effect",
+                "target_kind": "session_entity",
+                "save_ability": spell_context.get("save_ability"),
+                "save_dc": spell_context.get("save_dc"),
+                "save_success_outcome": spell_context.get("save_success_outcome"),
+                "effect_dice": spell_context.get("effect_dice"),
+                "effect_bonus": cls._safe_int(spell_context.get("effect_bonus"), 0),
+                "pending_spell_id": None,
+                "effect_roll_required": False,
+                "base_effect": None,
+                "action_cost": action_cost,
+                "summary_text": "Todos os alvos na área foram excluídos por regras mecânicas.",
+                "inventory_refresh_required": spell_context.get("source_kind") == "magic_item",
+                "concentration_check": None,
+                "concentration_checks": [],
+                "area_shape": area_spec["shape"],
+                "affected_target_ref_ids": list(targeting_result.affected_target_ref_ids),
+                "affected_cells": list(targeting_result.spatial_metadata.affected_cells),
+                "area_target_outcomes": area_target_outcomes,
+                "target_count": len(targeting_result.affected_target_ref_ids),
+                "elemental_affinity_eligible": bool(spell_context.get("elemental_affinity_eligible")),
+                "elemental_affinity_damage_type": spell_context.get("elemental_affinity_damage_type"),
+                "elemental_affinity_bonus": spell_context.get("elemental_affinity_bonus"),
+            }
+
         primary_result_target = (
             anchor_target
-            or (affected_participants[0] if affected_participants else None)
+            or (eligible_participants[0] if eligible_participants else None)
         )
         primary_target_ref_id = (
             primary_result_target["ref_id"]
@@ -294,6 +373,7 @@ class CastAreaMixin:
                 "affected_target_ref_ids": list(targeting_result.affected_target_ref_ids),
                 "affected_token_ids": list(targeting_result.spatial_metadata.affected_token_ids),
                 "area_targets": target_results_for_pending,
+                "area_guardrail_outcomes": excluded_target_outcomes,
             },
         )
 
@@ -306,13 +386,18 @@ class CastAreaMixin:
             await cls._emit_player_state_update(db, session_id, attacker["ref_id"], target_state)
         await cls._emit_state(session_id, state)
 
-        target_count = len(area_target_outcomes)
+        target_count = len(targeting_result.affected_target_ref_ids)
         area_label = f"Area ({target_count} alvo{'s' if target_count != 1 else ''})"
         log_lines = [
             f"{attacker['display_name']} lancou {spell_context['spell_name']} em area "
-            f"({area_spec['shape']}): {target_count} alvo{'s' if target_count != 1 else ''} afetado{'s' if target_count != 1 else ''}.",
+            f"({area_spec['shape']}): {target_count} alvo{'s' if target_count != 1 else ''} na area.",
         ]
         for area_outcome in area_target_outcomes:
+            if area_outcome.get("excluded_by_guardrail"):
+                log_lines.append(
+                    f"  {area_outcome['target_display_name']}: excluído por regra mecânica ({area_outcome.get('guardrail_reason')})."
+                )
+                continue
             save_text = "passou" if area_outcome["is_saved"] else "falhou"
             outcome_dc = area_outcome["effective_save_dc"]
             outcome_cover = area_outcome.get("cover")

--- a/apps/control-server/app/services/combat_service/spells/cast_area_effect.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_area_effect.py
@@ -33,6 +33,12 @@ class CastAreaEffectMixin:
         area_targets_payload = pending_spell.get("area_targets")
         if not isinstance(area_targets_payload, list) or not area_targets_payload:
             raise CombatServiceError("Pending area spell effect is missing target information.", 400)
+        guardrail_outcomes_payload = pending_spell.get("area_guardrail_outcomes")
+        guardrail_outcomes = (
+            [item for item in guardrail_outcomes_payload if isinstance(item, dict)]
+            if isinstance(guardrail_outcomes_payload, list)
+            else []
+        )
 
         effect_rolls: list[int] = []
         base_effect = 0
@@ -121,6 +127,8 @@ class CastAreaEffectMixin:
                 }
             )
 
+        area_target_outcomes.extend(guardrail_outcomes)
+
         cls._clear_participant_pending_attack(attacker)
         flag_modified(state, "participants")
         db.add(state)
@@ -135,14 +143,23 @@ class CastAreaEffectMixin:
         await cls._emit_state(session_id, state)
 
         target_count = len(area_target_outcomes)
-        saved_count = sum(1 for outcome in area_target_outcomes if outcome.get("is_saved"))
-        failed_count = target_count - saved_count
+        resolved_target_outcomes = [
+            outcome for outcome in area_target_outcomes if not outcome.get("excluded_by_guardrail")
+        ]
+        guardrail_blocked_count = target_count - len(resolved_target_outcomes)
+        saved_count = sum(1 for outcome in resolved_target_outcomes if outcome.get("is_saved"))
+        failed_count = len(resolved_target_outcomes) - saved_count
         log_text = (
             f"{attacker['display_name']} resolveu {pending_spell.get('spell_name') or 'magia'} em area: "
             f"{target_count} alvo{'s' if target_count != 1 else ''}, "
             f"{failed_count} falhou/falharam no save, {saved_count} passou/passaram. "
             f"Dano rolado {rolled_effect_total}; dano total aplicado {total_damage}."
         )
+        if guardrail_blocked_count > 0:
+            log_text = (
+                f"{log_text} {guardrail_blocked_count} alvo{'s' if guardrail_blocked_count != 1 else ''} "
+                "foram excluídos por regras mecânicas."
+            )
         if concentration_checks:
             summaries = [
                 check.get("summary_text")

--- a/apps/control-server/tests/test_aoe_preview_contract.py
+++ b/apps/control-server/tests/test_aoe_preview_contract.py
@@ -219,6 +219,67 @@ class AoEPreviewReadOnlyTests(TestCombatServiceBase):
         slots = attacker_state.state_json["spellcasting"]["slots"]["3"]
         self.assertEqual(slots["used"], 0)
 
+    def test_preview_surfaces_guardrail_exclusions_for_spatial_targets(self):
+        attacker_state = _make_attacker_state()
+        catalog = _make_spell_catalog()
+        self.state.participants.append(
+            {
+                "id": "p2",
+                "ref_id": "charmer-123",
+                "kind": "player",
+                "display_name": "Charmed Noble",
+                "initiative": 9,
+                "status": "active",
+                "team": "players",
+                "visible": True,
+                "actor_user_id": "user-2",
+            }
+        )
+        self.state.participants[0]["active_effects"] = [
+            {
+                "kind": "condition",
+                "condition_type": "charmed",
+                "metadata": {"charmer_participant_id": "p2"},
+            }
+        ]
+
+        map_client = MagicMock()
+        map_client.get_session_state.return_value = _make_map_session_state()
+        map_client.preview_area_targeting.return_value = _make_map_preview_response(
+            cells=[(10, 10), (10, 9)],
+            combatant_ids=["charmer-123", "enemy-123"],
+            token_ids=["tok_charmer", "tok_enemy"],
+        )
+
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state), \
+             patch("app.services.combat.CombatService._get_spell_catalog_entry_for_session", return_value=catalog), \
+             patch("app.services.combat.CombatService._get_stats", return_value=(attacker_state, 12, 10, 10, 3, 4)), \
+             patch("app.services.combat.CombatService._build_limiar_map_client", return_value=map_client):
+            result = CombatService.preview_area_spell_targeting(
+                self.db,
+                "session-123",
+                CombatAreaPreviewRequest(
+                    actor_participant_id="p1",
+                    origin_cell=CombatGridCell(x=8, y=8),
+                    anchor_cell=CombatGridCell(x=10, y=10),
+                    spell_canonical_key="fireball",
+                ),
+                "user-1",
+                False,
+            )
+
+        self.assertTrue(result["is_valid"])
+        self.assertEqual(result["affected_target_ref_ids"], ["charmer-123", "enemy-123"])
+        self.assertEqual(len(result["guardrail_target_outcomes"]), 1)
+        self.assertEqual(
+            result["guardrail_target_outcomes"][0]["target_ref_id"],
+            "charmer-123",
+        )
+        self.assertIn(
+            "hostile spell",
+            result["guardrail_target_outcomes"][0]["guardrail_reason"],
+        )
+
     def test_cone_preview_does_not_create_pending_spell(self):
         attacker_state = _make_attacker_state("burning_hands", "Burning Hands", 1)
         catalog = _make_spell_catalog(

--- a/apps/control-server/tests/test_combat_area_targeting_integration.py
+++ b/apps/control-server/tests/test_combat_area_targeting_integration.py
@@ -280,3 +280,145 @@ class CombatAreaTargetingIntegrationTests(TestCombatServiceBase):
         self.assertEqual(attacker_state.state_json["spellcasting"]["slots"]["5"]["used"], 1)
         mock_emit_state.assert_awaited()
         mock_emit_log.assert_awaited()
+
+    @patch("app.services.combat.CombatService._emit_player_state_update", new_callable=AsyncMock)
+    @patch("app.services.combat.CombatService._emit_entity_hp_update", new_callable=AsyncMock)
+    @patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock)
+    @patch("app.services.combat.CombatService._emit_log", new_callable=AsyncMock)
+    @patch("app.services.combat_service.spells.cast_area.resolve_saving_throw")
+    async def test_area_spell_surfaces_guardrail_exclusions_without_aborting_other_targets(
+        self,
+        mock_resolve_saving_throw,
+        mock_emit_log,
+        mock_emit_state,
+        mock_emit_entity_hp_update,
+        mock_emit_player_state_update,
+    ):
+        self.state.phase = CombatPhase.active
+        self.state.current_turn_index = 0
+        self.state.participants.append(
+            {
+                "id": "p2",
+                "ref_id": "charmer-123",
+                "kind": "player",
+                "display_name": "Charmed Noble",
+                "initiative": 9,
+                "status": "active",
+                "team": "players",
+                "visible": True,
+                "actor_user_id": "user-2",
+            }
+        )
+        self.state.participants[0]["active_effects"] = [
+            {
+                "kind": "condition",
+                "condition_type": "charmed",
+                "metadata": {"charmer_participant_id": "p2"},
+            }
+        ]
+
+        attacker_state = SessionState(
+            id="state-player",
+            session_id="session-123",
+            player_user_id="player-123",
+            state_json={
+                "abilities": {"charisma": 18},
+                "spellcasting": {
+                    "spells": [
+                        {
+                            "name": "Fireball",
+                            "canonicalKey": "fireball",
+                            "level": 3,
+                            "prepared": True,
+                        }
+                    ],
+                    "slots": {"3": {"used": 0, "max": 2}},
+                },
+            },
+        )
+        map_targeting_result = TargetingResult(
+            is_valid=True,
+            validated_primary_target_ref_id="enemy-123",
+            affected_target_ref_ids=["charmer-123", "enemy-123"],
+            target_kind="session_entity",
+            spatial_metadata=SpatialMetadata(
+                source_token_id="tok_player",
+                affected_token_ids=["tok_charmer", "tok_enemy"],
+                affected_cells=[{"x": 10, "y": 10}, {"x": 10, "y": 9}],
+                area_shape="sphere",
+                map_version=12,
+                targeting_authority="limiar_map",
+            ),
+        )
+
+        def get_stats_side_effect(_db, ref_id, kind, _session_id=""):
+            if ref_id == "player-123" and kind == "player":
+                return (attacker_state, 12, 10, 10, 3, 4)
+            if ref_id == "enemy-123" and kind == "session_entity":
+                return (MagicMock(), 13, 10, 10, 2, 0)
+            if ref_id == "charmer-123" and kind == "player":
+                return (MagicMock(), 12, 10, 10, 2, 0)
+            raise AssertionError(f"Unexpected get_stats call for {ref_id}/{kind}")
+
+        mock_resolve_saving_throw.return_value = MagicMock(total=7, success=False)
+
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state), patch(
+            "app.services.combat.CombatService._get_spell_catalog_entry_for_session",
+            return_value=MagicMock(
+                canonical_key="fireball",
+                name_en="Fireball",
+                name_pt="Bola de Fogo",
+                level=3,
+                resolution_type="saving_throw",
+                saving_throw="dexterity",
+                save_success_outcome="half_damage",
+                damage_type="fire",
+                damage_dice="8d6",
+                heal_dice=None,
+                upcast_json=None,
+                casting_time_type="action",
+                target_type="ranged", area_shape="sphere",
+                range_meters=45,
+                radius_meters=6,
+            ),
+        ), patch(
+            "app.services.combat.CombatService._get_stats",
+            side_effect=get_stats_side_effect,
+        ), patch(
+            "app.services.combat.CombatService._build_roll_actor_stats_for_save",
+            return_value=RollActorStats(
+                display_name="Target",
+                abilities={"dexterity": 10},
+                actor_kind="session_entity",
+                actor_ref_id="enemy-123",
+            ),
+        ), patch(
+            "app.services.combat_service.spells.cast_area.get_combat_targeting_service",
+            return_value=SimpleNamespace(validate=MagicMock(return_value=map_targeting_result)),
+        ):
+            result = await CombatService.cast_spell(
+                self.db,
+                "session-123",
+                CombatCastSpellRequest(
+                    actor_participant_id="p1",
+                    origin_cell=CombatGridCell(x=8, y=8),
+                    anchor_cell=CombatGridCell(x=10, y=10),
+                    spell_canonical_key="fireball",
+                ),
+                "user-1",
+                False,
+            )
+
+        self.assertTrue(result["effect_roll_required"])
+        self.assertEqual(result["affected_target_ref_ids"], ["charmer-123", "enemy-123"])
+        self.assertEqual(result["target_count"], 2)
+        blocked = next(
+            outcome for outcome in result["area_target_outcomes"]
+            if outcome["target_ref_id"] == "charmer-123"
+        )
+        self.assertTrue(blocked["excluded_by_guardrail"])
+        self.assertIn("hostile spell", blocked["guardrail_reason"])
+        pending_attack = self.state.participants[0]["pending_attack"]
+        self.assertEqual(len(pending_attack["area_targets"]), 1)
+        self.assertEqual(pending_attack["area_targets"][0]["target_ref_id"], "enemy-123")
+        self.assertEqual(len(pending_attack["area_guardrail_outcomes"]), 1)

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastDialogHeader.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastDialogHeader.tsx
@@ -291,6 +291,16 @@ export const SpellCastDialogHeader = ({
               })}
             </div>
           ) : null}
+          {mapPreviewModel.guardrailTargetOutcomes?.length ? (
+            <div className="mt-2 space-y-0.5 text-xs opacity-90">
+              <p className="font-semibold">Exclusões mecânicas previstas:</p>
+              {mapPreviewModel.guardrailTargetOutcomes.map((item) => (
+                <p key={item.target_ref_id}>
+                  {item.target_display_name}: {item.guardrail_reason}
+                </p>
+              ))}
+            </div>
+          ) : null}
           {mapPreviewModel.instanceStatuses?.length ? (
             <div className="mt-2 space-y-1 text-xs">
               {mapPreviewModel.instanceStatuses.map((instanceStatus) => {

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastResultPanel.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastResultPanel.tsx
@@ -45,6 +45,7 @@ export const SpellCastResultPanel = ({
   const outcomeLabel = getOutcomeLabel(result);
   const hasEffectInstanceOutcomes = Boolean(result.effect_instance_outcomes?.length);
   const hasAreaTargetOutcomes = Boolean(result.area_target_outcomes?.length);
+  const guardrailBlockedCount = result.area_target_outcomes?.filter((outcome) => outcome.excluded_by_guardrail).length ?? 0;
 
   return (
     <div className="mt-5 space-y-4">
@@ -97,6 +98,11 @@ export const SpellCastResultPanel = ({
               </p>
             ))}
           </div>
+        ) : null}
+        {!pendingEffect && guardrailBlockedCount > 0 ? (
+          <p className="mt-2 text-xs text-amber-100">
+            {guardrailBlockedCount} alvo{guardrailBlockedCount !== 1 ? "s" : ""} na área {guardrailBlockedCount === 1 ? "foi excluído" : "foram excluídos"} por regras mecânicas.
+          </p>
         ) : null}
         {!pendingEffect && !hasEffectInstanceOutcomes && !hasAreaTargetOutcomes && (result.damage > 0 || result.healing > 0) ? (
           <p className="mt-2 text-xs text-slate-300">{formatSpellEffectBreakdown(result)}</p>

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastDialogHeader.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastDialogHeader.test.tsx
@@ -146,6 +146,33 @@ describe("SpellCastDialogHeader tactical preview", () => {
     expect(markup).toContain("Motivo: linha de efeito bloqueada");
   });
 
+  it("mostra exclusoes mecanicas previstas para magias de area", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastDialogHeader
+        {...baseProps}
+        isAreaSpell
+        spell={{ ...baseSpell, name: "Fireball", canonicalKey: "fireball", areaShape: "sphere", selectionType: "point" }}
+        mapPreviewModel={buildMapPreviewModel({
+          status: "valid",
+          areaShape: "sphere",
+          guardrailTargetOutcomes: [
+            {
+              target_ref_id: "charmer-1",
+              target_display_name: "Charmed Noble",
+              target_kind: "player",
+              excluded_by_guardrail: true,
+              guardrail_reason: "You cannot use a hostile spell against Charmed Noble while charmed.",
+            },
+          ],
+        })}
+        previewModel={buildPreviewModel({ areaShape: "sphere" })}
+      />,
+    );
+
+    expect(markup).toContain("Exclusões mecânicas previstas:");
+    expect(markup).toContain("Charmed Noble: You cannot use a hostile spell against Charmed Noble while charmed.");
+  });
+
   it("renderiza status unknown como indisponível e não como erro", () => {
     const markup = renderToStaticMarkup(
       <SpellCastDialogHeader

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastHelpers.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastHelpers.ts
@@ -108,6 +108,10 @@ export const formatEffectInstanceOutcome = (
 export const formatAreaTargetOutcome = (
   outcome: NonNullable<CombatSpellResult["area_target_outcomes"]>[number],
 ) => {
+  if (outcome.excluded_by_guardrail) {
+    return `${outcome.target_display_name}: excluído por regra mecânica${outcome.guardrail_reason ? ` (${outcome.guardrail_reason})` : ""}`;
+  }
+
   const details: string[] = [];
   const coverLabel = outcome.cover === "half" ? "meia cobertura" : outcome.cover === "three_quarters" || outcome.cover === "threeQuarters" ? "três-quartos" : null;
 

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx
@@ -145,4 +145,45 @@ describe("SpellCastResultPanel", () => {
 
     expect(markup).toContain("1d6: [6] = 6");
   });
+
+  it("explica quando um alvo de area foi excluido por guardrail mecanico", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastResultPanel
+        {...baseProps}
+        result={{
+          spell_name: "Fireball",
+          spell_canonical_key: "fireball",
+          action_kind: "saving_throw",
+          effect_kind: "damage",
+          damage: 24,
+          healing: 0,
+          target_display_name: "Area effect",
+          target_kind: "session_entity",
+          area_shape: "sphere",
+          affected_target_ref_ids: ["charmer-1", "enemy-1"],
+          affected_cells: [{ x: 10, y: 10 }],
+          area_target_outcomes: [
+            {
+              target_ref_id: "charmer-1",
+              target_display_name: "Charmed Noble",
+              target_kind: "player",
+              excluded_by_guardrail: true,
+              guardrail_reason: "You cannot use a hostile spell against Charmed Noble while charmed.",
+            },
+            {
+              target_ref_id: "enemy-1",
+              target_display_name: "Goblin A",
+              target_kind: "session_entity",
+              is_saved: false,
+              damage_applied: 24,
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Charmed Noble: excluído por regra mecânica");
+    expect(markup).toContain("You cannot use a hostile spell against Charmed Noble while charmed.");
+    expect(markup).toContain("1 alvo na área foi excluído por regras mecânicas.");
+  });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewModel.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellMapPreviewModel.ts
@@ -1,5 +1,6 @@
 import { METERS_PER_CELL } from "../../../features/combat-ui/hooks/useTargetingPreview";
 import type {
+  CombatAreaGuardrailOutcome,
   AreaPreviewAffectedTargetSpatialMetadata,
   CombatAreaPreviewResponse,
 } from "../../../shared/api/combatRepo";
@@ -46,6 +47,7 @@ export type SpellMapPreviewModel = {
   affectedTargetCount?: number;
   affectedTargetNames?: string[];
   affectedTargetSpatialMetadata?: AreaTargetSpatialMetadata[];
+  guardrailTargetOutcomes?: CombatAreaGuardrailOutcome[];
   rangeMeters: number | null;
   areaShape: string | null;
   areaSizeMeters: number | null;
@@ -116,6 +118,19 @@ const toAreaTargetSpatialMetadata = (
     baseSaveDc: item.base_save_dc ?? null,
     effectiveSaveDc: item.effective_save_dc ?? null,
     coverModifier: item.cover_modifier ?? 0,
+  }));
+};
+
+const toGuardrailTargetOutcomes = (
+  raw?: CombatAreaGuardrailOutcome[],
+): CombatAreaGuardrailOutcome[] | undefined => {
+  if (!raw || raw.length === 0) return undefined;
+  return raw.map((item) => ({
+    target_ref_id: item.target_ref_id,
+    target_display_name: item.target_display_name,
+    target_kind: item.target_kind,
+    excluded_by_guardrail: item.excluded_by_guardrail ?? true,
+    guardrail_reason: item.guardrail_reason,
   }));
 };
 
@@ -212,6 +227,9 @@ export const buildSpellMapPreviewModel = ({
         affectedTargetSpatialMetadata: toAreaTargetSpatialMetadata(
           existingAreaPreviewResult?.affected_target_spatial_metadata,
         ),
+        guardrailTargetOutcomes: toGuardrailTargetOutcomes(
+          existingAreaPreviewResult?.guardrail_target_outcomes,
+        ),
       };
     }
 
@@ -229,6 +247,9 @@ export const buildSpellMapPreviewModel = ({
           .filter((name): name is string => Boolean(name)),
         affectedTargetSpatialMetadata: toAreaTargetSpatialMetadata(
           existingAreaPreviewResult.affected_target_spatial_metadata,
+        ),
+        guardrailTargetOutcomes: toGuardrailTargetOutcomes(
+          existingAreaPreviewResult.guardrail_target_outcomes,
         ),
       };
     }

--- a/apps/control-web/src/shared/api/combatRepo.ts
+++ b/apps/control-web/src/shared/api/combatRepo.ts
@@ -333,6 +333,8 @@ export type CombatSpellResult = {
     base_save_dc?: number | null;
     effective_save_dc?: number | null;
     cover_modifier?: number;
+    excluded_by_guardrail?: boolean;
+    guardrail_reason?: string | null;
   }>;
   effect_instance_outcomes?: Array<{
     instance_index: number;
@@ -472,6 +474,14 @@ export type AreaPreviewAffectedTargetSpatialMetadata = {
   cover_modifier?: number;
 };
 
+export type CombatAreaGuardrailOutcome = {
+  target_ref_id: string;
+  target_display_name: string;
+  target_kind: CombatParticipantKind;
+  excluded_by_guardrail?: boolean;
+  guardrail_reason: string;
+};
+
 export type CombatAreaPreviewResponse = {
   is_valid: boolean;
   reason?: string | null;
@@ -481,6 +491,7 @@ export type CombatAreaPreviewResponse = {
   affected_token_ids: string[];
   map_version?: number | null;
   affected_target_spatial_metadata?: AreaPreviewAffectedTargetSpatialMetadata[];
+  guardrail_target_outcomes?: CombatAreaGuardrailOutcome[];
 };
 
 export type CombatMovementPreviewRequest = {


### PR DESCRIPTION
## Summary

Implements #112.

Makes AoE preview and cast results clearly show when a target is inside the affected area, but is excluded by a mechanical guardrail.

This separates two concepts:

- spatial targeting: the target is inside `affected_cells`
- mechanical eligibility: the target can actually be affected by the spell

---

## Problem

Previously, AoE targeting could include a combatant spatially, but later mechanical rules could block that target.

Examples:

- `charmed` blocking hostile actions
- spell-specific automation validation

This could make the result look confusing, because a target appeared to be in the area but was not affected.

In some cases, one blocked target could also interrupt the whole AoE flow instead of allowing the spell to continue against eligible targets.

---

## Solution

AoE now tracks mechanical exclusions explicitly.

The preview returns `guardrail_target_outcomes` for targets that are inside the AoE area but cannot be affected due to mechanical rules.

During execution, the spell continues against eligible targets, while excluded targets are persisted separately and reported with their exclusion reason.

---

## Backend Changes

- Added `guardrail_target_outcomes` to AoE preview responses
- Detects targets inside `affected_cells` that are blocked by:
  - `charmed` hostile-action restrictions
  - spell-specific validation guardrails
- Prevents one blocked target from aborting the entire AoE cast
- Persists mechanically excluded targets separately from applied `area_target_outcomes`
- Includes exclusion reasons in final cast results
- Improves combat log output when mechanical exclusions occur

---

## Frontend Changes

- Preview header now displays **Mechanical exclusions predicted**
- Cast result panel now shows:
  - a summary line for mechanical exclusions
  - per-target exclusion reasons
- `area_target_outcomes` formatting now handles guardrail exclusions as a dedicated outcome type

---

## Validation

Backend:

```bash
apps/control-server/.venv/bin/pytest -q \
  apps/control-server/tests/test_aoe_preview_contract.py \
  apps/control-server/tests/test_combat_area_targeting_integration.py

Frontend:

npx vitest run \
  apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx \
  apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastDialogHeader.test.tsx

Results:

Backend: 17 tests passed
Frontend: 41 tests passed
Result

AoE behavior is now clearer and more resilient:

targets inside the area are still previewed spatially
mechanically blocked targets are explained
eligible targets are still affected
preview and execution both expose guardrail exclusions
players/GM can understand why a target was skipped