### PR TITLE
feat(effects): surface temporary HP grants in spell results

### DIFF
--- a/apps/control-server/app/schemas/combat_spells.py
+++ b/apps/control-server/app/schemas/combat_spells.py
@@ -197,6 +197,7 @@ class CombatAreaGuardrailOutcome(BaseModel):
 class AppliedDeclarativeEffectSummary(BaseModel):
     type: str
     params: dict = Field(default_factory=dict)
+    observability: dict | None = None
 
 
 class AppliedDeclarativeEffectsByTargetEntry(BaseModel):

--- a/apps/control-server/app/services/combat_service/spell_declarative_effects.py
+++ b/apps/control-server/app/services/combat_service/spell_declarative_effects.py
@@ -14,6 +14,67 @@ from .exceptions import CombatServiceError, _roll_dice_expression
 
 class CombatSpellDeclarativeEffectsMixin:
     @classmethod
+    def _build_temp_hp_observability_from_metadata(
+        cls,
+        metadata: dict,
+    ) -> dict | None:
+        rolled = metadata.get("rolled_temp_hp")
+        if not isinstance(rolled, int):
+            return None
+        observability = {
+            "rolled_temp_hp": rolled,
+            "applied_temp_hp": metadata.get("applied_temp_hp") is True,
+            "previous_temp_hp": metadata.get("previous_temp_hp")
+            if isinstance(metadata.get("previous_temp_hp"), int)
+            else None,
+            "final_temp_hp": metadata.get("final_temp_hp")
+            if isinstance(metadata.get("final_temp_hp"), int)
+            else None,
+            "does_not_expire_temp_hp": metadata.get("does_not_expire_temp_hp") is True,
+        }
+        return observability
+
+    @classmethod
+    def _format_temp_hp_observability_compact(
+        cls,
+        observability: dict | None,
+    ) -> str | None:
+        if not isinstance(observability, dict):
+            return None
+        rolled = observability.get("rolled_temp_hp")
+        previous = observability.get("previous_temp_hp")
+        final = observability.get("final_temp_hp")
+        if not isinstance(rolled, int):
+            return None
+        if isinstance(previous, int) and isinstance(final, int) and final <= previous:
+            return f"PV temporários: {rolled} rolados, mantidos {previous} existentes"
+        if isinstance(final, int):
+            return f"PV temporários: +{rolled} (final: {final})"
+        return f"PV temporários: +{rolled}"
+
+    @classmethod
+    def _format_applied_declarative_effects_for_log(
+        cls,
+        applied_declarative_effects_by_target: list[dict] | None,
+    ) -> str:
+        if not isinstance(applied_declarative_effects_by_target, list):
+            return ""
+        chunks: list[str] = []
+        for entry in applied_declarative_effects_by_target:
+            if not isinstance(entry, dict):
+                continue
+            target_name = entry.get("target_display_name")
+            if not isinstance(target_name, str) or not target_name.strip():
+                target_name = "Target"
+            for effect in entry.get("effects") or []:
+                if not isinstance(effect, dict) or effect.get("type") != "grant_temp_hp":
+                    continue
+                summary = cls._format_temp_hp_observability_compact(effect.get("observability"))
+                if summary:
+                    chunks.append(f"{target_name}: {summary}")
+        return f" {'; '.join(chunks)}." if chunks else ""
+
+    @classmethod
     def _build_applied_declarative_effects_by_target(
         cls,
         applied_effects: list[dict] | None,
@@ -55,14 +116,20 @@ class CombatSpellDeclarativeEffectsMixin:
                     "effects": [],
                 },
             )
-            target_entry["effects"].append(
-                {
-                    "type": declarative.get("type"),
-                    "params": declarative.get("params")
-                    if isinstance(declarative.get("params"), dict)
-                    else {},
-                }
+            effect_summary = {
+                "type": declarative.get("type"),
+                "params": declarative.get("params")
+                if isinstance(declarative.get("params"), dict)
+                else {},
+            }
+            observability = (
+                cls._build_temp_hp_observability_from_metadata(metadata)
+                if declarative.get("type") == "grant_temp_hp"
+                else None
             )
+            if observability is not None:
+                effect_summary["observability"] = observability
+            target_entry["effects"].append(effect_summary)
         return list(grouped.values())
 
     @classmethod
@@ -423,6 +490,9 @@ class CombatSpellDeclarativeEffectsMixin:
         )
         applied_effects = application["applied_effects"]
         cls._apply_temp_hp_from_granted_effects(db, state, applied_effects)
