### PR TITLE
refactor(dnd-base): extract spell progression tables to canonical frontend layer

### DIFF
--- a/apps/control-server/app/services/class_progression.py
+++ b/apps/control-server/app/services/class_progression.py
@@ -32,6 +32,8 @@ _HP_AVERAGE_BY_DIE: dict[int, int] = {
 # ── Spell Slot Tables (PHB) ────────────────────────────────────────────────────
 # Format: {character_level: {slot_level: count}}
 # Only non-zero slot counts are included per row.
+# Frontend counterpart (TypeScript):
+#   apps/control-web/src/entities/dnd-base/spellProgression.ts
 
 _FULL_CASTER_SLOTS: dict[int, dict[int, int]] = {
     1:  {1: 2},

--- a/apps/control-web/src/entities/dnd-base/index.ts
+++ b/apps/control-web/src/entities/dnd-base/index.ts
@@ -30,3 +30,15 @@ export {
   resolveSpellSourceClassId,
   seedSpellCatalogCache
 } from "./spellCatalogApi";
+export {
+  FULL_CASTER_SLOTS,
+  HALF_CASTER_SLOTS,
+  WARLOCK_SLOTS,
+  SLOT_TABLES_BY_CLASS,
+  CANTRIPS_BY_CLASS,
+  LEVELED_SPELLS_KNOWN_BY_CLASS,
+  PREPARED_SPELL_LEVEL_DIVISOR_BY_CLASS,
+  getSlotProgressionForLevel,
+  getMaxUnlockedSpellLevel,
+  getCantripCountForClassLevel,
+} from "./spellProgression";

--- a/apps/control-web/src/entities/dnd-base/spellProgression.ts
+++ b/apps/control-web/src/entities/dnd-base/spellProgression.ts
@@ -1,0 +1,178 @@
+/**
+ * D&D 5e spellcasting progression tables (PHB).
+ *
+ * Frontend single source of truth for spell slot counts, cantrip progression,
+ * spells-known counts, and prepared-spell divisors across all spellcasting classes.
+ *
+ * Backend counterpart (authoritative for server-side level-up logic):
+ *   apps/control-server/app/services/class_progression.py
+ *   (_FULL_CASTER_SLOTS, _HALF_CASTER_SLOTS, _WARLOCK_SLOTS, _CLASS_SLOT_TABLES)
+ *
+ * IMPORTANT: If slot data changes here, apply the same change to the Python file
+ * and vice versa to keep both ends in sync.
+ */
+import { resolveSpellSourceClassId } from "./spellCatalogApi";
+
+// ── Private builder utilities ─────────────────────────────────────────────────
+
+const buildLevelTable = (values: number[]) =>
+  Object.fromEntries(values.map((value, index) => [index + 1, value])) as Record<
+    number,
+    number
+  >;
+
+const buildSlotTable = (rows: Array<Record<number, number>>) =>
+  Object.fromEntries(rows.map((row, index) => [index + 1, row])) as Record<
+    number,
+    Record<number, number>
+  >;
+
+// ── Spell slot progression tables (PHB) ──────────────────────────────────────
+
+export const FULL_CASTER_SLOTS = buildSlotTable([
+  { 1: 2 },
+  { 1: 3 },
+  { 1: 4, 2: 2 },
+  { 1: 4, 2: 3 },
+  { 1: 4, 2: 3, 3: 2 },
+  { 1: 4, 2: 3, 3: 3 },
+  { 1: 4, 2: 3, 3: 3, 4: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 2 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 1, 7: 1, 8: 1, 9: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 2, 7: 1, 8: 1, 9: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 2, 7: 2, 8: 1, 9: 1 },
+]);
+
+export const HALF_CASTER_SLOTS = buildSlotTable([
+  {},
+  { 1: 2 },
+  { 1: 3 },
+  { 1: 3 },
+  { 1: 4, 2: 2 },
+  { 1: 4, 2: 2 },
+  { 1: 4, 2: 3 },
+  { 1: 4, 2: 3 },
+  { 1: 4, 2: 3, 3: 2 },
+  { 1: 4, 2: 3, 3: 2 },
+  { 1: 4, 2: 3, 3: 3 },
+  { 1: 4, 2: 3, 3: 3 },
+  { 1: 4, 2: 3, 3: 3, 4: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 2 },
+  { 1: 4, 2: 3, 3: 3, 4: 2 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2 },
+]);
+
+export const WARLOCK_SLOTS = buildSlotTable([
+  { 1: 1 },
+  { 1: 2 },
+  { 2: 2 },
+  { 2: 2 },
+  { 3: 2 },
+  { 3: 2 },
+  { 4: 2 },
+  { 4: 2 },
+  { 5: 2 },
+  { 5: 2 },
+  { 5: 3 },
+  { 5: 3 },
+  { 5: 3 },
+  { 5: 3 },
+  { 5: 3 },
+  { 5: 3 },
+  { 5: 4 },
+  { 5: 4 },
+  { 5: 4 },
+  { 5: 4 },
+]);
+
+export const SLOT_TABLES_BY_CLASS: Record<string, Record<number, Record<number, number>>> = {
+  bard: FULL_CASTER_SLOTS,
+  cleric: FULL_CASTER_SLOTS,
+  druid: FULL_CASTER_SLOTS,
+  guardian: HALF_CASTER_SLOTS,
+  paladin: HALF_CASTER_SLOTS,
+  ranger: HALF_CASTER_SLOTS,
+  sorcerer: FULL_CASTER_SLOTS,
+  warlock: WARLOCK_SLOTS,
+  wizard: FULL_CASTER_SLOTS,
+};
+
+// ── Cantrip and spells-known tables (PHB) ─────────────────────────────────────
+
+export const CANTRIPS_BY_CLASS = {
+  bard: buildLevelTable([2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]),
+  cleric: buildLevelTable([3, 3, 3, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5]),
+  druid: buildLevelTable([2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]),
+  sorcerer: buildLevelTable([4, 4, 4, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6]),
+  warlock: buildLevelTable([2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]),
+  wizard: buildLevelTable([3, 3, 3, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5]),
+} as const;
+
+export const LEVELED_SPELLS_KNOWN_BY_CLASS = {
+  bard: buildLevelTable([4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 15, 16, 18, 19, 19, 20, 22, 22, 22]),
+  ranger: buildLevelTable([0, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11]),
+  sorcerer: buildLevelTable([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12, 13, 13, 14, 14, 15, 15, 15, 15]),
+  warlock: buildLevelTable([2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15]),
+} as const;
+
+export const PREPARED_SPELL_LEVEL_DIVISOR_BY_CLASS: Record<string, number> = {
+  cleric: 1,
+  druid: 1,
+  paladin: 2,
+  wizard: 1,
+};
+
+// ── Private helpers ───────────────────────────────────────────────────────────
+
+const clampCharacterLevel = (level: number) => Math.max(1, Math.min(20, level));
+
+const normalizeSpellProgressionClassId = (className: string) =>
+  resolveSpellSourceClassId(className.trim().toLowerCase());
+
+// ── Public lookup API ─────────────────────────────────────────────────────────
+
+export const getSlotProgressionForLevel = (
+  className: string,
+  level: number
+): Record<number, number> => {
+  const table = SLOT_TABLES_BY_CLASS[normalizeSpellProgressionClassId(className)];
+  if (!table) return {};
+  return table[clampCharacterLevel(level)] ?? {};
+};
+
+export const getMaxUnlockedSpellLevel = (
+  className: string,
+  level: number,
+  fallbackLevelOneSlots = 0
+): number => {
+  const highestSlotLevel = Math.max(
+    0,
+    ...Object.entries(getSlotProgressionForLevel(className, level))
+      .filter(([, count]) => count > 0)
+      .map(([slotLevel]) => Number(slotLevel))
+  );
+
+  if (highestSlotLevel > 0) return highestSlotLevel;
+  return fallbackLevelOneSlots > 0 ? 1 : 0;
+};
+
+export const getCantripCountForClassLevel = (
+  className: string,
+  level: number
+): number | undefined =>
+  CANTRIPS_BY_CLASS[
+    normalizeSpellProgressionClassId(className) as keyof typeof CANTRIPS_BY_CLASS
+  ]?.[clampCharacterLevel(level)];

--- a/apps/control-web/src/features/character-sheet/utils/creationSpells.ts
+++ b/apps/control-web/src/features/character-sheet/utils/creationSpells.ts
@@ -5,8 +5,13 @@ import {
   getBaseSpellsForClass,
   getSpellAvailabilityClassIds,
   isSameSpellAuthority,
-  resolveSpellSourceClassId,
   resolveSpellByAuthority,
+  resolveSpellSourceClassId,
+  getSlotProgressionForLevel,
+  getMaxUnlockedSpellLevel,
+  getCantripCountForClassLevel,
+  LEVELED_SPELLS_KNOWN_BY_CLASS,
+  PREPARED_SPELL_LEVEL_DIVISOR_BY_CLASS,
 } from "../../../entities/dnd-base";
 import { getModifier } from "./calculations";
 import { getClassCreationConfig } from "../data/classCreation";
@@ -19,152 +24,6 @@ import type {
 type StartingSpellOptionGroup = {
   level: number;
   spells: ReturnType<typeof getBaseSpellsForClass>;
-};
-
-const buildLevelTable = (values: number[]) =>
-  Object.fromEntries(values.map((value, index) => [index + 1, value])) as Record<
-    number,
-    number
-  >;
-
-const buildSlotTable = (rows: Array<Record<number, number>>) =>
-  Object.fromEntries(rows.map((row, index) => [index + 1, row])) as Record<
-    number,
-    Record<number, number>
-  >;
-
-const FULL_CASTER_SLOTS = buildSlotTable([
-  { 1: 2 },
-  { 1: 3 },
-  { 1: 4, 2: 2 },
-  { 1: 4, 2: 3 },
-  { 1: 4, 2: 3, 3: 2 },
-  { 1: 4, 2: 3, 3: 3 },
-  { 1: 4, 2: 3, 3: 3, 4: 1 },
-  { 1: 4, 2: 3, 3: 3, 4: 2 },
-  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 1 },
-  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2 },
-  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1 },
-  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1 },
-  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1 },
-  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1 },
-  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1 },
-  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1 },
-  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1 },
-  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 1, 7: 1, 8: 1, 9: 1 },
-  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 2, 7: 1, 8: 1, 9: 1 },
-  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 2, 7: 2, 8: 1, 9: 1 },
-]);
-
-const HALF_CASTER_SLOTS = buildSlotTable([
-  {},
-  { 1: 2 },
-  { 1: 3 },
-  { 1: 3 },
-  { 1: 4, 2: 2 },
-  { 1: 4, 2: 2 },
-  { 1: 4, 2: 3 },
-  { 1: 4, 2: 3 },
-  { 1: 4, 2: 3, 3: 2 },
-  { 1: 4, 2: 3, 3: 2 },
-  { 1: 4, 2: 3, 3: 3 },
-  { 1: 4, 2: 3, 3: 3 },
-  { 1: 4, 2: 3, 3: 3, 4: 1 },
-  { 1: 4, 2: 3, 3: 3, 4: 1 },
-  { 1: 4, 2: 3, 3: 3, 4: 2 },
-  { 1: 4, 2: 3, 3: 3, 4: 2 },
-  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 1 },
-  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 1 },
-  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2 },
-  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2 },
-]);
-
-const WARLOCK_SLOTS = buildSlotTable([
-  { 1: 1 },
-  { 1: 2 },
-  { 2: 2 },
-  { 2: 2 },
-  { 3: 2 },
-  { 3: 2 },
-  { 4: 2 },
-  { 4: 2 },
-  { 5: 2 },
-  { 5: 2 },
-  { 5: 3 },
-  { 5: 3 },
-  { 5: 3 },
-  { 5: 3 },
-  { 5: 3 },
-  { 5: 3 },
-  { 5: 4 },
-  { 5: 4 },
-  { 5: 4 },
-  { 5: 4 },
-]);
-
-const SLOT_TABLES_BY_CLASS: Record<string, Record<number, Record<number, number>>> = {
-  bard: FULL_CASTER_SLOTS,
-  cleric: FULL_CASTER_SLOTS,
-  druid: FULL_CASTER_SLOTS,
-  guardian: HALF_CASTER_SLOTS,
-  paladin: HALF_CASTER_SLOTS,
-  ranger: HALF_CASTER_SLOTS,
-  sorcerer: FULL_CASTER_SLOTS,
-  warlock: WARLOCK_SLOTS,
-  wizard: FULL_CASTER_SLOTS,
-};
-
-const CANTRIPS_BY_CLASS = {
-  bard: buildLevelTable([2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]),
-  cleric: buildLevelTable([3, 3, 3, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5]),
-  druid: buildLevelTable([2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]),
-  sorcerer: buildLevelTable([4, 4, 4, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6]),
-  warlock: buildLevelTable([2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]),
-  wizard: buildLevelTable([3, 3, 3, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5]),
-} as const;
-
-const LEVELED_SPELLS_KNOWN_BY_CLASS = {
-  bard: buildLevelTable([4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 15, 16, 18, 19, 19, 20, 22, 22, 22]),
-  ranger: buildLevelTable([0, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11]),
-  sorcerer: buildLevelTable([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12, 13, 13, 14, 14, 15, 15, 15, 15]),
-  warlock: buildLevelTable([2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15]),
-} as const;
-
-const PREPARED_SPELL_LEVEL_DIVISOR_BY_CLASS: Record<string, number> = {
-  cleric: 1,
-  druid: 1,
-  paladin: 2,
-  wizard: 1,
-};
-
-const clampCharacterLevel = (level: number) => Math.max(1, Math.min(20, level));
-
-const getNormalizedSpellProgressionClassId = (className: string) =>
-  resolveSpellSourceClassId(className.trim().toLowerCase());
-
-const getSlotProgressionForLevel = (
-  className: string,
-  level: number
-): Record<number, number> => {
-  const table = SLOT_TABLES_BY_CLASS[getNormalizedSpellProgressionClassId(className)];
-  if (!table) return {};
-  return table[clampCharacterLevel(level)] ?? {};
-};
-
-const getMaxUnlockedSpellLevel = (
-  className: string,
-  level: number,
-  fallbackLevelOneSlots = 0
-) => {
-  const highestSlotLevel = Math.max(
-    0,
-    ...Object.entries(getSlotProgressionForLevel(className, level))
-      .filter(([, count]) => count > 0)
-      .map(([slotLevel]) => Number(slotLevel))
-  );
-
-  if (highestSlotLevel > 0) return highestSlotLevel;
-  return fallbackLevelOneSlots > 0 ? 1 : 0;
 };
 
 const sortSpells = (spells: Spell[]) =>
