### PR TITLE
feat(effects): surface declarative effects in combat UI

### DIFF
--- a/Base/base_spells.seed.json
+++ b/Base/base_spells.seed.json
@@ -1620,13 +1620,16 @@
                 "ability": "strength"
               },
               "stacking": "replace"
-            }
-          ],
-          "manualNotes": [
+            },
             {
-              "key": "carrying_capacity_multiplier",
-              "label": "Capacidade de carga",
-              "description": "Dobre manualmente a capacidade de carga do alvo enquanto a magia durar."
+              "type": "carrying_capacity_multiplier",
+              "target": "selected_target",
+              "duration": {
+                "type": "manual"
+              },
+              "params": {
+                "multiplier": 2
+              }
             }
           ]
         },
@@ -1642,13 +1645,16 @@
                 "ability": "dexterity"
               },
               "stacking": "replace"
-            }
-          ],
-          "manualNotes": [
+            },
             {
-              "key": "fall_damage_immunity_threshold",
-              "label": "Queda curta",
-              "description": "Ignore manualmente dano de queda de até 6 metros, se o alvo não estiver incapacitado."
+              "type": "fall_damage_immunity_threshold",
+              "target": "selected_target",
+              "duration": {
+                "type": "manual"
+              },
+              "params": {
+                "max_distance_meters": 6
+              }
             }
           ]
         },

--- a/apps/control-server/app/schemas/base_spell_effects.py
+++ b/apps/control-server/app/schemas/base_spell_effects.py
@@ -56,6 +56,7 @@ SpellDeclarativeRestrictActionKind = Literal[
     "movement",
 ]
 SpellDeclarativeEffectStacking = Literal["stack", "replace"]
+SpellDeclarativeAgainst = Literal["selected_target", "effect_target", "any"]
 
 
 class SpellDeclarativeDuration(BaseModel):
@@ -89,6 +90,7 @@ class ModifyStatParams(BaseModel):
 
 class CheckModifierParams(BaseModel):
     ability: AbilityName
+    against: SpellDeclarativeAgainst | None = None
 
 
 class RestrictActionParams(BaseModel):

--- a/apps/control-server/app/schemas/combat_spells.py
+++ b/apps/control-server/app/schemas/combat_spells.py
@@ -194,6 +194,20 @@ class CombatAreaGuardrailOutcome(BaseModel):
     guardrail_reason: str
 
 
+class AppliedDeclarativeEffectSummary(BaseModel):
+    type: str
+    params: dict = Field(default_factory=dict)
+
+
+class AppliedDeclarativeEffectsByTargetEntry(BaseModel):
+    target_display_name: str
+    target_participant_id: str | None = None
+    target_ref_id: str | None = None
+    variant_key: str | None = None
+    variant_label: str | None = None
+    effects: list[AppliedDeclarativeEffectSummary] = Field(default_factory=list)
+
+
 class CombatMapPreviewToken(BaseModel):
     token_id: str
     label: str
@@ -396,3 +410,4 @@ class CombatSpellResult(BaseModel):
     effect_instance_outcomes: list[EffectInstanceOutcome] = Field(default_factory=list)
     target_variant_assignments: list[dict] | None = None
     manual_notes_by_target: list[dict] | None = None
+    applied_declarative_effects_by_target: list[AppliedDeclarativeEffectsByTargetEntry] | None = None

--- a/apps/control-server/app/services/combat_service/save_resolve.py
+++ b/apps/control-server/app/services/combat_service/save_resolve.py
@@ -88,6 +88,7 @@ class CombatSaveResolveMixin:
             target_participant=target_p,
         )
         manual_notes_by_target = pending_spell_context.get("manual_notes_by_target")
+        applied_declarative_effects_by_target = None
 
         if effect_roll_required and (not is_saved or save_success_outcome == "half_damage"):
             if attacker:
