### PR TITLE
feat(combat): support modal variants with per-target pending resolution

### DIFF
--- a/apps/control-server/app/services/combat_service/save_resolve.py
+++ b/apps/control-server/app/services/combat_service/save_resolve.py
@@ -83,6 +83,11 @@ class CombatSaveResolveMixin:
             (p for p in state.participants if p["id"] == attacker_participant_id),
             None,
         )
+        pending_spell_context = cls._build_pending_spell_context_from_payload(
+            pending_save,
+            target_participant=target_p,
+        )
+        manual_notes_by_target = pending_spell_context.get("manual_notes_by_target")
 
         if effect_roll_required and (not is_saved or save_success_outcome == "half_damage"):
             if attacker:
@@ -110,6 +115,13 @@ class CombatSaveResolveMixin:
                         "roll": roll_result.total,
                         "roll_result": roll_result.model_dump(mode="json"),
                         "save_success_outcome": save_success_outcome,
+                        "variant_scope": pending_save.get("variant_scope"),
+                        "selected_variant_key": pending_spell_context.get("selected_variant_key"),
+                        "selected_variant_label": pending_spell_context.get("selected_variant_label"),
+                        "target_variant_assignments": pending_spell_context.get("target_variant_assignments"),
+                        "manual_notes_by_target": manual_notes_by_target,
+                        "effects": pending_spell_context.get("effects"),
+                        "on_end_effects": pending_spell_context.get("on_end_effects"),
                     },
                 )
         elif not is_saved or save_success_outcome == "half_damage":
@@ -162,6 +174,9 @@ class CombatSaveResolveMixin:
                 "new_hp": new_hp,
                 "roll_result": roll_result.model_dump(mode="json"),
                 "pending_spell_id": pending_spell_id,
+                "selected_variant_key": pending_spell_context.get("selected_variant_key"),
+                "target_variant_assignments": pending_spell_context.get("target_variant_assignments"),
+                "manual_notes_by_target": manual_notes_by_target,
             }
             flag_modified(state, "participants")
             db.add(state)
@@ -183,6 +198,7 @@ class CombatSaveResolveMixin:
             log_message += f" {amount} de {effect_kind} de {damage_type or 'energia'}{effect_msg}"
         if pending_spell_id:
             log_message += " Efeito pendente."
+        log_message = f"{log_message}{cls._format_manual_notes_for_log(manual_notes_by_target)}".strip()
         await cls._emit_log(session_id, {
             "message": log_message,
             "actorUserId": actor_user_id,
@@ -197,6 +213,7 @@ class CombatSaveResolveMixin:
             "damage": amount if effect_kind == "damage" else 0,
             "healing": amount if effect_kind == "healing" else 0,
             "damage_type": damage_type,
+            "selected_variant_key": pending_spell_context.get("selected_variant_key"),
             "is_critical": False,
             "is_hit": None,
             "is_saved": is_saved,
@@ -224,4 +241,6 @@ class CombatSaveResolveMixin:
             "elemental_affinity_bonus": pending_save.get("elemental_affinity_bonus"),
             "effect_rolls": effect_rolls,
             "effect_roll_source": req.roll_source,
+            "target_variant_assignments": pending_spell_context.get("target_variant_assignments"),
+            "manual_notes_by_target": manual_notes_by_target,
         }

--- a/apps/control-server/app/services/combat_service/spells/cast_target_effect.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target_effect.py
@@ -77,6 +77,19 @@ class CastTargetEffectMixin:
             raise CombatServiceError(
                 "Pending spell effect is missing target information.", 400
             )
+        target_participant = next(
+            (
+                participant
+                for participant in state.participants
+                if participant.get("ref_id") == target_ref_id and participant.get("kind") == target_kind
+            ),
+            None,
+        )
+        pending_spell_context = cls._build_pending_spell_context_from_payload(
+            pending_spell,
+            target_participant=target_participant,
+        )
+        manual_notes_by_target = pending_spell_context.get("manual_notes_by_target")
 
         effect_rolls: list[int] = []
         base_effect = 0
@@ -121,6 +134,15 @@ class CastTargetEffectMixin:
                 concentration_roll_source=req.concentration_roll_source,
                 concentration_manual_roll=req.concentration_manual_roll,
             )