+        applied_declarative_effects_by_target = cls._build_applied_declarative_effects_by_target(
+            applied_effects
+        )
         summary_target = target_participant or attacker
         summary_text = (
             f"{spell_context['spell_name']} aplicou {len(applied_effects)} efeito(s)."
@@ -439,13 +509,12 @@ class CombatSpellDeclarativeEffectsMixin:
             log_message=(
                 f"{attacker['display_name']} conjurou {spell_context['spell_name']} em "
                 f"{summary_target.get('display_name') or 'Target'}."
+                f"{cls._format_applied_declarative_effects_for_log(applied_declarative_effects_by_target)}"
             ),
             extra={
                 "__declarative_effect_group_id": application["effect_group_id"],
                 "__applied_effect_count": len(applied_effects),
-                "applied_declarative_effects_by_target": cls._build_applied_declarative_effects_by_target(
-                    applied_effects
-                ),
+                "applied_declarative_effects_by_target": applied_declarative_effects_by_target,
                 "concentration_group": application["effect_group_id"]
                 if spell_context.get("concentration")
                 else None,

--- a/apps/control-server/tests/test_spell_declarative_effects.py
+++ b/apps/control-server/tests/test_spell_declarative_effects.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -265,6 +266,18 @@ class TestSpellDeclarativeEffectRuntime(unittest.TestCase):
             active_area_effects=[],
             map_selection={"kind": "demo_map", "mapId": "demo"},
         )
+
+    def _make_player_target_state(self) -> CombatState:
+        state = self._make_state()
+        state.participants[1] = {
+            "id": "target-1",
+            "ref_id": "player-2",
+            "kind": "player",
+            "display_name": "Target Player",
+            "active_effects": [],
+            "status": "active",
+        }
+        return state
 
     def test_applies_friends_effect_and_on_end_hostility(self):
         state = self._make_state()
@@ -642,3 +655,219 @@ class TestSpellDeclarativeEffectRuntime(unittest.TestCase):
                 }
             ],
         )