@@ -182,6 +183,7 @@ class CombatSaveResolveMixin:
                 "concentration_group": pending_spell_context.get("concentration_group"),
                 "target_variant_assignments": pending_spell_context.get("target_variant_assignments"),
                 "manual_notes_by_target": manual_notes_by_target,
+                "applied_declarative_effects_by_target": applied_declarative_effects_by_target,
             }
             flag_modified(state, "participants")
             db.add(state)
@@ -256,4 +258,5 @@ class CombatSaveResolveMixin:
             "effect_roll_source": req.roll_source,
             "target_variant_assignments": pending_spell_context.get("target_variant_assignments"),
             "manual_notes_by_target": manual_notes_by_target,
+            "applied_declarative_effects_by_target": applied_declarative_effects_by_target,
         }

--- a/apps/control-server/app/services/combat_service/spell_automation.py
+++ b/apps/control-server/app/services/combat_service/spell_automation.py
@@ -132,6 +132,7 @@ class CombatSpellAutomationMixin:
             "save_ability": None, "save_dc": None, "save_success_outcome": None,
             "effect_dice": None, "effect_bonus": None, "pending_spell_id": None,
             "effect_roll_required": False, "summary_text": summary_text,
+            "applied_declarative_effects_by_target": None,
             "inventory_refresh_required": inventory_refresh_required,
             "__log_message": log_message, "__player_state_ids_to_emit": set(),
             "__entity_hp_update_target": None, "__entity_previous_hp": None,

--- a/apps/control-server/app/services/combat_service/spell_declarative_effects.py
+++ b/apps/control-server/app/services/combat_service/spell_declarative_effects.py
@@ -14,6 +14,58 @@ from .exceptions import CombatServiceError, _roll_dice_expression
 
 class CombatSpellDeclarativeEffectsMixin:
     @classmethod
+    def _build_applied_declarative_effects_by_target(
+        cls,
+        applied_effects: list[dict] | None,
+    ) -> list[dict]:
+        if not isinstance(applied_effects, list) or not applied_effects:
+            return []
+
+        grouped: dict[tuple[str | None, str | None, str], dict] = {}
+        for active_effect in applied_effects:
+            if not isinstance(active_effect, dict):
+                continue
+            metadata = cls._get_effect_metadata(active_effect)
+            declarative = metadata.get("declarative_effect")
+            if not isinstance(declarative, dict):
+                continue
+
+            target_participant_id = metadata.get("effect_target_participant_id")
+            if not isinstance(target_participant_id, str):
+                target_participant_id = None
+            target_ref_id = metadata.get("effect_target_ref_id")
+            if not isinstance(target_ref_id, str):
+                target_ref_id = None
+            target_display_name = metadata.get("effect_target_display_name")
+            if not isinstance(target_display_name, str) or not target_display_name.strip():
+                target_display_name = (
+                    target_participant_id
+                    or target_ref_id
+                    or "Target"
+                )
+            key = (target_participant_id, target_ref_id, target_display_name)
+            target_entry = grouped.setdefault(
+                key,
+                {
+                    "target_display_name": target_display_name,
+                    "target_participant_id": target_participant_id,
+                    "target_ref_id": target_ref_id,
+                    "variant_key": metadata.get("selected_variant_key"),
+                    "variant_label": metadata.get("selected_variant_label"),
+                    "effects": [],
+                },
+            )
+            target_entry["effects"].append(
+                {
+                    "type": declarative.get("type"),
+                    "params": declarative.get("params")
+                    if isinstance(declarative.get("params"), dict)
+                    else {},
+                }
+            )
+        return list(grouped.values())
+
+    @classmethod
     def _normalize_declarative_effects(cls, raw_effects: object) -> list[SpellDeclarativeEffect]:
         if not isinstance(raw_effects, list):
             return []
