### PR TITLE
test(contract): FE/BE parity tests for spell progression tables

### DIFF
--- a/apps/control-server/tests/test_class_progression.py
+++ b/apps/control-server/tests/test_class_progression.py
@@ -182,14 +182,17 @@ class SpellSlotTableTests(unittest.TestCase):
         self.assertIsNone(get_spell_slots_for_class_level("unknown", 5))
 
 
-# ── FE/BE Contract Tests ───────────────────────────────────────────────────────
+# ── FE/BE Contract / Sanity Tests ─────────────────────────────────────────────
+# These are NOT a shared source of truth — TS and Python are separate implementations.
+# They ensure behavioral equivalence, not code reuse. Do not attempt to unify them.
+#
 # Each scenario here must have an equivalent test on the frontend side in:
 #   apps/control-web/src/entities/dnd-base/spellProgression.test.ts
 #
 # If you change a slot table here and these tests still pass but the TS tests
 # fail (or vice versa), that is a FE/BE drift signal.
 
-class SpellSlotContractTests(unittest.TestCase):
+class SpellcastingProgressionContractTests(unittest.TestCase):
     def test_sorcerer_level_3_full_caster_unlocks_second_level_slots(self):
         slots = get_spell_slots_for_class_level("sorcerer", 3)
         self.assertEqual(slots, {1: 4, 2: 2})

--- a/apps/control-server/tests/test_class_progression.py
+++ b/apps/control-server/tests/test_class_progression.py
@@ -182,6 +182,77 @@ class SpellSlotTableTests(unittest.TestCase):
         self.assertIsNone(get_spell_slots_for_class_level("unknown", 5))
 
 
+# ── FE/BE Contract Tests ───────────────────────────────────────────────────────
+# Each scenario here must have an equivalent test on the frontend side in:
+#   apps/control-web/src/entities/dnd-base/spellProgression.test.ts
+#
+# If you change a slot table here and these tests still pass but the TS tests
+# fail (or vice versa), that is a FE/BE drift signal.
+
+class SpellSlotContractTests(unittest.TestCase):
+    def test_sorcerer_level_3_full_caster_unlocks_second_level_slots(self):
+        slots = get_spell_slots_for_class_level("sorcerer", 3)
+        self.assertEqual(slots, {1: 4, 2: 2})
+
+    def test_sorcerer_level_3_max_spell_level_is_2(self):
+        slots = get_spell_slots_for_class_level("sorcerer", 3)
+        self.assertEqual(max(slots.keys()), 2)
+
+    def test_wizard_level_5_full_caster_unlocks_third_level_slots(self):
+        slots = get_spell_slots_for_class_level("wizard", 5)
+        self.assertEqual(slots, {1: 4, 2: 3, 3: 2})
+
+    def test_wizard_level_5_max_spell_level_is_3(self):
+        slots = get_spell_slots_for_class_level("wizard", 5)
+        self.assertEqual(max(slots.keys()), 3)
+
+    def test_cleric_level_7_full_caster_unlocks_fourth_level_slots(self):
+        slots = get_spell_slots_for_class_level("cleric", 7)
+        self.assertEqual(slots, {1: 4, 2: 3, 3: 3, 4: 1})
+
+    def test_cleric_level_7_max_spell_level_is_4(self):
+        slots = get_spell_slots_for_class_level("cleric", 7)
+        self.assertEqual(max(slots.keys()), 4)
+
+    def test_paladin_level_5_half_caster_unlocks_second_level_slots(self):
+        slots = get_spell_slots_for_class_level("paladin", 5)
+        self.assertEqual(slots, {1: 4, 2: 2})
+
+    def test_paladin_level_5_max_spell_level_is_2(self):
+        slots = get_spell_slots_for_class_level("paladin", 5)
+        self.assertEqual(max(slots.keys()), 2)
+
+    def test_warlock_level_3_pact_magic_upgrades_to_second_level_slot(self):
+        slots = get_spell_slots_for_class_level("warlock", 3)
+        self.assertEqual(slots, {2: 2})
+
+    def test_warlock_level_3_max_spell_level_is_2(self):
+        slots = get_spell_slots_for_class_level("warlock", 3)
+        self.assertEqual(max(slots.keys()), 2)
+
+    def test_ranger_level_5_half_caster_unlocks_second_level_slots(self):
+        slots = get_spell_slots_for_class_level("ranger", 5)
+        self.assertEqual(slots, {1: 4, 2: 2})
+
+    def test_ranger_level_5_max_spell_level_is_2(self):
+        slots = get_spell_slots_for_class_level("ranger", 5)
+        self.assertEqual(max(slots.keys()), 2)
+
+    def test_guardian_level_5_inherits_ranger_half_caster_progression(self):
+        self.assertEqual(
+            get_spell_slots_for_class_level("guardian", 5),
+            get_spell_slots_for_class_level("ranger", 5),
+        )
+
+    def test_guardian_level_5_max_spell_level_is_2(self):
+        slots = get_spell_slots_for_class_level("guardian", 5)
+        self.assertEqual(max(slots.keys()), 2)
+
+    def test_paladin_level_1_has_no_slots(self):
+        slots = get_spell_slots_for_class_level("paladin", 1)
+        self.assertEqual(slots, {})
+
+
 # ── apply_level_up_stats ───────────────────────────────────────────────────────
 
 

