### PR TITLE
feat(combat-ui): modal variant observability and effect context debug (#137)

### DIFF
--- a/apps/control-server/app/api/routes/sessions/activity.py
+++ b/apps/control-server/app/api/routes/sessions/activity.py
@@ -148,6 +148,8 @@ def get_session_activity(
                 dc=payload.get("dc") if isinstance(payload.get("dc"), int) else None,
                 targetUserId=payload.get("targetUserId") if isinstance(payload.get("targetUserId"), str) else None,
                 targetDisplayName=payload.get("targetDisplayName") if isinstance(payload.get("targetDisplayName"), str) else None,
+                targetParticipantId=payload.get("targetParticipantId") if isinstance(payload.get("targetParticipantId"), str) else None,
+                debugModifiers=payload.get("debugModifiers") if isinstance(payload.get("debugModifiers"), list) else None,
                 timestamp=command.created_at,
                 sessionOffsetSeconds=offset(command.created_at),
             ))

--- a/apps/control-server/app/api/routes/sessions/commands_service.py
+++ b/apps/control-server/app/api/routes/sessions/commands_service.py
@@ -30,6 +30,15 @@ from .commands_common import (
 )
 
 AUTHORITATIVE_ROLL_TYPES = {"ability", "save", "skill", "initiative", "attack"}
+CHECK_MODIFIER_TYPES = {"advantage", "disadvantage"}
+CHECK_MODIFIER_ROLL_TYPES = {"ability", "skill"}
+CHECK_MODIFIER_AGAINST = {"any", "effect_target", "selected_target"}
+CHECK_MODIFIER_SKIP_REASONS = {
+    "target_mismatch",
+    "ability_mismatch",
+    "skill_mismatch",
+    "missing_target",
+}
 
 
 def record_gm_activity(
@@ -127,6 +136,62 @@ async def send_session_command_service(
         if target:
             activity_payload["targetUserId"] = target[0]
             activity_payload["targetDisplayName"] = target[1]
+
+        target_participant_id = payload_data.get("targetParticipantId")
+        if target_participant_id is not None:
+            if not isinstance(target_participant_id, str) or not target_participant_id.strip():
+                raise HTTPException(status_code=400, detail="targetParticipantId must be a non-empty string")
+            activity_payload["targetParticipantId"] = target_participant_id.strip()
+
+        debug_modifiers = payload_data.get("debugModifiers")
+        if debug_modifiers is not None:
+            if not isinstance(debug_modifiers, list):
+                raise HTTPException(status_code=400, detail="debugModifiers must be a list")
+            normalized_debug_modifiers: list[dict] = []
+            for entry_payload in debug_modifiers:
+                if not isinstance(entry_payload, dict):
+                    raise HTTPException(status_code=400, detail="Each debug modifier must be an object")
+                source_label = entry_payload.get("source_label")
+                modifier_type = entry_payload.get("modifier_type")
+                roll_type_value = entry_payload.get("roll_type")
+                applied = entry_payload.get("applied")
+                if not isinstance(source_label, str) or not source_label.strip():
+                    raise HTTPException(status_code=400, detail="debugModifiers.source_label must be a non-empty string")
+                if modifier_type not in CHECK_MODIFIER_TYPES:
+                    raise HTTPException(status_code=400, detail="debugModifiers.modifier_type is invalid")
+                if roll_type_value not in CHECK_MODIFIER_ROLL_TYPES:
+                    raise HTTPException(status_code=400, detail="debugModifiers.roll_type is invalid")
+                if not isinstance(applied, bool):
+                    raise HTTPException(status_code=400, detail="debugModifiers.applied must be a boolean")
+                against = entry_payload.get("against")
+                if against is not None and against not in CHECK_MODIFIER_AGAINST:
+                    raise HTTPException(status_code=400, detail="debugModifiers.against is invalid")
+                skip_reason = entry_payload.get("skip_reason")
+                if skip_reason is not None and skip_reason not in CHECK_MODIFIER_SKIP_REASONS:
+                    raise HTTPException(status_code=400, detail="debugModifiers.skip_reason is invalid")
+                normalized_debug_modifiers.append(
+                    {
+                        "source_label": source_label.strip(),
+                        "modifier_type": modifier_type,
+                        "roll_type": roll_type_value,
+                        "ability": entry_payload.get("ability")
+                        if isinstance(entry_payload.get("ability"), str)
+                        else None,
+                        "skill": entry_payload.get("skill")
+                        if isinstance(entry_payload.get("skill"), str)
+                        else None,
+                        "against": against,
+                        "selected_target_participant_id": entry_payload.get("selected_target_participant_id")
+                        if isinstance(entry_payload.get("selected_target_participant_id"), str)
+                        else None,
+                        "selected_target_display_name": entry_payload.get("selected_target_display_name")
+                        if isinstance(entry_payload.get("selected_target_display_name"), str)
+                        else None,
+                        "applied": applied,
+                        "skip_reason": skip_reason,
+                    }
+                )
+            activity_payload["debugModifiers"] = normalized_debug_modifiers
 
         event_type = "roll_requested"
         event_payload.update(activity_payload)

--- a/apps/control-server/app/schemas/combat_spells.py
+++ b/apps/control-server/app/schemas/combat_spells.py
@@ -338,6 +338,9 @@ class CombatSpellResult(BaseModel):
     spell_name: str
     spell_canonical_key: str | None = None
     selected_variant_key: str | None = None
+    selected_variant_label: str | None = None
+    context_origin: Literal["initial_cast", "pending_save", "pending_spell"] | None = None
+    concentration_group: str | None = None
     action_kind: Literal[
         "spell_attack", "saving_throw", "direct_damage", "heal", "utility"
     ]

--- a/apps/control-server/app/schemas/session.py
+++ b/apps/control-server/app/schemas/session.py
@@ -100,6 +100,8 @@ class RollRequestActivityEvent(BaseModel):
     dc: Optional[int] = None
     targetUserId: Optional[str] = None
     targetDisplayName: Optional[str] = None
+    targetParticipantId: Optional[str] = None
+    debugModifiers: Optional[List[dict]] = None
     timestamp: datetime
     sessionOffsetSeconds: int
 

--- a/apps/control-server/app/services/combat_service/condition_effects_predicates.py
+++ b/apps/control-server/app/services/combat_service/condition_effects_predicates.py
@@ -136,3 +136,77 @@ def resolve_check_advantage_mode(
     if has_dis and not has_adv:
         return "disadvantage"
     return "normal"
+
+
+def explain_check_modifier_sources(
+    participant: dict,
+    *,
+    ability: AbilityName,
+    roll_type: Literal["ability", "skill"] = "ability",
+    skill: str | None = None,
+    target_participant_id: str | None = None,
+) -> list[dict]:
+    explanations: list[dict] = []
+    for effect in participant.get("active_effects") or []:
+        if effect.get("kind") != "spell_effect":
+            continue
+        metadata = effect.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        declarative = metadata.get("declarative_effect")
+        if not isinstance(declarative, dict):
+            continue
+
+        effect_type = declarative.get("type")
+        if effect_type not in {"advantage_on_checks", "disadvantage_on_checks"}:
+            continue
+
+        params = declarative.get("params")
+        if not isinstance(params, dict):
+            continue
+
+        against = (
+            params.get("against")
+            if params.get("against") in {"any", "effect_target", "selected_target"}
+            else "any"
+        )
+        effect_ability = params.get("ability")
+        modifier_type = "advantage" if effect_type == "advantage_on_checks" else "disadvantage"
+        entry = {
+            "source_label": metadata.get("source_spell_name")
+            or effect.get("display_label")
+            or "Spell effect",
+            "modifier_type": modifier_type,
+            "roll_type": roll_type,
+            "ability": effect_ability if isinstance(effect_ability, str) else None,
+            "skill": skill if roll_type == "skill" else None,
+            "against": against,
+            "selected_target_participant_id": metadata.get("selected_target_participant_id")
+            if isinstance(metadata.get("selected_target_participant_id"), str)
+            else None,
+            "selected_target_display_name": metadata.get("selected_target_display_name")
+            if isinstance(metadata.get("selected_target_display_name"), str)
+            else None,
+            "applied": False,
+            "skip_reason": None,
+        }
+
+        if effect_ability != ability:
+            entry["skip_reason"] = "skill_mismatch" if roll_type == "skill" else "ability_mismatch"
+            explanations.append(entry)
+            continue
+
+        if against == "selected_target":
+            selected_target_id = metadata.get("selected_target_participant_id")
+            if not isinstance(target_participant_id, str) or not target_participant_id.strip():
+                entry["skip_reason"] = "missing_target"
+                explanations.append(entry)
+                continue
+            if target_participant_id != selected_target_id:
+                entry["skip_reason"] = "target_mismatch"
+                explanations.append(entry)
+                continue
+
+        entry["applied"] = True
+        explanations.append(entry)
+    return explanations

--- a/apps/control-server/app/services/combat_service/save_resolve.py
+++ b/apps/control-server/app/services/combat_service/save_resolve.py
@@ -118,6 +118,8 @@ class CombatSaveResolveMixin:
                         "variant_scope": pending_save.get("variant_scope"),
                         "selected_variant_key": pending_spell_context.get("selected_variant_key"),
                         "selected_variant_label": pending_spell_context.get("selected_variant_label"),
+                        "context_origin": "pending_save",
+                        "concentration_group": pending_spell_context.get("concentration_group"),
                         "target_variant_assignments": pending_spell_context.get("target_variant_assignments"),
                         "manual_notes_by_target": manual_notes_by_target,
                         "effects": pending_spell_context.get("effects"),
@@ -175,6 +177,9 @@ class CombatSaveResolveMixin:
                 "roll_result": roll_result.model_dump(mode="json"),
                 "pending_spell_id": pending_spell_id,
                 "selected_variant_key": pending_spell_context.get("selected_variant_key"),
+                "selected_variant_label": pending_spell_context.get("selected_variant_label"),
+                "context_origin": "pending_save",
+                "concentration_group": pending_spell_context.get("concentration_group"),
                 "target_variant_assignments": pending_spell_context.get("target_variant_assignments"),
                 "manual_notes_by_target": manual_notes_by_target,
             }
@@ -198,7 +203,12 @@ class CombatSaveResolveMixin:
             log_message += f" {amount} de {effect_kind} de {damage_type or 'energia'}{effect_msg}"
         if pending_spell_id:
             log_message += " Efeito pendente."
-        log_message = f"{log_message}{cls._format_manual_notes_for_log(manual_notes_by_target)}".strip()
+        log_message = (
+            f"{log_message}"
+            f"{cls._format_variant_assignments_for_log(pending_spell_context.get('target_variant_assignments'), manual_notes_by_target)}"
+            f"{cls._format_manual_notes_for_log(manual_notes_by_target)}"
+            f"{cls._format_concentration_group_for_log(pending_spell_context.get('concentration_group'))}"
+        ).strip()
         await cls._emit_log(session_id, {
             "message": log_message,
             "actorUserId": actor_user_id,
@@ -214,6 +224,9 @@ class CombatSaveResolveMixin:
             "healing": amount if effect_kind == "healing" else 0,
             "damage_type": damage_type,
             "selected_variant_key": pending_spell_context.get("selected_variant_key"),
+            "selected_variant_label": pending_spell_context.get("selected_variant_label"),
+            "context_origin": "pending_save",
+            "concentration_group": pending_spell_context.get("concentration_group"),
             "is_critical": False,
             "is_hit": None,
             "is_saved": is_saved,

--- a/apps/control-server/app/services/combat_service/spell_automation.py
+++ b/apps/control-server/app/services/combat_service/spell_automation.py
@@ -120,6 +120,10 @@ class CombatSpellAutomationMixin:
         result: dict = {
             "spell_name": spell_name,
             "spell_canonical_key": spell_context["spell_canonical_key"],
+            "selected_variant_key": spell_context.get("selected_variant_key"),
+            "selected_variant_label": spell_context.get("selected_variant_label"),
+            "context_origin": spell_context.get("context_origin") or "initial_cast",
+            "concentration_group": spell_context.get("concentration_group"),
             "action_kind": action_kind,
             "effect_kind": None, "damage": 0, "healing": 0, "damage_type": None,
             "is_critical": False, "is_hit": None, "is_saved": None, "new_hp": None,

--- a/apps/control-server/app/services/combat_service/spell_declarative_effects.py
+++ b/apps/control-server/app/services/combat_service/spell_declarative_effects.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from typing import Literal
 from uuid import uuid4
 
 from app.schemas.base_spell import SpellDeclarativeEffect
 from app.schemas.campaign_entity_shared import AbilityName, SKILL_ABILITY_MAP, SkillName
-from .condition_effects_predicates import resolve_check_advantage_mode
+from .condition_effects_predicates import (
+    explain_check_modifier_sources,
+    resolve_check_advantage_mode,
+)
 from .exceptions import CombatServiceError
 
 
@@ -123,8 +127,18 @@ class CombatSpellDeclarativeEffectsMixin:
             "selected_target_participant_id": target_participant.get("id")
             if isinstance(target_participant, dict)
             else None,
+            "selected_target_ref_id": target_participant.get("ref_id")
+            if isinstance(target_participant, dict)
+            else None,
+            "selected_target_display_name": target_participant.get("display_name")
+            if isinstance(target_participant, dict)
+            else None,
             "source_spell_key": spell_context.get("spell_canonical_key"),
             "source_spell_name": spell_context.get("spell_name"),
+            "selected_variant_key": spell_context.get("selected_variant_key"),
+            "selected_variant_label": spell_context.get("selected_variant_label"),
+            "target_assignment_source": spell_context.get("variant_scope"),
+            "context_origin": spell_context.get("context_origin") or "initial_cast",
             "concentration": bool(spell_context.get("concentration")),
             "concentration_group": effect_group_id if spell_context.get("concentration") else None,
         }
@@ -137,8 +151,13 @@ class CombatSpellDeclarativeEffectsMixin:
         )
         if resolved_target is None:
             return []
+        metadata["effect_target_participant_id"] = resolved_target.get("id")
+        metadata["effect_target_ref_id"] = resolved_target.get("ref_id")
+        metadata["effect_target_display_name"] = resolved_target.get("display_name")
 
         params = effect.params.model_dump(mode="json")
+        if effect.type in {"advantage_on_checks", "disadvantage_on_checks"}:
+            metadata["against"] = params.get("against") or "any"
         if effect.stacking == "replace":
             cls._replace_matching_effects(resolved_target, effect.type, params)
 
@@ -308,6 +327,9 @@ class CombatSpellDeclarativeEffectsMixin:
             extra={
                 "__declarative_effect_group_id": application["effect_group_id"],
                 "__applied_effect_count": len(applied_effects),
+                "concentration_group": application["effect_group_id"]
+                if spell_context.get("concentration")
+                else None,
             },
         )
 
@@ -354,5 +376,39 @@ class CombatSpellDeclarativeEffectsMixin:
             actor_kind=actor_kind,
             actor_ref_id=actor_ref_id,
             ability=SKILL_ABILITY_MAP[skill],
+            target_participant_id=target_participant_id,
+        )
+
+    @classmethod
+    def _explain_check_modifier_sources_for_actor(
+        cls,
+        db,
+        session_id: str,
+        *,
+        actor_kind: str,
+        actor_ref_id: str,
+        ability: AbilityName,
+        roll_type: Literal["ability", "skill"] = "ability",
+        skill: SkillName | None = None,
+        target_participant_id: str | None = None,
+    ) -> list[dict]:
+        state = cls.get_state(db, session_id)
+        if state is None:
+            return []
+        participant = next(
+            (
+                entry
+                for entry in state.participants
+                if entry.get("kind") == actor_kind and entry.get("ref_id") == actor_ref_id
+            ),
+            None,
+        )
+        if not isinstance(participant, dict):
+            return []
+        return explain_check_modifier_sources(
+            participant,
+            ability=ability,
+            roll_type=roll_type,
+            skill=skill,
             target_participant_id=target_participant_id,
         )

--- a/apps/control-server/app/services/combat_service/spells/cast_target.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target.py
@@ -342,6 +342,12 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
         ]
         merged["selected_variant_key"] = variant.key
         merged["selected_variant_label"] = variant.labelPt or variant.labelEn or variant.key