@@ -119,9 +171,9 @@ class CombatSpellDeclarativeEffectsMixin:
     ) -> list[dict]:
         metadata = {
             "declarative_effect_group_id": effect_group_id,
-            "declarative_effect": effect.model_dump(mode="json"),
+            "declarative_effect": effect.model_dump(mode="json", exclude_none=True),
             "declarative_on_end_effects": [
-                entry.model_dump(mode="json") for entry in on_end_effects
+                entry.model_dump(mode="json", exclude_none=True) for entry in on_end_effects
             ],
             "caster_participant_id": attacker.get("id"),
             "selected_target_participant_id": target_participant.get("id")
@@ -155,7 +207,7 @@ class CombatSpellDeclarativeEffectsMixin:
         metadata["effect_target_ref_id"] = resolved_target.get("ref_id")
         metadata["effect_target_display_name"] = resolved_target.get("display_name")
 
-        params = effect.params.model_dump(mode="json")
+        params = effect.params.model_dump(mode="json", exclude_none=True)
         if effect.type in {"advantage_on_checks", "disadvantage_on_checks"}:
             metadata["against"] = params.get("against") or "any"
         if effect.stacking == "replace":
@@ -391,6 +443,9 @@ class CombatSpellDeclarativeEffectsMixin:
             extra={
                 "__declarative_effect_group_id": application["effect_group_id"],
                 "__applied_effect_count": len(applied_effects),
+                "applied_declarative_effects_by_target": cls._build_applied_declarative_effects_by_target(
+                    applied_effects
+                ),
                 "concentration_group": application["effect_group_id"]
                 if spell_context.get("concentration")
                 else None,

--- a/apps/control-server/app/services/combat_service/spells/cast_target_effect.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target_effect.py
@@ -90,6 +90,7 @@ class CastTargetEffectMixin:
             target_participant=target_participant,
         )
         manual_notes_by_target = pending_spell_context.get("manual_notes_by_target")
+        applied_declarative_effects_by_target = None
 
         effect_rolls: list[int] = []
         base_effect = 0
@@ -137,11 +138,14 @@ class CastTargetEffectMixin:
         if target_participant is not None and cls._spell_context_has_declarative_effects(
             pending_spell_context
         ):
-            cls._apply_declarative_spell_effects(
+            declarative_application = cls._apply_declarative_spell_effects(
                 state=state,
                 attacker=attacker,
                 target_participant=target_participant,
                 spell_context=pending_spell_context,
+            )
+            applied_declarative_effects_by_target = cls._build_applied_declarative_effects_by_target(
+                declarative_application.get("applied_effects")
             )
 
         cls._clear_participant_pending_attack(attacker)
@@ -241,4 +245,5 @@ class CastTargetEffectMixin:
             "effect_roll_source": req.roll_source,
             "target_variant_assignments": pending_spell_context.get("target_variant_assignments"),
             "manual_notes_by_target": manual_notes_by_target,
+            "applied_declarative_effects_by_target": applied_declarative_effects_by_target,
         }

--- a/apps/control-server/app/services/combat_service/spells/spell_response.py
+++ b/apps/control-server/app/services/combat_service/spells/spell_response.py
@@ -296,4 +296,9 @@ class SpellResponseMixin:
                 if automation_result is not None
                 else spell_context.get("manual_notes_by_target")
             ),
+            "applied_declarative_effects_by_target": (
+                automation_result.get("applied_declarative_effects_by_target")
+                if automation_result is not None
+                else None
+            ),
         }

--- a/apps/control-server/tests/test_modal_pending_resolution.py
+++ b/apps/control-server/tests/test_modal_pending_resolution.py
@@ -307,6 +307,24 @@ class ModalPendingResolutionTests(unittest.IsolatedAsyncioTestCase):
             result["manual_notes_by_target"][0]["variant_key"],
             "bears_endurance",
         )