+
+    def test_builds_grant_temp_hp_summary_for_applied_and_replaced_cases(self):
+        state = self._make_player_target_state()
+        attacker = state.participants[0]
+        target = state.participants[1]
+        spell_context = {
+            "spell_name": "Enhance Ability",
+            "spell_canonical_key": "enhance_ability",
+            "concentration": True,
+            "selected_variant_key": "bears_endurance",
+            "selected_variant_label": "Resistência do Urso",
+            "effects": [
+                {
+                    "type": "grant_temp_hp",
+                    "target": "selected_target",
+                    "duration": {"type": "manual"},
+                    "params": {"dice": "2d6"},
+                }
+            ],
+            "on_end_effects": [],
+        }
+        target_model = MagicMock()
+        target_model.state_json = {"tempHP": 3}
+
+        with patch(
+            "app.services.combat_service.spell_declarative_effects._roll_dice_expression",
+            return_value=7,
+        ), patch.object(
+            CombatService,
+            "_get_stats",
+            return_value=(target_model, None, None, None, None, None),
+        ):
+            application = CombatService._apply_declarative_spell_effects(
+                state=state,
+                attacker=attacker,
+                target_participant=target,
+                spell_context=spell_context,
+            )
+            CombatService._apply_temp_hp_from_granted_effects(
+                MagicMock(),
+                state,
+                application["applied_effects"],
+            )
+
+        summary = CombatService._build_applied_declarative_effects_by_target(
+            application["applied_effects"]
+        )
+        self.assertEqual(
+            summary[0]["effects"][0]["observability"],
+            {
+                "rolled_temp_hp": 7,
+                "applied_temp_hp": True,
+                "previous_temp_hp": 3,
+                "final_temp_hp": 7,
+                "does_not_expire_temp_hp": True,
+            },
+        )
+
+    def test_builds_grant_temp_hp_summary_when_existing_value_is_kept(self):
+        state = self._make_player_target_state()
+        attacker = state.participants[0]
+        target = state.participants[1]
+        spell_context = {
+            "spell_name": "Enhance Ability",
+            "spell_canonical_key": "enhance_ability",
+            "concentration": True,
+            "selected_variant_key": "bears_endurance",
+            "selected_variant_label": "Resistência do Urso",
+            "effects": [
+                {
+                    "type": "grant_temp_hp",
+                    "target": "selected_target",
+                    "duration": {"type": "manual"},
+                    "params": {"dice": "2d6"},
+                }
+            ],
+            "on_end_effects": [],
+        }
+        target_model = MagicMock()
+        target_model.state_json = {"tempHP": 8}
+
+        with patch(
+            "app.services.combat_service.spell_declarative_effects._roll_dice_expression",
+            return_value=5,
+        ), patch.object(
+            CombatService,
+            "_get_stats",
+            return_value=(target_model, None, None, None, None, None),
+        ):
+            application = CombatService._apply_declarative_spell_effects(
+                state=state,
+                attacker=attacker,
+                target_participant=target,
+                spell_context=spell_context,
+            )
+            CombatService._apply_temp_hp_from_granted_effects(
+                MagicMock(),
+                state,
+                application["applied_effects"],
+            )
+
+        summary = CombatService._build_applied_declarative_effects_by_target(
+            application["applied_effects"]
+        )
+        self.assertEqual(
+            summary[0]["effects"][0]["observability"],
+            {
+                "rolled_temp_hp": 5,
+                "applied_temp_hp": True,
+                "previous_temp_hp": 8,
+                "final_temp_hp": 8,
+                "does_not_expire_temp_hp": True,
+            },
+        )
+
+    def test_clearing_concentration_removes_tracking_effect_but_keeps_temp_hp(self):
+        state = self._make_player_target_state()
+        attacker = state.participants[0]
+        target = state.participants[1]
+        spell_context = {
+            "spell_name": "Enhance Ability",
+            "spell_canonical_key": "enhance_ability",
+            "concentration": True,
+            "selected_variant_key": "bears_endurance",
+            "selected_variant_label": "Resistência do Urso",
+            "effects": [
+                {
+                    "type": "grant_temp_hp",
+                    "target": "selected_target",
+                    "duration": {"type": "manual"},
+                    "params": {"dice": "2d6"},
+                }
+            ],
+            "on_end_effects": [],
+        }
+        target_model = MagicMock()
+        target_model.state_json = {"tempHP": 0}
+
+        with patch(
+            "app.services.combat_service.spell_declarative_effects._roll_dice_expression",
+            return_value=9,
+        ), patch.object(
+            CombatService,
+            "_get_stats",
+            return_value=(target_model, None, None, None, None, None),
+        ):
+            application = CombatService._apply_declarative_spell_effects(
+                state=state,
+                attacker=attacker,
+                target_participant=target,
+                spell_context=spell_context,
+            )
+            CombatService._apply_temp_hp_from_granted_effects(
+                MagicMock(),
+                state,
+                application["applied_effects"],
+            )
+
+        self.assertEqual(target_model.state_json["tempHP"], 9)
+        result = CombatService._clear_concentration_for_source(
+            state,
+            source_participant_id=attacker["id"],
+        )
+        self.assertEqual(len(result["removed_effects"]), 1)
+        self.assertEqual(result["removed_effects"][0]["kind"], "temp_hp_granted")
+        self.assertEqual(target["active_effects"], [])
+        self.assertEqual(target_model.state_json["tempHP"], 9)
+
+    def test_declarative_cast_log_includes_temp_hp_summary(self):
+        state = self._make_player_target_state()
+        attacker = state.participants[0]
+        target = state.participants[1]
+        target_model = MagicMock()
+        target_model.state_json = {"tempHP": 8}
+        spell_context = {
+            "spell_name": "Enhance Ability",
+            "spell_canonical_key": "enhance_ability",
+            "spell_mode": "utility",
+            "concentration": True,
+            "selected_variant_key": "bears_endurance",
+            "selected_variant_label": "Resistência do Urso",
+            "effects": [
+                {
+                    "type": "grant_temp_hp",
+                    "target": "selected_target",
+                    "duration": {"type": "manual"},
+                    "params": {"dice": "2d6"},
+                }
+            ],
+            "on_end_effects": [],
+        }
+
+        with patch(
+            "app.services.combat_service.spell_declarative_effects._roll_dice_expression",
+            return_value=5,
+        ), patch.object(
+            CombatService,
+            "_get_stats",
+            return_value=(target_model, None, None, None, None, None),
+        ):
+            result = asyncio.run(
+                CombatService._cast_spell_via_declarative_effects(
+                    MagicMock(),
+                    "session-1",
+                    attacker=attacker,
+                    attacker_model=MagicMock(),
+                    actor_user_id="user-1",
+                    is_gm=False,
+                    req=MagicMock(),
+                    state=state,
+                    spell_context=spell_context,
+                    target_participant=target,
+                )
+            )
+
+        self.assertIn("Target Player: PV temporários: 5 rolados, mantidos 8 existentes.", result["__log_message"])