+        merged["variant_scope"] = (
+            "per_target"
+            if isinstance(target_variant_assignments, list) and len(target_variant_assignments) > 1
+            else "single_target"
+        )
+        merged["context_origin"] = spell_context.get("context_origin") or "initial_cast"
         merged["manual_notes_by_target"] = (
             [cls._build_variant_summary_for_target(participant=participant, variant=variant)]
             if isinstance(participant, dict) and variant.manualNotes
@@ -1008,6 +1014,7 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
                 {
                     "target_ref_id": participant.get("ref_id"),
                     "target_participant_id": participant.get("id"),
+                    "target_display_name": cls._participant_display_name(participant),
                     "variant_key": assignment["variant_key"],
                     "variant_label": assignment["variant_label"],
                 }
@@ -1202,6 +1209,12 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
             f"{attacker['display_name']} conjurou {spell_context['spell_name']} em {target_count} alvo"
             f"{'s' if target_count != 1 else ''}: {target_names}."
         )
+        log_message = (
+            f"{log_message}"
+            f"{cls._format_variant_assignments_for_log(target_variant_assignments, manual_notes_by_target)}"
+            f"{cls._format_manual_notes_for_log(manual_notes_by_target)}"
+            f"{cls._format_concentration_group_for_log(shared_effect_group_id)}"
+        ).strip()
         if was_overridden:
             log_message = f"[OVERRIDE: Limit for '{action_cost}' ignored] {log_message}"
         await cls._emit_log(session_id, {
@@ -1216,6 +1229,9 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
             "spell_name": spell_context["spell_name"],
             "spell_canonical_key": spell_context["spell_canonical_key"],
             "selected_variant_key": None,
+            "selected_variant_label": None,
+            "context_origin": "initial_cast",
+            "concentration_group": shared_effect_group_id,
             "action_kind": spell_mode,
             "effect_kind": spell_context.get("effect_kind"),
             "damage": total_damage,
@@ -1729,7 +1745,10 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
                 [
                     {
                         "target_participant_id": selected_participant.get("id"),
+                        "target_display_name": cls._participant_display_name(selected_participant),
                         "variant_key": selected_variant.key,
+                        "variant_label": selected_variant.labelPt or selected_variant.labelEn or selected_variant.key,
+                        "target_ref_id": selected_participant.get("ref_id"),
                     }
                 ]
                 if isinstance(selected_participant, dict)

--- a/apps/control-server/app/services/combat_service/spells/cast_target_effect.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target_effect.py
@@ -181,7 +181,12 @@ class CastTargetEffectMixin:
             concentration_check.get("summary_text"), str
         ):
             log_message = f"{log_message} {concentration_check['summary_text']}".strip()
-        log_message = f"{log_message}{cls._format_manual_notes_for_log(manual_notes_by_target)}".strip()
+        log_message = (
+            f"{log_message}"
+            f"{cls._format_variant_assignments_for_log(pending_spell_context.get('target_variant_assignments'), manual_notes_by_target)}"
+            f"{cls._format_manual_notes_for_log(manual_notes_by_target)}"
+            f"{cls._format_concentration_group_for_log(pending_spell_context.get('concentration_group'))}"
+        ).strip()
 
         await cls._emit_log(
             session_id,
@@ -196,6 +201,9 @@ class CastTargetEffectMixin:
             "spell_name": pending_spell.get("spell_name"),
             "spell_canonical_key": pending_spell.get("spell_canonical_key"),
             "selected_variant_key": pending_spell_context.get("selected_variant_key"),
+            "selected_variant_label": pending_spell_context.get("selected_variant_label"),
+            "context_origin": "pending_spell",
+            "concentration_group": pending_spell_context.get("concentration_group"),
             "action_kind": pending_spell.get("action_kind"),
             "effect_kind": effect_kind,
             "damage": amount if effect_kind == "damage" else 0,

--- a/apps/control-server/app/services/combat_service/spells/spell_resolution_common.py
+++ b/apps/control-server/app/services/combat_service/spells/spell_resolution_common.py
@@ -73,6 +73,7 @@ class SpellResolutionCommonMixin:
                     "variant_key": variant_key.strip(),
                     "variant_label": entry.get("variant_label"),
                     "target_ref_id": entry.get("target_ref_id"),
+                    "target_display_name": entry.get("target_display_name"),
                 }
             )
         return normalized