+        self.assertEqual(
+            result["applied_declarative_effects_by_target"],
+            [
+                {
+                    "target_display_name": "Target B",
+                    "target_participant_id": "e2",
+                    "target_ref_id": "enemy-2",
+                    "variant_key": "foxs_cunning",
+                    "variant_label": "Esperteza da Raposa",
+                    "effects": [
+                        {
+                            "type": "advantage_on_checks",
+                            "params": {"ability": "intelligence"},
+                        }
+                    ],
+                }
+            ],
+        )
         final_log = mock_emit_log.await_args.args[1]["message"]
         self.assertIn("Target B: Observação", final_log)
         self.assertIn("Target A: PV temporários", final_log)

--- a/apps/control-server/tests/test_spell_declarative_effects.py
+++ b/apps/control-server/tests/test_spell_declarative_effects.py
@@ -581,3 +581,64 @@ class TestSpellDeclarativeEffectRuntime(unittest.TestCase):
         declarative = effect["metadata"]["declarative_effect"]
         self.assertEqual(declarative["type"], "fall_damage_immunity_threshold")
         self.assertEqual(declarative["params"]["max_distance_meters"], 6.0)
+
+    def test_builds_applied_declarative_effects_summary_by_target(self):
+        state = self._make_state()
+        attacker = state.participants[0]
+        target = state.participants[1]
+        spell_context = {
+            "spell_name": "Enhance Ability",
+            "spell_canonical_key": "enhance_ability",
+            "concentration": True,
+            "selected_variant_key": "bulls_strength",
+            "selected_variant_label": "Força do Touro",
+            "effects": [
+                {
+                    "type": "advantage_on_checks",
+                    "target": "selected_target",
+                    "duration": {"type": "manual"},
+                    "params": {"ability": "strength"},
+                },
+                {
+                    "type": "carrying_capacity_multiplier",
+                    "target": "selected_target",
+                    "duration": {"type": "manual"},
+                    "params": {"multiplier": 2.0},
+                },
+            ],
+            "on_end_effects": [],
+        }
+
+        application = CombatService._apply_declarative_spell_effects(
+            state=state,
+            attacker=attacker,
+            target_participant=target,
+            spell_context=spell_context,
+        )
+
+        summary = CombatService._build_applied_declarative_effects_by_target(
+            application["applied_effects"]
+        )
+
+        self.assertEqual(
+            summary,
+            [
+                {
+                    "target_display_name": "Target",
+                    "target_participant_id": "target-1",
+                    "target_ref_id": "entity-1",
+                    "variant_key": "bulls_strength",
+                    "variant_label": "Força do Touro",
+                    "effects": [
+                        {
+                            "type": "advantage_on_checks",
+                            "params": {"ability": "strength"},
+                        },
+                        {
+                            "type": "carrying_capacity_multiplier",
+                            "params": {"multiplier": 2.0},
+                        },
+                    ],
+                }
+            ],
+        )

--- a/apps/control-web/src/features/combat-ui/spellVariantUi.test.ts
+++ b/apps/control-web/src/features/combat-ui/spellVariantUi.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   buildPendingSaveReason,
+  filterManualNotesByAppliedEffects,
+  formatAppliedDeclarativeEffectsByTarget,
+  formatDeclarativeEffectSummaryLine,
   formatEffectContextDebug,
   formatManualNotesByTarget,
   formatVariantAssignmentDebug,
