### PR TITLE
fix(catalog): unify modal variant validation across editors

### DIFF
--- a/apps/control-web/src/features/shop/components/CreateSpellCatalogForm.tsx
+++ b/apps/control-web/src/features/shop/components/CreateSpellCatalogForm.tsx
@@ -14,7 +14,7 @@ type Props = {
 };
 
 export const CreateSpellCatalogForm = ({ onCreate }: Props) => {
-  const { t } = useLocale();
+  const { locale, t } = useLocale();
   const [state, setState] = useState(createEmptySpellEditorState);
   const [isSaving, setIsSaving] = useState(false);
 
@@ -24,7 +24,7 @@ export const CreateSpellCatalogForm = ({ onCreate }: Props) => {
     Boolean(state.descriptionEn.trim()) &&
     state.level >= 0 &&
     state.level <= 9 &&
-    getSpellCatalogEditorVariantErrors(state).length === 0;
+    getSpellCatalogEditorVariantErrors(state, locale).length === 0;
 
   const handleCreate = async () => {
     if (!canSave || isSaving) {
@@ -33,7 +33,7 @@ export const CreateSpellCatalogForm = ({ onCreate }: Props) => {
 
     setIsSaving(true);
     try {
-      const created = await onCreate(buildSpellCreatePayload(state));
+      const created = await onCreate(buildSpellCreatePayload(state, locale));
       if (created) {
         setState(createEmptySpellEditorState());
       }

--- a/apps/control-web/src/features/shop/components/SpellCatalogEditor.tsx
+++ b/apps/control-web/src/features/shop/components/SpellCatalogEditor.tsx
@@ -17,7 +17,7 @@ type Props = {
 };
 
 export const SpellCatalogEditor = ({ spell, onSave, onCancel }: Props) => {
-  const { t } = useLocale();
+  const { locale, t } = useLocale();
   const [state, setState] = useState(() => createSpellEditorState(spell));
   const [isSaving, setIsSaving] = useState(false);
   const unsupportedValues = getUnsupportedSpellEditorValues(spell);
@@ -31,7 +31,7 @@ export const SpellCatalogEditor = ({ spell, onSave, onCancel }: Props) => {
     Boolean(state.descriptionEn.trim()) &&
     state.level >= 0 &&
     state.level <= 9 &&
-    getSpellCatalogEditorVariantErrors(state).length === 0;
+    getSpellCatalogEditorVariantErrors(state, locale).length === 0;
 
   const handleSave = async () => {
     if (!canSave || isSaving) {
@@ -40,7 +40,7 @@ export const SpellCatalogEditor = ({ spell, onSave, onCancel }: Props) => {
 
     setIsSaving(true);
     try {
-      const updated = await onSave(spell.id, buildSpellUpdatePayload(state));
+      const updated = await onSave(spell.id, buildSpellUpdatePayload(state, locale));
       if (updated) {
         onCancel();
       }

--- a/apps/control-web/src/features/shop/components/SpellCatalogVariantsFields.test.tsx
+++ b/apps/control-web/src/features/shop/components/SpellCatalogVariantsFields.test.tsx
@@ -1,0 +1,44 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { SpellCatalogVariantsFields } from "./SpellCatalogVariantsFields";
+
+vi.mock("../../../shared/hooks/useLocale", () => ({
+  useLocale: () => ({
+    locale: "pt",
+    t: (key: string) => key,
+  }),
+}));
+
+describe("SpellCatalogVariantsFields", () => {
+  it("shows inline validation for the affected variant and manual note", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCatalogVariantsFields
+        variants={[
+          {
+            key: "owls_wisdom",
+            labelPt: "Sabedoria da Coruja",
+            labelEn: "",
+            descriptionPt: "",
+            descriptionEn: "",
+            effects: [],
+            onEndEffects: [],
+            manualNotes: [
+              {
+                key: "",
+                label: "Percepção passiva",
+                description: "",
+              },
+            ],
+          },
+        ]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("Nota manual 1 da variante owls_wisdom precisa de uma chave.");
+    expect(markup).toContain("Nota manual 1 da variante owls_wisdom precisa de rótulo e descrição.");
+    expect(markup).toContain("está sem descrição em português");
+    expect(markup).toContain("localização EN incompleta");
+    expect(markup).toContain("depende apenas de notas manuais");
+  });
+});

--- a/apps/control-web/src/features/shop/components/SpellCatalogVariantsFields.tsx
+++ b/apps/control-web/src/features/shop/components/SpellCatalogVariantsFields.tsx
@@ -3,8 +3,8 @@ import { useLocale } from "../../../shared/hooks/useLocale";
 import {
   addSpellVariant,
   createEmptySpellVariantManualNote,
-  getSpellVariantErrors,
-  getSpellVariantWarnings,
+  getVariantIssueLabel,
+  validateSpellVariants,
   removeSpellVariant,
   summarizeSpellVariant,
 } from "../utils/spellVariantEditor";
@@ -34,28 +34,34 @@ const updateVariant = (
 ) => variants.map((variant, variantIndex) => (variantIndex === index ? updater(variant) : variant));
 
 export const SpellCatalogVariantsFields = ({ variants, onChange }: Props) => {
-  const { t } = useLocale();
-  const errors = getSpellVariantErrors(variants);
-  const warnings = getSpellVariantWarnings(variants);
+  const { locale, t } = useLocale();
+  const validation = validateSpellVariants(variants, locale);
+  const errors = validation.errors;
+  const warnings = validation.warnings;
 
   return (
     <Section title="Variants">
       {errors.length > 0 ? (
         <div className="space-y-2 rounded-2xl border border-rose-400/20 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
-          {errors.map((error) => (
-            <p key={error}>{error}</p>
+          {errors.map((error, index) => (
+            <p key={`${error.variantIndex}:${error.noteIndex ?? "variant"}:${index}`}>{error.message}</p>
           ))}
         </div>
       ) : null}
       {warnings.length > 0 ? (
         <div className="space-y-2 rounded-2xl border border-amber-400/20 bg-amber-400/10 px-4 py-3 text-sm text-amber-100">
-          {warnings.map((warning) => (
-            <p key={warning}>{warning}</p>
+          {warnings.map((warning, index) => (
+            <p key={`${warning.variantIndex}:${warning.noteIndex ?? "variant"}:${index}`}>{warning.message}</p>
           ))}
         </div>
       ) : null}
 
       {variants.map((variant, index) => (
+        (() => {
+          const variantErrors = validation.errors.filter((issue) => issue.variantIndex === index && issue.noteIndex == null);
+          const variantWarnings = validation.warnings.filter((issue) => issue.variantIndex === index && issue.noteIndex == null);
+          const noteIssues = validation.issues.filter((issue) => issue.variantIndex === index && issue.noteIndex != null);
+          return (
         <div
           key={`variant-${index}`}
           className="space-y-4 rounded-2xl border border-white/8 bg-slate-950/45 p-4"
@@ -63,13 +69,13 @@ export const SpellCatalogVariantsFields = ({ variants, onChange }: Props) => {
           <div className="flex items-center justify-between gap-3">
             <div>
               <p className="text-sm font-semibold text-white">
-                Variante {index + 1}
+                {getVariantIssueLabel(variant, index)}
               </p>
               <p className="text-xs text-slate-400">
                 Configure rótulos, descrições, efeitos e notas manuais desta opção de cast.
               </p>
               <p className="mt-1 text-xs text-violet-200/85">
-                {summarizeSpellVariant(variant, "pt")}
+                {summarizeSpellVariant(variant, locale)}
               </p>
             </div>
             <button
@@ -80,6 +86,21 @@ export const SpellCatalogVariantsFields = ({ variants, onChange }: Props) => {
               Remover variante
             </button>
           </div>
+
+          {variantErrors.length > 0 ? (
+            <div className="space-y-1 rounded-2xl border border-rose-400/20 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+              {variantErrors.map((issue, issueIndex) => (
+                <p key={`variant-error-${index}-${issueIndex}`}>{issue.message}</p>
+              ))}
+            </div>
+          ) : null}
+          {variantWarnings.length > 0 ? (
+            <div className="space-y-1 rounded-2xl border border-amber-400/20 bg-amber-400/10 px-4 py-3 text-sm text-amber-100">
+              {variantWarnings.map((issue, issueIndex) => (
+                <p key={`variant-warning-${index}-${issueIndex}`}>{issue.message}</p>
+              ))}
+            </div>
+          ) : null}
 
           <div className="grid gap-4 sm:grid-cols-2">
             <label className="block min-w-0">
@@ -234,10 +255,20 @@ export const SpellCatalogVariantsFields = ({ variants, onChange }: Props) => {
             </div>
 
             {(variant.manualNotes ?? []).map((note, noteIndex) => (
+              (() => {
+                const currentNoteIssues = noteIssues.filter((issue) => issue.noteIndex === noteIndex);
+                return (
               <div
                 key={`variant-${index}-note-${noteIndex}`}
                 className="space-y-3 rounded-2xl border border-white/8 bg-slate-950/55 p-3"
               >
+                {currentNoteIssues.length > 0 ? (
+                  <div className="space-y-1 rounded-2xl border border-rose-400/20 bg-rose-500/10 px-3 py-2 text-sm text-rose-100">
+                    {currentNoteIssues.map((issue, issueIndex) => (
+                      <p key={`variant-${index}-note-${noteIndex}-issue-${issueIndex}`}>{issue.message}</p>
+                    ))}
+                  </div>
+                ) : null}
                 <div className="grid gap-3 sm:grid-cols-3">
                   <input
                     value={note.key}
@@ -308,9 +339,13 @@ export const SpellCatalogVariantsFields = ({ variants, onChange }: Props) => {
                   placeholder="Explique o que ainda precisa ser aplicado manualmente."
                 />
               </div>
+                );
+              })()
             ))}
           </div>
         </div>
+          );
+        })()
       ))}
 
       <button

--- a/apps/control-web/src/features/shop/utils/spellCatalogForm.test.ts
+++ b/apps/control-web/src/features/shop/utils/spellCatalogForm.test.ts
@@ -328,7 +328,33 @@ describe("spellCatalogForm", () => {
 
     const errors = getSpellCatalogEditorVariantErrors(state);
     expect(errors.some((error) => error.includes("duplicada"))).toBe(true);
-    expect(errors.some((error) => error.includes("ao menos um efeito declarativo ou nota manual"))).toBe(true);
+    expect(errors.some((error) => error.includes("ao menos um efeito declarativo"))).toBe(true);
+  });
+
+  it("campaign payload builder throws when current locale label is missing", () => {
+    const state = createEmptySpellEditorState();
+    state.canonicalKey = "enhance_ability";
+    state.nameEn = "Enhance Ability";
+    state.descriptionEn = "Choose one ability.";
+    state.variants = [
+      {
+        key: "owls_wisdom",
+        labelPt: "",
+        labelEn: "Owl's Wisdom",
+        effects: [
+          {
+            type: "advantage_on_checks",
+            target: "selected_target",
+            duration: { type: "manual" },
+            params: { ability: "wisdom", against: "any" },
+          },
+        ],
+        onEndEffects: [],
+        manualNotes: [],
+      },
+    ];
+
+    expect(() => buildSpellCreatePayload(state, "pt")).toThrow(/rótulo em português/i);
   });
 
   it("hydrates and serializes persistent area semantics", () => {

--- a/apps/control-web/src/features/shop/utils/spellCatalogForm.ts
+++ b/apps/control-web/src/features/shop/utils/spellCatalogForm.ts
@@ -38,6 +38,7 @@ import {
   type TargetType,
   type UpcastMode,
 } from "../../../entities/base-spell";
+import type { Locale } from "../../../shared/i18n";
 import type { BaseSpellUpdatePayload } from "../../../shared/api/baseSpellsRepo";
 import type { CampaignSpellCreatePayload } from "../../../shared/api/campaignSpellsRepo";
 import { normalizeSpellVariantsForPayload } from "./spellVariantEditor";
@@ -426,8 +427,12 @@ export const getUnsupportedSpellEditorValues = (spell: BaseSpell) => {
 
 export const buildSpellUpdatePayload = (
   state: SpellCatalogEditorState,
+  locale: Locale = "pt",
 ): BaseSpellUpdatePayload => {
-  const normalizedVariants = normalizeSpellVariantsForPayload(state.variants);
+  const normalizedVariants = normalizeSpellVariantsForPayload(state.variants, locale);
+  if (normalizedVariants.errors.length > 0) {
+    throw new Error(normalizedVariants.errors[0]);
+  }
   return {
     castingTimeType: toNullableText(state.castingTimeType) as CastingTimeType | null,
     nameEn: state.nameEn.trim(),
@@ -507,17 +512,20 @@ export const buildSpellUpdatePayload = (
 
 export const buildSpellCreatePayload = (
   state: SpellCatalogEditorState,
+  locale: Locale = "pt",
 ): CampaignSpellCreatePayload => ({
   canonicalKey: normalizeSpellCanonicalKey(state.canonicalKey),
-  ...buildSpellUpdatePayload(state),
+  ...buildSpellUpdatePayload(state, locale),
   nameEn: state.nameEn.trim(),
   descriptionEn: state.descriptionEn.trim(),
   level: state.level,
   school: state.school,
 });
 
-export const getSpellCatalogEditorVariantErrors = (state: SpellCatalogEditorState) =>
-  normalizeSpellVariantsForPayload(state.variants).errors;
+export const getSpellCatalogEditorVariantErrors = (
+  state: SpellCatalogEditorState,
+  locale: Locale = "pt",
+) => normalizeSpellVariantsForPayload(state.variants, locale).errors;
 
 export type SpellCatalogEditorState = {
   canonicalKey: string;

--- a/apps/control-web/src/features/shop/utils/spellVariantEditor.test.ts
+++ b/apps/control-web/src/features/shop/utils/spellVariantEditor.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   addSpellVariant,
-  getSpellVariantWarnings,
   getSpellVariantErrors,
   normalizeSpellVariantsForPayload,
   removeSpellVariant,
   summarizeSpellVariant,
+  validateSpellVariants,
 } from "./spellVariantEditor";
 
 describe("spellVariantEditor", () => {
@@ -27,33 +27,33 @@ describe("spellVariantEditor", () => {
     ]);
   });
 
-  it("warns about duplicate and blank keys", () => {
-    const warnings = getSpellVariantWarnings([
+  it("reports duplicate and blank keys as blocking errors", () => {
+    const validation = validateSpellVariants([
       {
         key: "",
-        labelPt: "",
-        effects: [],
+        labelPt: "Sem chave",
+        effects: [{ type: "restrict_action", target: "selected_target", duration: { type: "manual" }, params: { action: "actions" } }],
         onEndEffects: [],
         manualNotes: [],
       },
       {
         key: "foxs_cunning",
         labelPt: "Esperteza da Raposa",
-        effects: [],
+        effects: [{ type: "restrict_action", target: "selected_target", duration: { type: "manual" }, params: { action: "actions" } }],
         onEndEffects: [],
         manualNotes: [],
       },
       {
         key: "foxs_cunning",
         labelPt: "Esperteza da Raposa 2",
-        effects: [],
+        effects: [{ type: "restrict_action", target: "selected_target", duration: { type: "manual" }, params: { action: "actions" } }],
         onEndEffects: [],
         manualNotes: [],
       },
     ]);
 
-    expect(warnings.some((warning) => warning.includes("sem chave"))).toBe(true);
-    expect(warnings.some((warning) => warning.includes("Chaves duplicadas"))).toBe(true);
+    expect(validation.errors.some((issue) => issue.message.includes("precisa de uma chave"))).toBe(true);
+    expect(validation.errors.some((issue) => issue.message.includes("Chave de variante duplicada"))).toBe(true);
   });
 
   it("blocks a variant that has neither effects nor manual notes", () => {
@@ -67,7 +67,7 @@ describe("spellVariantEditor", () => {
       },
     ]);
 
-    expect(errors[0]).toContain("ao menos um efeito declarativo ou nota manual");
+    expect(errors[0]).toContain("ao menos um efeito declarativo");
   });
 
   it("serializes manual notes and trims optional fields", () => {
@@ -134,5 +134,52 @@ describe("spellVariantEditor", () => {
         ],
       }),
     ).toBe("advantage_on_checks (CON) + manual (2d6 HP)");
+  });
+
+  it("requires a label in the current locale and warns about the secondary locale", () => {
+    const ptValidation = validateSpellVariants([
+      {
+        key: "owls_wisdom",
+        labelPt: "",
+        labelEn: "Owl's Wisdom",
+        descriptionPt: "",
+        descriptionEn: "Advantage on Wisdom checks.",
+        effects: [
+          {
+            type: "advantage_on_checks",
+            target: "selected_target",
+            duration: { type: "manual" },
+            params: { ability: "wisdom", against: "any" },
+          },
+        ],
+        onEndEffects: [],
+        manualNotes: [],
+      },
+    ], "pt");
+
+    expect(ptValidation.errors.some((issue) => issue.message.includes("rótulo em português"))).toBe(true);
+
+    const enValidation = validateSpellVariants([
+      {
+        key: "owls_wisdom",
+        labelPt: "Sabedoria da Coruja",
+        labelEn: "Owl's Wisdom",
+        descriptionPt: "",
+        descriptionEn: "",
+        effects: [
+          {
+            type: "advantage_on_checks",
+            target: "selected_target",
+            duration: { type: "manual" },
+            params: { ability: "wisdom", against: "any" },
+          },
+        ],
+        onEndEffects: [],
+        manualNotes: [],
+      },
+    ], "en");
+
+    expect(enValidation.warnings.some((issue) => issue.message.includes("missing an English description"))).toBe(true);
+    expect(enValidation.warnings.some((issue) => issue.message.includes("incomplete in PT localization"))).toBe(true);
   });
 });

--- a/apps/control-web/src/features/shop/utils/spellVariantEditor.ts
+++ b/apps/control-web/src/features/shop/utils/spellVariantEditor.ts
@@ -1,4 +1,19 @@
 import type { SpellVariant, SpellVariantManualNote } from "../../../entities/base-spell";
+import type { Locale } from "../../../shared/i18n";
+
+export type SpellVariantIssue = {
+  severity: "error" | "warning";
+  message: string;
+  variantIndex: number;
+  noteIndex?: number;
+};
+
+export type SpellVariantValidationResult = {
+  issues: SpellVariantIssue[];
+  errors: SpellVariantIssue[];
+  warnings: SpellVariantIssue[];
+  hasBlockingErrors: boolean;
+};
 
 export const createEmptySpellVariantManualNote = (): SpellVariantManualNote => ({
   key: "",
@@ -30,45 +45,153 @@ const trimToNull = (value: string | null | undefined) => {
   return normalized.length > 0 ? normalized : null;
 };
 
-const hasEffectEntries = (length: number | undefined) => Boolean(length && length > 0);
+const humanizeVariantKey = (variantKey: string) =>
+  variantKey
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
 
-export const getSpellVariantWarnings = (variants: SpellVariant[]) => {
-  const normalizedKeys = variants
-    .map((variant) => variant.key.trim())
-    .filter(Boolean);
-  const duplicateKeys = new Set(
-    normalizedKeys.filter((key, index) => normalizedKeys.indexOf(key) !== index),
-  );
+const hasAutomatedEffects = (variant: SpellVariant) =>
+  Boolean((variant.effects?.length ?? 0) > 0 || (variant.onEndEffects?.length ?? 0) > 0);
 
-  const warnings: string[] = [];
-  if (variants.some((variant) => variant.key.trim().length === 0)) {
-    warnings.push("Algumas variantes ainda estão sem chave.");
-  }
-  if (duplicateKeys.size > 0) {
-    warnings.push(
-      `Chaves duplicadas: ${Array.from(duplicateKeys)
-        .sort()
-        .join(", ")}.`,
-    );
-  }
-  if (
-    variants.some(
-      (variant) =>
-        !trimToNull(variant.labelPt) &&
-        !trimToNull(variant.labelEn) &&
-        !trimToNull(variant.descriptionPt) &&
-        !trimToNull(variant.descriptionEn),
-    )
-  ) {
-    warnings.push(
-      "Algumas variantes estão sem rótulos e descrições localizadas. A magia continuará válida, mas ficará ruim de operar no cast.",
-    );
-  }
-  return warnings;
+const noteHasAnyValue = (note: SpellVariantManualNote) =>
+  Boolean(note.key.trim() || note.label.trim() || note.description.trim());
+
+const getCurrentLocaleLabel = (variant: SpellVariant, locale: Locale) =>
+  locale === "en" ? trimToNull(variant.labelEn) : trimToNull(variant.labelPt);
+
+const getOtherLocaleLabel = (variant: SpellVariant, locale: Locale) =>
+  locale === "en" ? trimToNull(variant.labelPt) : trimToNull(variant.labelEn);
+
+const getCurrentLocaleDescription = (variant: SpellVariant, locale: Locale) =>
+  locale === "en" ? trimToNull(variant.descriptionEn) : trimToNull(variant.descriptionPt);
+
+const getOtherLocaleDescription = (variant: SpellVariant, locale: Locale) =>
+  locale === "en" ? trimToNull(variant.descriptionPt) : trimToNull(variant.descriptionEn);
+
+export const validateSpellVariants = (
+  variants: SpellVariant[],
+  locale: Locale = "pt",
+): SpellVariantValidationResult => {
+  const issues: SpellVariantIssue[] = [];
+  const seenKeys = new Map<string, number>();
+
+  variants.forEach((variant, variantIndex) => {
+    const key = variant.key.trim();
+    const currentLabel = getCurrentLocaleLabel(variant, locale);
+    const otherLabel = getOtherLocaleLabel(variant, locale);
+    const currentDescription = getCurrentLocaleDescription(variant, locale);
+    const otherDescription = getOtherLocaleDescription(variant, locale);
+    const activeManualNotes = (variant.manualNotes ?? []).filter(noteHasAnyValue);
+    const hasAnyEffect = hasAutomatedEffects(variant);
+
+    if (!key) {
+      issues.push({
+        severity: "error",
+        message: `Variante ${variantIndex + 1} precisa de uma chave.`,
+        variantIndex,
+      });
+    } else if (seenKeys.has(key)) {
+      issues.push({
+        severity: "error",
+        message: `Chave de variante duplicada: ${key}.`,
+        variantIndex,
+      });
+      issues.push({
+        severity: "error",
+        message: `Chave de variante duplicada: ${key}.`,
+        variantIndex: seenKeys.get(key) ?? variantIndex,
+      });
+    } else {
+      seenKeys.set(key, variantIndex);
+    }
+
+    if (!currentLabel) {
+      issues.push({
+        severity: "error",
+        message:
+          locale === "en"
+            ? `Variant ${key || variantIndex + 1} needs an English label.`
+            : `Variante ${key || variantIndex + 1} precisa de um rótulo em português.`,
+        variantIndex,
+      });
+    }
+
+    if (!hasAnyEffect && activeManualNotes.length === 0) {
+      issues.push({
+        severity: "error",
+        message: `Variante ${key || variantIndex + 1} precisa de ao menos um efeito declarativo, efeito ao terminar ou nota manual.`,
+        variantIndex,
+      });
+    }
+
+    if (currentLabel && !currentDescription) {
+      issues.push({
+        severity: "warning",
+        message:
+          locale === "en"
+            ? `Variant ${key || variantIndex + 1} is missing an English description.`
+            : `Variante ${key || variantIndex + 1} está sem descrição em português.`,
+        variantIndex,
+      });
+    }
+
+    if (!otherLabel || !otherDescription) {
+      issues.push({
+        severity: "warning",
+        message:
+          locale === "en"
+            ? `Variant ${key || variantIndex + 1} is incomplete in PT localization.`
+            : `Variante ${key || variantIndex + 1} está com localização EN incompleta.`,
+        variantIndex,
+      });
+    }
+
+    if (!hasAnyEffect && activeManualNotes.length > 0) {
+      issues.push({
+        severity: "warning",
+        message: `Variante ${key || variantIndex + 1} depende apenas de notas manuais.`,
+        variantIndex,
+      });
+    }
+
+    (variant.manualNotes ?? []).forEach((note, noteIndex) => {
+      if (!noteHasAnyValue(note)) {
+        return;
+      }
+      if (!note.key.trim()) {
+        issues.push({
+          severity: "error",
+          message: `Nota manual ${noteIndex + 1} da variante ${key || variantIndex + 1} precisa de uma chave.`,
+          variantIndex,
+          noteIndex,
+        });
+      }
+      if (!note.label.trim() || !note.description.trim()) {
+        issues.push({
+          severity: "error",
+          message: `Nota manual ${noteIndex + 1} da variante ${key || variantIndex + 1} precisa de rótulo e descrição.`,
+          variantIndex,
+          noteIndex,
+        });
+      }
+    });
+  });
+
+  return {
+    issues,
+    errors: issues.filter((issue) => issue.severity === "error"),
+    warnings: issues.filter((issue) => issue.severity === "warning"),
+    hasBlockingErrors: issues.some((issue) => issue.severity === "error"),
+  };
 };
 
-export const getSpellVariantErrors = (variants: SpellVariant[]) =>
-  normalizeSpellVariantsForPayload(variants).errors;
+export const getSpellVariantWarnings = (variants: SpellVariant[], locale: Locale = "pt") =>
+  validateSpellVariants(variants, locale).warnings.map((issue) => issue.message);
+
+export const getSpellVariantErrors = (variants: SpellVariant[], locale: Locale = "pt") =>
+  validateSpellVariants(variants, locale).errors.map((issue) => issue.message);
 
 const summarizeEffect = (variant: SpellVariant, locale: "pt" | "en") => {
   const summaries = (variant.effects ?? []).map((effect) => {
@@ -90,9 +213,7 @@ const summarizeEffect = (variant: SpellVariant, locale: "pt" | "en") => {
     return effect.type;
   });
 
-  const firstManualNote = variant.manualNotes?.find(
-    (note) => note.label.trim() || note.description.trim() || note.key.trim(),
-  );
+  const firstManualNote = variant.manualNotes?.find(noteHasAnyValue);
   if (firstManualNote) {
     summaries.push(`manual (${firstManualNote.label.trim() || firstManualNote.key.trim()})`);
   }
@@ -109,69 +230,50 @@ export const summarizeSpellVariant = (variant: SpellVariant, locale: "pt" | "en"
 
 export const normalizeSpellVariantsForPayload = (
   variants: SpellVariant[],
+  locale: Locale = "pt",
 ): { variants: SpellVariant[] | null; errors: string[] } => {
   if (variants.length === 0) {
     return { variants: null, errors: [] };
   }
 
-  const errors: string[] = [];
-  const normalizedVariants = variants.map((variant, variantIndex) => {
-    const key = variant.key.trim();
-    if (!key) {
-      errors.push(`Variante ${variantIndex + 1} precisa de uma chave.`);
-    }
-    if (!(variant.effects?.length) && !(variant.manualNotes?.some((note) => note.key.trim() || note.label.trim() || note.description.trim()))) {
-      errors.push(
-        `Variante ${key || variantIndex + 1} precisa de ao menos um efeito declarativo ou nota manual.`,
-      );
-    }
-
-    const normalizedManualNotes = (variant.manualNotes ?? [])
-      .map((note, noteIndex) => {
-        const hasAnyValue = Boolean(
-          note.key.trim() || note.label.trim() || note.description.trim(),
-        );
-        if (!hasAnyValue) {
-          return null;
-        }
-        if (!note.key.trim() || !note.label.trim() || !note.description.trim()) {
-          errors.push(
-            `Nota manual ${noteIndex + 1} da variante ${key || variantIndex + 1} precisa de chave, rótulo e descrição.`,
-          );
-        }
-        return {
-          key: note.key.trim(),
-          label: note.label.trim(),
-          description: note.description.trim(),
-        };
-      })
-      .filter((entry): entry is SpellVariantManualNote => Boolean(entry));
-
+  const validation = validateSpellVariants(variants, locale);
+  if (validation.hasBlockingErrors) {
     return {
-      key,
-      labelPt: variant.labelPt.trim(),
-      labelEn: trimToNull(variant.labelEn),
-      descriptionPt: trimToNull(variant.descriptionPt),
-      descriptionEn: trimToNull(variant.descriptionEn),
-      effects: hasEffectEntries(variant.effects?.length) ? variant.effects ?? [] : null,
-      onEndEffects: hasEffectEntries(variant.onEndEffects?.length)
-        ? variant.onEndEffects ?? []
-        : null,
-      manualNotes: normalizedManualNotes.length > 0 ? normalizedManualNotes : null,
-    } satisfies SpellVariant;
-  });
-
-  const seenKeys = new Set<string>();
-  for (const variant of normalizedVariants) {
-    if (!variant.key) continue;
-    if (seenKeys.has(variant.key)) {
-      errors.push(`Chave de variante duplicada: ${variant.key}.`);
-    }
-    seenKeys.add(variant.key);
+      variants: null,
+      errors: validation.errors.map((issue) => issue.message),
+    };
   }
 
   return {
-    variants: normalizedVariants,
-    errors,
+    variants: variants.map((variant) => {
+      const manualNotes = (variant.manualNotes ?? [])
+        .filter(noteHasAnyValue)
+        .map((note) => ({
+          key: note.key.trim(),
+          label: note.label.trim(),
+          description: note.description.trim(),
+        }));
+
+      return {
+        key: variant.key.trim(),
+        labelPt: variant.labelPt.trim(),
+        labelEn: trimToNull(variant.labelEn),
+        descriptionPt: trimToNull(variant.descriptionPt),
+        descriptionEn: trimToNull(variant.descriptionEn),
+        effects: (variant.effects?.length ?? 0) > 0 ? variant.effects ?? [] : null,
+        onEndEffects: (variant.onEndEffects?.length ?? 0) > 0 ? variant.onEndEffects ?? [] : null,
+        manualNotes: manualNotes.length > 0 ? manualNotes : null,
+      };
+    }),
+    errors: [],
   };
 };
+
+export const getVariantIssueLabel = (variant: SpellVariant, index: number) =>
+  trimToNull(variant.labelPt) ??
+  trimToNull(variant.labelEn) ??
+  trimToNull(variant.key) ??
+  `Variante ${index + 1}`;
+
+export const describeUnknownVariantKey = (key: string) =>
+  `Variante desconhecida (${humanizeVariantKey(key)})`;

--- a/apps/control-web/src/pages/CatalogPage/CatalogSpellEditPage.tsx
+++ b/apps/control-web/src/pages/CatalogPage/CatalogSpellEditPage.tsx
@@ -20,7 +20,7 @@ export const CatalogSpellEditPage = () => {
   const { spellId } = useParams<{ spellId: string }>();
   const { selectedCampaignId } = useCampaigns();
   const navigate = useNavigate();
-  const { t } = useLocale();
+  const { locale, t } = useLocale();
   const { toast, showToast, clearToast } = useToast();
 
   const {
@@ -81,7 +81,7 @@ export const CatalogSpellEditPage = () => {
     Boolean(formState.descriptionEn.trim()) &&
     formState.level >= 0 &&
     formState.level <= 9 &&
-    getSpellCatalogEditorVariantErrors(formState).length === 0;
+    getSpellCatalogEditorVariantErrors(formState, locale).length === 0;
 
   const handleSave = async () => {
     if (!canSave || isSaving) return;
@@ -91,7 +91,7 @@ export const CatalogSpellEditPage = () => {
       await campaignSpellsRepo.update(
         selectedCampaignId,
         spell.id,
-        buildSpellUpdatePayload(formState),
+        buildSpellUpdatePayload(formState, locale),
       );
       await refetchSpells();
       showToast({

--- a/apps/control-web/src/pages/CatalogPage/CatalogSpellNewPage.tsx
+++ b/apps/control-web/src/pages/CatalogPage/CatalogSpellNewPage.tsx
@@ -18,7 +18,7 @@ import { Toast } from "../../shared/ui/Toast";
 export const CatalogSpellNewPage = () => {
   const { selectedCampaignId } = useCampaigns();
   const navigate = useNavigate();
-  const { t } = useLocale();
+  const { locale, t } = useLocale();
   const { toast, showToast, clearToast } = useToast();
 
   const [state, setState] = useState(createEmptySpellEditorState);
@@ -34,14 +34,14 @@ export const CatalogSpellNewPage = () => {
     Boolean(state.descriptionEn.trim()) &&
     state.level >= 0 &&
     state.level <= 9 &&
-    getSpellCatalogEditorVariantErrors(state).length === 0;
+    getSpellCatalogEditorVariantErrors(state, locale).length === 0;
 
   const handleCreate = async () => {
     if (!canSave || isSaving) return;
 
     setIsSaving(true);
     try {
-      await campaignSpellsRepo.create(selectedCampaignId, buildSpellCreatePayload(state) as CampaignSpellCreatePayload);
+      await campaignSpellsRepo.create(selectedCampaignId, buildSpellCreatePayload(state, locale) as CampaignSpellCreatePayload);
       showToast({
         variant: "success",
         title: t("catalog.spells.createSuccessTitle"),

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/SystemSpellCatalogPage.tsx
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/SystemSpellCatalogPage.tsx
@@ -15,7 +15,7 @@ import {
 } from "./systemSpellCatalog.types";
 
 export const SystemSpellCatalogPage = () => {
-  const { t } = useLocale();
+  const { locale, t } = useLocale();
   const [spells, setSpells] = useState<BaseSpell[]>([]);
   const [loading, setLoading] = useState(true);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -93,7 +93,7 @@ export const SystemSpellCatalogPage = () => {
 
   const handleSave = async () => {
     const isNew = !selectedSpellId;
-    const built = buildPayload(form, isNew);
+    const built = buildPayload(form, isNew, locale);
     if (!built.payload) {
       setError(built.error ?? "Payload inválido.");
       return;

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.helpers.test.ts
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.helpers.test.ts
@@ -393,4 +393,36 @@ describe("systemSpellCatalog upcast helpers", () => {
     const result = buildPayload(form, true);
     expect(result.error).toContain("Chave de variante duplicada");
   });
+
+  it("blocks incomplete manual notes in the admin helper", () => {
+    const form = createEmptyForm();
+    form.canonicalKey = "enhance_ability";
+    form.nameEn = "Enhance Ability";
+    form.descriptionEn = "Choose one ability.";
+    form.variants = [
+      {
+        key: "owls_wisdom",
+        labelPt: "Sabedoria da Coruja",
+        effects: [
+          {
+            type: "advantage_on_checks",
+            target: "selected_target",
+            duration: { type: "manual" },
+            params: { ability: "wisdom", against: "any" },
+          },
+        ],
+        onEndEffects: [],
+        manualNotes: [
+          {
+            key: "",
+            label: "Percepção passiva",
+            description: "",
+          },
+        ],
+      },
+    ];
+
+    const result = buildPayload(form, true, "pt");
+    expect(result.error).toMatch(/nota manual/i);
+  });
 });

--- a/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.helpers.ts
+++ b/apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.helpers.ts
@@ -1,4 +1,5 @@
 import type { BaseSpell, BaseSpellWritePayload, CastingTimeType } from "../../entities/base-spell";
+import type { Locale } from "../../shared/i18n";
 import {
   SpellSource as SpellSourceValues,
   SpellSchool as SpellSchoolValues,
@@ -283,6 +284,7 @@ export const formFromSpell = (spell: BaseSpell): FormState => ({
 export const buildPayload = (
   form: FormState,
   isNew: boolean,
+  locale: Locale = "pt",
 ): { payload?: BaseSpellWritePayload; error?: string } => {
   const canonicalKey = normalizeCanonicalKey(form.canonicalKey);
   if (!canonicalKey) return { error: catalogPtBRDictionary["catalog.spells.validation.canonicalKeyRequired"] };
@@ -379,7 +381,7 @@ export const buildPayload = (
     if (!form.upcastUnlockSummary.trim()) return { error: catalogPtBRDictionary["catalog.spells.validation.extraEffectRequiresSummary"] };
   }
 
-  const normalizedVariants = normalizeSpellVariantsForPayload(form.variants);
+  const normalizedVariants = normalizeSpellVariantsForPayload(form.variants, locale);
   if (normalizedVariants.errors.length > 0) {
     return { error: normalizedVariants.errors[0] };
   }


### PR DESCRIPTION
## Summary
- unify modal spell variant validation rules across system/admin and campaign/shared editors
- block invalid variants before serialization while keeping localization and manual-only guidance as warnings
- show inline validation on the exact variant or manual note with the issue

## What Changed
- replaced ad-hoc variant validation with a shared structured validator that returns blocking errors and non-blocking warnings
- enforce the same blocking rules in both editor surfaces for blank/duplicate keys, incomplete manual notes, missing current-locale label, and no-op variants
- keep incomplete secondary localization and manual-only variants as warnings
- surface variant-level and manual-note-level inline messages inside the variants editor
- pass the active locale into payload builders so current-locale label requirements are checked correctly before save

## Validation
- `npx vitest run apps/control-web/src/features/shop/utils/spellVariantEditor.test.ts apps/control-web/src/features/shop/utils/spellCatalogForm.test.ts apps/control-web/src/pages/SystemSpellCatalogPage/systemSpellCatalog.helpers.test.ts apps/control-web/src/features/shop/components/SpellCatalogVariantsFields.test.tsx`

## Acceptance Notes
- campaign editor now blocks the same invalid variant states as the system editor
- invalid variants cannot be serialized into save payloads
- spells without variants remain unaffected
- warnings for incomplete localization and manual-only variants still render without blocking save