@@ -126,6 +127,8 @@ class SpellResolutionCommonMixin:
                 "variant_scope": "per_target",
                 "selected_variant_key": assignment["variant_key"],
                 "selected_variant_label": assignment.get("variant_label"),
+                "context_origin": spell_context.get("context_origin") or "initial_cast",
+                "concentration_group": spell_context.get("concentration_group"),
                 "target_variant_assignments": target_variant_assignments,
                 "manual_notes_by_target": manual_notes_by_target,
                 "effects": list(effects or []),
@@ -138,10 +141,13 @@ class SpellResolutionCommonMixin:
                 "variant_scope": "single_target",
                 "selected_variant_key": selected_variant_key.strip(),
                 "selected_variant_label": spell_context.get("selected_variant_label"),
+                "context_origin": spell_context.get("context_origin") or "initial_cast",
+                "concentration_group": spell_context.get("concentration_group"),
                 "target_variant_assignments": [
                     {
                         "target_participant_id": target_participant_id,
                         "target_ref_id": target_p.get("ref_id"),
+                        "target_display_name": target_p.get("display_name"),
                         "variant_key": selected_variant_key.strip(),
                         "variant_label": spell_context.get("selected_variant_label"),
                     }
@@ -166,6 +172,9 @@ class SpellResolutionCommonMixin:
             "spell_name": pending_payload.get("spell_name"),
             "spell_canonical_key": pending_payload.get("spell_canonical_key"),
             "concentration": bool(pending_payload.get("concentration")),
+            "context_origin": pending_payload.get("context_origin"),
+            "concentration_group": pending_payload.get("concentration_group"),
+            "variant_scope": pending_payload.get("variant_scope"),
             "effects": list(pending_payload.get("effects") or []),
             "on_end_effects": list(pending_payload.get("on_end_effects") or []),
             "selected_variant_key": pending_payload.get("selected_variant_key"),
@@ -213,6 +222,57 @@ class SpellResolutionCommonMixin:
             if labels:
                 chunks.append(f"{target_name}: {', '.join(labels)}")
         return f" Notas manuais: {'; '.join(chunks)}." if chunks else ""
+
+    @classmethod
+    def _format_variant_assignments_for_log(
+        cls,
+        target_variant_assignments: object,
+        manual_notes_by_target: object = None,
+    ) -> str:
+        if not isinstance(target_variant_assignments, list) or not target_variant_assignments:
+            return ""
+        display_names_by_id: dict[str, str] = {}
+        display_names_by_ref: dict[str, str] = {}
+        if isinstance(manual_notes_by_target, list):
+            for entry in manual_notes_by_target:
+                if not isinstance(entry, dict):
+                    continue
+                display_name = entry.get("target_display_name")
+                if not isinstance(display_name, str) or not display_name.strip():
+                    continue
+                participant_id = entry.get("target_participant_id")
+                ref_id = entry.get("target_ref_id")
+                if isinstance(participant_id, str):
+                    display_names_by_id[participant_id] = display_name
+                if isinstance(ref_id, str):
+                    display_names_by_ref[ref_id] = display_name
+        chunks: list[str] = []
+        for entry in target_variant_assignments:
+            if not isinstance(entry, dict):
+                continue
+            variant_label = entry.get("variant_label") or entry.get("variant_key")
+            if not isinstance(variant_label, str) or not variant_label.strip():
+                continue
+            participant_id = entry.get("target_participant_id")
+            ref_id = entry.get("target_ref_id")
+            explicit_target_name = entry.get("target_display_name")
+            target_name = None
+            if isinstance(explicit_target_name, str) and explicit_target_name.strip():
+                target_name = explicit_target_name
+            if target_name is None and isinstance(participant_id, str):
+                target_name = display_names_by_id.get(participant_id)
+            if target_name is None and isinstance(ref_id, str):
+                target_name = display_names_by_ref.get(ref_id)
+            if target_name is None:
+                target_name = participant_id or ref_id or "Target"
+            chunks.append(f"{target_name}={variant_label}")
+        return f" Variantes: {'; '.join(chunks)}." if chunks else ""
+
+    @classmethod
+    def _format_concentration_group_for_log(cls, concentration_group: object) -> str:
+        if isinstance(concentration_group, str) and concentration_group.strip():
+            return f" Concentração: {concentration_group.strip()}."
+        return ""
 
     @classmethod
     def _apply_spell_effect(
@@ -266,6 +326,8 @@ class SpellResolutionCommonMixin:
             "spell_name": spell_context["spell_name"],
             "spell_canonical_key": spell_context["spell_canonical_key"],
             "action_kind": action_kind,
+            "context_origin": spell_context.get("context_origin") or "initial_cast",
+            "concentration_group": spell_context.get("concentration_group"),
             "effect_kind": effect_kind,
             "effect_dice": spell_context["effect_dice"],
             "effect_bonus": effect_bonus,

--- a/apps/control-server/app/services/combat_service/spells/spell_response.py
+++ b/apps/control-server/app/services/combat_service/spells/spell_response.py
@@ -43,6 +43,12 @@ class SpellResponseMixin:
                 lines.append(f"  Instância {idx} → {name}: sem dano.")
 
         log_message = "\n".join(lines)
+        log_message = (
+            f"{log_message}"
+            f"{cls._format_variant_assignments_for_log(spell_context.get('target_variant_assignments'), spell_context.get('manual_notes_by_target'))}"
+            f"{cls._format_manual_notes_for_log(spell_context.get('manual_notes_by_target'))}"
+            f"{cls._format_concentration_group_for_log(spell_context.get('concentration_group'))}"
+        ).strip()
         if was_overridden:
             log_message = f"[OVERRIDE: Limit for '{action_cost}' ignored] {log_message}"
         return log_message
@@ -150,6 +156,13 @@ class SpellResponseMixin:
                 f"{log_message} {result.concentration_check['summary_text']}".strip()
             )
 
+        log_message = (
+            f"{log_message}"
+            f"{cls._format_variant_assignments_for_log(spell_context.get('target_variant_assignments'), spell_context.get('manual_notes_by_target'))}"
+            f"{cls._format_manual_notes_for_log(spell_context.get('manual_notes_by_target'))}"
+            f"{cls._format_concentration_group_for_log(spell_context.get('concentration_group'))}"
+        ).strip()
+
         if was_overridden:
             log_message = f"[OVERRIDE: Limit for '{action_cost}' ignored] {log_message}"
 
@@ -211,6 +224,21 @@ class SpellResponseMixin:
                 automation_result.get("selected_variant_key")
                 if automation_result is not None
                 else spell_context.get("selected_variant_key")
+            ),
+            "selected_variant_label": (
+                automation_result.get("selected_variant_label")
+                if automation_result is not None
+                else spell_context.get("selected_variant_label")
+            ),
+            "context_origin": (
+                automation_result.get("context_origin")
+                if automation_result is not None
+                else spell_context.get("context_origin") or "initial_cast"
+            ),
+            "concentration_group": (
+                automation_result.get("concentration_group")
+                if automation_result is not None
+                else spell_context.get("concentration_group")
             ),
             "action_kind": spell_mode,
             "effect_kind": effect_kind,

--- a/apps/control-server/tests/test_friends_contextual_advantage.py
+++ b/apps/control-server/tests/test_friends_contextual_advantage.py
@@ -14,6 +14,7 @@ Regression guard: prevents silent breakage of contextual advantages.
 import unittest
 
 from app.services.combat_service.condition_effects_predicates import (
+    explain_check_modifier_sources,
     resolve_check_advantage_mode,
 )
 
@@ -31,6 +32,7 @@ def _spell_effect_advantage(ability: str, against: str | None = None) -> dict:
                 },
             },
             "selected_target_participant_id": None,  # Will be set per scenario