@@ -123,5 +126,63 @@ describe("spellVariantUi", () => {
     expect(lines).toContain("Against: selected target");
     expect(lines).toContain("Concentration: group-1");
     expect(lines).toContain("Advantage: charisma checks");
+  });
+
+  it("formata efeitos declarativos aplicados por alvo e remove notas duplicadas", () => {
+    const entries = formatAppliedDeclarativeEffectsByTarget(
+      [
+        {
+          target_display_name: "Goblin A",
+          target_participant_id: "enemy-a",
+          variant_label: "Força do Touro",
+          effects: [{ type: "carrying_capacity_multiplier", params: { multiplier: 2 } }],
+        },
+      ],
+      [
+        {
+          target_participant_id: "enemy-a",
+          target_display_name: "Goblin A",
+          variant_key: "bulls_strength",
+          variant_label: "Força do Touro",
+          manual_notes: [
+            {
+              key: "carrying_capacity_multiplier",
+              label: "Capacidade de carga",
+              description: "Duplicada",
+            },
+            {
+              key: "reminder",
+              label: "Lembrete",
+              description: "Residual",
+            },
+          ],
+        },
+      ],
+    );
+
+    expect(entries).toEqual([
+      {
+        targetDisplayName: "Goblin A",
+        variantLabel: "Força do Touro",
+        effectLines: ["Capacidade de carga: x2"],
+        manualNoteLines: ["Lembrete - Residual"],
+      },
+    ]);
+  });
+
+  it("faz fallback seguro quando params declarativos estão ausentes", () => {
+    expect(
+      formatDeclarativeEffectSummaryLine({
+        type: "fall_damage_immunity_threshold",
+        params: null,
+      }),
+    ).toBeNull();
+
+    expect(
+      filterManualNotesByAppliedEffects(
+        [{ key: "fall_damage_immunity_threshold", label: "Queda", description: "Manual" }],
+        [{ type: "fall_damage_immunity_threshold", params: null }],
+      ),
+    ).toEqual([]);
   });
 });

--- a/apps/control-web/src/features/combat-ui/spellVariantUi.ts
+++ b/apps/control-web/src/features/combat-ui/spellVariantUi.ts
@@ -1,5 +1,9 @@
 import type { SpellVariantManualNote } from "../../entities/base-spell";
