### PR TITLE
feat: add area of effect footprint preview and calculations for spell…

### DIFF
--- a/apps/control-web/src/features/shop/components/SpellCatalogFormFields.tsx
+++ b/apps/control-web/src/features/shop/components/SpellCatalogFormFields.tsx
@@ -1,5 +1,6 @@
 import type { Dispatch, SetStateAction } from "react";
 import type { BaseSpell } from "../../../entities/base-spell";
+import { SpellAoeFootprintPreview } from "../../../pages/SystemSpellCatalogPage/SpellAoeFootprintPreview";
 import { useLocale } from "../../../shared/hooks/useLocale";
 import type { LocaleKey } from "../../../shared/i18n";
 import {
@@ -522,6 +523,13 @@ export const SpellCatalogFormFields = ({
             )}
           </div>
         ) : null}
+
+        <SpellAoeFootprintPreview
+          areaShape={state.areaShape}
+          radiusMeters={state.radiusMeters}
+          lengthMeters={state.lengthMeters}
+          sideMeters={state.sideMeters}
+        />
       </Section>
 
       <SpellCatalogResolutionFields

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/SpellAoeFootprintPreview.test.tsx
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/SpellAoeFootprintPreview.test.tsx
@@ -1,0 +1,136 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { SpellAoeFootprintPreview } from "./SpellAoeFootprintPreview";
+
+const defaultProps = {
+  areaShape: "",
+  radiusMeters: "",
+  lengthMeters: "",
+  sideMeters: "",
+};
+
+describe("SpellAoeFootprintPreview", () => {
+  it("shows empty state when no areaShape is set", () => {
+    const markup = renderToStaticMarkup(
+      <SpellAoeFootprintPreview {...defaultProps} />,
+    );
+    expect(markup).toContain("data-testid=\"spell-aoe-preview-empty\"");
+    expect(markup).not.toContain("data-testid=\"spell-aoe-preview\"");
+    expect(markup).not.toContain("data-testid=\"spell-aoe-preview-warning\"");
+  });
+
+  it("shows warning for sphere without radiusMeters", () => {
+    const markup = renderToStaticMarkup(
+      <SpellAoeFootprintPreview {...defaultProps} areaShape="sphere" />,
+    );
+    expect(markup).toContain("data-testid=\"spell-aoe-preview-warning\"");
+    expect(markup).toContain("raio");
+  });
+
+  it("shows warning for cone without lengthMeters", () => {
+    const markup = renderToStaticMarkup(
+      <SpellAoeFootprintPreview {...defaultProps} areaShape="cone" />,
+    );
+    expect(markup).toContain("data-testid=\"spell-aoe-preview-warning\"");
+    expect(markup).toContain("comprimento");
+  });
+
+  it("shows warning for cube without sideMeters", () => {
+    const markup = renderToStaticMarkup(
+      <SpellAoeFootprintPreview {...defaultProps} areaShape="cube" />,
+    );
+    expect(markup).toContain("data-testid=\"spell-aoe-preview-warning\"");
+    expect(markup).toContain("tamanho do lado");
+  });
+
+  it("shows warning for line without lengthMeters", () => {
+    const markup = renderToStaticMarkup(
+      <SpellAoeFootprintPreview {...defaultProps} areaShape="line" />,
+    );
+    expect(markup).toContain("data-testid=\"spell-aoe-preview-warning\"");
+  });
+
+  it("renders grid for sphere with valid radiusMeters", () => {
+    const markup = renderToStaticMarkup(
+      <SpellAoeFootprintPreview
+        {...defaultProps}
+        areaShape="sphere"
+        radiusMeters="6"
+      />,
+    );
+    expect(markup).toContain("data-testid=\"spell-aoe-preview\"");
+    expect(markup).toContain("célula");
+    expect(markup).not.toContain("data-testid=\"spell-aoe-preview-warning\"");
+  });
+
+  it("renders grid for cylinder with valid radiusMeters", () => {
+    const markup = renderToStaticMarkup(
+      <SpellAoeFootprintPreview
+        {...defaultProps}
+        areaShape="cylinder"
+        radiusMeters="3"
+      />,
+    );
+    expect(markup).toContain("data-testid=\"spell-aoe-preview\"");
+  });
+
+  it("renders grid for cone with valid lengthMeters", () => {
+    const markup = renderToStaticMarkup(
+      <SpellAoeFootprintPreview
+        {...defaultProps}
+        areaShape="cone"
+        lengthMeters="9"
+      />,
+    );
+    expect(markup).toContain("data-testid=\"spell-aoe-preview\"");
+  });
+
+  it("renders grid for line with valid lengthMeters", () => {
+    const markup = renderToStaticMarkup(
+      <SpellAoeFootprintPreview
+        {...defaultProps}
+        areaShape="line"
+        lengthMeters="9"
+      />,
+    );
+    expect(markup).toContain("data-testid=\"spell-aoe-preview\"");
+  });
+
+  it("renders grid for cube with valid sideMeters", () => {
+    const markup = renderToStaticMarkup(
+      <SpellAoeFootprintPreview
+        {...defaultProps}
+        areaShape="cube"
+        sideMeters="6"
+      />,
+    );
+    expect(markup).toContain("data-testid=\"spell-aoe-preview\"");
+  });
+
+  it("uses radiusMeters for sphere, not lengthMeters or sideMeters", () => {
+    // sphere with radiusMeters filled but lengthMeters missing → should show grid
+    const markup = renderToStaticMarkup(
+      <SpellAoeFootprintPreview
+        {...defaultProps}
+        areaShape="sphere"
+        radiusMeters="4.5"
+        lengthMeters=""
+        sideMeters=""
+      />,
+    );
+    expect(markup).toContain("data-testid=\"spell-aoe-preview\"");
+  });
+
+  it("uses sideMeters for cube, not radiusMeters", () => {
+    // cube with sideMeters filled but radiusMeters missing → should show grid
+    const markup = renderToStaticMarkup(
+      <SpellAoeFootprintPreview
+        {...defaultProps}
+        areaShape="cube"
+        radiusMeters=""
+        sideMeters="4.5"
+      />,
+    );
+    expect(markup).toContain("data-testid=\"spell-aoe-preview\"");
+  });
+});

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/SpellAoeFootprintPreview.tsx
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/SpellAoeFootprintPreview.tsx
@@ -1,0 +1,129 @@
+import { metersToCells } from "../../features/combat-ui/hooks/useTargetingPreview";
+import {
+  computeAoeFootprint,
+  getRequiredDimensionField,
+} from "./spellAoeFootprintCalc";
+
+type Props = {
+  areaShape: string;
+  radiusMeters: string;
+  lengthMeters: string;
+  sideMeters: string;
+};
+
+const DIMENSION_LABEL: Record<string, string> = {
+  radiusMeters: "raio",
+  lengthMeters: "comprimento",
+  sideMeters: "tamanho do lado",
+};
+
+const CELL_SIZE = 18;
+
+function buildGrid(cells: FootprintCell[]): {
+  grid: boolean[][];
+  gridWidth: number;
+  gridHeight: number;
+  offsetX: number;
+  offsetY: number;
+} {
+  if (cells.length === 0) return { grid: [], gridWidth: 0, gridHeight: 0, offsetX: 0, offsetY: 0 };
+
+  const minX = Math.min(...cells.map((c) => c.x));
+  const maxX = Math.max(...cells.map((c) => c.x));
+  const minY = Math.min(...cells.map((c) => c.y));
+  const maxY = Math.max(...cells.map((c) => c.y));
+
+  const gridWidth = maxX - minX + 1;
+  const gridHeight = maxY - minY + 1;
+
+  const grid: boolean[][] = Array.from({ length: gridHeight }, () =>
+    Array(gridWidth).fill(false),
+  );
+
+  const cellSet = new Set(cells.map((c) => `${c.x},${c.y}`));
+
+  for (let row = 0; row < gridHeight; row++) {
+    for (let col = 0; col < gridWidth; col++) {
+      const x = col + minX;
+      const y = row + minY;
+      if (cellSet.has(`${x},${y}`)) {
+        grid[row][col] = true;
+      }
+    }
+  }
+
+  return { grid, gridWidth, gridHeight, offsetX: minX, offsetY: minY };
+}
+
+export const SpellAoeFootprintPreview = ({
+  areaShape,
+  radiusMeters,
+  lengthMeters,
+  sideMeters,
+}: Props) => {
+  if (!areaShape) {
+    return (
+      <p className="text-xs text-slate-500" data-testid="spell-aoe-preview-empty">
+        Nenhuma forma de área selecionada.
+      </p>
+    );
+  }
+
+  const dimensionField = getRequiredDimensionField(areaShape);
+  const dimensionValue =
+    dimensionField === "radiusMeters"
+      ? radiusMeters
+      : dimensionField === "lengthMeters"
+        ? lengthMeters
+        : sideMeters;
+
+  const meters = parseFloat(dimensionValue);
+  const hasDimension = !Number.isNaN(meters) && meters > 0;
+
+  if (!hasDimension) {
+    return (
+      <p
+        className="text-xs text-amber-400/80"
+        data-testid="spell-aoe-preview-warning"
+      >
+        Configure o {DIMENSION_LABEL[dimensionField]} para ver o preview da área.
+      </p>
+    );
+  }
+
+  const sizeCells = metersToCells(meters);
+  const cells = computeAoeFootprint(areaShape, sizeCells);
+  const { grid, gridWidth, gridHeight } = buildGrid(cells);
+
+  return (
+    <div data-testid="spell-aoe-preview">
+      <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+        Preview da área
+      </p>
+      <div
+        className="inline-grid gap-px rounded border border-white/8 bg-white/4 p-1"
+        style={{
+          gridTemplateColumns: `repeat(${gridWidth}, ${CELL_SIZE}px)`,
+          gridTemplateRows: `repeat(${gridHeight}, ${CELL_SIZE}px)`,
+        }}
+      >
+        {grid.map((row, rowIdx) =>
+          row.map((cell, colIdx) => (
+            <div
+              key={`${rowIdx}-${colIdx}`}
+              className={
+                cell
+                  ? "rounded-sm bg-amber-500/40 ring-1 ring-inset ring-amber-400/60"
+                  : "rounded-sm bg-white/4"
+              }
+            />
+          )),
+        )}
+      </div>
+      <p className="mt-1.5 text-xs text-slate-400">
+        {cells.length} célula{cells.length !== 1 ? "s" : ""} afetada
+        {cells.length !== 1 ? "s" : ""}
+      </p>
+    </div>
+  );
+};

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/SystemSpellCatalogCastingFields.tsx
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/SystemSpellCatalogCastingFields.tsx
@@ -1,5 +1,6 @@
 import type { Dispatch, SetStateAction } from "react";
 