--- a/apps/control-web/src/features/combat-ui/components/ActiveEffectDebugPanel.test.tsx
+++ b/apps/control-web/src/features/combat-ui/components/ActiveEffectDebugPanel.test.tsx
@@ -70,7 +70,7 @@ describe("ActiveEffectDebugPanel", () => {
       />,
     );
 
-    expect(markup).toContain("PV temporários concedidos: 9");
+    expect(markup).toContain("PV temporários: +9 (final: 9).");
     expect(markup).toContain("Não expiram com a concentração");
   });
 

--- a/apps/control-web/src/features/combat-ui/spellVariantUi.test.ts
+++ b/apps/control-web/src/features/combat-ui/spellVariantUi.test.ts
@@ -185,4 +185,48 @@ describe("spellVariantUi", () => {
       ),
     ).toEqual([]);
   });
+
+  it("formata grant_temp_hp aplicado, substituido e ignorado", () => {
+    expect(
+      formatDeclarativeEffectSummaryLine({
+        type: "grant_temp_hp",
+        params: { dice: "2d6" },
+        observability: {
+          rolled_temp_hp: 7,
+          applied_temp_hp: true,
+          previous_temp_hp: 0,
+          final_temp_hp: 7,
+          does_not_expire_temp_hp: true,
+        },
+      }),
+    ).toBe("PV temporários: +7 (final: 7).");
+
+    expect(
+      formatDeclarativeEffectSummaryLine({
+        type: "grant_temp_hp",
+        params: { dice: "2d6" },
+        observability: {
+          rolled_temp_hp: 7,
+          applied_temp_hp: true,
+          previous_temp_hp: 3,
+          final_temp_hp: 7,
+          does_not_expire_temp_hp: true,
+        },
+      }),
+    ).toBe("PV temporários: +7 (final: 7).");
+
+    expect(
+      formatDeclarativeEffectSummaryLine({
+        type: "grant_temp_hp",
+        params: { dice: "2d6" },
+        observability: {
+          rolled_temp_hp: 5,
+          applied_temp_hp: true,
+          previous_temp_hp: 8,
+          final_temp_hp: 8,
+          does_not_expire_temp_hp: true,
+        },
+      }),
+    ).toBe("PV temporários: 5 rolados, mantidos 8 existentes.");
+  });
 });

