### PR TITLE
feat(character-creation): formalize guided preset classes and enhance…

### DIFF
--- a/apps/control-web/src/entities/dnd-base/index.ts
+++ b/apps/control-web/src/entities/dnd-base/index.ts
@@ -24,6 +24,7 @@ export {
   getBaseSpells,
   findBaseSpell,
   getBaseSpellsForClass,
+  getSpellAvailabilityClassIds,
   loadSpellCatalog,
   isSpellCatalogLoaded,
   resolveSpellSourceClassId,

--- a/apps/control-web/src/entities/dnd-base/spellCatalogApi.ts
+++ b/apps/control-web/src/entities/dnd-base/spellCatalogApi.ts
@@ -65,11 +65,16 @@ export type BaseSpell = {
 const BASE_SCOPE_KEY = "__base__";
 
 /**
- * Maps a class id to the catalog class whose spell entries it reuses.
- * This is an explicit spell-source-only mapping — it MUST NOT be used for
- * class identity, UI labels, sheet persistence, or validation.
+ * Maps a guided-preset class id to the catalog class whose spell entries it
+ * inherits by default.
  *
- * Guardian is its own class but reuses Ranger-tagged catalog spells.
+ * Availability rules:
+ * - the class keeps its own identity (`guardian` stays `guardian`)
+ * - inherited classes automatically gain spells tagged for the mapped family
+ * - explicitly tagged class entries remain valid extensions
+ *
+ * Example: `guardian` can use spells tagged for `Ranger` and also spells tagged
+ * directly for `Guardian`.
  */
 const SPELL_SOURCE_CLASS_MAP: Record<string, string> = {
   guardian: "ranger"
@@ -88,7 +93,16 @@ export const resolveSpellSourceClassId = (classId: string): string => {
   return SPELL_SOURCE_CLASS_MAP[normalized] ?? normalized;
 };
 
-const normalizeClassLookup = resolveSpellSourceClassId;
+const normalizeSpellClassTag = (value: string) => value.trim().toLowerCase();
+
+export const getSpellAvailabilityClassIds = (classId: string): string[] => {
+  const normalizedClassId = normalizeSpellClassTag(classId);
+  const inheritedClassId = resolveSpellSourceClassId(normalizedClassId);
+
+  return Array.from(
+    new Set([normalizedClassId, inheritedClassId].filter(Boolean))
+  );
+};
 
 // ---- Module-level cache ----
 let activeScopeKey = BASE_SCOPE_KEY;
@@ -193,11 +207,11 @@ export const getBaseSpellsForClass = (
   campaignId?: string | null
 ): BaseSpell[] => {
   const source = getBaseSpells(campaignId);
-  const lookupClass = normalizeClassLookup(className);
+  const lookupClasses = new Set(getSpellAvailabilityClassIds(className));
   return source.filter(
     (spell) =>
       spell.level <= maxLevel &&
-      spell.classes.some((c) => c.toLowerCase() === lookupClass)
+      spell.classes.some((c) => lookupClasses.has(normalizeSpellClassTag(c)))
   );
 };
 

--- a/apps/control-web/src/features/character-sheet/data/classFeatures.test.ts
+++ b/apps/control-web/src/features/character-sheet/data/classFeatures.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildClassFeatures,
+  getClassLevelAbilityBonuses,
+  getFixedFightingStyleForClassLevel,
+  getFixedSubclassForClassLevel,
+  validateGuidedPresetConfig,
+} from "./classFeatures";
+import type { GuidedPresetConfig } from "./guidedPresets";
+
+describe("guided preset validation", () => {
+  it("builds guardian guided preset progression and fixed milestones", () => {
+    expect(getFixedFightingStyleForClassLevel("guardian", 1)).toBeNull();
+    expect(getFixedFightingStyleForClassLevel("guardian", 2)).toBe("archery");
+    expect(getFixedSubclassForClassLevel("guardian", 2)).toBeNull();
+    expect(getFixedSubclassForClassLevel("guardian", 3)).toBe("hunter");
+    expect(getClassLevelAbilityBonuses("guardian", 4).dexterity).toBe(2);
+    expect(buildClassFeatures("guardian", 3, null).map((feature) => feature.id)).toEqual([
+      "favored_enemy_beasts",
+      "natural_explorer_forest",
+      "fighting_style_archery",
+      "spellcasting_guardian",
+      "primeval_awareness",
+      "subclass_hunter",
+      "hunter_colossus_slayer",
+    ]);
+  });
+
+  it("keeps ranger independent from guardian guided behavior", () => {
+    expect(getFixedFightingStyleForClassLevel("ranger", 2)).toBeNull();
+    expect(getFixedSubclassForClassLevel("ranger", 3)).toBeNull();
+    expect(getClassLevelAbilityBonuses("ranger", 4).dexterity).toBe(0);
+    expect(buildClassFeatures("ranger", 4, "hunter")).toEqual([]);
+  });
+
+  it("throws for unknown guided preset feature ids", () => {
+    const preset: GuidedPresetConfig = {
+      fixedSubclass: { id: "hunter", level: 3 },
+      fixedFightingStyle: { id: "archery", level: 2 },
+      fixedAsiBonuses: [{ ability: "dexterity", bonus: 2, level: 4 }],
+      featureProgression: [{ level: 1, features: [{ id: "missing_feature_id" }] }],
+    };
+
+    expect(() => validateGuidedPresetConfig("guardian", preset)).toThrowError(
+      'Guided preset "guardian" references unknown feature "missing_feature_id". Add it to FEATURE_REGISTRY or fix the preset config.'
+    );
+  });
+
+  it("throws for invalid fixed ASI abilities", () => {
+    const preset = {
+      fixedSubclass: { id: "hunter", level: 3 },
+      fixedFightingStyle: { id: "archery", level: 2 },
+      fixedAsiBonuses: [{ ability: "luck", bonus: 2, level: 4 }],
+      featureProgression: [{ level: 1, features: [{ id: "favored_enemy_beasts" }] }],
+    } as GuidedPresetConfig;
+
+    expect(() => validateGuidedPresetConfig("guardian", preset)).toThrowError(
+      'Guided preset "guardian" has invalid fixedAsiBonuses[0].ability "luck".'
+    );
+  });
+
+  it("throws for unknown mechanics families via class definition", () => {
+    const preset: GuidedPresetConfig = {
+      fixedSubclass: null,
+      fixedFightingStyle: null,
+      fixedAsiBonuses: null,
+      featureProgression: [],
+    };
+
+    expect(() => validateGuidedPresetConfig("missing-guided-class", preset)).toThrowError(
+      'Guided preset "missing-guided-class" references unknown class definition "missing-guided-class".'
+    );
+  });
+});

--- a/apps/control-web/src/features/character-sheet/data/classFeatures.ts
+++ b/apps/control-web/src/features/character-sheet/data/classFeatures.ts
@@ -3,16 +3,14 @@ import type {
   CharacterClassFeature,
   CharacterSheet
 } from "../model/characterSheet.types";
+import { FIGHTING_STYLES, getClass } from "./classes";
 import { getDraconicLineageState } from "./draconicAncestry";
+import type { GuidedPresetConfig } from "./guidedPresets";
+import { getGuidedPreset, GUIDED_PRESETS, isGuidedPreset, normalizeClassId } from "./guidedPresets";
 
 type FeatureDefinition = Omit<CharacterClassFeature, "levelGranted"> & {
   metadata?: Record<string, unknown> | null;
 };
-
-const normalizeClassId = (value: string | null | undefined) =>
-  String(value ?? "")
-    .trim()
-    .toLowerCase();
 
 const emptyAbilityBonuses = (): Record<AbilityName, number> => ({
   strength: 0,
@@ -22,6 +20,15 @@ const emptyAbilityBonuses = (): Record<AbilityName, number> => ({
   wisdom: 0,
   charisma: 0
 });
+
+const ABILITY_NAMES: AbilityName[] = [
+  "strength",
+  "dexterity",
+  "constitution",
+  "intelligence",
+  "wisdom",
+  "charisma"
+];
 
 const FEATURE_REGISTRY: Record<string, FeatureDefinition> = {
   favored_enemy_beasts: {
@@ -120,24 +127,141 @@ const FEATURE_REGISTRY: Record<string, FeatureDefinition> = {
   }
 };
 
+const isPositiveInteger = (value: unknown): value is number =>
+  Number.isInteger(value) && Number(value) >= 1;
+
+const assertPresetLevel = (
+  classId: string,
+  field: string,
+  value: unknown
+): asserts value is number => {
+  if (!isPositiveInteger(value)) {
+    throw new Error(
+      `Guided preset "${classId}" has invalid ${field}. Expected a positive integer level.`
+    );
+  }
+};
+
+const assertFeatureRegistryId = (
+  classId: string,
+  featureId: string
+): asserts featureId is keyof typeof FEATURE_REGISTRY => {
+  if (!FEATURE_REGISTRY[featureId]) {
+    throw new Error(
+      `Guided preset "${classId}" references unknown feature "${featureId}". Add it to FEATURE_REGISTRY or fix the preset config.`
+    );
+  }
+};
+
+export const validateGuidedPresetConfig = (
+  classId: string,
+  preset: GuidedPresetConfig
+): GuidedPresetConfig => {
+  const normalizedClassId = normalizeClassId(classId);
+  const cls = getClass(normalizedClassId);
+
+  if (!cls) {
+    throw new Error(
+      `Guided preset "${classId}" references unknown class definition "${normalizedClassId}".`
+    );
+  }
+
+  if (cls.mechanicsFamily) {
+    const familyClass = getClass(cls.mechanicsFamily);
+    if (!familyClass) {
+      throw new Error(
+        `Guided preset "${classId}" references unknown mechanicsFamily "${cls.mechanicsFamily}".`
+      );
+    }
+  }
+
+  if (preset.fixedSubclass) {
+    assertPresetLevel(classId, "fixedSubclass.level", preset.fixedSubclass.level);
+    if (!cls.subclasses.some((subclass) => subclass.id === preset.fixedSubclass?.id)) {
+      throw new Error(
+        `Guided preset "${classId}" references unknown fixedSubclass "${preset.fixedSubclass.id}".`
+      );
+    }
+  }
+
+  if (preset.fixedFightingStyle) {
+    assertPresetLevel(
+      classId,
+      "fixedFightingStyle.level",
+      preset.fixedFightingStyle.level
+    );
+    const hasStyle = FIGHTING_STYLES.some(
+      (style) => style.id === preset.fixedFightingStyle?.id
+    );
+    if (!hasStyle) {
+      throw new Error(
+        `Guided preset "${classId}" references unknown fixedFightingStyle "${preset.fixedFightingStyle.id}".`
+      );
+    }
+    if (!cls.fightingStyleOptions.includes(preset.fixedFightingStyle.id)) {
+      throw new Error(
+        `Guided preset "${classId}" uses fixedFightingStyle "${preset.fixedFightingStyle.id}" which is not allowed for class "${normalizedClassId}".`
+      );
+    }
+  }
+
+  if (preset.fixedAsiBonuses) {
+    for (const [index, asi] of preset.fixedAsiBonuses.entries()) {
+      assertPresetLevel(classId, `fixedAsiBonuses[${index}].level`, asi.level);
+      if (!ABILITY_NAMES.includes(asi.ability)) {
+        throw new Error(
+          `Guided preset "${classId}" has invalid fixedAsiBonuses[${index}].ability "${String(asi.ability)}".`
+        );
+      }
+      if (typeof asi.bonus !== "number" || !Number.isFinite(asi.bonus)) {
+        throw new Error(
+          `Guided preset "${classId}" has invalid fixedAsiBonuses[${index}].bonus "${String(asi.bonus)}".`
+        );
+      }
+    }
+  }
+
+  for (const [stepIndex, step] of preset.featureProgression.entries()) {
+    assertPresetLevel(classId, `featureProgression[${stepIndex}].level`, step.level);
+    for (const [featureIndex, feature] of step.features.entries()) {
+      assertFeatureRegistryId(classId, feature.id);
+      if (
+        feature.requiresSubclass &&
+        !cls.subclasses.some((subclass) => subclass.id === feature.requiresSubclass)
+      ) {
+        throw new Error(
+          `Guided preset "${classId}" has invalid featureProgression[${stepIndex}].features[${featureIndex}].requiresSubclass "${feature.requiresSubclass}".`
+        );
+      }
+    }
+  }
+
+  return preset;
+};
+
+const VALIDATED_GUIDED_PRESETS: Record<string, GuidedPresetConfig> = Object.fromEntries(
+  Object.entries(GUIDED_PRESETS).map(([classId, preset]) => [
+    classId,
+    validateGuidedPresetConfig(classId, preset)
+  ])
+);
+
 export const getFixedSubclassForClassLevel = (
   classId: string,
   level: number
 ): string | null => {
-  if (normalizeClassId(classId) === "guardian" && level >= 3) {
-    return "hunter";
-  }
-  return null;
+  const preset = VALIDATED_GUIDED_PRESETS[normalizeClassId(classId)] ?? getGuidedPreset(classId);
+  if (!preset?.fixedSubclass) return null;
+  return level >= preset.fixedSubclass.level ? preset.fixedSubclass.id : null;
 };
 
 export const getFixedFightingStyleForClassLevel = (
   classId: string,
   level: number
 ): string | null => {
-  if (normalizeClassId(classId) === "guardian" && level >= 2) {
-    return "archery";
-  }
-  return null;
+  const preset = VALIDATED_GUIDED_PRESETS[normalizeClassId(classId)] ?? getGuidedPreset(classId);
+  if (!preset?.fixedFightingStyle) return null;
+  return level >= preset.fixedFightingStyle.level ? preset.fixedFightingStyle.id : null;
 };
 
 export const hasFixedSubclassAtLevel = (
@@ -155,8 +279,13 @@ export const getClassLevelAbilityBonuses = (
   level: number
 ): Record<AbilityName, number> => {
   const bonuses = emptyAbilityBonuses();
-  if (normalizeClassId(classId) === "guardian" && level >= 4) {
-    bonuses.dexterity = 2;
+  const preset = VALIDATED_GUIDED_PRESETS[normalizeClassId(classId)] ?? getGuidedPreset(classId);
+  if (preset?.fixedAsiBonuses) {
+    for (const asi of preset.fixedAsiBonuses) {
+      if (level >= asi.level) {
+        bonuses[asi.ability] += asi.bonus;
+      }
+    }
   }
   return bonuses;
 };
@@ -273,6 +402,31 @@ const buildElementalAffinityFeature = (
   };
 };
 
+const buildGuidedPresetFeatures = (
+  classId: string,
+  level: number,
+  subclass: string | null | undefined,
+): CharacterClassFeature[] => {
+  const normalizedClassId = normalizeClassId(classId);
+  const preset =
+    VALIDATED_GUIDED_PRESETS[normalizedClassId] ?? getGuidedPreset(normalizedClassId);
+  if (!preset) return [];
+
+  const effectiveSubclass = subclass ?? getFixedSubclassForClassLevel(classId, level);
+  const features: CharacterClassFeature[] = [];
+
+  for (const step of preset.featureProgression) {
+    if (level < step.level) continue;
+    for (const entry of step.features) {
+      if (entry.requiresSubclass && entry.requiresSubclass !== effectiveSubclass) continue;
+      assertFeatureRegistryId(normalizedClassId, entry.id);
+      features.push(featureAtLevel(entry.id, step.level));
+    }
+  }
+
+  return features;
+};
+
 export const buildClassFeatures = (
   classId: string,
   level: number,
@@ -282,28 +436,8 @@ export const buildClassFeatures = (
   const normalizedClassId = normalizeClassId(classId);
   const features: CharacterClassFeature[] = [];
 
-  if (normalizedClassId === "guardian") {
-    if (level >= 1) {
-      features.push(featureAtLevel("favored_enemy_beasts", 1));
-      features.push(featureAtLevel("natural_explorer_forest", 1));
-    }
-    if (level >= 2) {
-      features.push(featureAtLevel("fighting_style_archery", 2));
-      features.push(featureAtLevel("spellcasting_guardian", 2));
-    }
-    if (level >= 3) {
-      features.push(featureAtLevel("primeval_awareness", 3));
-      if (
-        (subclass ?? getFixedSubclassForClassLevel(classId, level)) === "hunter"
-      ) {
-        features.push(featureAtLevel("subclass_hunter", 3));
-        features.push(featureAtLevel("hunter_colossus_slayer", 3));
-      }
-    }
-    if (level >= 4) {
-      features.push(featureAtLevel("asi_guardian_dexterity_2", 4));
-    }
-    return features;
+  if (isGuidedPreset(classId)) {
+    return buildGuidedPresetFeatures(classId, level, subclass);
   }
 
   if (normalizedClassId === "sorcerer" && subclass === "draconic_bloodline") {

--- a/apps/control-web/src/features/character-sheet/data/classes.ts
+++ b/apps/control-web/src/features/character-sheet/data/classes.ts
@@ -78,10 +78,10 @@ const ALL_FIGHTING_STYLE_IDS = FIGHTING_STYLES.map((style) => style.id);
 const PALADIN_FIGHTING_STYLE_IDS = ["defense", "dueling", "great_weapon_fighting", "protection"];
 const RANGER_FIGHTING_STYLE_IDS = ["archery", "defense", "dueling", "two_weapon_fighting"];
 
-const getDefaultFightingStyleOptions = (classId: string): string[] => {
+const getDefaultFightingStyleOptions = (classId: string, mechanicsFamily: string | null): string[] => {
   if (classId === "fighter") return ALL_FIGHTING_STYLE_IDS;
   if (classId === "paladin") return PALADIN_FIGHTING_STYLE_IDS;
-  if (classId === "ranger" || classId === "guardian") return RANGER_FIGHTING_STYLE_IDS;
+  if (classId === "ranger" || mechanicsFamily === "ranger") return RANGER_FIGHTING_STYLE_IDS;
   return [];
 };
 
@@ -236,7 +236,7 @@ export const getSubclassLanguageGrants = (
 
 export const CLASSES: DndClass[] = CLASS_DEFINITIONS.map((entry) => ({
   ...entry,
-  fightingStyleOptions: entry.fightingStyleOptions ?? getDefaultFightingStyleOptions(entry.id),
+  fightingStyleOptions: entry.fightingStyleOptions ?? getDefaultFightingStyleOptions(entry.id, entry.mechanicsFamily),
   startingEquipment: describeDefaultClassStartingEquipment(entry.id),
 }));
 

--- a/apps/control-web/src/features/character-sheet/data/guidedPresets.ts
+++ b/apps/control-web/src/features/character-sheet/data/guidedPresets.ts
@@ -1,0 +1,76 @@
+import type { AbilityName } from "../model/characterSheet.types";
+
+export type GuidedPresetFeatureEntry = {
+  id: string;
+  requiresSubclass?: string;
+};
+
+export type GuidedPresetFeatureStep = {
+  level: number;
+  features: GuidedPresetFeatureEntry[];
+};
+
+export type GuidedPresetAsiBonus = {
+  ability: AbilityName;
+  bonus: number;
+  level: number;
+};
+
+export type GuidedPresetConfig = {
+  /**
+   * Guided preset classes can be mostly configured through data, as long as
+   * their referenced features already exist in FEATURE_REGISTRY and any
+   * required spell source mappings are defined elsewhere.
+   */
+  fixedSubclass: { id: string; level: number } | null;
+  fixedFightingStyle: { id: string; level: number } | null;
+  fixedAsiBonuses: GuidedPresetAsiBonus[] | null;
+  featureProgression: GuidedPresetFeatureStep[];
+};
+
+export const normalizeClassId = (value: string | null | undefined) =>
+  String(value ?? "")
+    .trim()
+    .toLowerCase();
+
+export const GUIDED_PRESETS: Record<string, GuidedPresetConfig> = {
+  guardian: {
+    fixedSubclass: { id: "hunter", level: 3 },
+    fixedFightingStyle: { id: "archery", level: 2 },
+    fixedAsiBonuses: [{ ability: "dexterity", bonus: 2, level: 4 }],
+    featureProgression: [
+      {
+        level: 1,
+        features: [
+          { id: "favored_enemy_beasts" },
+          { id: "natural_explorer_forest" },
+        ],
+      },
+      {
+        level: 2,
+        features: [
+          { id: "fighting_style_archery" },
+          { id: "spellcasting_guardian" },
+        ],
+      },
+      {
+        level: 3,
+        features: [
+          { id: "primeval_awareness" },
+          { id: "subclass_hunter", requiresSubclass: "hunter" },
+          { id: "hunter_colossus_slayer", requiresSubclass: "hunter" },
+        ],
+      },
+      {
+        level: 4,
+        features: [{ id: "asi_guardian_dexterity_2" }],
+      },
+    ],
+  },
+};
+
+export const isGuidedPreset = (classId: string): boolean =>
+  normalizeClassId(classId) in GUIDED_PRESETS;
+
+export const getGuidedPreset = (classId: string): GuidedPresetConfig | undefined =>
+  GUIDED_PRESETS[normalizeClassId(classId)];

--- a/apps/control-web/src/features/character-sheet/hooks/guardianCreation.test.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/guardianCreation.test.ts
@@ -6,7 +6,8 @@ import { INITIAL_SHEET } from "../model/initialSheet";
 import { computeSpellSaveDC, computeWeaponAttack } from "../utils/calculations";
 import {
   seedSpellCatalogCache,
-  resolveSpellSourceClassId
+  resolveSpellSourceClassId,
+  getSpellAvailabilityClassIds,
 } from "../../../entities/dnd-base";
 import {
   resetCreationItemCatalogForTests,
@@ -19,7 +20,11 @@ import {
 } from "../utils/creationSpells";
 import { validateCreationSheet } from "../utils/creationValidation";
 import { getInitialClassEquipmentSelections } from "../utils/creationEquipment";
-import { getClass } from "../data/classes";
+import {
+  getClass,
+  hasFightingStyleAtCreation,
+  isSubclassUnlocked,
+} from "../data/classes";
 
 describe("guardian creation flow", () => {
   beforeEach(() => {
@@ -104,6 +109,22 @@ describe("guardian creation flow", () => {
         damageType: null,
         savingThrow: null,
         classes: ["Druid", "Ranger", "Wizard"]
+      },
+      {
+        canonicalKey: "guardian_beacon",
+        name: "Guardian Beacon",
+        level: 1,
+        school: "Abjuration",
+        castingTime: "1 action",
+        range: "9 m",
+        components: "V, S",
+        duration: "1 minute",
+        concentration: false,
+        ritual: false,
+        description: "",
+        damageType: null,
+        savingThrow: null,
+        classes: ["Guardian"]
       }
     ]);
   });
@@ -307,6 +328,20 @@ describe("guardian creation flow", () => {
     expect(cls!.spellcastingAbility).toBe("wisdom");
   });
 
+  it("treats guardian as its own class identity in display and choice flows", () => {
+    const guardianClass = getClass("guardian");
+    const rangerClass = getClass("ranger");
+
+    expect(guardianClass?.id).toBe("guardian");
+    expect(guardianClass?.name).toBe("Guardião");
+    expect(rangerClass?.id).toBe("ranger");
+    expect(rangerClass?.name).toBe("Patrulheiro");
+    expect(guardianClass?.subclassLabel).toBe("Arquétipo de Guardião");
+    expect(rangerClass?.subclassLabel).toBe("Arquétipo de Patrulheiro");
+    expect(hasFightingStyleAtCreation(guardianClass!, 2)).toBe(true);
+    expect(isSubclassUnlocked(guardianClass!, 3)).toBe(true);
+  });
+
   it("preserves guardian identity when leveling from 1 to 4", () => {
     const level1 = normalizeCreationAfterClassChange(
       { ...INITIAL_SHEET, level: 1, race: "human", background: "soldier" },
@@ -333,12 +368,23 @@ describe("guardian creation flow", () => {
     expect(resolveSpellSourceClassId("wizard")).toBe("wizard");
   });
 
-  it("provides ranger-tagged spells for guardian through explicit source mapping", () => {
+  it("builds guardian spell availability from ranger inheritance plus explicit guardian extensions", () => {
+    expect(getSpellAvailabilityClassIds("guardian")).toEqual([
+      "guardian",
+      "ranger",
+    ]);
+    expect(getSpellAvailabilityClassIds("ranger")).toEqual(["ranger"]);
+  });
+
+  it("provides ranger-tagged spells for guardian through mechanics-family inheritance", () => {
     const guardianSpells = getAvailableStartingSpells("guardian");
     const rangerSpells = getAvailableStartingSpells("ranger");
 
     expect(guardianSpells.leveled.map((s) => s.canonicalKey)).toEqual(
-      rangerSpells.leveled.map((s) => s.canonicalKey)
+      expect.arrayContaining(rangerSpells.leveled.map((s) => s.canonicalKey))
+    );
+    expect(guardianSpells.leveled.map((s) => s.canonicalKey)).toContain(
+      "guardian_beacon"
     );
     expect(guardianSpells.leveled.length).toBeGreaterThan(0);
   });
@@ -352,6 +398,26 @@ describe("guardian creation flow", () => {
     expect(spell).not.toBeNull();
     expect(spell!.canonicalKey).toBe("animal_friendship");
     expect(spell!.name).toBe("Animal Friendship");
+  });
+
+  it("allows selecting guardian-only catalog spells for guardian sheets", () => {
+    const spell = selectCatalogSpellForSheet(
+      "guardian_beacon",
+      "guardian",
+      "known"
+    );
+    expect(spell).not.toBeNull();
+    expect(spell!.canonicalKey).toBe("guardian_beacon");
+    expect(spell!.name).toBe("Guardian Beacon");
+  });
+
+  it("does not expose guardian-only catalog spells to ranger sheets", () => {
+    const spell = selectCatalogSpellForSheet(
+      "guardian_beacon",
+      "ranger",
+      "known"
+    );
+    expect(spell).toBeNull();
   });
 
   it("does not allow non-ranger spells for guardian sheets", () => {
@@ -392,6 +458,46 @@ describe("guardian creation flow", () => {
       classEquipmentSelections: getInitialClassEquipmentSelections("guardian")
     });
     expect(result.missingRequiredFields).not.toContain("leveledSpells");
+  });
+
+  it("does not require manual subclass or fighting style choices for guardian", () => {
+    const sheet = normalizeCreationAfterClassChange(
+      { ...INITIAL_SHEET, level: 3, race: "human", background: "soldier" },
+      "guardian"
+    );
+    const result = validateCreationSheet({
+      ...sheet,
+      name: "Guardian",
+      alignment: "Neutral",
+      playerName: "Player",
+      classSkillChoices: getClass("guardian")!.skillChoices.slice(0, 3),
+      classEquipmentSelections: getInitialClassEquipmentSelections("guardian"),
+    });
+
+    expect(result.missingRequiredFields).not.toContain("subclass");
+    expect(result.missingRequiredFields).not.toContain("fightingStyle");
+  });
+
+  it("keeps ranger normal choice flows independent from guardian", () => {
+    const ranger = normalizeCreationAfterClassChange(
+      { ...INITIAL_SHEET, level: 3, race: "human", background: "soldier" },
+      "ranger"
+    );
+    const result = validateCreationSheet({
+      ...ranger,
+      name: "Ranger",
+      alignment: "Neutral",
+      playerName: "Player",
+      classSkillChoices: getClass("ranger")!.skillChoices.slice(0, 3),
+      classEquipmentSelections: getInitialClassEquipmentSelections("ranger"),
+    });
+
+    expect(ranger.class).toBe("ranger");
+    expect(ranger.subclass).toBeNull();
+    expect(ranger.fightingStyle).toBeNull();
+    expect(ranger.classFeatures).toEqual([]);
+    expect(result.missingRequiredFields).toContain("subclass");
+    expect(result.missingRequiredFields).toContain("fightingStyle");
   });
 
   it("maintains consistent spellcasting through level 4 progression", () => {

--- a/apps/control-web/src/features/character-sheet/hooks/useCharacterSheet.setters.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/useCharacterSheet.setters.ts
@@ -8,6 +8,7 @@ import {
   stripClassLevelAbilityBonuses,
   applyClassLevelAbilityBonuses,
 } from "../data/classFeatures";
+import { isGuidedPreset } from "../data/guidedPresets";
 import {
   computeMaxHpAtLevel,
   safeParseInt,
@@ -59,8 +60,8 @@ export const buildCreationSetField = (
       if (!cls) return { ...sheet, level, abilities, classFeatures: buildClassFeatures(sheet.class, level, null, sheet.subclassConfig) };
       const fixedSubclass = getFixedSubclassForClassLevel(sheet.class, level);
       const fixedFightingStyle = getFixedFightingStyleForClassLevel(sheet.class, level);
-      const nextSubclass = fixedSubclass ?? (sheet.class === "guardian" ? null : sheet.subclass);
-      const nextFightingStyle = fixedFightingStyle ?? (sheet.class === "guardian" ? null : sheet.fightingStyle);
+      const nextSubclass = fixedSubclass ?? (isGuidedPreset(sheet.class) ? null : sheet.subclass);
+      const nextFightingStyle = fixedFightingStyle ?? (isGuidedPreset(sheet.class) ? null : sheet.fightingStyle);
       const maxHP = computeMaxHpAtLevel(cls.hitDice, level, abilities.constitution);
       const spellcasting = buildCreationSpellcasting(
         sheet.class,

--- a/apps/control-web/src/features/character-sheet/utils/creationSpells.ts
+++ b/apps/control-web/src/features/character-sheet/utils/creationSpells.ts
@@ -3,9 +3,9 @@ import {
   findBaseSpell,
   getBaseSpells,
   getBaseSpellsForClass,
+  getSpellAvailabilityClassIds,
   isSameSpellAuthority,
   resolveSpellByAuthority,
-  resolveSpellSourceClassId
 } from "../../../entities/dnd-base";
 import { getModifier } from "./calculations";
 import { getClassCreationConfig } from "../data/classCreation";
@@ -60,11 +60,11 @@ const toSheetSpell = (
   campaignId?: string | null
 ): Spell | null => {
   const baseSpell = findBaseSpell(spellIdentifier, campaignId);
-  const spellClassId = resolveSpellSourceClassId(className);
+  const allowedClassIds = new Set(getSpellAvailabilityClassIds(className));
   if (
     !baseSpell ||
     !baseSpell.classes.some(
-      (entry) => entry.toLowerCase() === spellClassId.toLowerCase()
+      (entry) => allowedClassIds.has(entry.toLowerCase())
     )
   ) {
     return null;

--- a/apps/control-web/src/features/character-sheet/utils/creationValidation.test.ts
+++ b/apps/control-web/src/features/character-sheet/utils/creationValidation.test.ts
@@ -24,6 +24,7 @@ beforeAll(() => {
     { canonicalKey: "goodberry", name: "Goodberry", level: 1, school: "Transmutation", castingTime: "1 action", range: "Touch", components: "V, S, M", duration: "Instantaneous", concentration: false, ritual: false, description: "", damageType: null, savingThrow: null, classes: ["Druid", "Ranger"] },
     { canonicalKey: "healing_word", name: "Healing Word", level: 1, school: "Evocation", castingTime: "1 bonus action", range: "18 m", components: "V", duration: "Instantaneous", concentration: false, ritual: false, description: "", damageType: null, savingThrow: null, classes: ["Bard", "Cleric", "Druid"] },
     { canonicalKey: "hunters_mark", name: "Hunter's Mark", level: 1, school: "Divination", castingTime: "1 bonus action", range: "27 m", components: "V", duration: "Up to 1 hour", concentration: true, ritual: false, description: "", damageType: null, savingThrow: null, classes: ["Ranger"] },
+    { canonicalKey: "guardian_beacon", name: "Guardian Beacon", level: 1, school: "Abjuration", castingTime: "1 action", range: "9 m", components: "V, S", duration: "1 minute", concentration: false, ritual: false, description: "", damageType: null, savingThrow: null, classes: ["Guardian"] },
   ]);
 });
 
@@ -137,6 +138,7 @@ describe("validateCreationSheet", () => {
       "cure_wounds",
       "goodberry",
       "hunters_mark",
+      "guardian_beacon",
     ]);
     expect(getStartingSpellLimits("guardian", INITIAL_SHEET.abilities, 1)).toBeNull();
     expect(getStartingSpellLimits("guardian", INITIAL_SHEET.abilities, 2)).toMatchObject({

--- a/apps/control-web/src/features/shop/utils/spellCatalogForm.test.ts
+++ b/apps/control-web/src/features/shop/utils/spellCatalogForm.test.ts
@@ -44,7 +44,7 @@ describe("spellCatalogForm", () => {
   it("filters unsupported legacy values from the editor state", () => {
     const state = createSpellEditorState(
       createSpell({
-        classesJson: ["Wizard", "Psion"],
+        classesJson: ["Wizard", "Guardian", "Psion"],
         componentsJson: ["V", "X"],
         damageType: "Void" as any,
         savingThrow: "LCK" as any,
@@ -52,7 +52,7 @@ describe("spellCatalogForm", () => {
       }),
     );
 
-    expect(state.classesJson).toEqual(["Wizard"]);
+    expect(state.classesJson).toEqual(["Wizard", "Guardian"]);
     expect(state.componentsJson).toEqual(["V"]);
     expect(state.damageType).toBe("");
     expect(state.savingThrow).toBe("");

--- a/apps/control-web/src/features/shop/utils/spellCatalogForm.ts
+++ b/apps/control-web/src/features/shop/utils/spellCatalogForm.ts
@@ -57,6 +57,7 @@ export const SPELL_CLASS_OPTIONS = [
   "Bard",
   "Cleric",
   "Druid",
+  "Guardian",
   "Paladin",
   "Ranger",
   "Sorcerer",

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.types.ts
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.types.ts
@@ -161,6 +161,7 @@ export const CLASS_OPTIONS = [
   "Bard",
   "Cleric",
   "Druid",
+  "Guardian",
   "Paladin",
   "Ranger",
   "Sorcerer",

--- a/apps/control-web/src/shared/i18n/domain/spell.ts
+++ b/apps/control-web/src/shared/i18n/domain/spell.ts
@@ -203,6 +203,7 @@ const SPELL_CLASS_LABELS: Record<string, LabelEntry> = {
   Bard: label("Bard", "Bardo"),
   Cleric: label("Cleric", "Clérigo"),
   Druid: label("Druid", "Druida"),
+  Guardian: label("Guardian", "Guardião"),
   Paladin: label("Paladin", "Paladino"),
   Ranger: label("Ranger", "Patrulheiro"),
   Sorcerer: label("Sorcerer", "Feiticeiro"),

--- a/apps/control-web/src/shared/i18n/domainLabels.test.ts
+++ b/apps/control-web/src/shared/i18n/domainLabels.test.ts
@@ -37,6 +37,7 @@ describe("domainLabels", () => {
   it("localizes spell classes", () => {
     expect(localizeSpellClass("Wizard", "pt")).toBe("Mago");
     expect(localizeSpellClass("Cleric", "en")).toBe("Cleric");
+    expect(localizeSpellClass("Guardian", "pt")).toBe("Guardião");
   });
 
   it("falls back safely for unknown values", () => {


### PR DESCRIPTION
Closes #122 

### 1. Overview
Este PR consolida a infraestrutura de **Guided Presets** e resolve a lógica de conjuração para a classe `Guardian`. A principal mudança é a transição de verificações *hardcoded* para um sistema orientado a dados (*data-driven*), garantindo que o `Guardian` herde mecanicamente traços de `Ranger` enquanto mantém sua identidade e exclusividades.

### 2. Mudanças Principais

#### Sistema de Magias (Unificação)
*   **Herança de Magias:** Implementado em `spellCatalogApi.ts` o método `getSpellAvailabilityClassIds()`. Agora, a disponibilidade de magias suporta um conjunto de classes elegíveis.
    *   `Guardian` agora resolve para `["guardian", "ranger"]`.
    *   `Ranger` permanece isolado, não herdando magias exclusivas de `Guardian`.
*   **Alinhamento de Runtime:** Atualizado o arquivo `creationSpells.ts` para que a normalização e seleção de magias na criação de personagem respeitem essa nova lógica de múltiplos IDs.

#### Endurecimento do Guided Preset
*   **Abstração de Dados:** Criação do `data/guidedPresets.ts` para centralizar o registro `GUIDED_PRESETS`. Isso remove a necessidade de `if (class === 'guardian')` espalhados pelo código.
*   **Validação Estrita:** Implementação do `validateGuidedPresetConfig` em `classFeatures.ts`. O sistema agora lança erros explícitos se um preset referenciar uma feature inexistente no `FEATURE_REGISTRY`.
*   **Desacoplamento em Hooks:** O hook `useCharacterSheet.setters.ts` agora utiliza `isGuidedPreset()` para gerenciar o estado de subclasses e estilos de luta de forma genérica.

### 3. Arquivos Modificados
*   `apps/control-web/src/entities/dnd-base/spellCatalogApi.ts`: Nova lógica de disponibilidade de magias.
*   `apps/control-web/src/features/character-sheet/utils/creationSpells.ts`: Sincronização da UI com o novo motor de busca de magias.
*   `data/guidedPresets.ts`: Novo arquivo de definição e tipos para presets.
*   `data/classFeatures.ts`: Migração para lookups baseados em dados (ASI, Fighting Styles, Subclasses).
*   `data/classes.ts`: Ajuste no `getDefaultFightingStyleOptions` para aceitar `mechanicsFamily`.

### 4. Verificação e Testes
*   **Suíte de Testes:** **49/49** testes aprovados (incluindo novas regressões em `classFeatures.test.ts` e `guardianCreation.test.ts`).
*   **Build:** `build:control` finalizado com sucesso.
*   **Casos Cobertos:**
    *   Herança automática Ranger -> Guardian.
    *   Magias exclusivas de Guardian funcionando corretamente.
    *   Isolamento de magias exclusivas (Ranger não acessa magias de Guardian).
    *   Preservação da identidade do Guardian no fluxo de criação.

> **Nota:** Os únicos avisos persistentes no build referem-se a chaves duplicadas nos arquivos de i18n (`catalog.ts`), que já existiam previamente e não possuem relação com estas alterações.