-import type { ActiveEffect, CombatSpellContextOrigin } from "../../shared/api/combatRepo";
+import type {
+  ActiveEffect,
+  AppliedDeclarativeEffectsByTargetEntry,
+  CombatSpellContextOrigin,
+} from "../../shared/api/combatRepo";
 
 type TargetVariantAssignmentLike = {
   target_participant_id?: string | null;
@@ -20,6 +24,11 @@ type ManualNotesByTargetEntryLike = {
 type TargetLookup = {
   targetParticipantId?: string | null;
   targetRefId?: string | null;
+};
+
+type DeclarativeEffectSummaryLike = {
+  type?: unknown;
+  params?: Record<string, unknown> | null;
 };
 
 const humanizeVariantKey = (variantKey: string) =>
@@ -186,6 +195,106 @@ const humanizeAgainst = (value: unknown) => {
   return null;
 };
 
+export const formatDeclarativeEffectSummaryLine = (
+  declarative: DeclarativeEffectSummaryLike | null | undefined,
+  metadata?: Record<string, unknown> | null,
+) => {
+  if (!declarative || typeof declarative !== "object") {
+    return null;
+  }
+  const p = declarative.params ?? {};
+  if (
+    (declarative.type === "advantage_on_checks" || declarative.type === "disadvantage_on_checks")
+    && typeof p.ability === "string"
+  ) {
+    return `${declarative.type === "advantage_on_checks" ? "Advantage" : "Disadvantage"}: ${p.ability} checks`;
+  }
+  if (declarative.type === "modify_stat" && typeof p.stat === "string") {
+    return `Effect: ${p.stat}`;
+  }
+  if (declarative.type === "apply_condition" && typeof p.condition === "string") {
+    return `Condition: ${p.condition}`;
+  }
+  if (declarative.type === "grant_temp_hp") {
+    const rolled = typeof metadata?.rolled_temp_hp === "number" ? metadata.rolled_temp_hp : null;
+    const applied = metadata?.applied_temp_hp === true;
+    const final = typeof metadata?.final_temp_hp === "number" ? metadata.final_temp_hp : null;
+    if (applied && final !== null) {
+      return `PV temporários concedidos: ${final}. Não expiram com a concentração.`;
+    }
+    if (rolled !== null) {
+      return `PV temporários: ${rolled} (aguardando aplicação)`;
+    }
+    if (typeof p.dice === "string") {
+      return `PV temporários: ${p.dice}`;
+    }
+    return null;
+  }
+  if (declarative.type === "passive_skill_bonus" && typeof p.skill === "string" && typeof p.bonus === "number") {
+    return `Bônus passivo: +${p.bonus} em ${p.skill}`;
+  }
+  if (declarative.type === "carrying_capacity_multiplier" && typeof p.multiplier === "number") {
+    return `Capacidade de carga: x${p.multiplier}`;
+  }
+  if (declarative.type === "fall_damage_immunity_threshold" && typeof p.max_distance_meters === "number") {
+    return `Imunidade a queda: até ${p.max_distance_meters}m`;
+  }
+  return null;
+};
+
+export const filterManualNotesByAppliedEffects = (
+  notes: SpellVariantManualNote[] | null | undefined,
+  effects: Array<DeclarativeEffectSummaryLike> | null | undefined,
+) => {
+  if (!notes?.length) {
+    return [];
+  }
+  const appliedKeys = new Set(
+    (effects ?? [])
+      .map((effect) => (typeof effect.type === "string" ? effect.type : null))
+      .filter((value): value is string => value !== null),
+  );
+  return notes.filter((note) => !appliedKeys.has(note.key));
+};
+
+export const formatAppliedDeclarativeEffectsByTarget = (
+  entries: AppliedDeclarativeEffectsByTargetEntry[] | null | undefined,
+  manualNotesByTarget: ManualNotesByTargetEntryLike[] | null | undefined,
+) => {
+  if (!entries?.length) {
+    return [];
+  }
+  return entries
+    .map((entry) => {
+      const lines = entry.effects
+        .map((effect) => formatDeclarativeEffectSummaryLine(effect))
+        .filter((line): line is string => Boolean(line));
+      if (!lines.length) {
+        return null;
+      }
+      const manualNotesEntry = findManualNotesForTarget(manualNotesByTarget, {
+        targetParticipantId: entry.target_participant_id,
+        targetRefId: entry.target_ref_id,
+      });
+      return {
+        targetDisplayName: entry.target_display_name,
+        variantLabel:
+          entry.variant_label
+          ?? resolveTargetVariantLabel({
+            manualNotesByTarget,
+            targetParticipantId: entry.target_participant_id,
+            targetRefId: entry.target_ref_id,
+          }),
+        effectLines: lines,
+        manualNoteLines: filterManualNotesByAppliedEffects(
+          manualNotesEntry?.manual_notes,
+          entry.effects,
+        ).map((note) => `${note.label} - ${note.description}`),
+      };
+    })
+    .filter((entry) => entry !== null);
+};
+
 export const formatEffectContextDebug = (
   effect: ActiveEffect,
   {
@@ -244,37 +353,12 @@ export const formatEffectContextDebug = (
   }
   const declarative = metadata.declarative_effect;
   if (declarative && typeof declarative === "object") {
-    const entry = declarative as {
-      type?: unknown;
-      params?: Record<string, unknown> | null;
-    };
-    const p = entry.params ?? {};
-    if (
-      (entry.type === "advantage_on_checks" || entry.type === "disadvantage_on_checks")
-      && typeof p.ability === "string"
-    ) {
-      lines.push(
-        `${entry.type === "advantage_on_checks" ? "Advantage" : "Disadvantage"}: ${p.ability} checks`,
-      );
-    } else if (entry.type === "modify_stat" && typeof p.stat === "string") {
-      lines.push(`Effect: ${p.stat}`);
-    } else if (entry.type === "apply_condition" && typeof p.condition === "string") {
-      lines.push(`Condition: ${p.condition}`);
-    } else if (entry.type === "grant_temp_hp") {
-      const rolled = typeof metadata.rolled_temp_hp === "number" ? metadata.rolled_temp_hp : null;
-      const applied = metadata.applied_temp_hp === true;
-      const final = typeof metadata.final_temp_hp === "number" ? metadata.final_temp_hp : null;
-      if (applied && final !== null) {
-        lines.push(`PV temporários concedidos: ${final}. Não expiram com a concentração.`);
-      } else if (rolled !== null) {
-        lines.push(`PV temporários: ${rolled} (aguardando aplicação)`);
-      }
-    } else if (entry.type === "passive_skill_bonus" && typeof p.skill === "string" && typeof p.bonus === "number") {
-      lines.push(`Bônus passivo: +${p.bonus} em ${p.skill}`);
-    } else if (entry.type === "carrying_capacity_multiplier" && typeof p.multiplier === "number") {
-      lines.push(`Capacidade de carga: x${p.multiplier}`);
-    } else if (entry.type === "fall_damage_immunity_threshold" && typeof p.max_distance_meters === "number") {
-      lines.push(`Imunidade a queda: até ${p.max_distance_meters}m`);
+    const summaryLine = formatDeclarativeEffectSummaryLine(
+      declarative as DeclarativeEffectSummaryLike,
+      metadata,
+    );
+    if (summaryLine) {
+      lines.push(summaryLine);
     }
   }
   return lines;

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastResultPanel.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/SpellCastResultPanel.tsx
@@ -1,5 +1,6 @@
 import { RollResultCard } from "../../../features/rolls/components/RollResultCard";
 import {
+  formatAppliedDeclarativeEffectsByTarget,
   formatManualNotesByTarget,
   formatVariantAssignmentDebug,
   originLabel,
@@ -63,7 +64,23 @@ export const SpellCastResultPanel = ({
     result.target_variant_assignments,
     result.manual_notes_by_target,
   );
-  const manualNoteLines = formatManualNotesByTarget(result.manual_notes_by_target);
+  const appliedDeclarativeEffectsByTarget = formatAppliedDeclarativeEffectsByTarget(
+    result.applied_declarative_effects_by_target,
+    result.manual_notes_by_target,
+  );
+  const appliedTargetKeys = new Set(
+    (result.applied_declarative_effects_by_target ?? []).map(
+      (entry) => `${entry.target_participant_id ?? ""}:${entry.target_ref_id ?? ""}`,
+    ),
+  );
+  const manualNoteLines = formatManualNotesByTarget(
+    appliedTargetKeys.size
+      ? (result.manual_notes_by_target ?? []).filter(
+          (entry) =>
+            !appliedTargetKeys.has(`${entry.target_participant_id ?? ""}:${entry.target_ref_id ?? ""}`),
+        )
+      : result.manual_notes_by_target,
+  );
 
   return (
     <div className="mt-5 space-y-4">
@@ -150,6 +167,22 @@ export const SpellCastResultPanel = ({
             {result.concentration_group ? (
               <p>Concentração: {result.concentration_group}</p>
             ) : null}
+          </div>
+        ) : null}
+        {appliedDeclarativeEffectsByTarget.length ? (
+          <div className="mt-3 space-y-3 text-xs text-emerald-100">
+            {appliedDeclarativeEffectsByTarget.map((entry, index) => (
+              <div key={`${entry.targetDisplayName}:${index}`} className="space-y-1">
+                <p className="font-semibold text-emerald-200">{entry.targetDisplayName}</p>
+                {entry.variantLabel ? <p>Variante: {entry.variantLabel}</p> : null}
+                {entry.effectLines.map((line, lineIndex) => (
+                  <p key={`effect:${index}:${lineIndex}`}>{line}</p>
+                ))}
+                {entry.manualNoteLines.map((line, lineIndex) => (
+                  <p key={`effect-note:${index}:${lineIndex}`}>{line}</p>
+                ))}
+              </div>
+            ))}
           </div>
         ) : null}
         {manualNoteLines.length ? (

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx
@@ -244,4 +244,62 @@ describe("SpellCastResultPanel", () => {
     expect(markup).toContain("Goblin B: Sabedoria da Coruja");
     expect(markup).toContain("Manual B - Descricao B");
   });
+
+  it("exibe efeitos declarativos aplicados por alvo sem duplicar nota manual equivalente", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastResultPanel
+        {...baseProps}
+        result={{
+          spell_name: "Enhance Ability",
+          spell_canonical_key: "enhance_ability",
+          action_kind: "utility",
+          effect_kind: "damage",
+          damage: 0,
+          healing: 0,
+          target_display_name: "Fighter",
+          target_kind: "player",
+          applied_declarative_effects_by_target: [
+            {
+              target_display_name: "Fighter",
+              target_participant_id: "ally-1",
+              variant_key: "bulls_strength",
+              variant_label: "Força do Touro",
+              effects: [
+                {
+                  type: "carrying_capacity_multiplier",
+                  params: { multiplier: 2 },
+                },
+              ],
+            },
+          ],
+          manual_notes_by_target: [
+            {
+              target_participant_id: "ally-1",
+              target_display_name: "Fighter",
+              variant_key: "bulls_strength",
+              variant_label: "Força do Touro",
+              manual_notes: [
+                {
+                  key: "carrying_capacity_multiplier",
+                  label: "Capacidade de carga",
+                  description: "Duplicada",
+                },
+                {
+                  key: "reminder",
+                  label: "Lembrete",
+                  description: "Conferir mochila",
+                },
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Fighter");
+    expect(markup).toContain("Variante: Força do Touro");
+    expect(markup).toContain("Capacidade de carga: x2");
+    expect(markup).toContain("Lembrete - Conferir mochila");
+    expect(markup).not.toContain("Capacidade de carga - Duplicada");
+  });
 });

--- a/apps/control-web/src/shared/api/combatRepo.ts
+++ b/apps/control-web/src/shared/api/combatRepo.ts
@@ -63,6 +63,20 @@ export type CombatSpellContextOrigin =
   | "pending_save"
   | "pending_spell";
 
+export type AppliedDeclarativeEffectSummary = {
+  type?: string | null;
+  params?: Record<string, unknown> | null;
+};
+
+export type AppliedDeclarativeEffectsByTargetEntry = {
+  target_display_name: string;
+  target_participant_id?: string | null;
+  target_ref_id?: string | null;
+  variant_key?: string | null;
+  variant_label?: string | null;
+  effects: AppliedDeclarativeEffectSummary[];
+};
+
 export type TurnResources = {
   action_used: boolean;
   bonus_action_used: boolean;
@@ -136,6 +150,7 @@ export type SaveResolution = {
     variant_label?: string | null;
     manual_notes: SpellVariantManualNote[];
   }> | null;
+  applied_declarative_effects_by_target?: AppliedDeclarativeEffectsByTargetEntry[] | null;
 };
 
 export type CombatParticipant = {
@@ -445,6 +460,7 @@ export type CombatSpellResult = {
     variant_label?: string | null;
     manual_notes: SpellVariantManualNote[];
   }> | null;
+  applied_declarative_effects_by_target?: AppliedDeclarativeEffectsByTargetEntry[] | null;
 };
 
 export type CombatMapPreviewToken = {


### PR DESCRIPTION
## What changed
- Moved Bull's Strength and Cat's Grace to declarative effects in the base seed.
- Added `applied_declarative_effects_by_target` as a descriptive cast-result summary.
- Reused shared formatting in the combat UI and removed duplicate manual notes where the declarative effect already covers the text.

## Validation
- `npx vitest run apps/control-web/src/features/combat-ui/spellVariantUi.test.ts apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx`
- `/home/caue/LimiarControl/apps/control-server/.venv/bin/pytest /home/caue/LimiarControl/apps/control-server/tests/test_spell_declarative_effects.py /home/caue/LimiarControl/apps/control-server/tests/test_modal_pending_resolution.py`