+            "selected_target_display_name": "Guard Captain",
             "caster_participant_id": "caster_id",
             "source_spell_key": "friends",
             "source_spell_name": "Friends",
@@ -185,6 +187,39 @@ class TestFriendsContextualAdvantage(unittest.TestCase):
         self.assertEqual(
             mode, "normal", "Charisma advantage should NOT apply to Strength checks"
         )
+
+    def test_explain_sources_marks_applied_entry(self):
+        effect = _spell_effect_advantage("charisma", against="selected_target")
+        effect["metadata"]["selected_target_participant_id"] = "target_a_id"
+        caster = _participant_with_effect("caster_id", [effect])
+
+        explanation = explain_check_modifier_sources(
+            caster,
+            ability="charisma",
+            roll_type="ability",
+            target_participant_id="target_a_id",
+        )
+
+        self.assertEqual(len(explanation), 1)
+        self.assertTrue(explanation[0]["applied"])
+        self.assertIsNone(explanation[0]["skip_reason"])
+        self.assertEqual(explanation[0]["selected_target_display_name"], "Guard Captain")
+
+    def test_explain_sources_marks_target_mismatch(self):
+        effect = _spell_effect_advantage("charisma", against="selected_target")
+        effect["metadata"]["selected_target_participant_id"] = "target_a_id"
+        caster = _participant_with_effect("caster_id", [effect])
+
+        explanation = explain_check_modifier_sources(
+            caster,
+            ability="charisma",
+            roll_type="ability",
+            target_participant_id="target_b_id",
+        )
+
+        self.assertEqual(len(explanation), 1)
+        self.assertFalse(explanation[0]["applied"])
+        self.assertEqual(explanation[0]["skip_reason"], "target_mismatch")
 
 
 if __name__ == "__main__":

--- a/apps/control-server/tests/test_spell_declarative_effects.py
+++ b/apps/control-server/tests/test_spell_declarative_effects.py
@@ -315,3 +315,49 @@ class TestSpellDeclarativeEffectRuntime(unittest.TestCase):
         self.assertEqual(second_metadata["declarative_effect_group_id"], "shared-group")
         self.assertEqual(first_metadata["concentration_group"], "shared-group")
         self.assertEqual(second_metadata["concentration_group"], "shared-group")
+
+    def test_active_effect_metadata_exposes_modal_and_contextual_debug_fields(self):
+        state = self._make_state()
+        attacker = state.participants[0]
+        target = state.participants[1]
+        spell_context = {
+            "spell_name": "Friends",
+            "spell_canonical_key": "friends",
+            "selected_variant_key": "eagles_splendor",
+            "selected_variant_label": "Esplendor da Aguia",
+            "variant_scope": "single_target",
+            "context_origin": "initial_cast",
+            "concentration": True,
+            "effects": [
+                {
+                    "type": "advantage_on_checks",
+                    "target": "caster",
+                    "params": {"ability": "charisma", "against": "selected_target"},
+                    "stacking": "replace",
+                }
+            ],
+            "on_end_effects": [],
+        }
+
+        CombatService._apply_declarative_spell_effects(
+            state=state,
+            attacker=attacker,
+            target_participant=target,
+            spell_context=spell_context,
+            effect_group_id="group-ctx",
+        )
+
+        metadata = attacker["active_effects"][0]["metadata"]
+        self.assertEqual(metadata["source_spell_name"], "Friends")
+        self.assertEqual(metadata["selected_variant_key"], "eagles_splendor")
+        self.assertEqual(metadata["selected_variant_label"], "Esplendor da Aguia")
+        self.assertEqual(metadata["target_assignment_source"], "single_target")
+        self.assertEqual(metadata["context_origin"], "initial_cast")
+        self.assertEqual(metadata["selected_target_participant_id"], "target-1")
+        self.assertEqual(metadata["selected_target_ref_id"], "entity-1")
+        self.assertEqual(metadata["selected_target_display_name"], "Target")
+        self.assertEqual(metadata["effect_target_participant_id"], "caster-1")
+        self.assertEqual(metadata["effect_target_ref_id"], "player-1")
+        self.assertEqual(metadata["effect_target_display_name"], "Caster")
+        self.assertEqual(metadata["against"], "selected_target")
+        self.assertEqual(metadata["concentration_group"], "group-ctx")

