### PR TITLE
[codex] apply passive perception bonuses outside combat

### DIFF
--- a/apps/control-web/src/features/character-sheet/CharacterSheetPage.tsx
+++ b/apps/control-web/src/features/character-sheet/CharacterSheetPage.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { buildCampaignDashboardPath, routes } from "../../app/routes/routes";
-import { useCampaignEvents } from "../sessions";
+import { useCampaignEvents, usePartyActiveSession } from "../sessions";
 import { partiesRepo } from "../../shared/api/partiesRepo";
 import type { RoleMode } from "../../shared/types/role";
 import { useLocale } from "../../shared/hooks/useLocale";
 import { CharacterSheet } from "./components/CharacterSheet";
+import { useCombatUiState } from "../combat-ui/useCombatUiState";
 
 type Props = {
   viewerUserId?: string | null;
@@ -54,6 +55,16 @@ export const CharacterSheetPage = ({ viewerUserId = null, viewerRole = "PLAYER" 
     viewerRole === "GM" && requestedMode === "play"
       ? requestedPlayerName || "Selected Player"
       : null;
+  const { activeSession } = usePartyActiveSession(
+    requestedMode === "play" ? (partyId ?? null) : null,
+  );
+  const combat = useCombatUiState({
+    enabled: requestedMode === "play" && activeSession?.status === "ACTIVE" && !!playPlayerUserId,
+    pollMs: 15_000,
+    sessionId: activeSession?.id ?? "",
+    userId: playPlayerUserId,
+  });
+  const activeEffects = combat.myParticipant?.active_effects ?? [];
 
   useEffect(() => {
     if (!partyId || requestedCampaignId) {
@@ -114,6 +125,7 @@ export const CharacterSheetPage = ({ viewerUserId = null, viewerRole = "PLAYER" 
       backHref={backHref}
       backLabel={backLabel}
       playContextLabel={playContextLabel}
+      activeEffects={activeEffects}
     />
   );
 };

--- a/apps/control-web/src/features/character-sheet/components/CharacterSheet.tsx
+++ b/apps/control-web/src/features/character-sheet/components/CharacterSheet.tsx
@@ -30,6 +30,7 @@ import {
 } from "../utils/proficiencyCatalog";
 import { useLocale } from "../../../shared/hooks/useLocale";
 import { useCharacterSheetDerived } from "../hooks/useCharacterSheetDerived";
+import type { ActiveEffect } from "../../../shared/api/combatRepo";
 
 type Props = {
   partyId?: string | null;
@@ -43,6 +44,7 @@ type Props = {
   backHref?: string | null;
   backLabel?: string | null;
   playContextLabel?: string | null;
+  activeEffects?: ActiveEffect[];
 };
 
 export const CharacterSheet = ({
@@ -57,6 +59,7 @@ export const CharacterSheet = ({
   backHref = null,
   backLabel = null,
   playContextLabel = null,
+  activeEffects = [],
 }: Props) => {
   const navigate = useNavigate();
   const actions = useCharacterSheet(partyId, mode, {
@@ -213,10 +216,11 @@ export const CharacterSheet = ({
     hpTextColor,
     initiative,
     passivePerception,
+    passivePerceptionBonus,
     profBonus,
     spellAttack,
     spellSaveDC,
-  } = useCharacterSheetDerived(sheet);
+  } = useCharacterSheetDerived(sheet, activeEffects);
 
   if (actions.loading) {
     return <CharacterSheetStateScreen />;
@@ -441,6 +445,7 @@ export const CharacterSheet = ({
                 skillProficiencies={sheet.skillProficiencies}
                 level={sheet.level}
                 onCycleProf={actions.cycleSkillProf}
+                passivePerceptionBonus={passivePerceptionBonus}
                 readOnly={isCreation ? !isEditableCreationDraft : isPlayReadOnly || isSheetLocked}
               />
           </div>

--- a/apps/control-web/src/features/character-sheet/hooks/useCharacterSheetDerived.test.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/useCharacterSheetDerived.test.ts
@@ -2,6 +2,27 @@ import { describe, expect, it } from "vitest";
 
 import { INITIAL_SHEET } from "../model/initialSheet";
 import { useCharacterSheetDerived } from "./useCharacterSheetDerived";
+import type { ActiveEffect } from "../../../shared/api/combatRepo";
+
+const makePassivePerceptionEffect = (
+  bonus: number,
+  label = "Owl's Wisdom",
+): ActiveEffect => ({
+  id: `effect-${label}-${bonus}`,
+  kind: "spell_effect",
+  duration_type: "rounds",
+  created_at: "2026-05-02T00:00:00Z",
+  display_label: label,
+  metadata: {
+    declarative_effect: {
+      type: "passive_skill_bonus",
+      params: {
+        skill: "perception",
+        bonus,
+      },
+    },
+  },
+});
 
 describe("useCharacterSheetDerived", () => {
   it("exposes dragonborn ancestry damage, resistance and breath weapon data", () => {
@@ -63,5 +84,35 @@ describe("useCharacterSheetDerived", () => {
     expect(derived.draconicResistanceType).toBeNull();
     expect(derived.hasElementalAffinity).toBe(false);
     expect(derived.resistances).toEqual([]);
+  });
+
+  it("adds passive perception bonus from active effects when present", () => {
+    const derived = useCharacterSheetDerived(INITIAL_SHEET, [
+      makePassivePerceptionEffect(5),
+    ]);
+
+    expect(derived.passivePerception).toBe(15);
+    expect(derived.passivePerceptionBonus).toBe(5);
+    expect(derived.passivePerceptionBonusSources).toEqual([
+      { label: "Owl's Wisdom", value: 5 },
+    ]);
+  });
+
+  it("stacks passive perception bonuses and preserves baseline without effects", () => {
+    const baseline = useCharacterSheetDerived(INITIAL_SHEET);
+    const derived = useCharacterSheetDerived(INITIAL_SHEET, [
+      makePassivePerceptionEffect(3, "Aura of Vigilance"),
+      makePassivePerceptionEffect(2, "Owl's Wisdom"),
+    ]);
+
+    expect(baseline.passivePerception).toBe(10);
+    expect(baseline.passivePerceptionBonus).toBe(0);
+    expect(baseline.passivePerceptionBonusSources).toEqual([]);
+    expect(derived.passivePerception).toBe(15);
+    expect(derived.passivePerceptionBonus).toBe(5);
+    expect(derived.passivePerceptionBonusSources).toEqual([
+      { label: "Aura of Vigilance", value: 3 },
+      { label: "Owl's Wisdom", value: 2 },
+    ]);
   });
 });

--- a/apps/control-web/src/features/character-sheet/hooks/useCharacterSheetDerived.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/useCharacterSheetDerived.ts
@@ -1,5 +1,7 @@
 import {
   computeInitiative,
+  computePassiveSkillBonus,
+  computePassiveSkillBonusSources,
   computePassivePerception,
   computeSpellAttack,
   computeSpellSaveDC,
@@ -17,15 +19,21 @@ import {
   resolveElementalAffinityEligibility,
 } from "../data/draconicAncestry";
 import { resolveDragonbornLineageState } from "../data/dragonbornAncestries";
+import type { ActiveEffect } from "../../../shared/api/combatRepo";
 
-export const useCharacterSheetDerived = (sheet: CharacterSheet) => {
+export const useCharacterSheetDerived = (
+  sheet: CharacterSheet,
+  activeEffects: ActiveEffect[] = [],
+) => {
   const acResult = calculateArmorClass(buildCharacterAcStateFromSheet(sheet));
   const ac = acResult.total;
   const acBreakdown = getArmorClassBreakdownRows(acResult);
   const dexMod = getModifier(sheet.abilities.dexterity);
   const initiative = computeInitiative(dexMod);
   const profBonus = getProficiencyBonus(sheet.level);
-  const passivePerception = computePassivePerception(sheet);
+  const passivePerceptionBonus = computePassiveSkillBonus(activeEffects, "perception");
+  const passivePerceptionBonusSources = computePassiveSkillBonusSources(activeEffects, "perception");
+  const passivePerception = computePassivePerception(sheet) + passivePerceptionBonus;
 
   const spellAbilityScore = sheet.spellcasting
     ? sheet.abilities[sheet.spellcasting.ability]
@@ -69,6 +77,8 @@ export const useCharacterSheetDerived = (sheet: CharacterSheet) => {
     hpTextColor,
     initiative,
     passivePerception,
+    passivePerceptionBonus,
+    passivePerceptionBonusSources,
     profBonus,
     dragonbornAncestry: dragonbornLineage.ancestry,
     dragonbornAncestryLabel: dragonbornLineage.ancestryLabel,

--- a/apps/control-web/src/pages/AdminCampaignsPage/AdminCampaignsPage.tsx
+++ b/apps/control-web/src/pages/AdminCampaignsPage/AdminCampaignsPage.tsx
@@ -1,10 +1,11 @@
 import { useDeferredValue, useEffect, useState } from "react";
+import { routes } from "../../app/routes/routes";
 import { adminSystemRepo } from "../../shared/api/adminSystemRepo";
 import type { AdminCampaign } from "../../entities/admin-system";
 import type { CampaignSystemType } from "../../entities/campaign";
 import { getCampaignSystemLabel } from "../../entities/campaign";
 import { useLocale, useToast } from "../../shared/hooks";
-import { Toast } from "../../shared/ui";
+import { BackButton, Toast } from "../../shared/ui";
 
 type SystemFilter = "ALL" | CampaignSystemType;
 
@@ -87,6 +88,13 @@ export const AdminCampaignsPage = () => {
     <>
       <Toast toast={toast} onClose={clearToast} />
       <section className="space-y-6">
+        <div className="flex items-start justify-start">
+          <BackButton
+            fallbackTo={routes.adminHome}
+            label={<><span aria-hidden>←</span>{t("campaignHome.back")}</>}
+            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/3 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-300 transition hover:border-white/16 hover:text-white"
+          />
+        </div>
         <section className="rounded-[30px] border border-white/8 bg-white/4 p-6">
           <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_260px]">
             <label className="space-y-2">

--- a/apps/control-web/src/pages/AdminHomePage/AdminHomePage.tsx
+++ b/apps/control-web/src/pages/AdminHomePage/AdminHomePage.tsx
@@ -4,6 +4,7 @@ import { routes } from "../../app/routes/routes";
 import { adminSystemRepo } from "../../shared/api/adminSystemRepo";
 import type { AdminOverview } from "../../entities/admin-system";
 import { useLocale } from "../../shared/hooks/useLocale";
+import { BackButton } from "../../shared/ui";
 
 export const AdminHomePage = () => {
   const { t } = useLocale();
@@ -47,6 +48,14 @@ export const AdminHomePage = () => {
 
   return (
     <section className="space-y-6">
+      <div className="flex items-start justify-start">
+        <BackButton
+          fallbackTo={routes.workspaceHome}
+          forceFallback
+          label={<><span aria-hidden>←</span>{t("campaignHome.back")}</>}
+          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/3 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-300 transition hover:border-white/16 hover:text-white"
+        />
+      </div>
       <section className="rounded-[32px] border border-white/8 bg-[linear-gradient(180deg,rgba(17,24,39,0.82),rgba(7,10,18,0.94))] p-6 shadow-[0_30px_90px_rgba(0,0,0,0.24)]">
         <div className="grid gap-4 lg:grid-cols-2">
           <Link

--- a/apps/control-web/src/pages/CampaignHomePage/CampaignHomePage.tsx
+++ b/apps/control-web/src/pages/CampaignHomePage/CampaignHomePage.tsx
@@ -139,6 +139,7 @@ export const CampaignHomePage = () => {
           <div className="flex flex-wrap items-center gap-3">
             <BackButton
               fallbackTo={routes.gmHome}
+              forceFallback
               label={<><span aria-hidden>←</span>{t("campaignHome.back")}</>}
               className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/3 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-300 transition hover:border-white/16 hover:text-white"
             />

--- a/apps/control-web/src/pages/PartyDetailsPage/PartyDetailsPageSections.tsx
+++ b/apps/control-web/src/pages/PartyDetailsPage/PartyDetailsPageSections.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { buildCampaignDashboardPath, routes } from "../../app/routes/routes";
 import { BackButton } from "../../shared/ui";
 import type { PartyActiveSession, PartyDetail } from "../../shared/api/partiesRepo";

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
@@ -112,6 +112,12 @@ export const PlayerBoardPage = () => {
     userId: user?.userId,
   });
 
+  const combatBarState = useCombatUiState({
+    enabled: Boolean(activeSession?.id) && combatActive && !combatModeVisible,
+    sessionId: activeSession?.id ?? "",
+    userId: user?.userId,
+  });
+  const boardActiveEffects = combatBarState.myParticipant?.active_effects ?? [];
   const {
     boardDescription,
     campaignTitle,
@@ -121,17 +127,13 @@ export const PlayerBoardPage = () => {
     sessionStatusTone,
   } = usePlayerBoardSummary({
     activeSession,
+    activeEffects: boardActiveEffects,
     effectiveCampaignId,
     inventory: myInventory,
     itemsById: catalogItems,
     playerSheet,
     selectedCampaignName: selectedCampaign?.name,
     t,
-  });
-  const combatBarState = useCombatUiState({
-    enabled: Boolean(activeSession?.id) && combatActive && !combatModeVisible,
-    sessionId: activeSession?.id ?? "",
-    userId: user?.userId,
   });
   const {
     armorOptions,

--- a/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardSummary.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardSummary.test.tsx
@@ -1,0 +1,77 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { INITIAL_SHEET } from "../../features/character-sheet/model/initialSheet";
+import { usePlayerBoardSummary } from "./usePlayerBoardSummary";
+import type { ActiveEffect } from "../../shared/api/combatRepo";
+import type { PlayerBoardStatusSummary } from "./playerBoard.types";
+
+vi.mock("../../shared/hooks/useLocale", () => ({
+  useLocale: () => ({
+    locale: "pt-BR",
+    t: (key: string) => key,
+  }),
+}));
+
+const makePassivePerceptionEffect = (
+  bonus: number,
+  label = "Owl's Wisdom",
+): ActiveEffect => ({
+  id: `effect-${label}-${bonus}`,
+  kind: "spell_effect",
+  duration_type: "rounds",
+  created_at: "2026-05-02T00:00:00Z",
+  display_label: label,
+  metadata: {
+    declarative_effect: {
+      type: "passive_skill_bonus",
+      params: {
+        skill: "perception",
+        bonus,
+      },
+    },
+  },
+});
+
+const renderSummary = (activeEffects: ActiveEffect[] = []): PlayerBoardStatusSummary | null => {
+  let captured: PlayerBoardStatusSummary | null = null;
+
+  const Probe = () => {
+    const summary = usePlayerBoardSummary({
+      activeSession: { status: "ACTIVE" },
+      activeEffects,
+      effectiveCampaignId: "campaign-1",
+      inventory: [],
+      itemsById: {},
+      playerSheet: INITIAL_SHEET,
+      selectedCampaignName: "Campanha",
+      t: (key) => key,
+    });
+
+    captured = summary.playerStatus;
+    return null;
+  };
+
+  renderToStaticMarkup(<Probe />);
+  return captured;
+};
+
+describe("usePlayerBoardSummary", () => {
+  it("aplica bônus passivo de percepção ao resumo do player board", () => {
+    const playerStatus = renderSummary([makePassivePerceptionEffect(5)]);
+
+    expect(playerStatus?.passivePerception).toBe(15);
+    expect(playerStatus?.passivePerceptionBonus).toBe(5);
+    expect(playerStatus?.passivePerceptionBonusSources).toEqual([
+      { label: "Owl's Wisdom", value: 5 },
+    ]);
+  });
+
+  it("mantém percepção passiva base quando activeEffects está ausente", () => {
+    const playerStatus = renderSummary();
+
+    expect(playerStatus?.passivePerception).toBe(10);
+    expect(playerStatus?.passivePerceptionBonus).toBe(0);
+    expect(playerStatus?.passivePerceptionBonusSources).toEqual([]);
+  });
+});

--- a/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardSummary.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardSummary.ts
@@ -6,6 +6,7 @@ import { useCharacterSheetDerived } from "../../features/character-sheet/hooks/u
 import { INITIAL_SHEET } from "../../features/character-sheet/model/initialSheet";
 import { getCharacterProgressState } from "../../features/character-sheet/utils/progression";
 import type { CharacterSheet } from "../../features/character-sheet/model/characterSheet.types";
+import type { ActiveEffect } from "../../shared/api/combatRepo";
 import type { LocaleKey } from "../../shared/i18n";
 import type { PlayerBoardStatusSummary } from "./playerBoard.types";
 import { buildPlayerBoardWeaponSummary } from "./playerBoardWeaponSummary";
@@ -20,6 +21,7 @@ type Props = {
   inventory: InventoryItem[] | null;
   itemsById: Record<string, Item>;
   playerSheet: CharacterSheet | null;
+  activeEffects?: ActiveEffect[];
   selectedCampaignName?: string | null;
   t: (key: LocaleKey) => string;
 };
@@ -30,12 +32,21 @@ export const usePlayerBoardSummary = ({
   inventory,
   itemsById,
   playerSheet,
+  activeEffects = [],
   selectedCampaignName,
   t,
 }: Props) => {
   const { locale } = useLocale();
-  const { ac, hpPercent, initiative, passivePerception, spellAttack, spellSaveDC } =
-    useCharacterSheetDerived(playerSheet ?? INITIAL_SHEET);
+  const {
+    ac,
+    hpPercent,
+    initiative,
+    passivePerception,
+    passivePerceptionBonus,
+    passivePerceptionBonusSources,
+    spellAttack,
+    spellSaveDC,
+  } = useCharacterSheetDerived(playerSheet ?? INITIAL_SHEET, activeEffects);
   const xpState = getCharacterProgressState(
     playerSheet?.level ?? INITIAL_SHEET.level,
     playerSheet?.experiencePoints ?? INITIAL_SHEET.experiencePoints,
@@ -98,12 +109,27 @@ export const usePlayerBoardSummary = ({
       maxHp: playerSheet.maxHP,
       nextLevelThreshold: xpState.nextLevelThreshold,
       passivePerception,
+      passivePerceptionBonus,
+      passivePerceptionBonusSources,
       spellAttack,
       spellSaveDC,
       tempHp: playerSheet.tempHP,
       xpPercent: xpState.progressPercent,
     };
-  }, [ac, currentWeapon, hpPercent, initiative, passivePerception, playerSheet, spellAttack, spellSaveDC, xpState.nextLevelThreshold, xpState.progressPercent]);
+  }, [
+    ac,
+    currentWeapon,
+    hpPercent,
+    initiative,
+    passivePerception,
+    passivePerceptionBonus,
+    passivePerceptionBonusSources,
+    playerSheet,
+    spellAttack,
+    spellSaveDC,
+    xpState.nextLevelThreshold,
+    xpState.progressPercent,
+  ]);
 
   return {
     boardDescription,

--- a/apps/control-web/src/shared/ui/BackButton.tsx
+++ b/apps/control-web/src/shared/ui/BackButton.tsx
@@ -7,6 +7,7 @@ type BackButtonProps = {
   fallbackTo?: string | null;
   className?: string;
   replace?: boolean;
+  forceFallback?: boolean;
 };
 
 export const BackButton = ({
@@ -14,10 +15,15 @@ export const BackButton = ({
   fallbackTo = null,
   className = "",
   replace = false,
+  forceFallback = false,
 }: BackButtonProps) => {
   const navigate = useNavigate();
 
   const handleClick = () => {
+    if (forceFallback && fallbackTo) {
+      navigate(fallbackTo, replace ? { replace: true } : undefined);
+      return;
+    }
     navigateBackOrFallback(navigate, { fallbackTo, replace });
   };
 


### PR DESCRIPTION
## Summary
- apply `passive_skill_bonus` to Passive Perception outside combat on the Character Sheet and Player Board
- reuse the existing shared passive skill bonus helpers instead of duplicating calculation logic
- source optional `active_effects` from the current combat participant when a play session is active

## Why
Passive perception bonuses like Owl's Wisdom were already reflected in combat, but the same character outside combat still showed the baseline value. This created an inconsistent UI and hid active passive bonuses from players.

## Impact
Players and GMs now see the same Passive Perception total outside combat that combat mode already uses, including source breakdown on the Player Board when applicable. When no active effects are available, the UI keeps the previous baseline behavior.

## Validation
- `npx vitest run apps/control-web/src/features/character-sheet/hooks/useCharacterSheetDerived.test.ts apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardSummary.test.tsx`