--- a/apps/control-web/src/entities/dnd-base/spellProgression.test.ts
+++ b/apps/control-web/src/entities/dnd-base/spellProgression.test.ts
@@ -6,10 +6,13 @@ import {
 } from "./spellProgression";
 
 /**
- * Contract tests: frontend spell progression tables (spellProgression.ts).
+ * Contract/sanity tests: frontend spell progression tables (spellProgression.ts).
+ *
+ * These are NOT a shared source of truth — TS and Python are separate implementations.
+ * They ensure behavioral equivalence, not code reuse. Do not attempt to unify them.
  *
  * Each scenario here must have an equivalent test on the backend side in:
- *   apps/control-server/tests/test_class_progression.py  (SpellSlotContractTests)
+ *   apps/control-server/tests/test_class_progression.py  (SpellcastingProgressionContractTests)
  *
  * If you change a slot table here and these tests still pass but the backend
  * tests fail (or vice versa), that is a FE/BE drift signal.

--- a/apps/control-web/src/entities/dnd-base/spellProgression.test.ts
+++ b/apps/control-web/src/entities/dnd-base/spellProgression.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  getCantripCountForClassLevel,
+  getMaxUnlockedSpellLevel,
+  getSlotProgressionForLevel,
+} from "./spellProgression";
+
+/**
+ * Contract tests: frontend spell progression tables (spellProgression.ts).
+ *
+ * Each scenario here must have an equivalent test on the backend side in:
+ *   apps/control-server/tests/test_class_progression.py  (SpellSlotContractTests)
+ *
+ * If you change a slot table here and these tests still pass but the backend
+ * tests fail (or vice versa), that is a FE/BE drift signal.
+ */
+
+describe("getSlotProgressionForLevel — contract scenarios", () => {
+  it("sorcerer level 3: full caster, unlocks 2nd level slots", () => {
+    expect(getSlotProgressionForLevel("sorcerer", 3)).toEqual({ 1: 4, 2: 2 });
+  });
+
+  it("wizard level 5: full caster, unlocks 3rd level slots", () => {
+    expect(getSlotProgressionForLevel("wizard", 5)).toEqual({ 1: 4, 2: 3, 3: 2 });
+  });
+
+  it("cleric level 7: full caster, unlocks 4th level slots", () => {
+    expect(getSlotProgressionForLevel("cleric", 7)).toEqual({ 1: 4, 2: 3, 3: 3, 4: 1 });
+  });
+
+  it("paladin level 5: half caster, unlocks 2nd level slots", () => {
+    expect(getSlotProgressionForLevel("paladin", 5)).toEqual({ 1: 4, 2: 2 });
+  });
+
+  it("warlock level 3: pact magic upgrades to 2nd level slot", () => {
+    expect(getSlotProgressionForLevel("warlock", 3)).toEqual({ 2: 2 });
+  });
+
+  it("ranger level 5: half caster, unlocks 2nd level slots", () => {
+    expect(getSlotProgressionForLevel("ranger", 5)).toEqual({ 1: 4, 2: 2 });
+  });
+
+  it("guardian level 5: inherits ranger half-caster progression", () => {
+    expect(getSlotProgressionForLevel("guardian", 5)).toEqual(
+      getSlotProgressionForLevel("ranger", 5)
+    );
+  });
+});
+
+describe("getMaxUnlockedSpellLevel — contract scenarios", () => {
+  it("sorcerer level 3: max spell level 2", () => {
+    expect(getMaxUnlockedSpellLevel("sorcerer", 3)).toBe(2);
+  });
+
+  it("wizard level 5: max spell level 3", () => {
+    expect(getMaxUnlockedSpellLevel("wizard", 5)).toBe(3);
+  });
+
+  it("cleric level 7: max spell level 4", () => {
+    expect(getMaxUnlockedSpellLevel("cleric", 7)).toBe(4);
+  });
+
+  it("paladin level 5: max spell level 2", () => {
+    expect(getMaxUnlockedSpellLevel("paladin", 5)).toBe(2);
+  });
+
+  it("warlock level 3: max spell level 2", () => {
+    expect(getMaxUnlockedSpellLevel("warlock", 3)).toBe(2);
+  });
+
+  it("ranger level 5: max spell level 2", () => {
+    expect(getMaxUnlockedSpellLevel("ranger", 5)).toBe(2);
+  });
+
+  it("guardian level 5: max spell level matches ranger level 5", () => {
+    expect(getMaxUnlockedSpellLevel("guardian", 5)).toBe(
+      getMaxUnlockedSpellLevel("ranger", 5)
+    );
+  });
+
+  it("paladin level 1: no slots yet, max spell level 0", () => {
+    expect(getMaxUnlockedSpellLevel("paladin", 1)).toBe(0);
+  });
+});
+
+describe("getCantripCountForClassLevel", () => {
+  it("sorcerer level 1: 4 cantrips", () => {
+    expect(getCantripCountForClassLevel("sorcerer", 1)).toBe(4);
+  });
+
+  it("wizard level 1: 3 cantrips", () => {
+    expect(getCantripCountForClassLevel("wizard", 1)).toBe(3);
+  });
+
+  it("cleric level 1: 3 cantrips", () => {
+    expect(getCantripCountForClassLevel("cleric", 1)).toBe(3);
+  });
+
+  it("ranger level 1: no cantrips (undefined)", () => {
+    expect(getCantripCountForClassLevel("ranger", 1)).toBeUndefined();
+  });
+});

