### PR TITLE
feat(catalog): support modal spell variants in editor

### DIFF
--- a/apps/control-web/src/features/shop/components/CreateSpellCatalogForm.tsx
+++ b/apps/control-web/src/features/shop/components/CreateSpellCatalogForm.tsx
@@ -5,6 +5,7 @@ import { SpellCatalogFormFields } from "./SpellCatalogFormFields";
 import {
   buildSpellCreatePayload,
   createEmptySpellEditorState,
+  getSpellCatalogEditorVariantErrors,
   normalizeSpellCanonicalKey,
 } from "../utils/spellCatalogForm";
 
@@ -22,7 +23,8 @@ export const CreateSpellCatalogForm = ({ onCreate }: Props) => {
     Boolean(state.nameEn.trim()) &&
     Boolean(state.descriptionEn.trim()) &&
     state.level >= 0 &&
-    state.level <= 9;
+    state.level <= 9 &&
+    getSpellCatalogEditorVariantErrors(state).length === 0;
 
   const handleCreate = async () => {
     if (!canSave || isSaving) {

--- a/apps/control-web/src/features/shop/components/SpellCatalogDeclarativeEffectsFields.tsx
+++ b/apps/control-web/src/features/shop/components/SpellCatalogDeclarativeEffectsFields.tsx
@@ -115,7 +115,7 @@ const retargetParams = (effectType: SpellDeclarativeEffectType): SpellDeclarativ
   }
 };
 
-const EffectEditor = ({
+export const SpellCatalogEffectEditor = ({
   title,
   effects,
   onChange,
@@ -494,12 +494,12 @@ export const SpellCatalogDeclarativeEffectsFields = ({
   setState,
 }: Props) => (
   <div className="space-y-5">
-    <EffectEditor
+    <SpellCatalogEffectEditor
       title="Efeitos declarativos"
       effects={state.effects}
       onChange={(next) => setState((current) => ({ ...current, effects: next }))}
     />
-    <EffectEditor
+    <SpellCatalogEffectEditor
       title="Efeitos ao terminar"
       effects={state.onEndEffects}
       onChange={(next) => setState((current) => ({ ...current, onEndEffects: next }))}

--- a/apps/control-web/src/features/shop/components/SpellCatalogEditor.tsx
+++ b/apps/control-web/src/features/shop/components/SpellCatalogEditor.tsx
@@ -6,6 +6,7 @@ import { SpellCatalogFormFields } from "./SpellCatalogFormFields";
 import {
   buildSpellUpdatePayload,
   createSpellEditorState,
+  getSpellCatalogEditorVariantErrors,
   getUnsupportedSpellEditorValues,
 } from "../utils/spellCatalogForm";
 
@@ -29,7 +30,8 @@ export const SpellCatalogEditor = ({ spell, onSave, onCancel }: Props) => {
     Boolean(state.nameEn.trim()) &&
     Boolean(state.descriptionEn.trim()) &&
     state.level >= 0 &&
-    state.level <= 9;
+    state.level <= 9 &&
+    getSpellCatalogEditorVariantErrors(state).length === 0;
 
   const handleSave = async () => {
     if (!canSave || isSaving) {

--- a/apps/control-web/src/features/shop/components/SpellCatalogFormFields.tsx
+++ b/apps/control-web/src/features/shop/components/SpellCatalogFormFields.tsx
@@ -18,6 +18,7 @@ import { SpellCatalogResolutionFields } from "./SpellCatalogResolutionFields";
 import { SpellCatalogTargetingRequirements } from "./SpellCatalogTargetingRequirements";
 import { SpellCatalogDeclarativeEffectsFields } from "./SpellCatalogDeclarativeEffectsFields";
 import { SpellCatalogPersistentAreaFields } from "./SpellCatalogPersistentAreaFields";
+import { SpellCatalogVariantsFields } from "./SpellCatalogVariantsFields";
 import {
     SPELL_CLASS_OPTIONS,
     SPELL_COMPONENT_OPTIONS,
@@ -546,6 +547,11 @@ export const SpellCatalogFormFields = ({
       <SpellCatalogDeclarativeEffectsFields
         state={state}
         setState={setState}
+      />
+
+      <SpellCatalogVariantsFields
+        variants={state.variants}
+        onChange={(next) => setState((current) => ({ ...current, variants: next }))}
       />
 
       <SpellCatalogPersistentAreaFields

--- a/apps/control-web/src/features/shop/components/SpellCatalogVariantsFields.tsx
+++ b/apps/control-web/src/features/shop/components/SpellCatalogVariantsFields.tsx
@@ -1,0 +1,325 @@
+import type { SpellVariant } from "../../../entities/base-spell";
+import { useLocale } from "../../../shared/hooks/useLocale";
+import {
+  addSpellVariant,
+  createEmptySpellVariantManualNote,
+  getSpellVariantErrors,
+  getSpellVariantWarnings,
+  removeSpellVariant,
+  summarizeSpellVariant,
+} from "../utils/spellVariantEditor";
+import { SpellCatalogEffectEditor } from "./SpellCatalogDeclarativeEffectsFields";
+
+type Props = {
+  variants: SpellVariant[];
+  onChange: (next: SpellVariant[]) => void;
+};
+
+const fieldClassName =
+  "w-full rounded-2xl border border-white/8 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-violet-400/60 focus:outline-none";
+
+const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
+  <div className="space-y-4 rounded-2xl border border-white/8 bg-slate-950/35 p-4">
+    <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+      {title}
+    </p>
+    <div className="space-y-4">{children}</div>
+  </div>
+);
+
+const updateVariant = (
+  variants: SpellVariant[],
+  index: number,
+  updater: (variant: SpellVariant) => SpellVariant,
+) => variants.map((variant, variantIndex) => (variantIndex === index ? updater(variant) : variant));
+
+export const SpellCatalogVariantsFields = ({ variants, onChange }: Props) => {
+  const { t } = useLocale();
+  const errors = getSpellVariantErrors(variants);
+  const warnings = getSpellVariantWarnings(variants);
+
+  return (
+    <Section title="Variants">
+      {errors.length > 0 ? (
+        <div className="space-y-2 rounded-2xl border border-rose-400/20 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+          {errors.map((error) => (
+            <p key={error}>{error}</p>
+          ))}
+        </div>
+      ) : null}
+      {warnings.length > 0 ? (
+        <div className="space-y-2 rounded-2xl border border-amber-400/20 bg-amber-400/10 px-4 py-3 text-sm text-amber-100">
+          {warnings.map((warning) => (
+            <p key={warning}>{warning}</p>
+          ))}
+        </div>
+      ) : null}
+
+      {variants.map((variant, index) => (
+        <div
+          key={`variant-${index}`}
+          className="space-y-4 rounded-2xl border border-white/8 bg-slate-950/45 p-4"
+        >
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-sm font-semibold text-white">
+                Variante {index + 1}
+              </p>
+              <p className="text-xs text-slate-400">
+                Configure rótulos, descrições, efeitos e notas manuais desta opção de cast.
+              </p>
+              <p className="mt-1 text-xs text-violet-200/85">
+                {summarizeSpellVariant(variant, "pt")}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => onChange(removeSpellVariant(variants, index))}
+              className="rounded-full border border-rose-400/20 px-3 py-2 text-xs uppercase tracking-[0.18em] text-rose-200"
+            >
+              Remover variante
+            </button>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="block min-w-0">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                Key
+              </span>
+              <input
+                value={variant.key}
+                onChange={(event) =>
+                  onChange(
+                    updateVariant(variants, index, (current) => ({
+                      ...current,
+                      key: event.target.value,
+                    })),
+                  )
+                }
+                className={`${fieldClassName} mt-2`}
+                placeholder="bears_endurance"
+              />
+            </label>
+
+            <label className="block min-w-0">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                Label PT
+              </span>
+              <input
+                value={variant.labelPt}
+                onChange={(event) =>
+                  onChange(
+                    updateVariant(variants, index, (current) => ({
+                      ...current,
+                      labelPt: event.target.value,
+                    })),
+                  )
+                }
+                className={`${fieldClassName} mt-2`}
+                placeholder="Resistência do Urso"
+              />
+            </label>
+
+            <label className="block min-w-0">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                Label EN
+              </span>
+              <input
+                value={variant.labelEn ?? ""}
+                onChange={(event) =>
+                  onChange(
+                    updateVariant(variants, index, (current) => ({
+                      ...current,
+                      labelEn: event.target.value,
+                    })),
+                  )
+                }
+                className={`${fieldClassName} mt-2`}
+                placeholder="Bear's Endurance"
+              />
+            </label>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="block min-w-0">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                Description PT
+              </span>
+              <textarea
+                value={variant.descriptionPt ?? ""}
+                onChange={(event) =>
+                  onChange(
+                    updateVariant(variants, index, (current) => ({
+                      ...current,
+                      descriptionPt: event.target.value,
+                    })),
+                  )
+                }
+                className={`${fieldClassName} mt-2 min-h-24`}
+              />
+            </label>
+
+            <label className="block min-w-0">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                Description EN
+              </span>
+              <textarea
+                value={variant.descriptionEn ?? ""}
+                onChange={(event) =>
+                  onChange(
+                    updateVariant(variants, index, (current) => ({
+                      ...current,
+                      descriptionEn: event.target.value,
+                    })),
+                  )
+                }
+                className={`${fieldClassName} mt-2 min-h-24`}
+              />
+            </label>
+          </div>
+
+          <SpellCatalogEffectEditor
+            title="Efeitos declarativos da variante"
+            effects={variant.effects ?? []}
+            onChange={(next) =>
+              onChange(
+                updateVariant(variants, index, (current) => ({
+                  ...current,
+                  effects: next,
+                })),
+              )
+            }
+          />
+
+          <SpellCatalogEffectEditor
+            title="Efeitos ao terminar da variante"
+            effects={variant.onEndEffects ?? []}
+            onChange={(next) =>
+              onChange(
+                updateVariant(variants, index, (current) => ({
+                  ...current,
+                  onEndEffects: next,
+                })),
+              )
+            }
+          />
+
+          <div className="space-y-3 rounded-2xl border border-white/8 bg-slate-950/35 p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+                  Manual notes
+                </p>
+                <p className="text-xs text-slate-400">
+                  Use para efeitos ainda não automatizados no motor.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() =>
+                  onChange(
+                    updateVariant(variants, index, (current) => ({
+                      ...current,
+                      manualNotes: [
+                        ...(current.manualNotes ?? []),
+                        createEmptySpellVariantManualNote(),
+                      ],
+                    })),
+                  )
+                }
+                className="rounded-full border border-violet-300/20 px-3 py-2 text-xs uppercase tracking-[0.18em] text-violet-100"
+              >
+                Adicionar nota
+              </button>
+            </div>
+
+            {(variant.manualNotes ?? []).map((note, noteIndex) => (
+              <div
+                key={`variant-${index}-note-${noteIndex}`}
+                className="space-y-3 rounded-2xl border border-white/8 bg-slate-950/55 p-3"
+              >
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <input
+                    value={note.key}
+                    onChange={(event) =>
+                      onChange(
+                        updateVariant(variants, index, (current) => ({
+                          ...current,
+                          manualNotes: (current.manualNotes ?? []).map((entry, entryIndex) =>
+                            entryIndex === noteIndex
+                              ? { ...entry, key: event.target.value }
+                              : entry,
+                          ),
+                        })),
+                      )
+                    }
+                    className={fieldClassName}
+                    placeholder="grant_temp_hp"
+                  />
+                  <input
+                    value={note.label}
+                    onChange={(event) =>
+                      onChange(
+                        updateVariant(variants, index, (current) => ({
+                          ...current,
+                          manualNotes: (current.manualNotes ?? []).map((entry, entryIndex) =>
+                            entryIndex === noteIndex
+                              ? { ...entry, label: event.target.value }
+                              : entry,
+                          ),
+                        })),
+                      )
+                    }
+                    className={fieldClassName}
+                    placeholder="PV temporários"
+                  />
+                  <button
+                    type="button"
+                    onClick={() =>
+                      onChange(
+                        updateVariant(variants, index, (current) => ({
+                          ...current,
+                          manualNotes: (current.manualNotes ?? []).filter(
+                            (_, entryIndex) => entryIndex !== noteIndex,
+                          ),
+                        })),
+                      )
+                    }
+                    className="rounded-full border border-rose-400/20 px-3 py-2 text-xs uppercase tracking-[0.18em] text-rose-200"
+                  >
+                    Remover nota
+                  </button>
+                </div>
+                <textarea
+                  value={note.description}
+                  onChange={(event) =>
+                    onChange(
+                      updateVariant(variants, index, (current) => ({
+                        ...current,
+                        manualNotes: (current.manualNotes ?? []).map((entry, entryIndex) =>
+                          entryIndex === noteIndex
+                            ? { ...entry, description: event.target.value }
+                            : entry,
+                        ),
+                      })),
+                    )
+                  }
+                  className={`${fieldClassName} min-h-20`}
+                  placeholder="Explique o que ainda precisa ser aplicado manualmente."
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+
+      <button
+        type="button"
+        onClick={() => onChange(addSpellVariant(variants))}
+        className="rounded-full border border-violet-300/20 px-3 py-2 text-xs uppercase tracking-[0.18em] text-violet-100"
+      >
+        {t("catalog.createAction")} variante
+      </button>
+    </Section>
+  );
+};

--- a/apps/control-web/src/features/shop/utils/spellCatalogForm.test.ts
+++ b/apps/control-web/src/features/shop/utils/spellCatalogForm.test.ts
@@ -5,6 +5,7 @@ import {
   buildSpellUpdatePayload,
   createEmptySpellEditorState,
   createSpellEditorState,
+  getSpellCatalogEditorVariantErrors,
   getUnsupportedSpellEditorValues,
   normalizeSpellCanonicalKey,
 } from "./spellCatalogForm";
@@ -237,6 +238,97 @@ describe("spellCatalogForm", () => {
     const payload = buildSpellUpdatePayload(state);
     expect(payload.effects).toEqual(state.effects);
     expect(payload.onEndEffects).toEqual(state.onEndEffects);
+  });
+
+  it("hydrates and serializes spell variants", () => {
+    const state = createSpellEditorState(
+      createSpell({
+        variants: [
+          {
+            key: "bears_endurance",
+            labelPt: "Resistência do Urso",
+            labelEn: "Bear's Endurance",
+            descriptionPt: "Ganha vantagem em testes de Constituição.",
+            descriptionEn: "Gain advantage on Constitution checks.",
+            effects: [
+              {
+                type: "advantage_on_checks",
+                target: "selected_target",
+                duration: { type: "manual" },
+                params: { ability: "constitution", against: "any" },
+              },
+            ],
+            onEndEffects: null,
+            manualNotes: [
+              {
+                key: "grant_temp_hp",
+                label: "PV temporários",
+                description: "Aplicar 2d6 PV temporários manualmente.",
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(state.variants).toHaveLength(1);
+    expect(state.variants[0]?.key).toBe("bears_endurance");
+
+    const payload = buildSpellUpdatePayload(state);
+    expect(payload.variants).toEqual([
+      {
+        key: "bears_endurance",
+        labelPt: "Resistência do Urso",
+        labelEn: "Bear's Endurance",
+        descriptionPt: "Ganha vantagem em testes de Constituição.",
+        descriptionEn: "Gain advantage on Constitution checks.",
+        effects: [
+          {
+            type: "advantage_on_checks",
+            target: "selected_target",
+            duration: { type: "manual" },
+            params: { ability: "constitution", against: "any" },
+          },
+        ],
+        onEndEffects: null,
+        manualNotes: [
+          {
+            key: "grant_temp_hp",
+            label: "PV temporários",
+            description: "Aplicar 2d6 PV temporários manualmente.",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("keeps existing spells without variants unchanged", () => {
+    const payload = buildSpellUpdatePayload(createSpellEditorState(createSpell()));
+    expect(payload.variants).toBeNull();
+  });
+
+  it("campaign editor validation blocks duplicate and no-op variants", () => {
+    const state = createEmptySpellEditorState();
+    state.variants = [
+      {
+        key: "owls_wisdom",
+        labelPt: "Sabedoria da Coruja",
+        effects: [],
+        onEndEffects: [],
+        manualNotes: [],
+      },
+      {
+        key: "owls_wisdom",
+        labelPt: "Sabedoria da Coruja 2",
+        effects: [],
+        onEndEffects: [],
+        manualNotes: [],
+      },
+    ];
+
+    const errors = getSpellCatalogEditorVariantErrors(state);
+    expect(errors.some((error) => error.includes("duplicada"))).toBe(true);
+    expect(errors.some((error) => error.includes("ao menos um efeito declarativo ou nota manual"))).toBe(true);
   });
 
   it("hydrates and serializes persistent area semantics", () => {

--- a/apps/control-web/src/features/shop/utils/spellCatalogForm.ts
+++ b/apps/control-web/src/features/shop/utils/spellCatalogForm.ts
@@ -24,6 +24,7 @@ import {
   type SaveSuccessOutcome,
   type SpellDamageType,
   type SpellDeclarativeEffect,
+  type SpellVariant,
   type SpellPersistentAreaKind,
   type SpellPersistentAreaObscurement,
   type SpellPersistentAreaTerrainEffect,
@@ -39,6 +40,7 @@ import {
 } from "../../../entities/base-spell";
 import type { BaseSpellUpdatePayload } from "../../../shared/api/baseSpellsRepo";
 import type { CampaignSpellCreatePayload } from "../../../shared/api/campaignSpellsRepo";
+import { normalizeSpellVariantsForPayload } from "./spellVariantEditor";
 
 export const SPELL_LEVEL_OPTIONS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
 
@@ -424,80 +426,84 @@ export const getUnsupportedSpellEditorValues = (spell: BaseSpell) => {
 
 export const buildSpellUpdatePayload = (
   state: SpellCatalogEditorState,
-): BaseSpellUpdatePayload => ({
-  castingTimeType: toNullableText(state.castingTimeType) as CastingTimeType | null,
-  nameEn: state.nameEn.trim(),
-  namePt: toNullableText(state.namePt),
-  descriptionEn: state.descriptionEn.trim(),
-  descriptionPt: toNullableText(state.descriptionPt),
-  level: state.level,
-  school: state.school,
-  classesJson: state.classesJson.length > 0 ? state.classesJson : null,
-  castingTime: deriveCastingTimeText(state.castingTimeType, state.castingTime),
-  rangeMeters: toNullableInteger(state.rangeMeters),
-  rangeText: toNullableText(state.rangeText),
-  targetType: toNullableText(state.targetType) as TargetType | null,
-  maxTargets: toNullableInteger(state.maxTargets),
-  selectionType: toNullableText(state.selectionType) as SpellSelectionType | null,
-  originType: toNullableText(state.originType) as SpellOriginType | null,
-  targetAnchor: toNullableText(state.targetAnchor) as SpellTargetAnchor | null,
-  attackType: toNullableText(state.attackType) as SpellAttackType | null,
-  rangeKind: toNullableText(state.rangeKind) as SpellRangeKind | null,
-  effectTiming: toNullableText(state.effectTiming) as SpellEffectTiming | null,
-  areaShape: toNullableText(state.areaShape) as AreaShape | null,
-  radiusMeters:
-    state.areaShape === "sphere" || state.areaShape === "cylinder"
-      ? toNullableFloat(state.radiusMeters)
+): BaseSpellUpdatePayload => {
+  const normalizedVariants = normalizeSpellVariantsForPayload(state.variants);
+  return {
+    castingTimeType: toNullableText(state.castingTimeType) as CastingTimeType | null,
+    nameEn: state.nameEn.trim(),
+    namePt: toNullableText(state.namePt),
+    descriptionEn: state.descriptionEn.trim(),
+    descriptionPt: toNullableText(state.descriptionPt),
+    level: state.level,
+    school: state.school,
+    classesJson: state.classesJson.length > 0 ? state.classesJson : null,
+    castingTime: deriveCastingTimeText(state.castingTimeType, state.castingTime),
+    rangeMeters: toNullableInteger(state.rangeMeters),
+    rangeText: toNullableText(state.rangeText),
+    targetType: toNullableText(state.targetType) as TargetType | null,
+    maxTargets: toNullableInteger(state.maxTargets),
+    selectionType: toNullableText(state.selectionType) as SpellSelectionType | null,
+    originType: toNullableText(state.originType) as SpellOriginType | null,
+    targetAnchor: toNullableText(state.targetAnchor) as SpellTargetAnchor | null,
+    attackType: toNullableText(state.attackType) as SpellAttackType | null,
+    rangeKind: toNullableText(state.rangeKind) as SpellRangeKind | null,
+    effectTiming: toNullableText(state.effectTiming) as SpellEffectTiming | null,
+    areaShape: toNullableText(state.areaShape) as AreaShape | null,
+    radiusMeters:
+      state.areaShape === "sphere" || state.areaShape === "cylinder"
+        ? toNullableFloat(state.radiusMeters)
+        : null,
+    lengthMeters:
+      state.areaShape === "cone" || state.areaShape === "line"
+        ? toNullableFloat(state.lengthMeters)
+        : null,
+    sideMeters:
+      state.areaShape === "cube"
+        ? toNullableFloat(state.sideMeters)
+        : null,
+    duration: toNullableText(state.duration),
+    componentsJson: state.componentsJson.length > 0 ? state.componentsJson : null,
+    materialComponentText: state.componentsJson.includes("M")
+      ? toNullableText(state.materialComponentText)
       : null,
-  lengthMeters:
-    state.areaShape === "cone" || state.areaShape === "line"
-      ? toNullableFloat(state.lengthMeters)
+    concentration: state.concentration,
+    ritual: state.ritual,
+    resolutionType: toNullableText(state.resolutionType) as ResolutionType | null,
+    damageDice:
+      state.resolutionType === "damage"
+        ? buildDiceExpression(
+            state.damageDiceCount,
+            state.damageDieSize,
+            state.damageFixedBonus,
+          )
+        : null,
+    damageType:
+      state.resolutionType === "damage"
+        ? (toNullableText(state.damageType) as SpellDamageType | null)
+        : null,
+    healDice: state.resolutionType === "heal" ? toNullableText(state.healDice) : null,
+    effects: state.effects.length > 0 ? state.effects : null,
+    onEndEffects: state.onEndEffects.length > 0 ? state.onEndEffects : null,
+    variants: normalizedVariants.variants,
+    persistentArea: buildPersistentArea(state),
+    savingThrow: supportsSavingThrow(state.resolutionType)
+      ? (toNullableText(state.savingThrow) as SpellSavingThrow | null)
       : null,
-  sideMeters:
-    state.areaShape === "cube"
-      ? toNullableFloat(state.sideMeters)
+    saveSuccessOutcome:
+      state.resolutionType === "damage" && state.savingThrow
+        ? ((toNullableText(state.saveSuccessOutcome) as SaveSuccessOutcome | null) ?? null)
+        : null,
+    coverAppliesToSave: supportsSavingThrow(state.resolutionType)
+      ? ((toNullableText(state.coverAppliesToSave) as "none" | "physical" | null) ?? null)
       : null,
-  duration: toNullableText(state.duration),
-  componentsJson: state.componentsJson.length > 0 ? state.componentsJson : null,
-  materialComponentText: state.componentsJson.includes("M")
-    ? toNullableText(state.materialComponentText)
-    : null,
-  concentration: state.concentration,
-  ritual: state.ritual,
-  resolutionType: toNullableText(state.resolutionType) as ResolutionType | null,
-  damageDice:
-    state.resolutionType === "damage"
-      ? buildDiceExpression(
-          state.damageDiceCount,
-          state.damageDieSize,
-          state.damageFixedBonus,
-        )
-      : null,
-  damageType:
-    state.resolutionType === "damage"
-      ? (toNullableText(state.damageType) as SpellDamageType | null)
-      : null,
-  healDice: state.resolutionType === "heal" ? toNullableText(state.healDice) : null,
-  effects: state.effects.length > 0 ? state.effects : null,
-  onEndEffects: state.onEndEffects.length > 0 ? state.onEndEffects : null,
-  persistentArea: buildPersistentArea(state),
-  savingThrow: supportsSavingThrow(state.resolutionType)
-    ? (toNullableText(state.savingThrow) as SpellSavingThrow | null)
-    : null,
-  saveSuccessOutcome:
-    state.resolutionType === "damage" && state.savingThrow
-      ? ((toNullableText(state.saveSuccessOutcome) as SaveSuccessOutcome | null) ?? null)
-      : null,
-  coverAppliesToSave: supportsSavingThrow(state.resolutionType)
-    ? ((toNullableText(state.coverAppliesToSave) as "none" | "physical" | null) ?? null)
-    : null,
-  requiresTargetSight: toNullableBoolean(state.requiresTargetSight),
-  requiresTargetEffect: toNullableBoolean(state.requiresTargetEffect),
-  requiresPointSight: toNullableBoolean(state.requiresPointSight),
-  requiresPointEffect: toNullableBoolean(state.requiresPointEffect),
-  upcast: buildStructuredUpcast(state),
-  cantripScaling: buildStructuredCantripScaling(state),
-});
+    requiresTargetSight: toNullableBoolean(state.requiresTargetSight),
+    requiresTargetEffect: toNullableBoolean(state.requiresTargetEffect),
+    requiresPointSight: toNullableBoolean(state.requiresPointSight),
+    requiresPointEffect: toNullableBoolean(state.requiresPointEffect),
+    upcast: buildStructuredUpcast(state),
+    cantripScaling: buildStructuredCantripScaling(state),
+  };
+};
 
 export const buildSpellCreatePayload = (
   state: SpellCatalogEditorState,
@@ -509,6 +515,9 @@ export const buildSpellCreatePayload = (
   level: state.level,
   school: state.school,
 });
+
+export const getSpellCatalogEditorVariantErrors = (state: SpellCatalogEditorState) =>
+  normalizeSpellVariantsForPayload(state.variants).errors;
 
 export type SpellCatalogEditorState = {
   canonicalKey: string;
@@ -546,6 +555,7 @@ export type SpellCatalogEditorState = {
   healDice: string;
   effects: SpellDeclarativeEffect[];
   onEndEffects: SpellDeclarativeEffect[];
+  variants: SpellVariant[];
   persistentAreaKind: SpellPersistentAreaKind | "";
   persistentAreaObscurement: SpellPersistentAreaObscurement | "";
   persistentAreaTerrainEffect: SpellPersistentAreaTerrainEffect | "";
@@ -735,6 +745,7 @@ export const createSpellEditorState = (spell: BaseSpell): SpellCatalogEditorStat
   healDice: spell.healDice ?? "",
   effects: spell.effects ?? [],
   onEndEffects: spell.onEndEffects ?? [],
+  variants: spell.variants ?? [],
   persistentAreaKind: spell.persistentArea?.kind ?? "",
   persistentAreaObscurement:
     spell.persistentArea?.kind === "obscurement"
@@ -824,6 +835,7 @@ export const createEmptySpellEditorState = (): SpellCatalogEditorState => ({
   healDice: "",
   effects: [],
   onEndEffects: [],
+  variants: [],
   persistentAreaKind: "",
   persistentAreaObscurement: "",
   persistentAreaTerrainEffect: "",

--- a/apps/control-web/src/features/shop/utils/spellVariantEditor.test.ts
+++ b/apps/control-web/src/features/shop/utils/spellVariantEditor.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  addSpellVariant,
+  getSpellVariantWarnings,
+  getSpellVariantErrors,
+  normalizeSpellVariantsForPayload,
+  removeSpellVariant,
+  summarizeSpellVariant,
+} from "./spellVariantEditor";
+
+describe("spellVariantEditor", () => {
+  it("allows adding and removing variants", () => {
+    const added = addSpellVariant([]);
+    expect(added).toHaveLength(1);
+    expect(added[0]?.key).toBe("");
+
+    const removed = removeSpellVariant(
+      [
+        { ...added[0], key: "bulls_strength", labelPt: "Força do Touro" },
+        { ...added[0], key: "owls_wisdom", labelPt: "Sabedoria da Coruja" },
+      ],
+      0,
+    );
+
+    expect(removed).toEqual([
+      expect.objectContaining({ key: "owls_wisdom", labelPt: "Sabedoria da Coruja" }),
+    ]);
+  });
+
+  it("warns about duplicate and blank keys", () => {
+    const warnings = getSpellVariantWarnings([
+      {
+        key: "",
+        labelPt: "",
+        effects: [],
+        onEndEffects: [],
+        manualNotes: [],
+      },
+      {
+        key: "foxs_cunning",
+        labelPt: "Esperteza da Raposa",
+        effects: [],
+        onEndEffects: [],
+        manualNotes: [],
+      },
+      {
+        key: "foxs_cunning",
+        labelPt: "Esperteza da Raposa 2",
+        effects: [],
+        onEndEffects: [],
+        manualNotes: [],
+      },
+    ]);
+
+    expect(warnings.some((warning) => warning.includes("sem chave"))).toBe(true);
+    expect(warnings.some((warning) => warning.includes("Chaves duplicadas"))).toBe(true);
+  });
+
+  it("blocks a variant that has neither effects nor manual notes", () => {
+    const errors = getSpellVariantErrors([
+      {
+        key: "empty_variant",
+        labelPt: "Variante vazia",
+        effects: [],
+        onEndEffects: [],
+        manualNotes: [],
+      },
+    ]);
+
+    expect(errors[0]).toContain("ao menos um efeito declarativo ou nota manual");
+  });
+
+  it("serializes manual notes and trims optional fields", () => {
+    const normalized = normalizeSpellVariantsForPayload([
+      {
+        key: " bears_endurance ",
+        labelPt: " Resistência do Urso ",
+        labelEn: " Bear's Endurance ",
+        descriptionPt: " ",
+        descriptionEn: " Temporary hit points. ",
+        effects: [],
+        onEndEffects: [],
+        manualNotes: [
+          {
+            key: " grant_temp_hp ",
+            label: " PV temporários ",
+            description: " Remover quando a magia terminar. ",
+          },
+        ],
+      },
+    ]);
+
+    expect(normalized.errors).toEqual([]);
+    expect(normalized.variants).toEqual([
+      {
+        key: "bears_endurance",
+        labelPt: "Resistência do Urso",
+        labelEn: "Bear's Endurance",
+        descriptionPt: null,
+        descriptionEn: "Temporary hit points.",
+        effects: null,
+        onEndEffects: null,
+        manualNotes: [
+          {
+            key: "grant_temp_hp",
+            label: "PV temporários",
+            description: "Remover quando a magia terminar.",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("builds a compact summary for quick scanning", () => {
+    expect(
+      summarizeSpellVariant({
+        key: "bears_endurance",
+        labelPt: "Resistência do Urso",
+        effects: [
+          {
+            type: "advantage_on_checks",
+            target: "selected_target",
+            duration: { type: "manual" },
+            params: { ability: "constitution", against: "any" },
+          },
+        ],
+        onEndEffects: [],
+        manualNotes: [
+          {
+            key: "grant_temp_hp",
+            label: "2d6 HP",
+            description: "Aplicar manualmente.",
+          },
+        ],
+      }),
+    ).toBe("advantage_on_checks (CON) + manual (2d6 HP)");
+  });
+});

--- a/apps/control-web/src/features/shop/utils/spellVariantEditor.ts
+++ b/apps/control-web/src/features/shop/utils/spellVariantEditor.ts
@@ -1,0 +1,177 @@
+import type { SpellVariant, SpellVariantManualNote } from "../../../entities/base-spell";
+
+export const createEmptySpellVariantManualNote = (): SpellVariantManualNote => ({
+  key: "",
+  label: "",
+  description: "",
+});
+
+export const createEmptySpellVariant = (): SpellVariant => ({
+  key: "",
+  labelPt: "",
+  labelEn: "",
+  descriptionPt: "",
+  descriptionEn: "",
+  effects: [],
+  onEndEffects: [],
+  manualNotes: [],
+});
+
+export const addSpellVariant = (variants: SpellVariant[]) => [
+  ...variants,
+  createEmptySpellVariant(),
+];
+
+export const removeSpellVariant = (variants: SpellVariant[], index: number) =>
+  variants.filter((_, entryIndex) => entryIndex !== index);
+
+const trimToNull = (value: string | null | undefined) => {
+  const normalized = value?.trim() ?? "";
+  return normalized.length > 0 ? normalized : null;
+};
+
+const hasEffectEntries = (length: number | undefined) => Boolean(length && length > 0);
+
+export const getSpellVariantWarnings = (variants: SpellVariant[]) => {
+  const normalizedKeys = variants
+    .map((variant) => variant.key.trim())
+    .filter(Boolean);
+  const duplicateKeys = new Set(
+    normalizedKeys.filter((key, index) => normalizedKeys.indexOf(key) !== index),
+  );
+
+  const warnings: string[] = [];
+  if (variants.some((variant) => variant.key.trim().length === 0)) {
+    warnings.push("Algumas variantes ainda estão sem chave.");
+  }
+  if (duplicateKeys.size > 0) {
+    warnings.push(
+      `Chaves duplicadas: ${Array.from(duplicateKeys)
+        .sort()
+        .join(", ")}.`,
+    );
+  }
+  if (
+    variants.some(
+      (variant) =>
+        !trimToNull(variant.labelPt) &&
+        !trimToNull(variant.labelEn) &&
+        !trimToNull(variant.descriptionPt) &&
+        !trimToNull(variant.descriptionEn),
+    )
+  ) {
+    warnings.push(
+      "Algumas variantes estão sem rótulos e descrições localizadas. A magia continuará válida, mas ficará ruim de operar no cast.",
+    );
+  }
+  return warnings;
+};
+
+export const getSpellVariantErrors = (variants: SpellVariant[]) =>
+  normalizeSpellVariantsForPayload(variants).errors;
+
+const summarizeEffect = (variant: SpellVariant, locale: "pt" | "en") => {
+  const summaries = (variant.effects ?? []).map((effect) => {
+    if (
+      (effect.type === "advantage_on_checks" || effect.type === "disadvantage_on_checks") &&
+      "ability" in effect.params
+    ) {
+      return `${effect.type} (${String(effect.params.ability).slice(0, 3).toUpperCase()})`;
+    }
+    if (effect.type === "apply_condition" && "condition" in effect.params) {
+      return `condition (${effect.params.condition})`;
+    }
+    if (effect.type === "modify_stat" && "stat" in effect.params) {
+      return `modify_stat (${effect.params.stat})`;
+    }
+    if (effect.type === "restrict_action" && "action" in effect.params) {
+      return `restrict_action (${effect.params.action})`;
+    }
+    return effect.type;
+  });
+
+  const firstManualNote = variant.manualNotes?.find(
+    (note) => note.label.trim() || note.description.trim() || note.key.trim(),
+  );
+  if (firstManualNote) {
+    summaries.push(`manual (${firstManualNote.label.trim() || firstManualNote.key.trim()})`);
+  }
+
+  if (summaries.length === 0) {
+    return locale === "pt" ? "Sem efeito configurado" : "No configured effect";
+  }
+
+  return summaries.join(" + ");
+};
+
+export const summarizeSpellVariant = (variant: SpellVariant, locale: "pt" | "en" = "pt") =>
+  summarizeEffect(variant, locale);
+
+export const normalizeSpellVariantsForPayload = (
+  variants: SpellVariant[],
+): { variants: SpellVariant[] | null; errors: string[] } => {
+  if (variants.length === 0) {
+    return { variants: null, errors: [] };
+  }
+
+  const errors: string[] = [];
+  const normalizedVariants = variants.map((variant, variantIndex) => {
+    const key = variant.key.trim();
+    if (!key) {
+      errors.push(`Variante ${variantIndex + 1} precisa de uma chave.`);
+    }
+    if (!(variant.effects?.length) && !(variant.manualNotes?.some((note) => note.key.trim() || note.label.trim() || note.description.trim()))) {
+      errors.push(
+        `Variante ${key || variantIndex + 1} precisa de ao menos um efeito declarativo ou nota manual.`,
+      );
+    }
+
+    const normalizedManualNotes = (variant.manualNotes ?? [])
+      .map((note, noteIndex) => {
+        const hasAnyValue = Boolean(
+          note.key.trim() || note.label.trim() || note.description.trim(),
+        );
+        if (!hasAnyValue) {
+          return null;
+        }
+        if (!note.key.trim() || !note.label.trim() || !note.description.trim()) {
+          errors.push(
+            `Nota manual ${noteIndex + 1} da variante ${key || variantIndex + 1} precisa de chave, rótulo e descrição.`,
+          );
+        }
+        return {
+          key: note.key.trim(),
+          label: note.label.trim(),
+          description: note.description.trim(),
+        };
+      })
+      .filter((entry): entry is SpellVariantManualNote => Boolean(entry));
+
+    return {
+      key,
+      labelPt: variant.labelPt.trim(),
+      labelEn: trimToNull(variant.labelEn),
+      descriptionPt: trimToNull(variant.descriptionPt),
+      descriptionEn: trimToNull(variant.descriptionEn),
+      effects: hasEffectEntries(variant.effects?.length) ? variant.effects ?? [] : null,
+      onEndEffects: hasEffectEntries(variant.onEndEffects?.length)
+        ? variant.onEndEffects ?? []
+        : null,
+      manualNotes: normalizedManualNotes.length > 0 ? normalizedManualNotes : null,
+    } satisfies SpellVariant;
+  });
+
+  const seenKeys = new Set<string>();
+  for (const variant of normalizedVariants) {
+    if (!variant.key) continue;
+    if (seenKeys.has(variant.key)) {
+      errors.push(`Chave de variante duplicada: ${variant.key}.`);
+    }
+    seenKeys.add(variant.key);
+  }
+
+  return {
+    variants: normalizedVariants,
+    errors,
+  };
+};

--- a/apps/control-web/src/pages/CatalogPage/CatalogSpellEditPage.tsx
+++ b/apps/control-web/src/pages/CatalogPage/CatalogSpellEditPage.tsx
@@ -7,6 +7,7 @@ import { SpellCatalogFormFields } from "../../features/shop/components/SpellCata
 import {
   buildSpellUpdatePayload,
   createSpellEditorState,
+  getSpellCatalogEditorVariantErrors,
   getUnsupportedSpellEditorValues,
   type SpellCatalogEditorState,
 } from "../../features/shop/utils/spellCatalogForm";
@@ -79,7 +80,8 @@ export const CatalogSpellEditPage = () => {
     Boolean(formState.nameEn.trim()) &&
     Boolean(formState.descriptionEn.trim()) &&
     formState.level >= 0 &&
-    formState.level <= 9;
+    formState.level <= 9 &&
+    getSpellCatalogEditorVariantErrors(formState).length === 0;
 
   const handleSave = async () => {
     if (!canSave || isSaving) return;

--- a/apps/control-web/src/pages/CatalogPage/CatalogSpellNewPage.tsx
+++ b/apps/control-web/src/pages/CatalogPage/CatalogSpellNewPage.tsx
@@ -6,6 +6,7 @@ import { SpellCatalogFormFields } from "../../features/shop/components/SpellCata
 import {
   buildSpellCreatePayload,
   createEmptySpellEditorState,
+  getSpellCatalogEditorVariantErrors,
   normalizeSpellCanonicalKey,
 } from "../../features/shop/utils/spellCatalogForm";
 import type { CampaignSpellCreatePayload } from "../../shared/api/campaignSpellsRepo";
@@ -32,7 +33,8 @@ export const CatalogSpellNewPage = () => {
     Boolean(state.nameEn.trim()) &&
     Boolean(state.descriptionEn.trim()) &&
     state.level >= 0 &&
-    state.level <= 9;
+    state.level <= 9 &&
+    getSpellCatalogEditorVariantErrors(state).length === 0;
 
   const handleCreate = async () => {
     if (!canSave || isSaving) return;

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/SystemSpellCatalogSpellForm.tsx
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/SystemSpellCatalogSpellForm.tsx
@@ -10,6 +10,7 @@ import {
 import { SystemSpellCatalogCastingFields } from "./SystemSpellCatalogCastingFields";
 import { SystemSpellCatalogFormSection } from "./SystemSpellCatalogFormSection";
 import { SystemSpellCatalogResolutionFields } from "./SystemSpellCatalogResolutionFields";
+import { SpellCatalogVariantsFields } from "../../features/shop/components/SpellCatalogVariantsFields";
 import { toggleListValue } from "./systemSpellCatalog.helpers";
 import {
   CLASS_OPTIONS,
@@ -224,6 +225,11 @@ export const SystemSpellCatalogSpellForm = ({
       <SystemSpellCatalogCastingFields form={form} setForm={setForm} />
 
       <SystemSpellCatalogResolutionFields form={form} setForm={setForm} />
+
+      <SpellCatalogVariantsFields
+        variants={form.variants}
+        onChange={(next) => setForm((c) => ({ ...c, variants: next }))}
+      />
 
       <SystemSpellCatalogFormSection title={t("catalog.spells.form.description")}>
         <div className="grid gap-4 md:grid-cols-2">

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.helpers.test.ts
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.helpers.test.ts
@@ -273,4 +273,124 @@ describe("systemSpellCatalog upcast helpers", () => {
 
     expect(form.coverAppliesToSave).toBe("physical");
   });
+
+  it("hydrates and serializes variants through the admin helper", () => {
+    const spell: BaseSpell = {
+      id: "spell-enhance",
+      system: "DND5E",
+      canonicalKey: "enhance_ability",
+      nameEn: "Enhance Ability",
+      namePt: "Aprimorar Habilidade",
+      descriptionEn: "Choose one ability.",
+      descriptionPt: "Escolha uma habilidade.",
+      level: 2,
+      school: "transmutation",
+      classesJson: ["Bard", "Druid"],
+      castingTimeType: "action",
+      castingTime: "1 action",
+      rangeMeters: null,
+      rangeText: "Touch",
+      targetType: "touch",
+      maxTargets: 1,
+      selectionType: "creature",
+      originType: "selected_target",
+      targetAnchor: "selected_target",
+      attackType: "none",
+      rangeKind: "distance",
+      effectTiming: "immediate",
+      duration: "Concentração, até 1 hora",
+      componentsJson: ["V", "S", "M"],
+      materialComponentText: "fur or a feather from a beast",
+      concentration: true,
+      ritual: false,
+      resolutionType: "utility",
+      savingThrow: null,
+      saveSuccessOutcome: null,
+      coverAppliesToSave: null,
+      damageDice: null,
+      damageType: null,
+      healDice: null,
+      upcast: null,
+      variants: [
+        {
+          key: "owls_wisdom",
+          labelPt: "Sabedoria da Coruja",
+          labelEn: "Owl's Wisdom",
+          descriptionPt: "Vantagem em testes de Sabedoria.",
+          descriptionEn: "Advantage on Wisdom checks.",
+          effects: [
+            {
+              type: "advantage_on_checks",
+              target: "selected_target",
+              duration: { type: "manual" },
+              params: { ability: "wisdom", against: "any" },
+            },
+          ],
+          onEndEffects: null,
+          manualNotes: [
+            {
+              key: "passive_perception_bonus",
+              label: "Percepção passiva",
+              description: "+5 enquanto durar.",
+            },
+          ],
+        },
+      ],
+      source: "admin_panel",
+      sourceRef: null,
+      isSrd: false,
+      isActive: true,
+      aliases: [],
+      effects: null,
+      onEndEffects: null,
+    };
+
+    const form = formFromSpell(spell);
+    expect(form.variants).toHaveLength(1);
+    expect(form.variants[0]?.labelPt).toBe("Sabedoria da Coruja");
+
+    const result = buildPayload(form, true);
+    expect(result.error).toBeUndefined();
+    expect(result.payload?.variants).toEqual(spell.variants);
+  });
+
+  it("blocks duplicate variant keys in the admin helper", () => {
+    const form = createEmptyForm();
+    form.canonicalKey = "enhance_ability";
+    form.nameEn = "Enhance Ability";
+    form.descriptionEn = "Choose one ability.";
+    form.variants = [
+      {
+        key: "owls_wisdom",
+        labelPt: "Sabedoria da Coruja",
+        effects: [
+          {
+            type: "advantage_on_checks",
+            target: "selected_target",
+            duration: { type: "manual" },
+            params: { ability: "wisdom", against: "any" },
+          },
+        ],
+        onEndEffects: [],
+        manualNotes: [],
+      },
+      {
+        key: "owls_wisdom",
+        labelPt: "Sabedoria da Coruja 2",
+        effects: [
+          {
+            type: "advantage_on_checks",
+            target: "selected_target",
+            duration: { type: "manual" },
+            params: { ability: "wisdom", against: "any" },
+          },
+        ],
+        onEndEffects: [],
+        manualNotes: [],
+      },
+    ];
+
+    const result = buildPayload(form, true);
+    expect(result.error).toContain("Chave de variante duplicada");
+  });
 });

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.helpers.ts
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.helpers.ts
@@ -4,6 +4,7 @@ import {
   SpellSchool as SpellSchoolValues,
 } from "../../entities/base-spell";
 import { catalogPtBRDictionary } from "../../shared/i18n/ptBR/catalog";
+import { normalizeSpellVariantsForPayload } from "../../features/shop/utils/spellVariantEditor";
 import type { FormState } from "./systemSpellCatalog.types";
 
 const CASTING_TIME_LABELS: Record<CastingTimeType, string> = {
@@ -177,6 +178,7 @@ export const createEmptyForm = (): FormState => ({
   isActive: true,
   effects: [],
   onEndEffects: [],
+  variants: [],
 });
 
 export const formFromSpell = (spell: BaseSpell): FormState => ({
@@ -275,6 +277,7 @@ export const formFromSpell = (spell: BaseSpell): FormState => ({
   isActive: spell.isActive,
   effects: spell.effects ?? [],
   onEndEffects: spell.onEndEffects ?? [],
+  variants: spell.variants ?? [],
 });
 
 export const buildPayload = (
@@ -374,6 +377,11 @@ export const buildPayload = (
   if (shouldValidateUpcast && form.upcastMode === "extra_effect") {
     if (!form.upcastUnlockKey.trim()) return { error: catalogPtBRDictionary["catalog.spells.validation.extraEffectRequiresKey"] };
     if (!form.upcastUnlockSummary.trim()) return { error: catalogPtBRDictionary["catalog.spells.validation.extraEffectRequiresSummary"] };
+  }
+
+  const normalizedVariants = normalizeSpellVariantsForPayload(form.variants);
+  if (normalizedVariants.errors.length > 0) {
+    return { error: normalizedVariants.errors[0] };
   }
 
   return {
@@ -511,6 +519,7 @@ export const buildPayload = (
           : null,
       effects: form.effects.length > 0 ? form.effects : null,
       onEndEffects: form.onEndEffects.length > 0 ? form.onEndEffects : null,
+      variants: normalizedVariants.variants,
       source: form.source,
       sourceRef: normalizeOptionalText(form.sourceRef) ?? null,
       isSrd: form.isSrd,

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.types.ts
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.types.ts
@@ -7,6 +7,7 @@ import type {
   SpellAttackType,
   SpellDamageType,
   SpellDeclarativeEffect,
+  SpellVariant,
   SpellEffectTiming,
   SpellOriginType,
   SpellRangeKind,
@@ -114,6 +115,7 @@ export type FormState = {
   isActive: boolean;
   effects: SpellDeclarativeEffect[];
   onEndEffects: SpellDeclarativeEffect[];
+  variants: SpellVariant[];
 };
 
 export { SpellSchoolValues, SpellSourceValues, UpcastModeValues };


### PR DESCRIPTION
## Summary
- add modal spell variant editing to the spell catalog forms and the system/admin base spell editor
- reuse the declarative effects editor inside each variant and support manual notes authoring
- align frontend validation so invalid variants are blocked consistently in both admin and campaign flows

## What Changed
- added a dedicated `Variants` editor section with add/remove support, labels/descriptions, declarative effects, on-end effects, and manual notes
- introduced shared variant normalization/validation helpers for duplicate keys, blank keys, no-op variants, and manual note completeness
- added compact per-variant summaries so editors can scan configured modes without opening every block
- wired variants into campaign spell form state/payload serialization and into the system spell catalog admin editor
- preserved existing behavior for non-variant spells by serializing `variants: null` when no variants are configured

## Validation
- `npx vitest run apps/control-web/src/features/shop/utils/spellVariantEditor.test.ts apps/control-web/src/features/shop/utils/spellCatalogForm.test.ts apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.helpers.test.ts`
- `npx vitest run apps/control-web/src/features/shop/components/SpellCatalogResolutionFields.test.tsx`

## Acceptance Notes
- admins can add/remove/edit variants directly from the editor
- variant declarative effects reuse the existing effect editor
- manual notes persist through read/write helpers
- duplicate or blank variant keys are blocked in both admin and campaign forms
- variants with no declarative effects and no manual notes are blocked
- `Enhance Ability` can now be represented end-to-end from the editor