### PR TITLE
fix(tactical-engine): use circular footprint for sphere and cylinder AoE

### DIFF
--- a/apps/control-web/src/pages/SystemSpellCatalogPage/spellAoeFootprintCalc.test.ts
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/spellAoeFootprintCalc.test.ts
@@ -72,21 +72,29 @@ describe("computeAoeFootprint", () => {
   });
 
   describe("cone", () => {
-    it("includes origin", () => {
+    it("does not include origin (matches combat behavior)", () => {
       const cells = computeAoeFootprint("cone", 2);
-      expect(cells).toContainEqual({ x: 0, y: 0 });
+      expect(cells).not.toContainEqual({ x: 0, y: 0 });
     });
 
-    it("expands width per distance step", () => {
+    it("step 1 has width 1 (only center cell, matching resolveCone spread)", () => {
       const cells = computeAoeFootprint("cone", 2);
       const coordSet = new Set(cells.map((c) => `${c.x},${c.y}`));
-      // at x=1: y in [-1..1]
-      expect(coordSet.has("1,-1")).toBe(true);
+      // at x=1: spread -(1-1)..+(1-1) = 0..0 → only (1,0)
       expect(coordSet.has("1,0")).toBe(true);
-      expect(coordSet.has("1,1")).toBe(true);
-      // at x=2: y in [-2..2]
-      expect(coordSet.has("2,-2")).toBe(true);
-      expect(coordSet.has("2,2")).toBe(true);
+      expect(coordSet.has("1,-1")).toBe(false);
+      expect(coordSet.has("1,1")).toBe(false);
+    });
+
+    it("step 2 has width 3 (matching resolveCone spread)", () => {
+      const cells = computeAoeFootprint("cone", 2);
+      const coordSet = new Set(cells.map((c) => `${c.x},${c.y}`));
+      // at x=2: spread -(2-1)..+(2-1) = -1..1
+      expect(coordSet.has("2,-1")).toBe(true);
+      expect(coordSet.has("2,0")).toBe(true);
+      expect(coordSet.has("2,1")).toBe(true);
+      expect(coordSet.has("2,-2")).toBe(false);
+      expect(coordSet.has("2,2")).toBe(false);
     });
 
     it("does not include cells beyond the size", () => {

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/spellAoeFootprintCalc.ts
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/spellAoeFootprintCalc.ts
@@ -25,9 +25,9 @@ export function computeAoeFootprint(
   }
 
   if (shape === "cone") {
-    const cells: FootprintCell[] = [{ x: 0, y: 0 }];
+    const cells: FootprintCell[] = [];
     for (let x = 1; x <= sizeCells; x++) {
-      for (let y = -x; y <= x; y++) {
+      for (let y = -(x - 1); y <= x - 1; y++) {
         cells.push({ x, y });
       }
     }

--- a/packages/tactical-engine/src/targeting/resolve-sphere.js
+++ b/packages/tactical-engine/src/targeting/resolve-sphere.js
@@ -1,12 +1,13 @@
-import { chebyshevDistance } from "../grid/coordinates";
 import { blocksEffect } from "../validation/obstacle-rules";
 import { canEffectReachAoE } from "./aoe-filter";
 export function resolveSphere(center, radius, obstacles, edgeObstacles = []) {
     const result = [];
     for (let x = center.x - radius; x <= center.x + radius; x += 1) {
         for (let y = center.y - radius; y <= center.y + radius; y += 1) {
+            const dx = x - center.x;
+            const dy = y - center.y;
             const coordinate = { x, y };
-            if (chebyshevDistance(center, coordinate) <= radius &&
+            if (dx * dx + dy * dy <= radius * radius &&
                 !blocksEffect(obstacles, coordinate) &&
                 canEffectReachAoE(center, coordinate, obstacles, edgeObstacles)) {
                 result.push(coordinate);

--- a/packages/tactical-engine/src/targeting/resolve-sphere.ts
+++ b/packages/tactical-engine/src/targeting/resolve-sphere.ts
@@ -1,15 +1,16 @@
 import type { Coordinate, EdgeObstacle, Obstacle } from "@limiarmap/shared-contracts";
-import { chebyshevDistance } from "../grid/coordinates";
 import { blocksEffect } from "../validation/obstacle-rules";
 import { canEffectReachAoE } from "./aoe-filter";
 
 /**
  * Resolves a sphere-shaped AoE centered on `center` with the given `radius`.
  *
- * Phase 11: after computing the geometric footprint (Chebyshev radius),
- * filters each candidate cell through `canEffectReachAoE` from the sphere's
- * center. Cells inside the radius that are separated from the center by a
- * blocking cell or edge obstacle are excluded (shadow zone behind walls).
+ * Uses Euclidean distance (dx² + dy² ≤ radius²) for a circular footprint.
+ *
+ * Phase 11: after computing the geometric footprint, filters each candidate
+ * cell through `canEffectReachAoE` from the sphere's center. Cells inside the
+ * radius that are separated from the center by a blocking cell or edge
+ * obstacle are excluded (shadow zone behind walls).
  */
 export function resolveSphere(
   center: Coordinate,
@@ -21,9 +22,11 @@ export function resolveSphere(
 
   for (let x = center.x - radius; x <= center.x + radius; x += 1) {
     for (let y = center.y - radius; y <= center.y + radius; y += 1) {
+      const dx = x - center.x;
+      const dy = y - center.y;
       const coordinate = { x, y };
       if (
-        chebyshevDistance(center, coordinate) <= radius &&
+        dx * dx + dy * dy <= radius * radius &&
         !blocksEffect(obstacles, coordinate) &&
         canEffectReachAoE(center, coordinate, obstacles, edgeObstacles)
       ) {

--- a/packages/tactical-engine/tests/unit/aoe-propagation.test.ts
+++ b/packages/tactical-engine/tests/unit/aoe-propagation.test.ts
@@ -165,10 +165,24 @@ describe("resolveCone — Phase 11 shadow filtering", () => {
 // ─── resolveSphere ───────────────────────────────────────────────────────────
 
 describe("resolveSphere — Phase 11 shadow filtering", () => {
-  it("backward compatible: no obstacles, all cells within radius included", () => {
+  it("no obstacles: all cells within Euclidean radius included", () => {
     const result = resolveSphere({ x: 5, y: 5 }, 2, [], []);
-    // Chebyshev radius 2 → 5×5 = 25 cells
-    expect(result.length).toBe(25);
+    // Euclidean radius 2 → circular footprint, 13 cells (dx²+dy² ≤ 4)
+    expect(result.length).toBe(13);
+  });
+
+  it("sphere does not include Chebyshev corners outside Euclidean radius", () => {
+    const result = resolveSphere({ x: 5, y: 5 }, 2, [], []);
+    const coords = new Set(result.map((c) => `${c.x},${c.y}`));
+    expect(coords.has("3,3")).toBe(false);
+    expect(coords.has("7,3")).toBe(false);
+    expect(coords.has("3,7")).toBe(false);
+    expect(coords.has("7,7")).toBe(false);
+    // cardinal edge cells remain included
+    expect(coords.has("3,5")).toBe(true);
+    expect(coords.has("7,5")).toBe(true);
+    expect(coords.has("5,3")).toBe(true);
+    expect(coords.has("5,7")).toBe(true);
   });
 
   it("cells inside radius but behind a cell-obstacle wall are excluded", () => {


### PR DESCRIPTION
## Summary

- Fix tactical-engine sphere/cylinder resolution to use Euclidean distance (dx²+dy²≤r²) instead of Chebyshev
- Align catalog preview cone with combat behavior: remove origin, use |y|≤x-1 width
- Update all related tests to reflect the new geometry

## Test Coverage

✅ 145 tactical-engine tests pass
✅ 588 control-web tests pass

### Geometry Changes

| Shape | Before | After | Notes |
|-------|--------|-------|-------|
| sphere radius 2 | 25 cells (Chebyshev square) | 13 cells (Euclidean circle) | Matches catalog preview |
| cone step 1 | origin + 3 cells | 1 cell | Matches resolveCone |
| cone step 2 | 5 cells | 3 cells | Matches resolveCone |

## Testing

1. Sphere/cylinder now render as circular AoE on tactical grid
2. Cone width per step matches combat resolution exactly
3. All existing shadow-zone and obstacle filtering remains intact

Resolves #116 and audits catalog preview alignment with combat behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)