### PR TITLE
feat(combat-ui): support modal variant assignments through pending spell resolution

### DIFF
--- a/apps/control-web/src/features/combat-ui/gm/GmPendingSavesPanel.tsx
+++ b/apps/control-web/src/features/combat-ui/gm/GmPendingSavesPanel.tsx
@@ -1,4 +1,8 @@
 import { useState } from "react";
+import {
+  findManualNotesForTarget,
+  resolveTargetVariantLabel,
+} from "../spellVariantUi";
 import type { CombatParticipant } from "../../../shared/api/combatRepo";
 import { useLocale } from "../../../shared/hooks/useLocale";
 
@@ -26,6 +30,18 @@ export const GmPendingSavesPanel = ({
         {pendingSaves.map((p) => {
           const save = p.pending_save;
           const isExpanded = expandedId === p.id;
+          const variantLabel = resolveTargetVariantLabel({
+            targetVariantAssignments: save.target_variant_assignments,
+            manualNotesByTarget: save.manual_notes_by_target,
+            selectedVariantKey: save.selected_variant_key,
+            selectedVariantLabel: save.selected_variant_label,
+            targetParticipantId: p.id,
+            targetRefId: p.ref_id,
+          });
+          const manualNotesEntry = findManualNotesForTarget(save.manual_notes_by_target, {
+            targetParticipantId: p.id,
+            targetRefId: p.ref_id,
+          });
           return (
             <div key={p.id} className="rounded-2xl bg-slate-950/40 p-4 space-y-3">
               <div className="flex flex-wrap items-center justify-between gap-3">
@@ -35,6 +51,18 @@ export const GmPendingSavesPanel = ({
                     {save.spell_name} — save de {save.save_ability} CD {save.save_dc}
                     {save.attacker_display_name ? ` (lancado por ${save.attacker_display_name})` : ""}
                   </p>
+                  {variantLabel ? (
+                    <p className="mt-1 text-xs text-fuchsia-200">Variante: {variantLabel}</p>
+                  ) : null}
+                  {manualNotesEntry?.manual_notes.length ? (
+                    <div className="mt-2 space-y-1 text-xs text-amber-100">
+                      {manualNotesEntry.manual_notes.map((note) => (
+                        <p key={note.key}>
+                          {note.label} - {note.description}
+                        </p>
+                      ))}
+                    </div>
+                  ) : null}
                 </div>
               </div>
               {isExpanded ? (

--- a/apps/control-web/src/features/combat-ui/gm/gmPendingSavesPanel.test.tsx
+++ b/apps/control-web/src/features/combat-ui/gm/gmPendingSavesPanel.test.tsx
@@ -1,0 +1,86 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { GmPendingSavesPanel } from "./GmPendingSavesPanel";
+
+vi.mock("../../../shared/hooks/useLocale", () => ({
+  useLocale: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("GmPendingSavesPanel", () => {
+  it("exibe a variante e as notas manuais do alvo correto", () => {
+    const markup = renderToStaticMarkup(
+      <GmPendingSavesPanel
+        pendingSaves={[
+          {
+            id: "enemy-1",
+            kind: "session_entity",
+            ref_id: "session_entity:goblin-a",
+            display_name: "Goblin A",
+            initiative: 12,
+            status: "active",
+            team: "enemies",
+            visible: true,
+            actor_user_id: null,
+            pending_save: {
+              id: "pending-save-1",
+              status: "pending",
+              spell_name: "Modal Save Test Spell",
+              save_ability: "wisdom",
+              save_dc: 14,
+              attacker_display_name: "Mage",
+              selected_variant_key: "foxs_cunning",
+              target_variant_assignments: [
+                {
+                  target_participant_id: "enemy-1",
+                  variant_key: "foxs_cunning",
+                  variant_label: "Esperteza da Raposa",
+                },
+                {
+                  target_participant_id: "enemy-2",
+                  variant_key: "owls_wisdom",
+                  variant_label: "Sabedoria da Coruja",
+                },
+              ],
+              manual_notes_by_target: [
+                {
+                  target_participant_id: "enemy-1",
+                  target_display_name: "Goblin A",
+                  variant_key: "foxs_cunning",
+                  variant_label: "Esperteza da Raposa",
+                  manual_notes: [
+                    {
+                      key: "fox-note",
+                      label: "Manual A",
+                      description: "Descricao A",
+                    },
+                  ],
+                },
+                {
+                  target_participant_id: "enemy-2",
+                  target_display_name: "Goblin B",
+                  variant_key: "owls_wisdom",
+                  variant_label: "Sabedoria da Coruja",
+                  manual_notes: [
+                    {
+                      key: "owl-note",
+                      label: "Manual B",
+                      description: "Descricao B",
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ]}
+        submitting={false}
+        onResolveSave={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("Variante: Esperteza da Raposa");
+    expect(markup).toContain("Manual A - Descricao A");
+    expect(markup).not.toContain("Manual B - Descricao B");
+  });
+});

--- a/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
+++ b/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
@@ -39,6 +39,7 @@ import {
   useMovementPreview,
 } from "../map/useMovementPreview";
 import { combatRepo, type PendingSave } from "../../../shared/api/combatRepo";
+import { buildPendingSaveReason, resolveTargetVariantLabel } from "../spellVariantUi";
 
 type Props = {
   campaignId?: string | null;
@@ -583,7 +584,18 @@ export const PlayerCombatModeShell = ({
             ability: activePendingSave.save_ability as AbilityName,
             advantageMode: "normal",
             dc: activePendingSave.save_dc,
-            reason: `${activePendingSave.spell_name} - save de ${activePendingSave.save_ability}`,
+            reason: buildPendingSaveReason({
+              spellName: activePendingSave.spell_name,
+              saveAbility: activePendingSave.save_ability,
+              variantLabel: resolveTargetVariantLabel({
+                targetVariantAssignments: activePendingSave.target_variant_assignments,
+                manualNotesByTarget: activePendingSave.manual_notes_by_target,
+                selectedVariantKey: activePendingSave.selected_variant_key,
+                selectedVariantLabel: activePendingSave.selected_variant_label,
+                targetParticipantId: activePendingSave.participantId,
+                targetRefId: activePendingSave.participantRefId,
+              }),
+            }),
             issuedBy: activePendingSave.attacker_display_name ?? undefined,
             issuedByLabel: t("combatUi.castBy"),
           }}

--- a/apps/control-web/src/features/combat-ui/spellVariantUi.test.ts
+++ b/apps/control-web/src/features/combat-ui/spellVariantUi.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPendingSaveReason,
+  resolveTargetVariantLabel,
+} from "./spellVariantUi";
+
+describe("spellVariantUi", () => {
+  it("resolve a variante correta por alvo mesmo fora de ordem", () => {
+    const targetVariantAssignments = [
+      {
+        target_participant_id: "enemy-b",
+        variant_key: "owls_wisdom",
+        variant_label: "Sabedoria da Coruja",
+      },
+      {
+        target_participant_id: "enemy-a",
+        variant_key: "foxs_cunning",
+        variant_label: "Esperteza da Raposa",
+      },
+    ];
+
+    expect(
+      resolveTargetVariantLabel({
+        targetVariantAssignments,
+        selectedVariantKey: null,
+        targetParticipantId: "enemy-a",
+      }),
+    ).toBe("Esperteza da Raposa");
+
+    expect(
+      resolveTargetVariantLabel({
+        targetVariantAssignments,
+        selectedVariantKey: null,
+        targetParticipantId: "enemy-b",
+      }),
+    ).toBe("Sabedoria da Coruja");
+  });
+
+  it("monta o reason do pending save com a variante reidratada", () => {
+    expect(
+      buildPendingSaveReason({
+        spellName: "Modal Save Test Spell",
+        saveAbility: "wisdom",
+        variantLabel: "Esperteza da Raposa",
+      }),
+    ).toBe("Modal Save Test Spell - save de wisdom - variante: Esperteza da Raposa");
+  });
+
+  it("faz fallback visual seguro quando a chave da variante e desconhecida", () => {
+    expect(
+      resolveTargetVariantLabel({
+        selectedVariantKey: "mystery_mode",
+      }),
+    ).toBe("Variante desconhecida (Mystery Mode)");
+  });
+});

--- a/apps/control-web/src/features/combat-ui/spellVariantUi.ts
+++ b/apps/control-web/src/features/combat-ui/spellVariantUi.ts
@@ -1,0 +1,133 @@
+import type { SpellVariantManualNote } from "../../entities/base-spell";
+
+type TargetVariantAssignmentLike = {
+  target_participant_id?: string | null;
+  target_ref_id?: string | null;
+  variant_key: string;
+  variant_label?: string | null;
+};
+
+type ManualNotesByTargetEntryLike = {
+  target_participant_id?: string | null;
+  target_ref_id?: string | null;
+  target_display_name: string;
+  variant_key: string;
+  variant_label?: string | null;
+  manual_notes: SpellVariantManualNote[];
+};
+
+type TargetLookup = {
+  targetParticipantId?: string | null;
+  targetRefId?: string | null;
+};
+
+const humanizeVariantKey = (variantKey: string) =>
+  variantKey
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+
+const matchesTarget = (
+  entry: { target_participant_id?: string | null; target_ref_id?: string | null },
+  lookup: TargetLookup,
+) => {
+  if (lookup.targetParticipantId && entry.target_participant_id === lookup.targetParticipantId) {
+    return true;
+  }
+  if (lookup.targetRefId && entry.target_ref_id === lookup.targetRefId) {
+    return true;
+  }
+  return false;
+};
+
+export const findTargetVariantAssignment = (
+  targetVariantAssignments: TargetVariantAssignmentLike[] | null | undefined,
+  lookup: TargetLookup,
+) => {
+  if (!targetVariantAssignments?.length) {
+    return null;
+  }
+  return targetVariantAssignments.find((entry) => matchesTarget(entry, lookup)) ?? null;
+};
+
+export const findManualNotesForTarget = (
+  manualNotesByTarget: ManualNotesByTargetEntryLike[] | null | undefined,
+  lookup: TargetLookup,
+) => {
+  if (!manualNotesByTarget?.length) {
+    return null;
+  }
+  return manualNotesByTarget.find((entry) => matchesTarget(entry, lookup)) ?? null;
+};
+
+export const resolveTargetVariantLabel = ({
+  targetVariantAssignments,
+  manualNotesByTarget,
+  selectedVariantKey,
+  selectedVariantLabel,
+  targetParticipantId,
+  targetRefId,
+}: {
+  targetVariantAssignments?: TargetVariantAssignmentLike[] | null;
+  manualNotesByTarget?: ManualNotesByTargetEntryLike[] | null;
+  selectedVariantKey?: string | null;
+  selectedVariantLabel?: string | null;
+  targetParticipantId?: string | null;
+  targetRefId?: string | null;
+}) => {
+  const assignment = findTargetVariantAssignment(targetVariantAssignments, {
+    targetParticipantId,
+    targetRefId,
+  });
+  if (assignment?.variant_label) {
+    return assignment.variant_label;
+  }
+  if (assignment?.variant_key) {
+    return humanizeVariantKey(assignment.variant_key);
+  }
+
+  const manualNotesEntry = findManualNotesForTarget(manualNotesByTarget, {
+    targetParticipantId,
+    targetRefId,
+  });
+  if (manualNotesEntry?.variant_label) {
+    return manualNotesEntry.variant_label;
+  }
+  if (manualNotesEntry?.variant_key) {
+    return humanizeVariantKey(manualNotesEntry.variant_key);
+  }
+
+  if (selectedVariantKey) {
+    const assignmentByKey = targetVariantAssignments?.find(
+      (entry) => entry.variant_key === selectedVariantKey,
+    );
+    if (assignmentByKey?.variant_label) {
+      return assignmentByKey.variant_label;
+    }
+    const manualNotesByKey = manualNotesByTarget?.find(
+      (entry) => entry.variant_key === selectedVariantKey,
+    );
+    if (manualNotesByKey?.variant_label) {
+      return manualNotesByKey.variant_label;
+    }
+  }
+
+  if (selectedVariantLabel) {
+    return selectedVariantLabel;
+  }
+  return selectedVariantKey ? `Variante desconhecida (${humanizeVariantKey(selectedVariantKey)})` : null;
+};
+
+export const buildPendingSaveReason = ({
+  spellName,
+  saveAbility,
+  variantLabel,
+}: {
+  spellName: string;
+  saveAbility: string;
+  variantLabel?: string | null;
+}) =>
+  variantLabel
+    ? `${spellName} - save de ${saveAbility} - variante: ${variantLabel}`
+    : `${spellName} - save de ${saveAbility}`;

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
@@ -181,6 +181,40 @@ export const getEffectiveEffectInstanceContext = (
       };
 };
 
+export const mergePendingSaveResolutionResult = (
+  result: CombatSpellResult,
+  resolution: CombatParticipant["last_save_resolution"],
+): CombatSpellResult => {
+  if (!resolution) {
+    return result;
+  }
+
+  return {
+    ...result,
+    action_kind: "saving_throw",
+    damage: resolution.damage,
+    healing: resolution.healing,
+    damage_type: resolution.damage_type ?? result.damage_type,
+    effect_kind: resolution.effect_kind ?? result.effect_kind,
+    effect_roll_required: Boolean(resolution.pending_spell_id),
+    is_critical: false,
+    is_hit: null,
+    is_saved: resolution.is_saved,
+    new_hp: resolution.new_hp ?? null,
+    pending_save_id: null,
+    pending_spell_id: resolution.pending_spell_id ?? null,
+    roll: resolution.roll_total,
+    roll_result: resolution.roll_result,
+    save_ability: (resolution.save_ability as AbilityName) ?? result.save_ability,
+    save_dc: resolution.save_dc,
+    selected_variant_key: resolution.selected_variant_key ?? result.selected_variant_key,
+    target_variant_assignments:
+      resolution.target_variant_assignments ?? result.target_variant_assignments ?? null,
+    manual_notes_by_target:
+      resolution.manual_notes_by_target ?? result.manual_notes_by_target ?? null,
+  };
+};
+
 export const PlayerSpellCastDialog = ({
   actor,
   actorParticipantId,
@@ -557,25 +591,7 @@ export const PlayerSpellCastDialog = ({
     }
     handledSaveResolutionKeyRef.current = resolutionKey;
 
-    const resolved: CombatSpellResult = {
-      ...result,
-      action_kind: "saving_throw",
-      damage: resolution.damage,
-      healing: resolution.healing,
-      damage_type: resolution.damage_type ?? result.damage_type,
-      effect_kind: resolution.effect_kind ?? result.effect_kind,
-      effect_roll_required: Boolean(resolution.pending_spell_id),
-      is_critical: false,
-      is_hit: null,
-      is_saved: resolution.is_saved,
-      new_hp: resolution.new_hp ?? null,
-      pending_save_id: null,
-      pending_spell_id: resolution.pending_spell_id ?? null,
-      roll: resolution.roll_total,
-      roll_result: resolution.roll_result,
-      save_ability: (resolution.save_ability as AbilityName) ?? result.save_ability,
-      save_dc: resolution.save_dc,
-    };
+    const resolved = mergePendingSaveResolutionResult(result, resolution);
 
     setResult(resolved);
     setManualEffectRolls([]);

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastResultPanel.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastResultPanel.tsx
@@ -1,4 +1,5 @@
 import { RollResultCard } from "../../../features/rolls/components/RollResultCard";
+import { resolveTargetVariantLabel } from "../../../features/combat-ui/spellVariantUi";
 import type { CombatSpellResult } from "../../../shared/api/combatRepo";
 import {
   formatAreaTargetOutcome,
@@ -46,6 +47,13 @@ export const SpellCastResultPanel = ({
   const hasEffectInstanceOutcomes = Boolean(result.effect_instance_outcomes?.length);
   const hasAreaTargetOutcomes = Boolean(result.area_target_outcomes?.length);
   const guardrailBlockedCount = result.area_target_outcomes?.filter((outcome) => outcome.excluded_by_guardrail).length ?? 0;
+  const resolvedVariantLabel = resolveTargetVariantLabel({
+    targetVariantAssignments: result.target_variant_assignments,
+    manualNotesByTarget: result.manual_notes_by_target,
+    selectedVariantKey: result.selected_variant_key,
+    targetRefId: null,
+    targetParticipantId: null,
+  });
 
   return (
     <div className="mt-5 space-y-4">
@@ -116,6 +124,9 @@ export const SpellCastResultPanel = ({
           <p className="mt-2 text-xs text-amber-100">
             Afinidade Elemental elegível: {result.elemental_affinity_damage_type ?? "tipo"}{typeof result.elemental_affinity_bonus === "number" ? ` · bonus potencial +${result.elemental_affinity_bonus}` : ""}
           </p>
+        ) : null}
+        {resolvedVariantLabel ? (
+          <p className="mt-2 text-xs text-slate-300">Variante resolvida: {resolvedVariantLabel}</p>
         ) : null}
         {result.manual_notes_by_target?.length ? (
           <div className="mt-3 space-y-2 text-xs text-amber-100">

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/playerSpellCastDialog.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/playerSpellCastDialog.test.tsx
@@ -4,6 +4,7 @@ import {
   PlayerSpellCastDialog,
   buildNonAreaSpellCastPayload,
   getEffectiveEffectInstanceContext,
+  mergePendingSaveResolutionResult,
 } from "./PlayerSpellCastDialog";
 import { reconcileEffectInstanceTargets, resolveEffectInstanceContext } from "./InstanceTargetSelector";
 
@@ -594,5 +595,91 @@ describe("PlayerSpellCastDialog", () => {
 
     expect(lastActionsProps?.submitDisabled).toBe(true);
     expect(lastActionsProps?.validationMessage).toBe("Escolha um alvo para cada instância da magia.");
+  });
+
+  it("preserva contexto modal ao mesclar last_save_resolution com o resultado local", () => {
+    const merged = mergePendingSaveResolutionResult(
+      {
+        spell_name: "Modal Save Test Spell",
+        spell_canonical_key: "modal_save_test_spell",
+        selected_variant_key: null,
+        action_kind: "saving_throw",
+        effect_kind: "damage",
+        damage: 0,
+        healing: 0,
+        target_display_name: "Goblin A",
+        target_kind: "session_entity",
+        pending_save_id: "pending-save-1",
+        pending_spell_id: null,
+      },
+      {
+        spell_name: "Modal Save Test Spell",
+        pending_save_id: "pending-save-1",
+        target_display_name: "Goblin A",
+        save_ability: "wisdom",
+        save_dc: 14,
+        is_saved: false,
+        roll_total: 9,
+        damage: 0,
+        healing: 0,
+        effect_kind: "damage",
+        roll_result: {
+          event_id: "roll-1",
+          roll_type: "save",
+          actor_kind: "session_entity",
+          actor_ref_id: "session_entity:goblin-a",
+          actor_display_name: "Goblin A",
+          rolls: [8],
+          selected_roll: 8,
+          advantage_mode: "normal",
+          modifier_used: 1,
+          override_used: false,
+          formula: "1d20+1",
+          total: 9,
+          ability: "wisdom",
+          success: false,
+          is_gm_roll: true,
+          roll_source: "manual",
+          timestamp: "2026-04-30T00:00:00Z",
+        },
+        pending_spell_id: "pending-spell-1",
+        selected_variant_key: "foxs_cunning",
+        target_variant_assignments: [
+          {
+            target_participant_id: "enemy-1",
+            variant_key: "foxs_cunning",
+            variant_label: "Esperteza da Raposa",
+          },
+        ],
+        manual_notes_by_target: [
+          {
+            target_participant_id: "enemy-1",
+            target_display_name: "Goblin A",
+            variant_key: "foxs_cunning",
+            variant_label: "Esperteza da Raposa",
+            manual_notes: [{ key: "k", label: "Nota", description: "Descricao" }],
+          },
+        ],
+      },
+    );
+
+    expect(merged.selected_variant_key).toBe("foxs_cunning");
+    expect(merged.pending_spell_id).toBe("pending-spell-1");
+    expect(merged.target_variant_assignments).toEqual([
+      {
+        target_participant_id: "enemy-1",
+        variant_key: "foxs_cunning",
+        variant_label: "Esperteza da Raposa",
+      },
+    ]);
+    expect(merged.manual_notes_by_target).toEqual([
+      {
+        target_participant_id: "enemy-1",
+        target_display_name: "Goblin A",
+        variant_key: "foxs_cunning",
+        variant_label: "Esperteza da Raposa",
+        manual_notes: [{ key: "k", label: "Nota", description: "Descricao" }],
+      },
+    ]);
   });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx
@@ -186,4 +186,58 @@ describe("SpellCastResultPanel", () => {
     expect(markup).toContain("You cannot use a hostile spell against Charmed Noble while charmed.");
     expect(markup).toContain("1 alvo na área foi excluído por regras mecânicas.");
   });
+
+  it("exibe variante resolvida e notas manuais agrupadas por alvo", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastResultPanel
+        {...baseProps}
+        result={{
+          spell_name: "Modal Save Test Spell",
+          spell_canonical_key: "modal_save_test_spell",
+          selected_variant_key: "foxs_cunning",
+          action_kind: "saving_throw",
+          effect_kind: "damage",
+          damage: 7,
+          healing: 0,
+          is_saved: false,
+          target_display_name: "Goblin A",
+          target_kind: "session_entity",
+          target_variant_assignments: [
+            {
+              target_participant_id: "enemy-1",
+              variant_key: "foxs_cunning",
+              variant_label: "Esperteza da Raposa",
+            },
+            {
+              target_participant_id: "enemy-2",
+              variant_key: "owls_wisdom",
+              variant_label: "Sabedoria da Coruja",
+            },
+          ],
+          manual_notes_by_target: [
+            {
+              target_participant_id: "enemy-1",
+              target_display_name: "Goblin A",
+              variant_key: "foxs_cunning",
+              variant_label: "Esperteza da Raposa",
+              manual_notes: [{ key: "a", label: "Manual A", description: "Descricao A" }],
+            },
+            {
+              target_participant_id: "enemy-2",
+              target_display_name: "Goblin B",
+              variant_key: "owls_wisdom",
+              variant_label: "Sabedoria da Coruja",
+              manual_notes: [{ key: "b", label: "Manual B", description: "Descricao B" }],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Variante resolvida: Esperteza da Raposa");
+    expect(markup).toContain("Goblin A: Esperteza da Raposa");
+    expect(markup).toContain("Manual A - Descricao A");
+    expect(markup).toContain("Goblin B: Sabedoria da Coruja");
+    expect(markup).toContain("Manual B - Descricao B");
+  });
 });

--- a/apps/control-web/src/shared/api/combatRepo.ts
+++ b/apps/control-web/src/shared/api/combatRepo.ts
@@ -78,6 +78,22 @@ export type PendingSave = {
   save_ability: string;
   save_dc: number;
   effect_kind?: "damage" | "healing" | null;
+  selected_variant_key?: string | null;
+  selected_variant_label?: string | null;
+  target_variant_assignments?: Array<{
+    target_participant_id?: string | null;
+    target_ref_id?: string | null;
+    variant_key: string;
+    variant_label?: string | null;
+  }> | null;
+  manual_notes_by_target?: Array<{
+    target_participant_id?: string | null;
+    target_ref_id?: string | null;
+    target_display_name: string;
+    variant_key: string;
+    variant_label?: string | null;
+    manual_notes: SpellVariantManualNote[];
+  }> | null;
 };
 
 export type SaveResolution = {
@@ -95,6 +111,21 @@ export type SaveResolution = {
   new_hp?: number | null;
   roll_result: RollResult;
   pending_spell_id?: string | null;
+  selected_variant_key?: string | null;
+  target_variant_assignments?: Array<{
+    target_participant_id?: string | null;
+    target_ref_id?: string | null;
+    variant_key: string;
+    variant_label?: string | null;
+  }> | null;
+  manual_notes_by_target?: Array<{
+    target_participant_id?: string | null;
+    target_ref_id?: string | null;
+    target_display_name: string;
+    variant_key: string;
+    variant_label?: string | null;
+    manual_notes: SpellVariantManualNote[];
+  }> | null;
 };
 
 export type CombatParticipant = {


### PR DESCRIPTION
## Summary
- preserve modal `target_variant_assignments` and `manual_notes_by_target` through player and GM pending save UI flows
- show the target-specific variant during pending save resolution and in final pending spell results
- add safe fallback rendering for unknown variant keys and focused frontend coverage for rehydrate/order-sensitive cases

## What Changed
- extended combat frontend API typings for pending saves and save resolutions
- added shared modal-variant UI helpers for target lookup, pending-save reason text, and fallback labels
- preserved modal context when merging `last_save_resolution` into player spell dialog state
- surfaced variant labels and manual notes in pending save and result panels without affecting non-modal flows
- added focused tests for target order, rehydration, result formatting, GM pending saves, and unknown variant fallback

## Validation
- `npx vitest run apps/control-web/src/features/combat-ui/spellVariantUi.test.ts apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/playerSpellCastDialog.test.tsx apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx apps/control-web/src/features/combat-ui/gm/gmPendingSavesPanel.test.tsx`

## Edge Cases Checked
- reload / rehydrate during a pending save keeps the target-specific variant visible
- resolving target B before target A still shows the correct variant because lookup is by target identity, not list order
- unknown `variant_key` falls back to a safe visual label instead of breaking the UI