--- a/apps/control-web/src/entities/roll/rollResolution.types.ts
+++ b/apps/control-web/src/entities/roll/rollResolution.types.ts
@@ -47,6 +47,7 @@ export type AbilityRollRequest = {
   roll_source?: RollSource;
   manual_roll?: number | null;
   manual_rolls?: [number, number] | null;
+  target_participant_id?: string | null;
 };
 
 export type SaveRollRequest = {
@@ -59,6 +60,7 @@ export type SaveRollRequest = {
   roll_source?: RollSource;
   manual_roll?: number | null;
   manual_rolls?: [number, number] | null;
+  target_participant_id?: string | null;
 };
 
 export type SkillRollRequest = {
@@ -71,6 +73,7 @@ export type SkillRollRequest = {
   roll_source?: RollSource;
   manual_roll?: number | null;
   manual_rolls?: [number, number] | null;
+  target_participant_id?: string | null;
 };
 
 export type InitiativeRollRequest = {
@@ -81,6 +84,7 @@ export type InitiativeRollRequest = {
   roll_source?: RollSource;
   manual_roll?: number | null;
   manual_rolls?: [number, number] | null;
+  target_participant_id?: string | null;
 };
 
 export type AttackBaseRollRequest = {
@@ -92,6 +96,7 @@ export type AttackBaseRollRequest = {
   roll_source?: RollSource;
   manual_roll?: number | null;
   manual_rolls?: [number, number] | null;
+  target_participant_id?: string | null;
 };
 
 // --- Result (received from backend + via realtime) ---

--- a/apps/control-web/src/features/combat-ui/components/ActiveEffectDebugPanel.test.tsx
+++ b/apps/control-web/src/features/combat-ui/components/ActiveEffectDebugPanel.test.tsx
@@ -1,0 +1,44 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { ActiveEffectDebugPanel } from "./ActiveEffectDebugPanel";
+
+vi.mock("../../../shared/hooks/useLocale", () => ({
+  useLocale: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("ActiveEffectDebugPanel", () => {
+  it("renderiza metadados contextuais do efeito ativo", () => {
+    const markup = renderToStaticMarkup(
+      <ActiveEffectDebugPanel
+        targetDisplayName="Caster"
+        effects={[
+          {
+            id: "effect-1",
+            kind: "spell_effect",
+            duration_type: "manual",
+            created_at: "2026-05-01T00:00:00Z",
+            display_label: "Friends",
+            metadata: {
+              source_spell_name: "Friends",
+              selected_target_display_name: "Guard Captain",
+              against: "selected_target",
+              concentration: false,
+              context_origin: "initial_cast",
+              declarative_effect: {
+                type: "advantage_on_checks",
+                params: { ability: "charisma" },
+              },
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Source: Friends");
+    expect(markup).toContain("Selected target: Guard Captain");
+    expect(markup).toContain("Against: selected target");
+    expect(markup).toContain("Advantage: charisma checks");
+  });
+});

--- a/apps/control-web/src/features/combat-ui/components/ActiveEffectDebugPanel.tsx
+++ b/apps/control-web/src/features/combat-ui/components/ActiveEffectDebugPanel.tsx
@@ -1,0 +1,46 @@
+import { formatEffectContextDebug } from "../spellVariantUi";
+import { getCombatEffectLabel } from "../combatUi.helpers";
+import type { ActiveEffect } from "../../../shared/api/combatRepo";
+import { useLocale } from "../../../shared/hooks/useLocale";
+
+type Props = {
+  effects: ActiveEffect[];
+  targetDisplayName?: string | null;
+};
+
+export const ActiveEffectDebugPanel = ({
+  effects,
+  targetDisplayName = null,
+}: Props) => {
+  const { t } = useLocale();
+  const debugEntries = effects
+    .map((effect) => ({
+      effect,
+      lines: formatEffectContextDebug(effect, { targetDisplayName }),
+    }))
+    .filter((entry) => entry.lines.length > 0);
+
+  if (!debugEntries.length) {
+    return null;
+  }
+
+  return (
+    <div className="mt-3 space-y-2">
+      {debugEntries.map(({ effect, lines }) => (
+        <details
+          key={effect.id}
+          className="rounded-2xl border border-sky-500/20 bg-sky-500/8 px-3 py-2"
+        >
+          <summary className="cursor-pointer text-xs font-semibold uppercase tracking-[0.16em] text-sky-100">
+            {getCombatEffectLabel(t, effect)}
+          </summary>
+          <div className="mt-2 space-y-1 text-xs text-slate-200">
+            {lines.map((line, index) => (
+              <p key={`${effect.id}:${index}`}>{line}</p>
+            ))}
+          </div>
+        </details>
+      ))}
+    </div>
+  );
+};

--- a/apps/control-web/src/features/combat-ui/components/CombatParticipantRoster.tsx
+++ b/apps/control-web/src/features/combat-ui/components/CombatParticipantRoster.tsx
@@ -1,6 +1,7 @@
 import { useLocale } from "../../../shared/hooks/useLocale";
 import { getCombatEffectLabel, getCombatStatusLabel, getTurnResourceLabel } from "../combatUi.helpers";
 import type { CombatParticipantView } from "../types";
+import { ActiveEffectDebugPanel } from "./ActiveEffectDebugPanel";
 
 type Props = {
   onRemoveEffect?: (participantId: string, effectId: string) => void | Promise<void>;
@@ -74,28 +75,34 @@ export const CombatParticipantRoster = ({
             </div>
 
             {participant.activeEffects.length > 0 ? (
-              <div className="mt-3 flex flex-wrap gap-2">
-                {participant.activeEffects.map((effect) => (
-                  <span
-                    key={effect.id}
-                    className="inline-flex items-center gap-1 rounded-full border border-fuchsia-500/25 bg-fuchsia-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-fuchsia-100"
-                  >
-                    {getCombatEffectLabel(t, effect)}
-                    {onRemoveEffect ? (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          void onRemoveEffect(participant.id, effect.id);
-                        }}
-                        className="text-fuchsia-200 transition-colors hover:text-white"
-                        aria-label={t("combatUi.removeEffect")}
-                      >
-                        x
-                      </button>
-                    ) : null}
-                  </span>
-                ))}
-              </div>
+              <>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {participant.activeEffects.map((effect) => (
+                    <span
+                      key={effect.id}
+                      className="inline-flex items-center gap-1 rounded-full border border-fuchsia-500/25 bg-fuchsia-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-fuchsia-100"
+                    >
+                      {getCombatEffectLabel(t, effect)}
+                      {onRemoveEffect ? (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            void onRemoveEffect(participant.id, effect.id);
+                          }}
+                          className="text-fuchsia-200 transition-colors hover:text-white"
+                          aria-label={t("combatUi.removeEffect")}
+                        >
+                          x
+                        </button>
+                      ) : null}
+                    </span>
+                  ))}
+                </div>
+                <ActiveEffectDebugPanel
+                  effects={participant.activeEffects}
+                  targetDisplayName={participant.display_name}
+                />
+              </>
             ) : null}
           </article>
         ))}

--- a/apps/control-web/src/features/combat-ui/gm/GmPendingSavesPanel.tsx
+++ b/apps/control-web/src/features/combat-ui/gm/GmPendingSavesPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import {
   findManualNotesForTarget,
+  formatManualNotesByTarget,
   resolveTargetVariantLabel,
 } from "../spellVariantUi";
 import type { CombatParticipant } from "../../../shared/api/combatRepo";
@@ -42,6 +43,9 @@ export const GmPendingSavesPanel = ({
             targetParticipantId: p.id,
             targetRefId: p.ref_id,
           });
+          const manualNoteLines = formatManualNotesByTarget(
+            manualNotesEntry ? [manualNotesEntry] : null,
+          );
           return (
             <div key={p.id} className="rounded-2xl bg-slate-950/40 p-4 space-y-3">
               <div className="flex flex-wrap items-center justify-between gap-3">
@@ -54,11 +58,17 @@ export const GmPendingSavesPanel = ({
                   {variantLabel ? (
                     <p className="mt-1 text-xs text-fuchsia-200">Variante: {variantLabel}</p>
                   ) : null}
-                  {manualNotesEntry?.manual_notes.length ? (
+                  {save.context_origin ? (
+                    <p className="mt-1 text-xs text-sky-200">Origem: {save.context_origin}</p>
+                  ) : null}
+                  {save.concentration_group ? (
+                    <p className="mt-1 text-xs text-sky-200">Concentração: {save.concentration_group}</p>
+                  ) : null}
+                  {manualNoteLines.length ? (
                     <div className="mt-2 space-y-1 text-xs text-amber-100">
-                      {manualNotesEntry.manual_notes.map((note) => (
-                        <p key={note.key}>
-                          {note.label} - {note.description}
+                      {manualNoteLines.map((line, index) => (
+                        <p key={`${p.id}:${index}`}>
+                          {line.replace(`${p.display_name}: `, "")}
                         </p>
                       ))}
                     </div>

--- a/apps/control-web/src/features/combat-ui/gm/gmPendingSavesPanel.test.tsx
+++ b/apps/control-web/src/features/combat-ui/gm/gmPendingSavesPanel.test.tsx
@@ -31,6 +31,9 @@ describe("GmPendingSavesPanel", () => {
               save_dc: 14,
               attacker_display_name: "Mage",
               selected_variant_key: "foxs_cunning",
+              selected_variant_label: "Esperteza da Raposa",
+              context_origin: "pending_save",
+              concentration_group: "group-1",
               target_variant_assignments: [
                 {
                   target_participant_id: "enemy-1",
@@ -80,6 +83,8 @@ describe("GmPendingSavesPanel", () => {
     );
 
     expect(markup).toContain("Variante: Esperteza da Raposa");
+    expect(markup).toContain("Origem: pending_save");
+    expect(markup).toContain("Concentração: group-1");
     expect(markup).toContain("Manual A - Descricao A");
     expect(markup).not.toContain("Manual B - Descricao B");
   });

--- a/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
+++ b/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
@@ -11,6 +11,7 @@ import { SpellSlotSummary } from "../../../shared/ui/SpellSlotSummary";
 import { CombatLogPanel } from "../components/CombatLogPanel";
 import { CombatModeBar } from "../components/CombatModeBar";
 import { CombatParticipantRoster } from "../components/CombatParticipantRoster";
+import { ActiveEffectDebugPanel } from "../components/ActiveEffectDebugPanel";
 import { buildCombatParticipantViews, getCombatEffectLabel, getCombatStatusLabel } from "../combatUi.helpers";
 import { PlayerAttackRollDialog } from "../../../pages/PlayerBoardPage/player-combat-debug/PlayerAttackRollDialog";
 import { PlayerSpellCastDialog } from "../../../pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog";
@@ -472,16 +473,22 @@ export const PlayerCombatModeShell = ({
                   </span>
                 </div>
                 {myParticipant?.active_effects?.length ? (
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    {myParticipant.active_effects.map((effect) => (
-                      <span
-                        key={effect.id}
-                        className="rounded-full border border-fuchsia-500/25 bg-fuchsia-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-fuchsia-100"
-                      >
-                        {getCombatEffectLabel(t, effect)}
-                      </span>
-                    ))}
-                  </div>
+                  <>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {myParticipant.active_effects.map((effect) => (
+                        <span
+                          key={effect.id}
+                          className="rounded-full border border-fuchsia-500/25 bg-fuchsia-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-fuchsia-100"
+                        >
+                          {getCombatEffectLabel(t, effect)}
+                        </span>
+                      ))}
+                    </div>
+                    <ActiveEffectDebugPanel
+                      effects={myParticipant.active_effects}
+                      targetDisplayName={myParticipant.display_name}
+                    />
+                  </>
                 ) : (
                   <p className="mt-3 text-sm text-slate-400">{t("combatUi.noEffects")}</p>
                 )}
@@ -555,8 +562,10 @@ export const PlayerCombatModeShell = ({
             skill: (pendingRoll.skill ?? undefined) as SkillName | undefined,
             advantageMode: (pendingRoll.mode ?? "normal") as AdvantageMode,
             dc: pendingRoll.dc,
+            targetParticipantId: pendingRoll.targetParticipantId ?? undefined,
             reason: pendingRoll.reason,
             issuedBy: pendingRoll.issuedBy,
+            debugModifiers: pendingRoll.debugModifiers ?? undefined,
           }}
           sessionId={sessionId}
           actorKind="player"
@@ -596,6 +605,7 @@ export const PlayerCombatModeShell = ({
                 targetRefId: activePendingSave.participantRefId,
               }),
             }),
+            targetParticipantId: activePendingSave.participantId,
             issuedBy: activePendingSave.attacker_display_name ?? undefined,
             issuedByLabel: t("combatUi.castBy"),
           }}

--- a/apps/control-web/src/features/combat-ui/spellVariantUi.test.ts
+++ b/apps/control-web/src/features/combat-ui/spellVariantUi.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   buildPendingSaveReason,
+  formatEffectContextDebug,
+  formatManualNotesByTarget,
+  formatVariantAssignmentDebug,
   resolveTargetVariantLabel,
 } from "./spellVariantUi";
 
@@ -52,5 +55,73 @@ describe("spellVariantUi", () => {
         selectedVariantKey: "mystery_mode",
       }),
     ).toBe("Variante desconhecida (Mystery Mode)");
+  });
+
+  it("formata assignments e notas manuais por alvo", () => {
+    expect(
+      formatVariantAssignmentDebug(
+        [
+          {
+            target_participant_id: "enemy-a",
+            variant_key: "foxs_cunning",
+            variant_label: "Esperteza da Raposa",
+          },
+        ],
+        [
+          {
+            target_participant_id: "enemy-a",
+            target_display_name: "Goblin A",
+            variant_key: "foxs_cunning",
+            variant_label: "Esperteza da Raposa",
+            manual_notes: [{ key: "a", label: "Manual A", description: "Descricao A" }],
+          },
+        ],
+      ),
+    ).toEqual(["Goblin A: Esperteza da Raposa"]);
+
+    expect(
+      formatManualNotesByTarget([
+        {
+          target_participant_id: "enemy-a",
+          target_display_name: "Goblin A",
+          variant_key: "foxs_cunning",
+          variant_label: "Esperteza da Raposa",
+          manual_notes: [{ key: "a", label: "Manual A", description: "Descricao A" }],
+        },
+      ]),
+    ).toEqual(["Goblin A: Manual A - Descricao A"]);
+  });
+
+  it("formata contexto debug de active effect declarativo", () => {
+    const lines = formatEffectContextDebug(
+      {
+        id: "effect-1",
+        kind: "spell_effect",
+        duration_type: "manual",
+        created_at: "2026-05-01T00:00:00Z",
+        metadata: {
+          source_spell_name: "Friends",
+          selected_variant_label: "Esplendor da Aguia",
+          effect_target_display_name: "Caster",
+          selected_target_display_name: "Guard Captain",
+          against: "selected_target",
+          context_origin: "initial_cast",
+          concentration: true,
+          concentration_group: "group-1",
+          declarative_effect: {
+            type: "advantage_on_checks",
+            params: { ability: "charisma" },
+          },
+        },
+      },
+      { targetDisplayName: "Caster" },
+    );
+
+    expect(lines).toContain("Source: Friends");
+    expect(lines).toContain("Variant: Esplendor da Aguia");
+    expect(lines).toContain("Selected target: Guard Captain");
+    expect(lines).toContain("Against: selected target");
+    expect(lines).toContain("Concentration: group-1");
+    expect(lines).toContain("Advantage: charisma checks");
   });
 });

--- a/apps/control-web/src/features/combat-ui/spellVariantUi.ts
+++ b/apps/control-web/src/features/combat-ui/spellVariantUi.ts
@@ -1,4 +1,5 @@
 import type { SpellVariantManualNote } from "../../entities/base-spell";
+import type { ActiveEffect, CombatSpellContextOrigin } from "../../shared/api/combatRepo";
 
 type TargetVariantAssignmentLike = {
   target_participant_id?: string | null;
@@ -131,3 +132,135 @@ export const buildPendingSaveReason = ({
   variantLabel
     ? `${spellName} - save de ${saveAbility} - variante: ${variantLabel}`
     : `${spellName} - save de ${saveAbility}`;
+
+export const formatVariantAssignmentDebug = (
+  targetVariantAssignments: TargetVariantAssignmentLike[] | null | undefined,
+  manualNotesByTarget: ManualNotesByTargetEntryLike[] | null | undefined,
+) => {
+  if (!targetVariantAssignments?.length) {
+    return [];
+  }
+  return targetVariantAssignments.map((entry) => {
+    const manualEntry = findManualNotesForTarget(manualNotesByTarget, {
+      targetParticipantId: entry.target_participant_id,
+      targetRefId: entry.target_ref_id,
+    });
+    const targetName =
+      manualEntry?.target_display_name
+      ?? entry.target_participant_id
+      ?? entry.target_ref_id
+      ?? "Target";
+    const variantLabel = entry.variant_label ?? humanizeVariantKey(entry.variant_key);
+    return `${targetName}: ${variantLabel}`;
+  });
+};
+
+export const formatManualNotesByTarget = (
+  manualNotesByTarget: ManualNotesByTargetEntryLike[] | null | undefined,
+) => {
+  if (!manualNotesByTarget?.length) {
+    return [];
+  }
+  return manualNotesByTarget.flatMap((entry) =>
+    entry.manual_notes.map((note) => `${entry.target_display_name}: ${note.label} - ${note.description}`),
+  );
+};
+
+const originLabel = (origin: CombatSpellContextOrigin | null | undefined) => {
+  switch (origin) {
+    case "initial_cast":
+      return "initial cast";
+    case "pending_save":
+      return "pending save";
+    case "pending_spell":
+      return "pending spell";
+    default:
+      return null;
+  }
+};
+
+const humanizeAgainst = (value: unknown) => {
+  if (value === "selected_target") return "selected target";
+  if (value === "effect_target") return "effect target";
+  if (value === "any") return "any";
+  return null;
+};
+
+export const formatEffectContextDebug = (
+  effect: ActiveEffect,
+  {
+    targetDisplayName,
+  }: {
+    targetDisplayName?: string | null;
+  } = {},
+) => {
+  const metadata = effect.metadata;
+  if (!metadata || typeof metadata !== "object") {
+    return [];
+  }
+  const lines: string[] = [];
+  const sourceSpellName =
+    typeof metadata.source_spell_name === "string" ? metadata.source_spell_name : null;
+  if (sourceSpellName) {
+    lines.push(`Source: ${sourceSpellName}`);
+  }
+  const variantLabel =
+    typeof metadata.selected_variant_label === "string"
+      ? metadata.selected_variant_label
+      : typeof metadata.selected_variant_key === "string"
+        ? humanizeVariantKey(metadata.selected_variant_key)
+        : null;
+  if (variantLabel) {
+    lines.push(`Variant: ${variantLabel}`);
+  }
+  const recipient =
+    typeof metadata.effect_target_display_name === "string"
+      ? metadata.effect_target_display_name
+      : targetDisplayName ?? null;
+  if (recipient) {
+    lines.push(`Recipient: ${recipient}`);
+  }
+  if (typeof metadata.selected_target_display_name === "string") {
+    lines.push(`Selected target: ${metadata.selected_target_display_name}`);
+  }
+  const againstLabel = humanizeAgainst(metadata.against);
+  if (againstLabel) {
+    lines.push(`Against: ${againstLabel}`);
+  }
+  const origin = originLabel(
+    typeof metadata.context_origin === "string"
+      ? (metadata.context_origin as CombatSpellContextOrigin)
+      : null,
+  );
+  if (origin) {
+    lines.push(`Context: ${origin}`);
+  }
+  if (metadata.concentration === true) {
+    lines.push(
+      typeof metadata.concentration_group === "string"
+        ? `Concentration: ${metadata.concentration_group}`
+        : "Concentration: yes",
+    );
+  }
+  const declarative = metadata.declarative_effect;
+  if (declarative && typeof declarative === "object") {
+    const entry = declarative as {
+      type?: unknown;
+      params?: { ability?: unknown; stat?: unknown; condition?: unknown } | null;
+    };
+    if (
+      (entry.type === "advantage_on_checks" || entry.type === "disadvantage_on_checks")
+      && entry.params
+      && typeof entry.params.ability === "string"
+    ) {
+      lines.push(
+        `${entry.type === "advantage_on_checks" ? "Advantage" : "Disadvantage"}: ${entry.params.ability} checks`,
+      );
+    } else if (entry.type === "modify_stat" && entry.params && typeof entry.params.stat === "string") {
+      lines.push(`Effect: ${entry.params.stat}`);
+    } else if (entry.type === "apply_condition" && entry.params && typeof entry.params.condition === "string") {
+      lines.push(`Condition: ${entry.params.condition}`);
+    }
+  }
+  return lines;
+};

--- a/apps/control-web/src/features/rolls/components/AuthoritativeRollDialog.test.tsx
+++ b/apps/control-web/src/features/rolls/components/AuthoritativeRollDialog.test.tsx
@@ -1,0 +1,71 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { AuthoritativeRollDialog } from "./AuthoritativeRollDialog";
+
+vi.mock("../../../shared/hooks/useLocale", () => ({
+  useLocale: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("../hooks/useRollResolution", () => ({
+  useRollResolution: () => ({
+    result: null,
+    loading: false,
+    error: null,
+    submitRoll: vi.fn(),
+    clearResult: vi.fn(),
+  }),
+}));
+
+vi.mock("./RollResultCard", () => ({
+  RollResultCard: () => <div>result</div>,
+}));
+
+describe("AuthoritativeRollDialog", () => {
+  it("renderiza explicacoes debug aplicadas e puladas", () => {
+    const markup = renderToStaticMarkup(
+      <AuthoritativeRollDialog
+        request={{
+          rollType: "ability",
+          ability: "charisma",
+          advantageMode: "advantage",
+          targetParticipantId: "guard-1",
+          reason: "Persuasion check",
+          debugModifiers: [
+            {
+              source_label: "Friends",
+              modifier_type: "advantage",
+              roll_type: "ability",
+              ability: "charisma",
+              against: "selected_target",
+              selected_target_participant_id: "guard-1",
+              selected_target_display_name: "Guard Captain",
+              applied: true,
+              skip_reason: null,
+            },
+            {
+              source_label: "Friends",
+              modifier_type: "advantage",
+              roll_type: "ability",
+              ability: "charisma",
+              against: "selected_target",
+              selected_target_participant_id: "guard-2",
+              selected_target_display_name: "Other Guard",
+              applied: false,
+              skip_reason: "target_mismatch",
+            },
+          ],
+        }}
+        sessionId="session-1"
+        actorKind="player"
+        actorRefId="player-1"
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Effect Context");
+    expect(markup).toContain("Friends: advantage em charisma contra Guard Captain");
+    expect(markup).toContain("Não aplicado: Friends só vale contra Other Guard");
+  });
+});

--- a/apps/control-web/src/features/rolls/components/AuthoritativeRollDialog.tsx
+++ b/apps/control-web/src/features/rolls/components/AuthoritativeRollDialog.tsx
@@ -16,9 +16,22 @@ export type AuthoritativeRollRequest = {
   skill?: SkillName;
   advantageMode: AdvantageMode;
   dc?: number | null;
+  targetParticipantId?: string | null;
   reason?: string;
   issuedBy?: string;
   issuedByLabel?: string;
+  debugModifiers?: Array<{
+    source_label: string;
+    modifier_type: "advantage" | "disadvantage";
+    roll_type: "ability" | "skill";
+    ability?: string | null;
+    skill?: string | null;
+    against?: "any" | "effect_target" | "selected_target" | null;
+    selected_target_participant_id?: string | null;
+    selected_target_display_name?: string | null;
+    applied: boolean;
+    skip_reason?: "target_mismatch" | "ability_mismatch" | "skill_mismatch" | "missing_target" | null;
+  }> | null;
 };
 
 type Props = {
@@ -82,6 +95,7 @@ export const AuthoritativeRollDialog = ({
           skill: request.skill,
           advantageMode: request.advantageMode,
           dc: request.dc,
+          targetParticipantId: request.targetParticipantId,
           rollSource: "system",
         });
     if (result) {
@@ -106,6 +120,7 @@ export const AuthoritativeRollDialog = ({
             skill: request.skill,
             advantageMode: request.advantageMode,
             dc: request.dc,
+            targetParticipantId: request.targetParticipantId,
             rollSource: "manual",
             manualRolls: [manualD20, value],
           });
@@ -124,6 +139,7 @@ export const AuthoritativeRollDialog = ({
             skill: request.skill,
             advantageMode: request.advantageMode,
             dc: request.dc,
+            targetParticipantId: request.targetParticipantId,
             rollSource: "manual",
             manualRoll: value,
           });
@@ -135,6 +151,31 @@ export const AuthoritativeRollDialog = ({
   };
 
   const context = request.ability ?? request.skill ?? null;
+  const debugModifiers = request.debugModifiers ?? [];
+
+  const formatDebugModifier = (entry: NonNullable<typeof request.debugModifiers>[number]) => {
+    const subject = entry.roll_type === "skill" ? entry.skill ?? entry.ability ?? "check" : entry.ability ?? "check";
+    const base = `${entry.source_label}: ${entry.modifier_type} em ${subject}`;
+    if (entry.applied) {
+      if (entry.against === "selected_target" && entry.selected_target_display_name) {
+        return `${base} contra ${entry.selected_target_display_name}`;
+      }
+      return base;
+    }
+    if (entry.skip_reason === "target_mismatch" && entry.selected_target_display_name) {
+      return `Não aplicado: ${entry.source_label} só vale contra ${entry.selected_target_display_name}`;
+    }
+    if (entry.skip_reason === "missing_target") {
+      return `Não aplicado: ${entry.source_label} exige um alvo contextual`;
+    }
+    if (entry.skip_reason === "skill_mismatch") {
+      return `Não aplicado: ${entry.source_label} não afeta ${entry.skill ?? "esta perícia"}`;
+    }
+    if (entry.skip_reason === "ability_mismatch") {
+      return `Não aplicado: ${entry.source_label} não afeta ${entry.ability ?? "este atributo"}`;
+    }
+    return `Não aplicado: ${base}`;
+  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 px-4">
@@ -170,6 +211,21 @@ export const AuthoritativeRollDialog = ({
             {request.issuedByLabel ?? t("playerBoard.requestedBy" as Parameters<typeof t>[0])} {request.issuedBy}
           </p>
         )}
+
+        {debugModifiers.length > 0 ? (
+          <div className="mt-4 rounded-2xl border border-sky-500/25 bg-sky-500/10 px-4 py-3">
+            <p className="text-[11px] font-bold uppercase tracking-[0.24em] text-sky-200">
+              Effect Context
+            </p>
+            <div className="mt-2 space-y-1 text-xs text-slate-200">
+              {debugModifiers.map((entry, index) => (
+                <p key={`${entry.source_label}:${entry.modifier_type}:${index}`}>
+                  {formatDebugModifier(entry)}
+                </p>
+              ))}
+            </div>
+          </div>
+        ) : null}
 
         {/* Result display */}
         {displayedResult && (

--- a/apps/control-web/src/features/rolls/hooks/useRollResolution.ts
+++ b/apps/control-web/src/features/rolls/hooks/useRollResolution.ts
@@ -16,6 +16,7 @@ export type AuthoritativeRollParams = {
   advantageMode: AdvantageMode;
   dc?: number | null;
   targetAc?: number | null;
+  targetParticipantId?: string | null;
   bonusOverride?: number | null;
   rollSource: "system" | "manual";
   manualRoll?: number | null;
@@ -46,6 +47,7 @@ export const useRollResolution = (
           actor_ref_id: actorRefId,
           advantage_mode: params.advantageMode,
           bonus_override: params.bonusOverride ?? undefined,
+          target_participant_id: params.targetParticipantId ?? undefined,
           roll_source: params.rollSource,
           manual_roll: params.manualRoll ?? undefined,
           manual_rolls: params.manualRolls ?? undefined,

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
@@ -393,8 +393,10 @@ export const PlayerBoardPage = () => {
             skill: (pendingRoll.skill ?? undefined) as SkillName | undefined,
             advantageMode: (pendingRoll.mode ?? "normal") as AdvantageMode,
             dc: pendingRoll.dc,
+            targetParticipantId: pendingRoll.targetParticipantId ?? undefined,
             reason: pendingRoll.reason,
             issuedBy: pendingRoll.issuedBy,
+            debugModifiers: pendingRoll.debugModifiers ?? undefined,
           }}
           sessionId={activeSession?.id ?? ""}
           actorKind="player"

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
@@ -208,6 +208,9 @@ export const mergePendingSaveResolutionResult = (
     save_ability: (resolution.save_ability as AbilityName) ?? result.save_ability,
     save_dc: resolution.save_dc,
     selected_variant_key: resolution.selected_variant_key ?? result.selected_variant_key,
+    selected_variant_label: resolution.selected_variant_label ?? result.selected_variant_label,
+    context_origin: resolution.context_origin ?? result.context_origin,
+    concentration_group: resolution.concentration_group ?? result.concentration_group,
     target_variant_assignments:
       resolution.target_variant_assignments ?? result.target_variant_assignments ?? null,
     manual_notes_by_target:

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastResultPanel.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastResultPanel.tsx
@@ -1,5 +1,9 @@
 import { RollResultCard } from "../../../features/rolls/components/RollResultCard";
-import { resolveTargetVariantLabel } from "../../../features/combat-ui/spellVariantUi";
+import {
+  formatManualNotesByTarget,
+  formatVariantAssignmentDebug,
+  resolveTargetVariantLabel,
+} from "../../../features/combat-ui/spellVariantUi";
 import type { CombatSpellResult } from "../../../shared/api/combatRepo";
 import {
   formatAreaTargetOutcome,
@@ -54,6 +58,11 @@ export const SpellCastResultPanel = ({
     targetRefId: null,
     targetParticipantId: null,
   });
+  const variantAssignmentLines = formatVariantAssignmentDebug(
+    result.target_variant_assignments,
+    result.manual_notes_by_target,
+  );
+  const manualNoteLines = formatManualNotesByTarget(result.manual_notes_by_target);
 
   return (
     <div className="mt-5 space-y-4">
@@ -125,22 +134,29 @@ export const SpellCastResultPanel = ({
             Afinidade Elemental elegível: {result.elemental_affinity_damage_type ?? "tipo"}{typeof result.elemental_affinity_bonus === "number" ? ` · bonus potencial +${result.elemental_affinity_bonus}` : ""}
           </p>
         ) : null}
-        {resolvedVariantLabel ? (
-          <p className="mt-2 text-xs text-slate-300">Variante resolvida: {resolvedVariantLabel}</p>
+        {(variantAssignmentLines.length || resolvedVariantLabel || result.context_origin || result.concentration_group) ? (
+          <div className="mt-3 space-y-1 text-xs text-sky-100">
+            {variantAssignmentLines.length ? (
+              variantAssignmentLines.map((line, index) => (
+                <p key={`variant:${index}`}>{line}</p>
+              ))
+            ) : resolvedVariantLabel ? (
+              <p>Variante: {resolvedVariantLabel}</p>
+            ) : null}
+            {result.context_origin ? (
+              <p>Origem: {result.context_origin}</p>
+            ) : null}
+            {result.concentration_group ? (
+              <p>Concentração: {result.concentration_group}</p>
+            ) : null}
+          </div>
         ) : null}
-        {result.manual_notes_by_target?.length ? (
+        {manualNoteLines.length ? (
           <div className="mt-3 space-y-2 text-xs text-amber-100">
-            {result.manual_notes_by_target.map((entry) => (
-              <div key={`${entry.target_participant_id ?? entry.target_ref_id ?? entry.target_display_name}:${entry.variant_key}`}>
-                <p>
-                  {entry.target_display_name}: {entry.variant_label ?? entry.variant_key}
-                </p>
-                {entry.manual_notes.map((note) => (
-                  <p key={note.key}>
-                    {note.label} - {note.description}
-                  </p>
-                ))}
-              </div>
+            {manualNoteLines.map((line, index) => (
+              <p key={`note:${index}`}>
+                {line}
+              </p>
             ))}
           </div>
         ) : null}

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/playerSpellCastDialog.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/playerSpellCastDialog.test.tsx
@@ -644,6 +644,9 @@ describe("PlayerSpellCastDialog", () => {
         },
         pending_spell_id: "pending-spell-1",
         selected_variant_key: "foxs_cunning",
+        selected_variant_label: "Esperteza da Raposa",
+        context_origin: "pending_save",
+        concentration_group: "group-1",
         target_variant_assignments: [
           {
             target_participant_id: "enemy-1",
@@ -664,6 +667,9 @@ describe("PlayerSpellCastDialog", () => {
     );
 
     expect(merged.selected_variant_key).toBe("foxs_cunning");
+    expect(merged.selected_variant_label).toBe("Esperteza da Raposa");
+    expect(merged.context_origin).toBe("pending_save");
+    expect(merged.concentration_group).toBe("group-1");
     expect(merged.pending_spell_id).toBe("pending-spell-1");
     expect(merged.target_variant_assignments).toEqual([
       {

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx
@@ -195,6 +195,9 @@ describe("SpellCastResultPanel", () => {
           spell_name: "Modal Save Test Spell",
           spell_canonical_key: "modal_save_test_spell",
           selected_variant_key: "foxs_cunning",
+          selected_variant_label: "Esperteza da Raposa",
+          context_origin: "pending_spell",
+          concentration_group: "group-1",
           action_kind: "saving_throw",
           effect_kind: "damage",
           damage: 7,
@@ -234,7 +237,8 @@ describe("SpellCastResultPanel", () => {
       />,
     );
 
-    expect(markup).toContain("Variante resolvida: Esperteza da Raposa");
+    expect(markup).toContain("Origem: pending_spell");
+    expect(markup).toContain("Concentração: group-1");
     expect(markup).toContain("Goblin A: Esperteza da Raposa");
     expect(markup).toContain("Manual A - Descricao A");
     expect(markup).toContain("Goblin B: Sabedoria da Coruja");

--- a/apps/control-web/src/pages/PlayerBoardPage/playerBoard.types.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/playerBoard.types.ts
@@ -12,6 +12,21 @@ export type PendingRoll = {
   skill?: string | null;
   /** DC set by GM. */
   dc?: number | null;
+  /** Optional combat target context for debug explanations. */
+  targetParticipantId?: string | null;
+  /** Debug-only modifier explanations shown in the authoritative dialog. */
+  debugModifiers?: Array<{
+    source_label: string;
+    modifier_type: "advantage" | "disadvantage";
+    roll_type: "ability" | "skill";
+    ability?: string | null;
+    skill?: string | null;
+    against?: "any" | "effect_target" | "selected_target" | null;
+    selected_target_participant_id?: string | null;
+    selected_target_display_name?: string | null;
+    applied: boolean;
+    skip_reason?: "target_mismatch" | "ability_mismatch" | "skill_mismatch" | "missing_target" | null;
+  }> | null;
 };
 
 export type PlayerBoardStatusSummary = {

--- a/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardRollRequests.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardRollRequests.ts
@@ -153,6 +153,13 @@ export const usePlayerBoardRollRequests = ({
     const ability = (lastCommand.data?.ability as string | undefined) ?? null;
     const skill = (lastCommand.data?.skill as string | undefined) ?? null;
     const dc = typeof lastCommand.data?.dc === "number" ? lastCommand.data.dc : null;
+    const targetParticipantId =
+      typeof lastCommand.data?.targetParticipantId === "string"
+        ? lastCommand.data.targetParticipantId
+        : null;
+    const debugModifiers = Array.isArray(lastCommand.data?.debugModifiers)
+      ? lastCommand.data.debugModifiers
+      : null;
     const requestActivity: RollRequestActivityEvent = {
       type: "roll_request",
       expression,
@@ -162,6 +169,8 @@ export const usePlayerBoardRollRequests = ({
       ability,
       skill,
       dc,
+      targetParticipantId,
+      debugModifiers,
       targetUserId: targetUserId ?? null,
       timestamp: String(lastCommand.issuedAt ?? new Date().toISOString()),
       sessionOffsetSeconds: 0,
@@ -176,6 +185,8 @@ export const usePlayerBoardRollRequests = ({
       ability,
       skill,
       dc,
+      targetParticipantId,
+      debugModifiers,
     }, requestActivity);
   }, [activeSessionId, lastCommand, reconcileAndShowRollPrompt, userId]);
 
@@ -211,6 +222,13 @@ export const usePlayerBoardRollRequests = ({
     const ability = (typeof lastEvent.payload.ability === "string" ? lastEvent.payload.ability : null);
     const skill = (typeof lastEvent.payload.skill === "string" ? lastEvent.payload.skill : null);
     const dc = typeof lastEvent.payload.dc === "number" ? lastEvent.payload.dc : null;
+    const targetParticipantId =
+      typeof lastEvent.payload.targetParticipantId === "string"
+        ? lastEvent.payload.targetParticipantId
+        : null;
+    const debugModifiers = Array.isArray(lastEvent.payload.debugModifiers)
+      ? lastEvent.payload.debugModifiers
+      : null;
     const requestActivity: RollRequestActivityEvent = {
       type: "roll_request",
       expression,
@@ -220,6 +238,8 @@ export const usePlayerBoardRollRequests = ({
       ability,
       skill,
       dc,
+      targetParticipantId,
+      debugModifiers,
       targetUserId,
       timestamp: String(lastEvent.payload.issuedAt ?? ""),
       sessionOffsetSeconds: 0,
@@ -234,6 +254,8 @@ export const usePlayerBoardRollRequests = ({
       ability,
       skill,
       dc,
+      targetParticipantId,
+      debugModifiers,
     }, requestActivity);
   }, [activeSessionId, lastEvent, reconcileAndShowRollPrompt, userId]);
 
@@ -282,6 +304,8 @@ export const usePlayerBoardRollRequests = ({
         ability: latestRequest.ability ?? null,
         skill: latestRequest.skill ?? null,
         dc: latestRequest.dc ?? null,
+        targetParticipantId: latestRequest.targetParticipantId ?? null,
+        debugModifiers: latestRequest.debugModifiers ?? null,
       });
     } catch {
       // Ignore fallback polling errors; realtime remains the primary path.

--- a/apps/control-web/src/shared/api/combatRepo.ts
+++ b/apps/control-web/src/shared/api/combatRepo.ts
@@ -58,6 +58,11 @@ export type ActiveEffect = {
   display_label?: string | null;
 };
 
+export type CombatSpellContextOrigin =
+  | "initial_cast"
+  | "pending_save"
+  | "pending_spell";
+
 export type TurnResources = {
   action_used: boolean;
   bonus_action_used: boolean;
@@ -80,6 +85,8 @@ export type PendingSave = {
   effect_kind?: "damage" | "healing" | null;
   selected_variant_key?: string | null;
   selected_variant_label?: string | null;
+  context_origin?: CombatSpellContextOrigin | null;
+  concentration_group?: string | null;
   target_variant_assignments?: Array<{
     target_participant_id?: string | null;
     target_ref_id?: string | null;
@@ -112,6 +119,9 @@ export type SaveResolution = {
   roll_result: RollResult;
   pending_spell_id?: string | null;
   selected_variant_key?: string | null;
+  selected_variant_label?: string | null;
+  context_origin?: CombatSpellContextOrigin | null;
+  concentration_group?: string | null;
   target_variant_assignments?: Array<{
     target_participant_id?: string | null;
     target_ref_id?: string | null;
@@ -339,6 +349,9 @@ export type CombatSpellResult = {
   spell_name: string;
   spell_canonical_key?: string | null;
   selected_variant_key?: string | null;
+  selected_variant_label?: string | null;
+  context_origin?: CombatSpellContextOrigin | null;
+  concentration_group?: string | null;
   action_kind: CombatSpellMode;
   effect_kind?: "damage" | "healing" | null;
   damage: number;

--- a/apps/control-web/src/shared/api/sessionsRepo.ts
+++ b/apps/control-web/src/shared/api/sessionsRepo.ts
@@ -52,6 +52,19 @@ export type RollRequestActivityEvent = {
   dc?: number | null;
   targetUserId?: string | null;
   targetDisplayName?: string | null;
+  targetParticipantId?: string | null;
+  debugModifiers?: Array<{
+    source_label: string;
+    modifier_type: "advantage" | "disadvantage";
+    roll_type: "ability" | "skill";
+    ability?: string | null;
+    skill?: string | null;
+    against?: "any" | "effect_target" | "selected_target" | null;
+    selected_target_participant_id?: string | null;
+    selected_target_display_name?: string | null;
+    applied: boolean;
+    skip_reason?: "target_mismatch" | "ability_mismatch" | "skill_mismatch" | "missing_target" | null;
+  }> | null;
   timestamp: string;
   sessionOffsetSeconds: number;
 };


### PR DESCRIPTION
## Summary

- **Backend**: enriquece `ActiveEffect.metadata` com contexto de debug estável (source_spell_name, selected_variant_key/label, context_origin, selected/effect_target, against, concentration_group); adiciona campos debug em payloads de spell/pending e logs de cast; adiciona helper puro `explain_check_modifier_sources()`; estende `request_roll`/`activity` com `targetParticipantId` e `debugModifiers`
- **Frontend**: `AuthoritativeRollDialog` exibe seção _Effect Context_ quando `debugModifiers` presente; `SpellCastResultPanel` consolida variante/origem/concentração em seção única sem duplicar a label; `GmPendingSavesPanel` exibe variante por alvo, origem, concentração e notas manuais do alvo correto; novo `ActiveEffectDebugPanel` plugado em `PlayerCombatModeShell` e `CombatParticipantRoster`
- **Cleanup de review**: consolidação visual em `SpellCastResultPanel` elimina redundância entre label genérica de variante e breakdown por alvo

## Test plan

- [x] 27 testes frontend passando (`spellVariantUi`, `gmPendingSavesPanel`, `spellCastResultPanel`, `playerSpellCastDialog`, `ActiveEffectDebugPanel`, `AuthoritativeRollDialog`)
- [x] Compilação Python dos arquivos backend: ok
- [x] Testar manualmente: conjurar spell modal com múltiplos alvos e verificar painel de resultado, pending saves e efeitos ativos

🤖 Generated with [Claude Code](https://claude.com/claude-code)