@@ -356,10 +215,11 @@ export const getFixedStartingSpells = (
         spell !== undefined
     );
 
-const getCantripCountForClassLevel = (className: string, level: number) =>
-  CANTRIPS_BY_CLASS[
-    getNormalizedSpellProgressionClassId(className) as keyof typeof CANTRIPS_BY_CLASS
-  ]?.[clampCharacterLevel(level)];
+// Private helpers used by getLeveledSpellCountForClassLevel and getStartingSpellLimits.
+// The underlying data tables live in entities/dnd-base/spellProgression.ts.
+const clampCharacterLevel = (level: number) => Math.max(1, Math.min(20, level));
+const normalizeSpellProgressionClassId = (className: string) =>
+  resolveSpellSourceClassId(className.trim().toLowerCase());
 
 const getLeveledSpellCountForClassLevel = (
   className: string,
@@ -368,7 +228,7 @@ const getLeveledSpellCountForClassLevel = (
   preparationAbility: keyof CharacterSheet["abilities"] | undefined,
   abilities: CharacterSheet["abilities"]
 ) => {
-  const normalizedClassName = getNormalizedSpellProgressionClassId(className);
+  const normalizedClassName = normalizeSpellProgressionClassId(className);
   const clampedLevel = clampCharacterLevel(level);
 
   if (mode === "spellbook" && normalizedClassName === "wizard") {


### PR DESCRIPTION
## Contexto

As tabelas de progressão de spell slots (FULL_CASTER_SLOTS, HALF_CASTER_SLOTS, WARLOCK_SLOTS) e dados relacionados viviam misturados em `creationSpells.ts` junto com lógica de aplicação. O backend já tinha sua própria cópia em `class_progression.py`, sem nenhuma ligação declarada entre os dois.

## O que mudou

- **Novo:** `entities/dnd-base/spellProgression.ts` — fonte única frontend para todas as tabelas PHB de progressão de conjuração e 3 funções de lookup públicas (`getSlotProgressionForLevel`, `getMaxUnlockedSpellLevel`, `getCantripCountForClassLevel`)
- **`dnd-base/index.ts`** — re-exporta tudo de `spellProgression.ts`
- **`creationSpells.ts`** — ~150 linhas de dados/helpers removidas; passa a importar de `dnd-base`
- **`class_progression.py`** — comentário de cross-reference apontando para o contraparte TS

## O que fica em `creationSpells.ts`

`getLeveledSpellCountForClassLevel` permanece na feature layer por depender de `CharacterSheet["abilities"]` e `getModifier` — mover criaria dep circular. Os dados que ela usa (`LEVELED_SPELLS_KNOWN_BY_CLASS`, `PREPARED_SPELL_LEVEL_DIVISOR_BY_CLASS`) agora vêm importados de `dnd-base`.

## Observação sobre FE vs BE

Frontend (TS) e backend (Python) continuam sendo fontes separadas — impossível compartilhar código entre linguagens. O que este PR resolve é o frontend ter uma fonte declarada e isolada. A divergência FE/BE está agora controlada via comentários de cross-reference; testes de contrato são uma issue futura.

## Verificação

```
npm --prefix apps/control-web test -- --run \
  src/features/character-sheet/utils/creationSpells.test.ts \
  src/features/character-sheet/utils/creationValidation.test.ts \
  src/features/character-sheet/hooks/paladinRangerCreation.test.ts \
  src/features/character-sheet/hooks/guardianCreation.test.ts
```

56 testes passando. Nenhum arquivo de teste alterado — API pública de `creationSpells.ts` preservada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)