--- a/apps/control-web/src/features/combat-ui/spellVariantUi.ts
+++ b/apps/control-web/src/features/combat-ui/spellVariantUi.ts
@@ -29,6 +29,7 @@ type TargetLookup = {
 type DeclarativeEffectSummaryLike = {
   type?: unknown;
   params?: Record<string, unknown> | null;
+  observability?: Record<string, unknown> | null;
 };
 
 const humanizeVariantKey = (variantKey: string) =>
@@ -216,11 +217,20 @@ export const formatDeclarativeEffectSummaryLine = (
     return `Condition: ${p.condition}`;
   }
   if (declarative.type === "grant_temp_hp") {
-    const rolled = typeof metadata?.rolled_temp_hp === "number" ? metadata.rolled_temp_hp : null;
-    const applied = metadata?.applied_temp_hp === true;
-    const final = typeof metadata?.final_temp_hp === "number" ? metadata.final_temp_hp : null;
-    if (applied && final !== null) {
-      return `PV temporários concedidos: ${final}. Não expiram com a concentração.`;
+    const observed = declarative.observability ?? metadata ?? null;
+    const rolled = typeof observed?.rolled_temp_hp === "number" ? observed.rolled_temp_hp : null;
+    const applied = observed?.applied_temp_hp === true;
+    const previous = typeof observed?.previous_temp_hp === "number" ? observed.previous_temp_hp : null;
+    const final = typeof observed?.final_temp_hp === "number" ? observed.final_temp_hp : null;
+    const noExpire =
+      metadata && observed?.does_not_expire_temp_hp === true
+        ? " Não expiram com a concentração."
+        : "";
+    if (applied && rolled !== null && previous !== null && final !== null && final <= previous) {
+      return `PV temporários: ${rolled} rolados, mantidos ${previous} existentes.${noExpire}`;
+    }
+    if (applied && rolled !== null && final !== null) {
+      return `PV temporários: +${rolled} (final: ${final}).${noExpire}`;
     }
     if (rolled !== null) {
       return `PV temporários: ${rolled} (aguardando aplicação)`;

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx
@@ -302,4 +302,88 @@ describe("SpellCastResultPanel", () => {
     expect(markup).toContain("Lembrete - Conferir mochila");
     expect(markup).not.toContain("Capacidade de carga - Duplicada");
   });
+
+  it("exibe grant_temp_hp aplicado por alvo", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastResultPanel
+        {...baseProps}
+        result={{
+          spell_name: "Enhance Ability",
+          spell_canonical_key: "enhance_ability",
+          action_kind: "utility",
+          effect_kind: "damage",
+          damage: 0,
+          healing: 0,
+          target_display_name: "Barbarian",
+          target_kind: "player",
+          applied_declarative_effects_by_target: [
+            {
+              target_display_name: "Barbarian",
+              target_participant_id: "ally-2",
+              variant_key: "bears_endurance",
+              variant_label: "Resistência do Urso",
+              effects: [
+                {
+                  type: "grant_temp_hp",
+                  params: { dice: "2d6" },
+                  observability: {
+                    rolled_temp_hp: 7,
+                    applied_temp_hp: true,
+                    previous_temp_hp: 0,
+                    final_temp_hp: 7,
+                    does_not_expire_temp_hp: true,
+                  },
+                },
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Barbarian");
+    expect(markup).toContain("Variante: Resistência do Urso");
+    expect(markup).toContain("PV temporários: +7 (final: 7).");
+  });
+
+  it("exibe grant_temp_hp ignorado quando alvo ja tinha valor maior", () => {
+    const markup = renderToStaticMarkup(
+      <SpellCastResultPanel
+        {...baseProps}
+        result={{
+          spell_name: "Enhance Ability",
+          spell_canonical_key: "enhance_ability",
+          action_kind: "utility",
+          effect_kind: "damage",
+          damage: 0,
+          healing: 0,
+          target_display_name: "Barbarian",
+          target_kind: "player",
+          applied_declarative_effects_by_target: [
+            {
+              target_display_name: "Barbarian",
+              target_participant_id: "ally-2",
+              variant_key: "bears_endurance",
+              variant_label: "Resistência do Urso",
+              effects: [
+                {
+                  type: "grant_temp_hp",
+                  params: { dice: "2d6" },
+                  observability: {
+                    rolled_temp_hp: 5,
+                    applied_temp_hp: true,
+                    previous_temp_hp: 8,
+                    final_temp_hp: 8,
+                    does_not_expire_temp_hp: true,
+                  },
+                },
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(markup).toContain("PV temporários: 5 rolados, mantidos 8 existentes.");
+  });
 });

--- a/apps/control-web/src/shared/api/combatRepo.ts
+++ b/apps/control-web/src/shared/api/combatRepo.ts
@@ -66,6 +66,13 @@ export type CombatSpellContextOrigin =
 export type AppliedDeclarativeEffectSummary = {
   type?: string | null;
   params?: Record<string, unknown> | null;
+  observability?: {
+    rolled_temp_hp?: number | null;
+    applied_temp_hp?: boolean | null;
+    previous_temp_hp?: number | null;
+    final_temp_hp?: number | null;
+    does_not_expire_temp_hp?: boolean | null;
+  } | null;
 };
 
 export type AppliedDeclarativeEffectsByTargetEntry = {


### PR DESCRIPTION
Closes #145 

## What changed
- Extended `applied_declarative_effects_by_target` with temp HP observability for `grant_temp_hp`.
- Surfaced temporary HP outcomes in spell results and declarative cast logs.
- Added coverage for applied, upgraded, ignored, and concentration-cleanup cases.

## Validation
- `npx vitest run apps/control-web/src/features/combat-ui/spellVariantUi.test.ts apps/control-web/src/features/combat-ui/components/ActiveEffectDebugPanel.test.tsx apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/spellCastResultPanel.test.tsx`
- `/home/caue/LimiarControl/apps/control-server/.venv/bin/pytest /home/caue/LimiarControl/apps/control-server/tests/test_spell_declarative_effects.py /home/caue/LimiarControl/apps/control-server/tests/test_modal_pending_resolution.py`