+import { SpellAoeFootprintPreview } from "./SpellAoeFootprintPreview";
 import type {
   AreaShape,
   CastingTimeType,
@@ -462,6 +463,13 @@ export const SystemSpellCatalogCastingFields = ({ form, setForm }: Props) => {
             )}
           </div>
         )}
+
+        <SpellAoeFootprintPreview
+          areaShape={form.areaShape}
+          radiusMeters={form.radiusMeters}
+          lengthMeters={form.lengthMeters}
+          sideMeters={form.sideMeters}
+        />
       </SystemSpellCatalogFormSection>
     </>
   );

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/spellAoeFootprintCalc.test.ts
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/spellAoeFootprintCalc.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeAoeFootprint,
+  getRequiredDimensionField,
+} from "./spellAoeFootprintCalc";
+
+describe("getRequiredDimensionField", () => {
+  it("returns radiusMeters for sphere", () => {
+    expect(getRequiredDimensionField("sphere")).toBe("radiusMeters");
+  });
+
+  it("returns radiusMeters for cylinder", () => {
+    expect(getRequiredDimensionField("cylinder")).toBe("radiusMeters");
+  });
+
+  it("returns lengthMeters for cone", () => {
+    expect(getRequiredDimensionField("cone")).toBe("lengthMeters");
+  });
+
+  it("returns lengthMeters for line", () => {
+    expect(getRequiredDimensionField("line")).toBe("lengthMeters");
+  });
+
+  it("returns sideMeters for cube", () => {
+    expect(getRequiredDimensionField("cube")).toBe("sideMeters");
+  });
+});
+
+describe("computeAoeFootprint", () => {
+  describe("sphere", () => {
+    it("includes origin and cardinal edge cells for radius 4", () => {
+      // Fireball: 6m radius / 1.5m per cell = 4 cells
+      const cells = computeAoeFootprint("sphere", 4);
+      const coordSet = new Set(cells.map((c) => `${c.x},${c.y}`));
+      expect(coordSet.has("0,0")).toBe(true);
+      expect(coordSet.has("0,-4")).toBe(true);
+      expect(coordSet.has("4,0")).toBe(true);
+      expect(coordSet.has("0,4")).toBe(true);
+      expect(coordSet.has("-4,0")).toBe(true);
+    });
+
+    it("does not return 81 cells for radius 4 (not a Chebyshev square)", () => {
+      const cells = computeAoeFootprint("sphere", 4);
+      expect(cells).not.toHaveLength(81);
+    });
+
+    it("does not render sphere/cylinder as Chebyshev squares", () => {
+      const cells4 = computeAoeFootprint("sphere", 4);
+      const coords = new Set(cells4.map((c) => `${c.x},${c.y}`));
+      // Chebyshev corners would be included in a square; euclidean must exclude them
+      expect(coords.has("-4,-4")).toBe(false);
+      expect(coords.has("4,4")).toBe(false);
+      expect(coords.has("-4,4")).toBe(false);
+      expect(coords.has("4,-4")).toBe(false);
+    });
+
+    it("uses euclidean distance: cells satisfy x²+y² ≤ r²", () => {
+      const r = 3;
+      const cells = computeAoeFootprint("sphere", r);
+      for (const { x, y } of cells) {
+        expect(x * x + y * y).toBeLessThanOrEqual(r * r);
+      }
+    });
+  });
+
+  describe("cylinder", () => {
+    it("produces same footprint as sphere", () => {
+      expect(computeAoeFootprint("cylinder", 2)).toEqual(
+        computeAoeFootprint("sphere", 2),
+      );
+    });
+  });
+
+  describe("cone", () => {
+    it("includes origin", () => {
+      const cells = computeAoeFootprint("cone", 2);
+      expect(cells).toContainEqual({ x: 0, y: 0 });
+    });
+
+    it("expands width per distance step", () => {
+      const cells = computeAoeFootprint("cone", 2);
+      const coordSet = new Set(cells.map((c) => `${c.x},${c.y}`));
+      // at x=1: y in [-1..1]
+      expect(coordSet.has("1,-1")).toBe(true);
+      expect(coordSet.has("1,0")).toBe(true);
+      expect(coordSet.has("1,1")).toBe(true);
+      // at x=2: y in [-2..2]
+      expect(coordSet.has("2,-2")).toBe(true);
+      expect(coordSet.has("2,2")).toBe(true);
+    });
+
+    it("does not include cells beyond the size", () => {
+      const cells = computeAoeFootprint("cone", 2);
+      expect(cells.some((c) => c.x > 2)).toBe(false);
+    });
+  });
+
+  describe("line", () => {
+    it("returns cells in a straight horizontal line", () => {
+      const cells = computeAoeFootprint("line", 3);
+      expect(cells).toEqual([
+        { x: 1, y: 0 },
+        { x: 2, y: 0 },
+        { x: 3, y: 0 },
+      ]);
+    });
+
+    it("has length equal to sizeCells", () => {
+      expect(computeAoeFootprint("line", 4)).toHaveLength(4);
+    });
+
+    it("does not include origin", () => {
+      const cells = computeAoeFootprint("line", 2);
+      expect(cells).not.toContainEqual({ x: 0, y: 0 });
+    });
+  });
+
+  describe("cube", () => {
+    it("size 2 produces a 2x2 square anchored at (0,0)", () => {
+      const cells = computeAoeFootprint("cube", 2);
+      expect(cells).toHaveLength(4);
+      expect(cells).toContainEqual({ x: 0, y: 0 });
+      expect(cells).toContainEqual({ x: 1, y: 1 });
+    });
+
+    it("size 3 produces 9 cells", () => {
+      expect(computeAoeFootprint("cube", 3)).toHaveLength(9);
+    });
+  });
+
+  it("returns empty array for unknown shape", () => {
+    expect(computeAoeFootprint("unknown_shape", 3)).toEqual([]);
+  });
+});

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/spellAoeFootprintCalc.ts
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/spellAoeFootprintCalc.ts
@@ -1,0 +1,56 @@
+export type FootprintCell = { x: number; y: number };
+
+export function getRequiredDimensionField(
+  shape: string,
+): "radiusMeters" | "lengthMeters" | "sideMeters" {
+  if (shape === "sphere" || shape === "cylinder") return "radiusMeters";
+  if (shape === "cone" || shape === "line") return "lengthMeters";
+  return "sideMeters";
+}
+
+export function computeAoeFootprint(
+  shape: string,
+  sizeCells: number,
+): FootprintCell[] {
+  if (shape === "sphere" || shape === "cylinder") {
+    const cells: FootprintCell[] = [];
+    for (let x = -sizeCells; x <= sizeCells; x++) {
+      for (let y = -sizeCells; y <= sizeCells; y++) {
+        if (x * x + y * y <= sizeCells * sizeCells) {
+          cells.push({ x, y });
+        }
+      }
+    }
+    return cells;
+  }
+
+  if (shape === "cone") {
+    const cells: FootprintCell[] = [{ x: 0, y: 0 }];
+    for (let x = 1; x <= sizeCells; x++) {
+      for (let y = -x; y <= x; y++) {
+        cells.push({ x, y });
+      }
+    }
+    return cells;
+  }
+
+  if (shape === "line") {
+    const cells: FootprintCell[] = [];
+    for (let x = 1; x <= sizeCells; x++) {
+      cells.push({ x, y: 0 });
+    }
+    return cells;
+  }
+
+  if (shape === "cube") {
+    const cells: FootprintCell[] = [];
+    for (let x = 0; x < sizeCells; x++) {
+      for (let y = 0; y < sizeCells; y++) {
+        cells.push({ x, y });
+      }
+    }
+    return cells;
+  }
+
+  return [];
+}