+        if target_participant is not None and cls._spell_context_has_declarative_effects(
+            pending_spell_context
+        ):
+            cls._apply_declarative_spell_effects(
+                state=state,
+                attacker=attacker,
+                target_participant=target_participant,
+                spell_context=pending_spell_context,
+            )
 
         cls._clear_participant_pending_attack(attacker)
         flag_modified(state, "participants")
@@ -159,6 +181,7 @@ class CastTargetEffectMixin:
             concentration_check.get("summary_text"), str
         ):
             log_message = f"{log_message} {concentration_check['summary_text']}".strip()
+        log_message = f"{log_message}{cls._format_manual_notes_for_log(manual_notes_by_target)}".strip()
 
         await cls._emit_log(
             session_id,
@@ -172,6 +195,7 @@ class CastTargetEffectMixin:
         return {
             "spell_name": pending_spell.get("spell_name"),
             "spell_canonical_key": pending_spell.get("spell_canonical_key"),
+            "selected_variant_key": pending_spell_context.get("selected_variant_key"),
             "action_kind": pending_spell.get("action_kind"),
             "effect_kind": effect_kind,
             "damage": amount if effect_kind == "damage" else 0,
@@ -207,4 +231,6 @@ class CastTargetEffectMixin:
             "elemental_affinity_bonus": pending_spell.get("elemental_affinity_bonus"),
             "effect_rolls": effect_rolls,
             "effect_roll_source": req.roll_source,
+            "target_variant_assignments": pending_spell_context.get("target_variant_assignments"),
+            "manual_notes_by_target": manual_notes_by_target,
         }

--- a/apps/control-server/app/services/combat_service/spells/spell_resolution_common.py
+++ b/apps/control-server/app/services/combat_service/spells/spell_resolution_common.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from sqlmodel import Session
 
 from app.models.combat import CombatState
+from app.services.combat_service.exceptions import CombatServiceError
 from app.schemas.roll import RollResult
 
 
@@ -35,6 +36,184 @@ class SpellResolutionResult:
 
 
 class SpellResolutionCommonMixin:
+    @classmethod
+    def _normalize_pending_target_variant_assignments(
+        cls,
+        raw_assignments: object,
+    ) -> list[dict]:
+        if not isinstance(raw_assignments, list):
+            return []
+        normalized: list[dict] = []
+        seen_target_ids: set[str] = set()
+        for entry in raw_assignments:
+            if not isinstance(entry, dict):
+                continue
+            target_participant_id = entry.get("target_participant_id")
+            variant_key = entry.get("variant_key")
+            if not isinstance(target_participant_id, str) or not target_participant_id.strip():
+                raise CombatServiceError(
+                    "Modal pending state is missing target_participant_id in a variant assignment.",
+                    400,
+                )
+            if not isinstance(variant_key, str) or not variant_key.strip():
+                raise CombatServiceError(
+                    "Modal pending state is missing variant_key in a target assignment.",
+                    400,
+                )
+            normalized_target_id = target_participant_id.strip()
+            if normalized_target_id in seen_target_ids:
+                raise CombatServiceError(
+                    f"Duplicate modal pending variant assignment for participant {normalized_target_id}.",
+                    400,
+                )
+            seen_target_ids.add(normalized_target_id)
+            normalized.append(
+                {
+                    "target_participant_id": normalized_target_id,
+                    "variant_key": variant_key.strip(),
+                    "variant_label": entry.get("variant_label"),
+                    "target_ref_id": entry.get("target_ref_id"),
+                }
+            )
+        return normalized
+
+    @classmethod
+    def _find_pending_target_variant_assignment(
+        cls,
+        pending_payload: dict,
+        *,
+        target_participant_id: str | None,
+    ) -> dict | None:
+        if not isinstance(target_participant_id, str):
+            return None
+        assignments = cls._normalize_pending_target_variant_assignments(
+            pending_payload.get("target_variant_assignments")
+        )
+        for assignment in assignments:
+            if assignment["target_participant_id"] == target_participant_id:
+                return assignment
+        return None
+
+    @classmethod
+    def _build_pending_modal_payload(
+        cls,
+        spell_context: dict,
+        target_p: dict,
+    ) -> dict:
+        target_participant_id = target_p.get("id")
+        target_variant_assignments = cls._normalize_pending_target_variant_assignments(
+            spell_context.get("target_variant_assignments")
+        )
+        manual_notes_by_target = [
+            entry
+            for entry in (spell_context.get("manual_notes_by_target") or [])
+            if isinstance(entry, dict)
+        ]
+        effects = spell_context.get("effects")
+        on_end_effects = spell_context.get("on_end_effects")
+
+        if target_variant_assignments:
+            assignment = cls._find_pending_target_variant_assignment(
+                {"target_variant_assignments": target_variant_assignments},
+                target_participant_id=target_participant_id,
+            )
+            if assignment is None:
+                raise CombatServiceError(
+                    f"Missing modal variant assignment for target participant {target_participant_id}.",
+                    400,
+                )
+            return {
+                "variant_scope": "per_target",
+                "selected_variant_key": assignment["variant_key"],
+                "selected_variant_label": assignment.get("variant_label"),
+                "target_variant_assignments": target_variant_assignments,
+                "manual_notes_by_target": manual_notes_by_target,
+                "effects": list(effects or []),
+                "on_end_effects": list(on_end_effects or []),
+            }
+
+        selected_variant_key = spell_context.get("selected_variant_key")
+        if isinstance(selected_variant_key, str) and selected_variant_key.strip():
+            return {
+                "variant_scope": "single_target",
+                "selected_variant_key": selected_variant_key.strip(),
+                "selected_variant_label": spell_context.get("selected_variant_label"),
+                "target_variant_assignments": [
+                    {
+                        "target_participant_id": target_participant_id,
+                        "target_ref_id": target_p.get("ref_id"),
+                        "variant_key": selected_variant_key.strip(),
+                        "variant_label": spell_context.get("selected_variant_label"),
+                    }
+                ]
+                if isinstance(target_participant_id, str)
+                else None,
+                "manual_notes_by_target": manual_notes_by_target,
+                "effects": list(effects or []),
+                "on_end_effects": list(on_end_effects or []),
+            }
+
+        return {}
+
+    @classmethod
+    def _build_pending_spell_context_from_payload(
+        cls,
+        pending_payload: dict,
+        *,
+        target_participant: dict | None,
+    ) -> dict:
+        spell_context = {
+            "spell_name": pending_payload.get("spell_name"),
+            "spell_canonical_key": pending_payload.get("spell_canonical_key"),
+            "concentration": bool(pending_payload.get("concentration")),
+            "effects": list(pending_payload.get("effects") or []),
+            "on_end_effects": list(pending_payload.get("on_end_effects") or []),
+            "selected_variant_key": pending_payload.get("selected_variant_key"),
+            "selected_variant_label": pending_payload.get("selected_variant_label"),
+            "target_variant_assignments": pending_payload.get("target_variant_assignments"),
+            "manual_notes_by_target": pending_payload.get("manual_notes_by_target"),
+        }
+        variant_scope = pending_payload.get("variant_scope")
+        if variant_scope != "per_target":
+            return spell_context
+
+        target_participant_id = (
+            target_participant.get("id") if isinstance(target_participant, dict) else None
+        )
+        assignment = cls._find_pending_target_variant_assignment(
+            pending_payload,
+            target_participant_id=target_participant_id,
+        )
+        if assignment is None:
+            raise CombatServiceError(
+                f"Pending modal spell is missing a variant assignment for target participant {target_participant_id}.",
+                400,
+            )
+        spell_context["selected_variant_key"] = assignment["variant_key"]
+        spell_context["selected_variant_label"] = assignment.get("variant_label")
+        return spell_context
+
+    @classmethod
+    def _format_manual_notes_for_log(cls, manual_notes_by_target: object) -> str:
+        if not isinstance(manual_notes_by_target, list):
+            return ""
+        chunks: list[str] = []
+        for entry in manual_notes_by_target:
+            if not isinstance(entry, dict):
+                continue
+            target_name = entry.get("target_display_name") or "Target"
+            notes = entry.get("manual_notes")
+            if not isinstance(notes, list) or not notes:
+                continue
+            labels = [
+                note.get("label")
+                for note in notes
+                if isinstance(note, dict) and isinstance(note.get("label"), str)
+            ]
+            if labels:
+                chunks.append(f"{target_name}: {', '.join(labels)}")
+        return f" Notas manuais: {'; '.join(chunks)}." if chunks else ""
+
     @classmethod
     def _apply_spell_effect(
         cls,
@@ -102,6 +281,7 @@ class SpellResolutionCommonMixin:
             "is_critical": is_critical,
             "roll": roll_total,
             "roll_result": roll_result.model_dump(mode="json") if roll_result else None,
+            **cls._build_pending_modal_payload(spell_context, target_p),
         }
         if target_ac is not None:
             base["target_ac"] = target_ac

--- a/apps/control-server/tests/test_modal_pending_resolution.py
+++ b/apps/control-server/tests/test_modal_pending_resolution.py
@@ -1,0 +1,415 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.models.combat import CombatPhase, CombatState
+from app.models.session_state import SessionState
+from app.schemas.combat import CombatResolveSaveRequest, CombatResolveSpellEffectRequest
+from app.schemas.roll import RollResult
+from app.services.combat import CombatService, CombatServiceError
+
+
+def _build_state() -> CombatState:
+    return CombatState(
+        id="combat-modal-pending",
+        session_id="session-modal-pending",
+        phase=CombatPhase.active,
+        round=1,
+        current_turn_index=0,
+        participants=[
+            {
+                "id": "p1",
+                "ref_id": "player-1",
+                "kind": "player",
+                "display_name": "Mage",
+                "initiative": 15,
+                "status": "active",
+                "team": "players",
+                "visible": True,
+                "actor_user_id": "user-1",
+                "active_effects": [],
+            },
+            {
+                "id": "e1",
+                "ref_id": "enemy-1",
+                "kind": "session_entity",
+                "display_name": "Target A",
+                "initiative": 10,
+                "status": "active",
+                "team": "enemies",
+                "visible": True,
+                "actor_user_id": None,
+                "active_effects": [],
+            },
+            {
+                "id": "e2",
+                "ref_id": "enemy-2",
+                "kind": "session_entity",
+                "display_name": "Target B",
+                "initiative": 8,
+                "status": "active",
+                "team": "enemies",
+                "visible": True,
+                "actor_user_id": None,
+                "active_effects": [],
+            },
+        ],
+    )
+
+
+def _attacker_state() -> SessionState:
+    return SessionState(
+        id="state-1",
+        session_id="session-modal-pending",
+        player_user_id="user-1",
+        state_json={
+            "wildShape": {"active": False},
+            "spellcasting": {"slots": {"1": {"used": 0, "max": 4}}},
+        },
+    )
+
+
+def _manual_notes() -> list[dict]:
+    return [
+        {
+            "target_participant_id": "e1",
+            "target_ref_id": "enemy-1",
+            "target_display_name": "Target A",
+            "variant_key": "bears_endurance",
+            "variant_label": "Resistência do Urso",
+            "manual_notes": [
+                {
+                    "key": "grant_temp_hp",
+                    "label": "PV temporários",
+                    "description": "Conceda 2d6 PV temporários manualmente.",
+                }
+            ],
+        },
+        {
+            "target_participant_id": "e2",
+            "target_ref_id": "enemy-2",
+            "target_display_name": "Target B",
+            "variant_key": "foxs_cunning",
+            "variant_label": "Esperteza da Raposa",
+            "manual_notes": [
+                {
+                    "key": "recall",
+                    "label": "Observação",
+                    "description": "Sem efeito secundário automatizado.",
+                }
+            ],
+        },
+    ]
+
+
+def _target_variant_assignments() -> list[dict]:
+    return [
+        {
+            "target_participant_id": "e1",
+            "target_ref_id": "enemy-1",
+            "variant_key": "bears_endurance",
+            "variant_label": "Resistência do Urso",
+        },
+        {
+            "target_participant_id": "e2",
+            "target_ref_id": "enemy-2",
+            "variant_key": "foxs_cunning",
+            "variant_label": "Esperteza da Raposa",
+        },
+    ]
+
+
+class ModalPendingResolutionTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.db = MagicMock()
+        self.state = _build_state()
+        self.attacker_state = _attacker_state()
+
+    def _get_stats_side_effect(self, _db, ref_id, kind, _session_id):
+        if ref_id == "player-1" and kind == "player":
+            return (self.attacker_state, 12, 10, 10, 3, 4)
+        raise AssertionError(f"Unexpected stats lookup: {ref_id}/{kind}")
+
+    @patch("app.services.combat.CombatService._emit_log", new_callable=AsyncMock)
+    @patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock)
+    @patch("app.services.combat.CombatService._emit_entity_hp_update", new_callable=AsyncMock)
+    async def test_resolve_pending_save_uses_assignment_for_resolved_target(
+        self,
+        _mock_emit_entity_hp_update,
+        _mock_emit_state,
+        mock_emit_log,
+    ):
+        target_b = self.state.participants[2]
+        target_b["pending_save"] = {
+            "id": "pending-save-1",
+            "status": "pending",
+            "spell_name": "Modal Save Test Spell",
+            "spell_canonical_key": "modal_save_test_spell",
+            "action_kind": "saving_throw",
+            "save_ability": "wisdom",
+            "save_dc": 15,
+            "effect_kind": "damage",
+            "effect_bonus": 0,
+            "effect_dice": "1d6",
+            "effect_roll_required": True,
+            "save_success_outcome": "none",
+            "damage_type": "psychic",
+            "attacker_ref_id": "player-1",
+            "attacker_participant_id": "p1",
+            "attacker_display_name": "Mage",
+            "variant_scope": "per_target",
+            "selected_variant_key": "bears_endurance",
+            "selected_variant_label": "Resistência do Urso",
+            "target_variant_assignments": _target_variant_assignments(),
+            "manual_notes_by_target": _manual_notes(),
+            "effects": [
+                {
+                    "type": "advantage_on_checks",
+                    "target": "selected_target",
+                    "params": {"ability": "intelligence"},
+                    "stacking": "replace",
+                }
+            ],
+            "on_end_effects": [],
+        }
+
+        save_roll = RollResult(
+            event_id="save-roll-1",
+            roll_type="save",
+            actor_kind="session_entity",
+            actor_ref_id="enemy-2",
+            actor_display_name="Target B",
+            rolls=[5],
+            selected_roll=5,
+            advantage_mode="normal",
+            modifier_used=0,
+            override_used=False,
+            formula="1d20 + 0",
+            total=5,
+            ability="wisdom",
+            dc=15,
+            success=False,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state), patch(
+            "app.services.combat.CombatService._get_stats",
+            side_effect=self._get_stats_side_effect,
+        ), patch(
+            "app.services.combat.CombatService._build_roll_actor_stats_for_save",
+            return_value=MagicMock(),
+        ), patch(
+            "app.services.combat.CombatService._create_pending_spell_effect",
+            wraps=CombatService._create_pending_spell_effect,
+        ), patch(
+            "app.services.combat_service.save_resolve.resolve_saving_throw",
+            return_value=save_roll,
+        ):
+            result = await CombatService.resolve_pending_save(
+                self.db,
+                "session-modal-pending",
+                CombatResolveSaveRequest(
+                    target_participant_id="e2",
+                    pending_save_id="pending-save-1",
+                ),
+                "user-1",
+                True,
+            )
+
+        pending_spell = self.state.participants[0]["pending_attack"]
+        self.assertEqual(result["selected_variant_key"], "foxs_cunning")
+        self.assertEqual(pending_spell["selected_variant_key"], "foxs_cunning")
+        self.assertEqual(
+            pending_spell["target_variant_assignments"][1]["target_participant_id"], "e2"
+        )
+        self.assertEqual(
+            pending_spell["manual_notes_by_target"][1]["variant_key"], "foxs_cunning"
+        )
+        self.assertIn("Notas manuais", mock_emit_log.await_args.args[1]["message"])
+
+    @patch("app.services.combat.CombatService._emit_log", new_callable=AsyncMock)
+    @patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock)
+    @patch("app.services.combat.CombatService._emit_entity_hp_update", new_callable=AsyncMock)
+    async def test_cast_spell_effect_applies_only_target_variant_effect(
+        self,
+        _mock_emit_entity_hp_update,
+        _mock_emit_state,
+        mock_emit_log,
+    ):
+        attacker = self.state.participants[0]
+        target_b = self.state.participants[2]
+        attacker["pending_attack"] = {
+            "id": "pending-spell-1",
+            "type": "player_spell_effect",
+            "spell_name": "Modal Save Test Spell",
+            "spell_canonical_key": "modal_save_test_spell",
+            "action_kind": "saving_throw",
+            "effect_kind": "damage",
+            "effect_dice": None,
+            "effect_bonus": 0,
+            "damage_type": "psychic",
+            "target_ref_id": "enemy-2",
+            "target_kind": "session_entity",
+            "target_display_name": "Target B",
+            "variant_scope": "per_target",
+            "selected_variant_key": "bears_endurance",
+            "selected_variant_label": "Resistência do Urso",
+            "target_variant_assignments": _target_variant_assignments(),
+            "manual_notes_by_target": _manual_notes(),
+            "effects": [
+                {
+                    "type": "advantage_on_checks",
+                    "target": "selected_target",
+                    "params": {"ability": "intelligence"},
+                    "stacking": "replace",
+                }
+            ],
+            "on_end_effects": [],
+        }
+
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state), patch(
+            "app.services.combat.CombatService._get_stats",
+            side_effect=self._get_stats_side_effect,
+        ):
+            result = await CombatService.cast_spell_effect(
+                self.db,
+                "session-modal-pending",
+                CombatResolveSpellEffectRequest(
+                    actor_participant_id="p1",
+                    pending_spell_id="pending-spell-1",
+                ),
+                "user-1",
+                False,
+            )
+
+        self.assertEqual(result["selected_variant_key"], "foxs_cunning")
+        self.assertEqual(len(target_b["active_effects"]), 1)
+        self.assertEqual(
+            target_b["active_effects"][0]["metadata"]["declarative_effect"]["params"]["ability"],
+            "intelligence",
+        )
+        self.assertEqual(len(result["manual_notes_by_target"]), 2)
+        self.assertEqual(
+            result["manual_notes_by_target"][1]["target_participant_id"],
+            "e2",
+        )
+        self.assertEqual(
+            result["manual_notes_by_target"][1]["variant_key"],
+            "foxs_cunning",
+        )
+        self.assertEqual(
+            result["manual_notes_by_target"][1]["manual_notes"][0]["label"],
+            "Observação",
+        )
+        self.assertEqual(
+            result["manual_notes_by_target"][0]["variant_key"],
+            "bears_endurance",
+        )
+        final_log = mock_emit_log.await_args.args[1]["message"]
+        self.assertIn("Target B: Observação", final_log)
+        self.assertIn("Target A: PV temporários", final_log)
+
+    @patch("app.services.combat.CombatService._emit_log", new_callable=AsyncMock)
+    @patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock)
+    @patch("app.services.combat.CombatService._emit_entity_hp_update", new_callable=AsyncMock)
+    async def test_pending_spell_result_keeps_resolved_target_variant_and_notes(
+        self,
+        _mock_emit_entity_hp_update,
+        _mock_emit_state,
+        mock_emit_log,
+    ):
+        attacker = self.state.participants[0]
+        attacker["pending_attack"] = {
+            "id": "pending-spell-3",
+            "type": "player_spell_effect",
+            "spell_name": "Modal Save Test Spell",
+            "spell_canonical_key": "modal_save_test_spell",
+            "action_kind": "saving_throw",
+            "effect_kind": "damage",
+            "effect_dice": "1d6",
+            "effect_bonus": 0,
+            "damage_type": "psychic",
+            "target_ref_id": "enemy-1",
+            "target_kind": "session_entity",
+            "target_display_name": "Target A",
+            "is_saved": False,
+            "save_success_outcome": "none",
+            "variant_scope": "per_target",
+            "selected_variant_key": "foxs_cunning",
+            "selected_variant_label": "Esperteza da Raposa",
+            "target_variant_assignments": _target_variant_assignments(),
+            "manual_notes_by_target": _manual_notes(),
+            "effects": [],
+            "on_end_effects": [],
+        }
+
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state), patch(
+            "app.services.combat.CombatService._get_stats",
+            side_effect=self._get_stats_side_effect,
+        ), patch(
+            "app.services.combat.CombatService._apply_damage_to_target",
+            return_value=(4, "", 10, None),
+        ):
+            result = await CombatService.cast_spell_effect(
+                self.db,
+                "session-modal-pending",
+                CombatResolveSpellEffectRequest(
+                    actor_participant_id="p1",
+                    pending_spell_id="pending-spell-3",
+                    roll_source="manual",
+                    manual_rolls=[4],
+                ),
+                "user-1",
+                False,
+            )
+
+        self.assertEqual(result["selected_variant_key"], "bears_endurance")
+        self.assertEqual(result["target_display_name"], "Target A")
+        self.assertEqual(result["manual_notes_by_target"][0]["target_participant_id"], "e1")
+        self.assertEqual(result["manual_notes_by_target"][0]["variant_key"], "bears_endurance")
+        self.assertEqual(result["manual_notes_by_target"][0]["manual_notes"][0]["label"], "PV temporários")
+        self.assertEqual(result["manual_notes_by_target"][1]["variant_key"], "foxs_cunning")
+        final_log = mock_emit_log.await_args.args[1]["message"]
+        self.assertIn("Target A: PV temporários", final_log)
+        self.assertIn("Target B: Observação", final_log)
+
+    async def test_cast_spell_effect_fails_when_target_assignment_is_missing(self):
+        attacker = self.state.participants[0]
+        attacker["pending_attack"] = {
+            "id": "pending-spell-2",
+            "type": "player_spell_effect",
+            "spell_name": "Modal Save Test Spell",
+            "spell_canonical_key": "modal_save_test_spell",
+            "action_kind": "saving_throw",
+            "effect_kind": "damage",
+            "effect_dice": None,
+            "effect_bonus": 0,
+            "damage_type": "psychic",
+            "target_ref_id": "enemy-2",
+            "target_kind": "session_entity",
+            "target_display_name": "Target B",
+            "variant_scope": "per_target",
+            "selected_variant_key": "bears_endurance",
+            "target_variant_assignments": [_target_variant_assignments()[0]],
+            "manual_notes_by_target": _manual_notes(),
+            "effects": [],
+            "on_end_effects": [],
+        }
+
+        with patch("app.services.combat.CombatService.get_state", return_value=self.state), patch(
+            "app.services.combat.CombatService._get_stats",
+            side_effect=self._get_stats_side_effect,
+        ):
+            with self.assertRaises(CombatServiceError):
+                await CombatService.cast_spell_effect(
+                    self.db,
+                    "session-modal-pending",
+                    CombatResolveSpellEffectRequest(
+                        actor_participant_id="p1",
+                        pending_spell_id="pending-spell-2",
+                    ),
+                    "user-1",
+                    False,
+                )


### PR DESCRIPTION
## What changed

- persists modal variant assignments and manual notes through pending save and pending spell effect state
- rehydrates modal variant context per target during pending resolution
- applies only the resolved target's variant when the pending effect is finally executed
- adds focused backend coverage with a dedicated fake modal spell pipeline for per-target pending resolution

## Why

Modal multi-target spells already support per-target variants for immediate and declarative effects, but the pending resolution pipeline could not safely carry target-specific variant context across save/effect stages. This blocked future spells that need both per-target variant assignment and delayed mechanical resolution.

## Scope

- `Enhance Ability` remains a regression case only
- this phase is validated primarily through a dedicated fake modal spell that combines per-target variant assignments with pending save resolution
- multi-target modal pending casts require explicit `target_variant_assignments`
- pending resolution uses the assignment for the target being resolved, never a global or first-selected variant

## Validation

- `python3 -m py_compile apps/control-server/app/services/combat_service/spells/spell_resolution_common.py apps/control-server/app/services/combat_service/save_resolve.py apps/control-server/app/services/combat_service/spells/cast_target_effect.py apps/control-server/tests/test_modal_pending_resolution.py`