--- a/apps/control-web/src/features/character-sheet/utils/creationSpells.test.ts
+++ b/apps/control-web/src/features/character-sheet/utils/creationSpells.test.ts
@@ -547,3 +547,37 @@ describe("creation spell progression", () => {
     ).not.toContain("enhance_ability");
   });
 });
+
+/**
+ * Contract tests: prepared/known spell counts via getStartingSpellLimits.
+ *
+ * These validate the application-layer formula (level + modifier, floor(level/2) + modifier,
+ * spellbook formula) that sits on top of the canonical tables in spellProgression.ts.
+ * No catalog seeding needed — counts are derived from class config + progression tables alone.
+ *
+ * Backend counterpart: the slot progression side is covered in
+ *   apps/control-server/tests/test_class_progression.py (SpellSlotContractTests).
+ * Prepared/known counts are a frontend-only concept (creation flow).
+ */
+describe("getStartingSpellLimits — prepared/known spell count contract", () => {
+  it("wizard level 5 spellbook: 6 + 2×(level-1) = 14 leveled spells", () => {
+    const limits = getStartingSpellLimits("wizard", INITIAL_SHEET.abilities, 5);
+    expect(limits?.leveledSpells).toBe(14);
+    expect(limits?.maxSpellLevel).toBe(3);
+  });
+
+  it("cleric level 7 WIS 16: level + modifier = 7 + 3 = 10 prepared spells", () => {
+    const abilities = { ...INITIAL_SHEET.abilities, wisdom: 16 };
+    const limits = getStartingSpellLimits("cleric", abilities, 7);
+    expect(limits?.leveledSpells).toBe(10);
+    expect(limits?.maxSpellLevel).toBe(4);
+  });
+
+  it("paladin level 5 CHA 16: floor(level/2) + modifier = 2 + 3 = 5 prepared spells", () => {
+    const abilities = { ...INITIAL_SHEET.abilities, charisma: 16 };
+    const limits = getStartingSpellLimits("paladin", abilities, 5);
+    expect(limits?.leveledSpells).toBe(5);
+    expect(limits?.maxSpellLevel).toBe(2);
+    expect(limits?.slots).toEqual({ 1: 4, 2: 2 });
+  });
+});

--- a/apps/control-web/src/features/character-sheet/utils/creationSpells.test.ts
+++ b/apps/control-web/src/features/character-sheet/utils/creationSpells.test.ts
@@ -556,7 +556,7 @@ describe("creation spell progression", () => {
  * No catalog seeding needed — counts are derived from class config + progression tables alone.
  *
  * Backend counterpart: the slot progression side is covered in
- *   apps/control-server/tests/test_class_progression.py (SpellSlotContractTests).
+ *   apps/control-server/tests/test_class_progression.py (SpellcastingProgressionContractTests).
  * Prepared/known counts are a frontend-only concept (creation flow).
  */
 describe("getStartingSpellLimits — prepared/known spell count contract", () => {


### PR DESCRIPTION
## Contexto

Após a extração das tabelas de progressão para `spellProgression.ts` (PR #151), frontend e backend passaram a ter fontes declaradas e separadas. Esta PR implementa os testes de contrato descritos na issue, garantindo que drift entre as duas camadas cause falha de teste em pelo menos um dos lados.

## O que foi adicionado

**Frontend** — novo arquivo `entities/dnd-base/spellProgression.test.ts`:
- `getSlotProgressionForLevel`: 7 cenários (sorcerer/wizard/cleric/paladin/warlock/ranger/guardian)
- `getMaxUnlockedSpellLevel`: mesmo conjunto de cenários + paladin nível 1 (sem slots)
- `getCantripCountForClassLevel`: sorcerer, wizard, cleric, ranger

**Frontend** — adicionado ao `creationSpells.test.ts`:
- Wizard nível 5 spellbook: `6 + 2×(level-1) = 14` magias de grimório
- Cleric nível 7 WIS 16: `level + modifier = 7 + 3 = 10` magias preparadas
- Paladin nível 5 CHA 16: `floor(level/2) + modifier = 2 + 3 = 5` magias preparadas

**Backend** — nova classe `SpellSlotContractTests` em `test_class_progression.py`:
- Mesmos 7 cenários de slot + max spell level via `get_spell_slots_for_class_level`

## Resultados

```
Frontend:  31 testes passando (2 arquivos)
Backend:   72 testes passando
```