### PR DESCRIPTION
## Summary

Fixes AoE footprint inconsistency by switching `sphere` and `cylinder` shapes from Chebyshev (square) distance to Euclidean (circular) distance.

Both combat resolution and catalog preview now produce consistent circular footprints.

---

## Problem

AoE shapes `sphere` and `cylinder` were previously resolved using Chebyshev distance:

```ts
max(|dx|, |dy|) <= radius
```

This produced square footprints (e.g. 9x9 = 81 cells for radius 4), which is incorrect for circular/spherical AoE.

At the same time, the catalog preview was updated to use Euclidean distance:

dx² + dy² <= radius²

This created an inconsistency:

Combat → square AoE
Preview → circular AoE
Solution

Updated tactical-engine AoE resolution for sphere and cylinder to use Euclidean distance:

dx * dx + dy * dy <= radius * radius

This aligns:

combat behavior
preview rendering
expected semantics of circular AoE
Scope
Updated
sphere
cylinder
Unchanged
cube → remains square
line → unchanged
cone → unchanged
movement/range rules → still use Chebyshev where appropriate
Impact
Fireball and similar spells now produce circular footprints instead of squares
Removes mismatch between preview and actual combat behavior
Slight change in affected targets (corner cells no longer included)
Validation
Visual validation of AoE footprints in catalog preview
Manual validation in combat scenarios (e.g. Fireball)
Existing tests pass
New expected behavior verified (corner cells excluded)
Result

AoE behavior is now:

geometrically correct
consistent across systems
aligned with intended spell semantics

Square AoE is now only used where explicitly intended (cube).