### PR TITLE
fix(character-creation): respect real character level for spell progression

### DIFF
--- a/apps/control-web/src/features/character-sheet/components/CreationSpellPicker.tsx
+++ b/apps/control-web/src/features/character-sheet/components/CreationSpellPicker.tsx
@@ -48,11 +48,12 @@ export const CreationSpellPicker = ({
     );
   }
 
-  const options = getAvailableStartingSpells(className, campaignId);
+  const options = getAvailableStartingSpells(className, level, campaignId);
   const fixedSpellNames = new Set(
     getFixedStartingSpells(className, level, campaignId).map((spell) => spell.name.toLowerCase()),
   );
   const selectedNames = new Set(selectedSpells.map((spell) => spell.name.toLowerCase()));
+  const selectedLeveledCount = selectedSpells.filter((spell) => spell.level > 0).length;
 
   return (
     <div className="mt-5 space-y-4">
@@ -64,14 +65,17 @@ export const CreationSpellPicker = ({
         fixedNames={fixedSpellNames}
         onToggle={onToggle}
       />
-      <SpellChoiceGroup
-        title={`Level 1 Spells (${selectedSpells.filter((spell) => spell.level === 1).length}/${availableLeveled})`}
-        limitReached={selectedSpells.filter((spell) => spell.level === 1).length >= availableLeveled}
-        selectedNames={selectedNames}
-        names={options.leveled.map((spell) => spell.name)}
-        fixedNames={fixedSpellNames}
-        onToggle={onToggle}
-      />
+      {options.leveledGroups.map((group) => (
+        <SpellChoiceGroup
+          key={`spell-level-${group.level}`}
+          title={`Level ${group.level} Spells (${selectedLeveledCount}/${availableLeveled})`}
+          limitReached={selectedLeveledCount >= availableLeveled}
+          selectedNames={selectedNames}
+          names={group.spells.map((spell) => spell.name)}
+          fixedNames={fixedSpellNames}
+          onToggle={onToggle}
+        />
+      ))}
     </div>
   );
 };

--- a/apps/control-web/src/features/character-sheet/components/Spellcasting.tsx
+++ b/apps/control-web/src/features/character-sheet/components/Spellcasting.tsx
@@ -164,9 +164,15 @@ export const Spellcasting = ({
       {startingSpellLimits && creationConfig && onToggleCreationSpell && (
         <>
           <div className={`mt-4 rounded-2xl border p-4 px-4 py-3 text-xs text-slate-400 ${hasSpellError ? "border-red-500/30 bg-red-950/20" : "border-white/6 bg-white/3"}`}>
-            <p className="font-semibold text-slate-200">
-              {t("sheet.spells.levelSlots").replace("{n}", "1")}: <span className="text-violet-300">{startingSpellLimits.levelOneSlots}</span>
-            </p>
+            <div className="space-y-1">
+              {Object.entries(startingSpellLimits.slots)
+                .filter(([, slotCount]) => slotCount > 0)
+                .map(([slotLevel, slotCount]) => (
+                  <p key={`creation-slot-${slotLevel}`} className="font-semibold text-slate-200">
+                    {t("sheet.spells.levelSlots").replace("{n}", slotLevel)}: <span className="text-violet-300">{slotCount}</span>
+                  </p>
+                ))}
+            </div>
             <p className="mt-1">
               {spellcasting.mode === "spellbook"
                 ? t("sheet.spells.spellbookMode")

--- a/apps/control-web/src/features/character-sheet/data/classCreation.config.ts
+++ b/apps/control-web/src/features/character-sheet/data/classCreation.config.ts
@@ -251,7 +251,7 @@ export const CLASS_CREATION_CONFIG: Record<string, ClassCreationConfig> = {
       { id: "wizard-focus", label: "Escolha seu foco", options: packOptions(["Bolsa de Componentes", "Component Pouch"], ["Foco Arcano", "Arcane Focus"]) },
       { id: "wizard-pack", label: "Escolha sua mochila", options: packOptions(["Mochila do Estudioso", "Scholar's Pack"], ["Mochila do Explorador", "Explorer's Pack"]) },
     ],
-    startingSpells: { cantrips: 3, leveledSpells: 6, leveledMode: "spellbook", preparationAbility: "intelligence", levelOneSlots: 2 },
+    startingSpells: { cantrips: 3, leveledMode: "spellbook", preparationAbility: "intelligence", levelOneSlots: 2 },
   },
 };
 

--- a/apps/control-web/src/features/character-sheet/data/classCreation.types.ts
+++ b/apps/control-web/src/features/character-sheet/data/classCreation.types.ts
@@ -18,7 +18,7 @@ export type StartingSpellMode = SpellcastingMode;
 export type StartingSpellConfig = {
   minimumLevel?: number;
   cantrips: number;
-  leveledSpells: number;
+  leveledSpells?: number;
   leveledMode: SpellcastingMode;
   preparationAbility?: AbilityName;
   levelOneSlots?: number;

--- a/apps/control-web/src/features/character-sheet/hooks/guardianCreation.test.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/guardianCreation.test.ts
@@ -377,8 +377,8 @@ describe("guardian creation flow", () => {
   });
 
   it("provides ranger-tagged spells for guardian through mechanics-family inheritance", () => {
-    const guardianSpells = getAvailableStartingSpells("guardian");
-    const rangerSpells = getAvailableStartingSpells("ranger");
+    const guardianSpells = getAvailableStartingSpells("guardian", 2);
+    const rangerSpells = getAvailableStartingSpells("ranger", 2);
 
     expect(guardianSpells.leveled.map((s) => s.canonicalKey)).toEqual(
       expect.arrayContaining(rangerSpells.leveled.map((s) => s.canonicalKey))

--- a/apps/control-web/src/features/character-sheet/hooks/paladinRangerCreation.test.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/paladinRangerCreation.test.ts
@@ -154,7 +154,7 @@ describe("paladin and ranger creation spellcasting", () => {
       }
     });
     expect(level2Paladin.spellcasting?.spells).toEqual([]);
-    expect(getAvailableStartingSpells("paladin").leveled.map((spell) => spell.canonicalKey)).toEqual([
+    expect(getAvailableStartingSpells("paladin", 2).leveled.map((spell) => spell.canonicalKey)).toEqual([
       "bless",
       "cure_wounds",
       "detect_magic"
@@ -164,7 +164,10 @@ describe("paladin and ranger creation spellcasting", () => {
       cantrips: 0,
       leveledSpells: 1,
       leveledMode: "prepared",
-      levelOneSlots: 2
+      levelOneSlots: 2,
+      slots: {
+        1: 2,
+      },
     });
   });
 
@@ -200,7 +203,7 @@ describe("paladin and ranger creation spellcasting", () => {
       }
     });
     expect(level2Ranger.spellcasting?.spells).toEqual([]);
-    expect(getAvailableStartingSpells("ranger").leveled.map((spell) => spell.canonicalKey)).toEqual(
+    expect(getAvailableStartingSpells("ranger", 2).leveled.map((spell) => spell.canonicalKey)).toEqual(
       expect.arrayContaining([
         "animal_friendship",
         "cure_wounds",
@@ -209,7 +212,7 @@ describe("paladin and ranger creation spellcasting", () => {
         "hunters_mark"
       ])
     );
-    expect(getAvailableStartingSpells("ranger").leveled).toHaveLength(5);
+    expect(getAvailableStartingSpells("ranger", 2).leveled).toHaveLength(5);
     expect(getClassCreationConfig("ranger")?.startingSpells).toBeTruthy();
     expect(getStartingSpellLimits("ranger", level2Ranger.abilities, 2)).toMatchObject({
       cantrips: 0,

--- a/apps/control-web/src/features/character-sheet/utils/creationSpells.test.ts
+++ b/apps/control-web/src/features/character-sheet/utils/creationSpells.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it, afterEach } from "vitest";
 import { seedSpellCatalogCache } from "../../../entities/dnd-base";
 import { INITIAL_SHEET } from "../model/initialSheet";
 import {
+  getAvailableStartingSpells,
+  getStartingSpellLimits,
   normalizeCreationSpellSelection,
-  selectCatalogSpellForSheet
+  selectCatalogSpellForSheet,
+  toggleStartingSpell,
 } from "./creationSpells";
 
 const BASE_SPELL = {
@@ -257,5 +260,290 @@ describe("toSheetSpell / selectCatalogSpellForSheet", () => {
         }),
       ]),
     );
+  });
+});
+
+describe("creation spell progression", () => {
+  it("unlocks level 2 sorcerer spells at character level 3", () => {
+    seedSpellCatalogCache([
+      {
+        canonicalKey: "light",
+        name: "Light",
+        level: 0,
+        school: "Evocation",
+        castingTime: "1 action",
+        range: "Touch",
+        components: "V, M",
+        duration: "1 hour",
+        concentration: false,
+        ritual: false,
+        description: "",
+        damageType: null,
+        savingThrow: null,
+        classes: ["Sorcerer"],
+      },
+      {
+        canonicalKey: "magic_missile",
+        name: "Magic Missile",
+        level: 1,
+        school: "Evocation",
+        castingTime: "1 action",
+        range: "36 m",
+        components: "V, S",
+        duration: "Instantaneous",
+        concentration: false,
+        ritual: false,
+        description: "",
+        damageType: "Force",
+        savingThrow: null,
+        classes: ["Sorcerer"],
+      },
+      {
+        canonicalKey: "enhance_ability",
+        name: "Enhance Ability",
+        level: 2,
+        school: "Transmutation",
+        castingTime: "1 action",
+        range: "Touch",
+        components: "V, S, M",
+        duration: "Concentration, up to 1 hour",
+        concentration: true,
+        ritual: false,
+        description: "",
+        damageType: null,
+        savingThrow: null,
+        classes: ["Sorcerer"],
+      },
+    ]);
+
+    expect(
+      getAvailableStartingSpells("sorcerer", 3).leveled.map(
+        (spell) => spell.canonicalKey
+      )
+    ).toEqual(["magic_missile", "enhance_ability"]);
+
+    expect(getStartingSpellLimits("sorcerer", INITIAL_SHEET.abilities, 3)).toMatchObject({
+      leveledSpells: 4,
+      maxSpellLevel: 2,
+      slots: {
+        1: 4,
+        2: 2,
+      },
+    });
+  });
+
+  it("keeps higher-level creation spells when normalizing a level 3 sorcerer", () => {
+    seedSpellCatalogCache([
+      {
+        canonicalKey: "light",
+        name: "Light",
+        level: 0,
+        school: "Evocation",
+        castingTime: "1 action",
+        range: "Touch",
+        components: "V, M",
+        duration: "1 hour",
+        concentration: false,
+        ritual: false,
+        description: "",
+        damageType: null,
+        savingThrow: null,
+        classes: ["Sorcerer"],
+      },
+      {
+        canonicalKey: "magic_missile",
+        name: "Magic Missile",
+        level: 1,
+        school: "Evocation",
+        castingTime: "1 action",
+        range: "36 m",
+        components: "V, S",
+        duration: "Instantaneous",
+        concentration: false,
+        ritual: false,
+        description: "",
+        damageType: "Force",
+        savingThrow: null,
+        classes: ["Sorcerer"],
+      },
+      {
+        canonicalKey: "enhance_ability",
+        name: "Enhance Ability",
+        level: 2,
+        school: "Transmutation",
+        castingTime: "1 action",
+        range: "Touch",
+        components: "V, S, M",
+        duration: "Concentration, up to 1 hour",
+        concentration: true,
+        ritual: false,
+        description: "",
+        damageType: null,
+        savingThrow: null,
+        classes: ["Sorcerer"],
+      },
+    ]);
+
+    const updated = toggleStartingSpell(
+      {
+        ability: "charisma",
+        mode: "known",
+        slots: { 1: { max: 4, used: 0 }, 2: { max: 2, used: 0 } },
+        spells: [],
+      },
+      "sorcerer",
+      INITIAL_SHEET.abilities,
+      3,
+      "Enhance Ability"
+    );
+
+    expect(updated?.spells).toEqual([
+      expect.objectContaining({
+        canonicalKey: "enhance_ability",
+        level: 2,
+      }),
+    ]);
+    expect(updated?.slots).toMatchObject({
+      1: { max: 4, used: 0 },
+      2: { max: 2, used: 0 },
+    });
+  });
+
+  it("surfaces Enhance Ability for full casters once level 2 spells unlock", () => {
+    seedSpellCatalogCache([
+      {
+        canonicalKey: "magic_missile",
+        name: "Magic Missile",
+        level: 1,
+        school: "Evocation",
+        castingTime: "1 action",
+        range: "36 m",
+        components: "V, S",
+        duration: "Instantaneous",
+        concentration: false,
+        ritual: false,
+        description: "",
+        damageType: "Force",
+        savingThrow: null,
+        classes: ["Bard", "Sorcerer", "Wizard"],
+      },
+      {
+        canonicalKey: "bless",
+        name: "Bless",
+        level: 1,
+        school: "Enchantment",
+        castingTime: "1 action",
+        range: "9 m",
+        components: "V, S, M",
+        duration: "Concentration, up to 1 minute",
+        concentration: true,
+        ritual: false,
+        description: "",
+        damageType: null,
+        savingThrow: null,
+        classes: ["Cleric"],
+      },
+      {
+        canonicalKey: "cure_wounds",
+        name: "Cure Wounds",
+        level: 1,
+        school: "Evocation",
+        castingTime: "1 action",
+        range: "Touch",
+        components: "V, S",
+        duration: "Instantaneous",
+        concentration: false,
+        ritual: false,
+        description: "",
+        damageType: null,
+        savingThrow: null,
+        classes: ["Druid", "Cleric", "Bard"],
+      },
+      {
+        canonicalKey: "enhance_ability",
+        name: "Enhance Ability",
+        level: 2,
+        school: "Transmutation",
+        castingTime: "1 action",
+        range: "Touch",
+        components: "V, S, M",
+        duration: "Concentration, up to 1 hour",
+        concentration: true,
+        ritual: false,
+        description: "",
+        damageType: null,
+        savingThrow: null,
+        classes: ["Bard", "Cleric", "Druid", "Sorcerer"],
+      },
+    ]);
+
+    expect(
+      getAvailableStartingSpells("sorcerer", 3).leveled.map(
+        (spell) => spell.canonicalKey
+      )
+    ).toContain("enhance_ability");
+    expect(
+      getAvailableStartingSpells("bard", 3).leveled.map(
+        (spell) => spell.canonicalKey
+      )
+    ).toContain("enhance_ability");
+    expect(
+      getAvailableStartingSpells("cleric", 3).leveled.map(
+        (spell) => spell.canonicalKey
+      )
+    ).toContain("enhance_ability");
+    expect(
+      getAvailableStartingSpells("druid", 3).leveled.map(
+        (spell) => spell.canonicalKey
+      )
+    ).toContain("enhance_ability");
+  });
+
+  it("keeps Enhance Ability hidden for sorcerers before level 3", () => {
+    seedSpellCatalogCache([
+      {
+        canonicalKey: "magic_missile",
+        name: "Magic Missile",
+        level: 1,
+        school: "Evocation",
+        castingTime: "1 action",
+        range: "36 m",
+        components: "V, S",
+        duration: "Instantaneous",
+        concentration: false,
+        ritual: false,
+        description: "",
+        damageType: "Force",
+        savingThrow: null,
+        classes: ["Sorcerer"],
+      },
+      {
+        canonicalKey: "enhance_ability",
+        name: "Enhance Ability",
+        level: 2,
+        school: "Transmutation",
+        castingTime: "1 action",
+        range: "Touch",
+        components: "V, S, M",
+        duration: "Concentration, up to 1 hour",
+        concentration: true,
+        ritual: false,
+        description: "",
+        damageType: null,
+        savingThrow: null,
+        classes: ["Sorcerer"],
+      },
+    ]);
+
+    expect(
+      getAvailableStartingSpells("sorcerer", 1).leveled.map(
+        (spell) => spell.canonicalKey
+      )
+    ).not.toContain("enhance_ability");
+    expect(
+      getAvailableStartingSpells("sorcerer", 2).leveled.map(
+        (spell) => spell.canonicalKey
+      )
+    ).not.toContain("enhance_ability");
   });
 });

--- a/apps/control-web/src/features/character-sheet/utils/creationSpells.ts
+++ b/apps/control-web/src/features/character-sheet/utils/creationSpells.ts
@@ -5,6 +5,7 @@ import {
   getBaseSpellsForClass,
   getSpellAvailabilityClassIds,
   isSameSpellAuthority,
+  resolveSpellSourceClassId,
   resolveSpellByAuthority,
 } from "../../../entities/dnd-base";
 import { getModifier } from "./calculations";
@@ -14,6 +15,157 @@ import type {
   Spell,
   SpellcastingData
 } from "../model/characterSheet.types";
+
+type StartingSpellOptionGroup = {
+  level: number;
+  spells: ReturnType<typeof getBaseSpellsForClass>;
+};
+
+const buildLevelTable = (values: number[]) =>
+  Object.fromEntries(values.map((value, index) => [index + 1, value])) as Record<
+    number,
+    number
+  >;
+
+const buildSlotTable = (rows: Array<Record<number, number>>) =>
+  Object.fromEntries(rows.map((row, index) => [index + 1, row])) as Record<
+    number,
+    Record<number, number>
+  >;
+
+const FULL_CASTER_SLOTS = buildSlotTable([
+  { 1: 2 },
+  { 1: 3 },
+  { 1: 4, 2: 2 },
+  { 1: 4, 2: 3 },
+  { 1: 4, 2: 3, 3: 2 },
+  { 1: 4, 2: 3, 3: 3 },
+  { 1: 4, 2: 3, 3: 3, 4: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 2 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 1, 7: 1, 8: 1, 9: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 2, 7: 1, 8: 1, 9: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 2, 7: 2, 8: 1, 9: 1 },
+]);
+
+const HALF_CASTER_SLOTS = buildSlotTable([
+  {},
+  { 1: 2 },
+  { 1: 3 },
+  { 1: 3 },
+  { 1: 4, 2: 2 },
+  { 1: 4, 2: 2 },
+  { 1: 4, 2: 3 },
+  { 1: 4, 2: 3 },
+  { 1: 4, 2: 3, 3: 2 },
+  { 1: 4, 2: 3, 3: 2 },
+  { 1: 4, 2: 3, 3: 3 },
+  { 1: 4, 2: 3, 3: 3 },
+  { 1: 4, 2: 3, 3: 3, 4: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 2 },
+  { 1: 4, 2: 3, 3: 3, 4: 2 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2 },
+]);
+
+const WARLOCK_SLOTS = buildSlotTable([
+  { 1: 1 },
+  { 1: 2 },
+  { 2: 2 },
+  { 2: 2 },
+  { 3: 2 },
+  { 3: 2 },
+  { 4: 2 },
+  { 4: 2 },
+  { 5: 2 },
+  { 5: 2 },
+  { 5: 3 },
+  { 5: 3 },
+  { 5: 3 },
+  { 5: 3 },
+  { 5: 3 },
+  { 5: 3 },
+  { 5: 4 },
+  { 5: 4 },
+  { 5: 4 },
+  { 5: 4 },
+]);
+
+const SLOT_TABLES_BY_CLASS: Record<string, Record<number, Record<number, number>>> = {
+  bard: FULL_CASTER_SLOTS,
+  cleric: FULL_CASTER_SLOTS,
+  druid: FULL_CASTER_SLOTS,
+  guardian: HALF_CASTER_SLOTS,
+  paladin: HALF_CASTER_SLOTS,
+  ranger: HALF_CASTER_SLOTS,
+  sorcerer: FULL_CASTER_SLOTS,
+  warlock: WARLOCK_SLOTS,
+  wizard: FULL_CASTER_SLOTS,
+};
+
+const CANTRIPS_BY_CLASS = {
+  bard: buildLevelTable([2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]),
+  cleric: buildLevelTable([3, 3, 3, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5]),
+  druid: buildLevelTable([2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]),
+  sorcerer: buildLevelTable([4, 4, 4, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6]),
+  warlock: buildLevelTable([2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]),
+  wizard: buildLevelTable([3, 3, 3, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5]),
+} as const;
+
+const LEVELED_SPELLS_KNOWN_BY_CLASS = {
+  bard: buildLevelTable([4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 15, 16, 18, 19, 19, 20, 22, 22, 22]),
+  ranger: buildLevelTable([0, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11]),
+  sorcerer: buildLevelTable([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12, 13, 13, 14, 14, 15, 15, 15, 15]),
+  warlock: buildLevelTable([2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15]),
+} as const;
+
+const PREPARED_SPELL_LEVEL_DIVISOR_BY_CLASS: Record<string, number> = {
+  cleric: 1,
+  druid: 1,
+  paladin: 2,
+  wizard: 1,
+};
+
+const clampCharacterLevel = (level: number) => Math.max(1, Math.min(20, level));
+
+const getNormalizedSpellProgressionClassId = (className: string) =>
+  resolveSpellSourceClassId(className.trim().toLowerCase());
+
+const getSlotProgressionForLevel = (
+  className: string,
+  level: number
+): Record<number, number> => {
+  const table = SLOT_TABLES_BY_CLASS[getNormalizedSpellProgressionClassId(className)];
+  if (!table) return {};
+  return table[clampCharacterLevel(level)] ?? {};
+};
+
+const getMaxUnlockedSpellLevel = (
+  className: string,
+  level: number,
+  fallbackLevelOneSlots = 0
+) => {
+  const highestSlotLevel = Math.max(
+    0,
+    ...Object.entries(getSlotProgressionForLevel(className, level))
+      .filter(([, count]) => count > 0)
+      .map(([slotLevel]) => Number(slotLevel))
+  );
+
+  if (highestSlotLevel > 0) return highestSlotLevel;
+  return fallbackLevelOneSlots > 0 ? 1 : 0;
+};
 
 const sortSpells = (spells: Spell[]) =>
   [...spells].sort(
@@ -204,6 +356,43 @@ export const getFixedStartingSpells = (
         spell !== undefined
     );
 
+const getCantripCountForClassLevel = (className: string, level: number) =>
+  CANTRIPS_BY_CLASS[
+    getNormalizedSpellProgressionClassId(className) as keyof typeof CANTRIPS_BY_CLASS
+  ]?.[clampCharacterLevel(level)];
+
+const getLeveledSpellCountForClassLevel = (
+  className: string,
+  level: number,
+  mode: SpellcastingData["mode"],
+  preparationAbility: keyof CharacterSheet["abilities"] | undefined,
+  abilities: CharacterSheet["abilities"]
+) => {
+  const normalizedClassName = getNormalizedSpellProgressionClassId(className);
+  const clampedLevel = clampCharacterLevel(level);
+
+  if (mode === "spellbook" && normalizedClassName === "wizard") {
+    return 6 + Math.max(0, clampedLevel - 1) * 2;
+  }
+
+  if (mode === "prepared" && preparationAbility) {
+    const levelDivisor =
+      PREPARED_SPELL_LEVEL_DIVISOR_BY_CLASS[normalizedClassName] ?? 1;
+    const effectiveCasterLevel = Math.max(
+      1,
+      Math.floor(clampedLevel / levelDivisor)
+    );
+    return Math.max(
+      1,
+      effectiveCasterLevel + getModifier(abilities[preparationAbility])
+    );
+  }
+
+  return LEVELED_SPELLS_KNOWN_BY_CLASS[
+    normalizedClassName as keyof typeof LEVELED_SPELLS_KNOWN_BY_CLASS
+  ]?.[clampedLevel];
+};
+
 export const getStartingSpellLimits = (
   className: string,
   abilities: CharacterSheet["abilities"],
@@ -213,42 +402,100 @@ export const getStartingSpellLimits = (
   if (!config) return null;
   if (config.minimumLevel && level < config.minimumLevel) return null;
 
-  const levelConfig = config.byLevel?.[level] ?? {};
-  const cantrips = levelConfig.cantrips ?? config.cantrips;
+  const clampedLevel = clampCharacterLevel(level);
+  const levelConfig = config.byLevel?.[clampedLevel] ?? {};
+  const cantrips =
+    levelConfig.cantrips ??
+    getCantripCountForClassLevel(className, clampedLevel) ??
+    config.cantrips;
   const effectivePreparationAbility = config.preparationAbility;
   const leveledMode = config.leveledMode;
   const fixedCantripCount = getFixedSpellKeys(
     className,
-    level,
+    clampedLevel,
     "cantrip"
   ).length;
   const fixedLeveledCount = getFixedSpellKeys(
     className,
-    level,
+    clampedLevel,
     "leveled"
   ).length;
 
   const leveledSpells =
-    leveledMode === "prepared" && effectivePreparationAbility
-      ? Math.max(1, level + getModifier(abilities[effectivePreparationAbility]))
-      : (levelConfig.leveledSpells ?? config.leveledSpells);
+    levelConfig.leveledSpells ??
+    getLeveledSpellCountForClassLevel(
+      className,
+      clampedLevel,
+      leveledMode,
+      effectivePreparationAbility,
+      abilities
+    ) ??
+    config.leveledSpells ??
+    0;
+
+  const legacyLevelOneSlots = levelConfig.levelOneSlots ?? config.levelOneSlots ?? 0;
+  const slots = getSlotProgressionForLevel(className, clampedLevel);
+  const maxSpellLevel = getMaxUnlockedSpellLevel(
+    className,
+    clampedLevel,
+    legacyLevelOneSlots
+  );
 
   return {
     cantrips: Math.max(cantrips, fixedCantripCount),
     leveledSpells: Math.max(leveledSpells, fixedLeveledCount),
     leveledMode,
-    levelOneSlots: levelConfig.levelOneSlots ?? config.levelOneSlots ?? 0
+    levelOneSlots: legacyLevelOneSlots,
+    maxSpellLevel,
+    slots:
+      Object.keys(slots).length > 0
+        ? slots
+        : legacyLevelOneSlots > 0
+          ? { 1: legacyLevelOneSlots }
+          : {}
   };
 };
 
 export const getAvailableStartingSpells = (
   className: string,
+  level = 1,
   campaignId?: string | null
 ) => {
-  const spells = getBaseSpellsForClass(className, 1, campaignId);
+  const config = getClassCreationConfig(className)?.startingSpells;
+  if (!config) {
+    return {
+      cantrips: [],
+      leveled: [],
+      leveledGroups: [] as StartingSpellOptionGroup[],
+    };
+  }
+  if (config.minimumLevel && level < config.minimumLevel) {
+    return {
+      cantrips: [],
+      leveled: [],
+      leveledGroups: [] as StartingSpellOptionGroup[],
+    };
+  }
+
+  const fallbackLevelOneSlots = config.byLevel?.[level]?.levelOneSlots ?? config.levelOneSlots ?? 0;
+  const maxSpellLevel = getMaxUnlockedSpellLevel(
+    className,
+    level,
+    fallbackLevelOneSlots
+  );
+  const spells = getBaseSpellsForClass(className, maxSpellLevel, campaignId);
+  const leveled = spells.filter((spell) => spell.level > 0);
+  const leveledGroups = Array.from(new Set(leveled.map((spell) => spell.level)))
+    .sort((left, right) => left - right)
+    .map((spellLevel) => ({
+      level: spellLevel,
+      spells: leveled.filter((spell) => spell.level === spellLevel),
+    }));
+
   return {
     cantrips: spells.filter((spell) => spell.level === 0),
-    leveled: spells.filter((spell) => spell.level === 1)
+    leveled,
+    leveledGroups,
   };
 };
 
@@ -267,7 +514,11 @@ export const normalizeCreationSpellSelection = (
   if (!limits) return null;
 
   const mode = spellcasting.mode;
-  const allowedSpells = getBaseSpellsForClass(className, 1, campaignId);
+  const allowedSpells = getBaseSpellsForClass(
+    className,
+    limits.maxSpellLevel,
+    campaignId
+  );
   const selected = ensureFixedStartingSpells(
     spellcasting.spells.filter((spell) =>
       Boolean(resolveSpellByAuthority(allowedSpells, spell))
@@ -282,19 +533,25 @@ export const normalizeCreationSpellSelection = (
     getFixedSpellKeys(className, level, "cantrip")
   ).slice(0, limits.cantrips);
   const leveled = prioritizeFixedSpells(
-    selected.filter((spell) => spell.level === 1),
+    selected.filter((spell) => spell.level > 0),
     getFixedSpellKeys(className, level, "leveled")
   ).slice(0, limits.leveledSpells);
 
   return {
     ...spellcasting,
-    slots: {
-      ...spellcasting.slots,
-      1: {
-        max: limits.levelOneSlots,
-        used: Math.min(spellcasting.slots[1]?.used ?? 0, limits.levelOneSlots)
-      }
-    },
+    slots: Object.fromEntries(
+      Array.from({ length: 9 }, (_, index) => index + 1).map((slotLevel) => {
+        const slotLimit = limits.slots[slotLevel] ?? 0;
+        const existingSlot = spellcasting.slots[slotLevel] ?? { max: 0, used: 0 };
+        return [
+          slotLevel,
+          {
+            max: slotLimit,
+            used: Math.min(existingSlot.used, slotLimit),
+          },
+        ];
+      })
+    ),
     spells: sortSpells(
       [...cantrips, ...leveled].map((spell) => ({
         ...spell,
@@ -316,7 +573,7 @@ export const toggleStartingSpell = (
   if (!spellcasting) return null;
   const limits = getStartingSpellLimits(className, abilities, level);
   const spell = findBaseSpell(spellName, campaignId);
-  if (!limits || !spell || spell.level > 1) return spellcasting;
+  if (!limits || !spell || spell.level > limits.maxSpellLevel) return spellcasting;
   if (
     getFixedStartingSpellCanonicalKeys(className, level).includes(
       spell.canonicalKey
@@ -341,11 +598,15 @@ export const toggleStartingSpell = (
     );
   }
 
-  const sameLevelCount = spellcasting.spells.filter(
-    (entry) => entry.level === spell.level
+  const selectedLeveledCount = spellcasting.spells.filter(
+    (entry) => entry.level > 0
   ).length;
   const limit = spell.level === 0 ? limits.cantrips : limits.leveledSpells;
-  if (sameLevelCount >= limit) {
+  if (
+    (spell.level === 0
+      ? spellcasting.spells.filter((entry) => entry.level === 0).length
+      : selectedLeveledCount) >= limit
+  ) {
     return spellcasting;
   }
 

--- a/apps/control-web/src/features/character-sheet/utils/creationValidation.test.ts
+++ b/apps/control-web/src/features/character-sheet/utils/creationValidation.test.ts
@@ -25,12 +25,13 @@ beforeAll(() => {
     { canonicalKey: "healing_word", name: "Healing Word", level: 1, school: "Evocation", castingTime: "1 bonus action", range: "18 m", components: "V", duration: "Instantaneous", concentration: false, ritual: false, description: "", damageType: null, savingThrow: null, classes: ["Bard", "Cleric", "Druid"] },
     { canonicalKey: "hunters_mark", name: "Hunter's Mark", level: 1, school: "Divination", castingTime: "1 bonus action", range: "27 m", components: "V", duration: "Up to 1 hour", concentration: true, ritual: false, description: "", damageType: null, savingThrow: null, classes: ["Ranger"] },
     { canonicalKey: "guardian_beacon", name: "Guardian Beacon", level: 1, school: "Abjuration", castingTime: "1 action", range: "9 m", components: "V, S", duration: "1 minute", concentration: false, ritual: false, description: "", damageType: null, savingThrow: null, classes: ["Guardian"] },
+    { canonicalKey: "enhance_ability", name: "Enhance Ability", level: 2, school: "Transmutation", castingTime: "1 action", range: "Touch", components: "V, S, M", duration: "Up to 1 hour", concentration: true, ritual: false, description: "", damageType: null, savingThrow: null, classes: ["Bard", "Cleric", "Druid", "Sorcerer"] },
   ]);
 });
 
-const buildSpellSelection = (className: string, cantripCount: number, leveledCount: number) => {
+const buildSpellSelection = (className: string, level: number, cantripCount: number, leveledCount: number) => {
   const cls = getClass(className);
-  const spells = getAvailableStartingSpells(className);
+  const spells = getAvailableStartingSpells(className, level);
   const mode = getClassCreationConfig(className)?.startingSpells?.leveledMode ?? "known";
 
   return {
@@ -118,7 +119,7 @@ describe("validateCreationSheet", () => {
       alignment: "Neutral Good",
       playerName: "Player Two",
       classSkillChoices: ["history", "religion"],
-      spellcasting: buildSpellSelection("cleric", 2, 0),
+      spellcasting: buildSpellSelection("cleric", 1, 2, 0),
     });
 
     expect(result.isValid).toBe(false);
@@ -133,7 +134,7 @@ describe("validateCreationSheet", () => {
   });
 
   it("uses the ranger spell list and level-aware slot limits for guardian", () => {
-    expect(getAvailableStartingSpells("guardian").leveled.map((spell) => spell.canonicalKey)).toEqual([
+    expect(getAvailableStartingSpells("guardian", 2).leveled.map((spell) => spell.canonicalKey)).toEqual([
       "animal_friendship",
       "cure_wounds",
       "goodberry",
@@ -155,7 +156,7 @@ describe("validateCreationSheet", () => {
   it("requires paladin spell picks once spellcasting unlocks", () => {
     const result = validateCreationSheet({
       ...buildBaseCreationSheet("paladin", 2),
-      spellcasting: buildSpellSelection("paladin", 0, 0),
+      spellcasting: buildSpellSelection("paladin", 2, 0, 0),
     });
 
     expect(result.isValid).toBe(false);
@@ -172,7 +173,7 @@ describe("validateCreationSheet", () => {
   it("requires ranger spell picks once spellcasting unlocks", () => {
     const result = validateCreationSheet({
       ...buildBaseCreationSheet("ranger", 2),
-      spellcasting: buildSpellSelection("ranger", 0, 0),
+      spellcasting: buildSpellSelection("ranger", 2, 0, 0),
     });
 
     expect(result.isValid).toBe(false);
@@ -199,7 +200,7 @@ describe("validateCreationSheet", () => {
       classSkillChoices: ["history", "religion"],
       classEquipmentSelections: getInitialClassEquipmentSelections("cleric"),
       languageChoices: ["Élfico", "Anão", "Gnomo"],
-      spellcasting: buildSpellSelection("cleric", 3, 1),
+      spellcasting: buildSpellSelection("cleric", 1, 3, 1),
     });
 
     expect(result.isValid).toBe(true);
@@ -233,7 +234,7 @@ describe("validateCreationSheet", () => {
       ...buildBaseCreationSheet("guardian", 3),
       subclass: "hunter",
       fightingStyle: "archery",
-      spellcasting: buildSpellSelection("guardian", 0, 1),
+      spellcasting: buildSpellSelection("guardian", 3, 0, 1),
     });
 
     expect(result.missingRequiredFields).not.toContain("subclass");
@@ -283,7 +284,7 @@ describe("validateCreationSheet", () => {
       ...buildBaseCreationSheet("sorcerer", 1),
       subclass: "draconic_bloodline",
       subclassConfig: { draconicAncestry: "red" },
-      spellcasting: buildSpellSelection("sorcerer", 4, 2),
+      spellcasting: buildSpellSelection("sorcerer", 1, 4, 2),
     });
 
     expect(result.missingRequiredFields).not.toContain("subclassConfig");

--- a/apps/control-web/src/features/character-sheet/utils/creationValidation.ts
+++ b/apps/control-web/src/features/character-sheet/utils/creationValidation.ts
@@ -136,7 +136,7 @@ export const validateCreationSheet = (
   const spellLimits = getStartingSpellLimits(sheet.class, sheet.abilities, sheet.level);
   if (spellLimits) {
     const selectedCantrips = sheet.spellcasting?.spells.filter((spell) => spell.level === 0).length ?? 0;
-    const selectedLevelOneSpells = sheet.spellcasting?.spells.filter((spell) => spell.level === 1).length ?? 0;
+    const selectedLeveledSpells = sheet.spellcasting?.spells.filter((spell) => spell.level > 0).length ?? 0;
     const selectedSpellKeys = new Set(
       (sheet.spellcasting?.spells ?? [])
         .map((spell) => spell.canonicalKey?.toLowerCase())
@@ -146,7 +146,7 @@ export const validateCreationSheet = (
       .some((spellKey) => !selectedSpellKeys.has(spellKey.toLowerCase()));
 
     const needCantrips = selectedCantrips < spellLimits.cantrips;
-    const needLeveled = selectedLevelOneSpells < spellLimits.leveledSpells || missingRequiredSpells;
+    const needLeveled = selectedLeveledSpells < spellLimits.leveledSpells || missingRequiredSpells;
 
     if (needCantrips) missingRequiredFields.push("cantrips");
     if (needLeveled) missingRequiredFields.push("leveledSpells");
@@ -155,7 +155,7 @@ export const validateCreationSheet = (
       spellDetails = {
         selectedCantrips,
         totalCantrips: spellLimits.cantrips,
-        selectedLeveled: selectedLevelOneSpells,
+        selectedLeveled: selectedLeveledSpells,
         totalLeveled: spellLimits.leveledSpells,
       };
     }


### PR DESCRIPTION
## Problema

Fixes #149

A criação de ficha ignorava o nível real do personagem para magias: o picker exibia apenas Cantrips + magias de nível 1, os slots mostrados eram sempre "Espaços Nível 1", e a validação contava só magias de círculo 1. Um Sorcerer nível 3 não conseguia selecionar Enhance Ability, por exemplo.

## O que mudou

- **`creationSpells.ts`** — progressão de slots e círculo máximo liberado derivados das tabelas reais por classe/nível (`FULL_CASTER_SLOTS`, `HALF_CASTER_SLOTS`, `WARLOCK_SLOTS`). Wizard usa fórmula level-aware (6 + 2 por nível acima de 1) em vez de valor estático.
- **`classCreation.config.ts`** — removido `leveledSpells: 6` do wizard (fallback morto; a fórmula sempre retorna antes).
- **`classCreation.types.ts`** — `leveledSpells` tornado opcional em `StartingSpellConfig` para refletir que classes podem derivar a contagem dinamicamente.
- **`CreationSpellPicker.tsx`** — renderiza `leveledGroups` (um grupo por nível de magia) em vez de uma lista única de nível 1.
- **`Spellcasting.tsx`** — painel de slots itera `Object.entries(startingSpellLimits.slots)` mostrando todos os níveis disponíveis.
- **`creationValidation.ts`** — validação conta total de magias de círculo, não só nível 1.

## Escopo coberto

Bard, Cleric, Druid, Sorcerer, Warlock, Wizard — progressão completa. Paladin e Ranger (meia progressão). Guardian herda Ranger.

## Testes

- 56 testes · 4 arquivos · tudo passando
- Testes explícitos: Enhance Ability aparece para Sorcerer/Bard/Cleric/Druid nível 3; não aparece para Sorcerer níveis 1 e 2; normalização preserva seleções de círculo 2+.

```
npm --prefix apps/control-web test -- --run \
  src/features/character-sheet/utils/creationSpells.test.ts \
  src/features/character-sheet/utils/creationValidation.test.ts \
  src/features/character-sheet/hooks/paladinRangerCreation.test.ts \
  src/features/character-sheet/hooks/guardianCreation.test.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)