### PR TITLE
feat(rules): expose spell progression via API with optional frontend adapter

### DIFF
--- a/apps/control-server/app/api/routes/__init__.py
+++ b/apps/control-server/app/api/routes/__init__.py
@@ -23,6 +23,7 @@ from app.api.routes.me import router as me_router
 from app.api.routes.users import router as users_router
 from app.api.routes.centrifugo import router as centrifugo_router
 from app.api.routes.combat import router as combat_router
+from app.api.routes.rules import router as rules_router
 from app.api.routes.wild_shape import router as wild_shape_router
 from app.api.routes.uploads import router as uploads_router
 from app.api.routes.assets import router as assets_router
@@ -53,6 +54,7 @@ __all__ = [
     "me_router",
     "users_router",
     "combat_router",
+    "rules_router",
     "wild_shape_router",
     "uploads_router",
     "assets_router",

--- a/apps/control-server/app/api/routes/rules.py
+++ b/apps/control-server/app/api/routes/rules.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from app.api.deps import get_current_user
+from app.models.user import User
+from app.services.class_progression import get_class_spell_progression
+
+router = APIRouter()
+
+
+class ClassSpellProgressionResponse(BaseModel):
+    className: str
+    level: int
+    slots: dict[int, int]
+    maxSpellLevel: int
+    cantrips: int
+    leveledSpellsKnown: int | None
+    spellcastingType: str | None
+
+
+@router.get("/spell-progression", response_model=ClassSpellProgressionResponse)
+def get_spell_progression(
+    class_name: str = Query(..., alias="class"),
+    level: int = Query(..., ge=1, le=20),
+    _user: User = Depends(get_current_user),
+) -> ClassSpellProgressionResponse:
+    """Return pure class spell progression for a given class and character level.
+
+    Does not include prepared spell counts — those depend on character ability scores
+    and are computed on the frontend from this data.
+    """
+    result = get_class_spell_progression(class_name, level)
+    if result is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No spell progression found for class '{class_name}'",
+        )
+    return ClassSpellProgressionResponse(**result)

--- a/apps/control-server/app/main.py
+++ b/apps/control-server/app/main.py
@@ -24,6 +24,7 @@ from app.api.routes import (
     character_sheets_router,
     combat_router,
     wild_shape_router,
+    rules_router,
     dev_router,
     inventory_router,
     items_router,
@@ -123,6 +124,7 @@ app.include_router(auth_router, prefix="/api", tags=["auth"])
 app.include_router(me_router, prefix="/api/me", tags=["me"])
 app.include_router(users_router, prefix="/api/users", tags=["users"])
 app.include_router(combat_router, prefix="/api", tags=["combat"])
+app.include_router(rules_router, prefix="/api/rules", tags=["rules"])
 app.include_router(wild_shape_router, prefix="/api", tags=["wild-shape"])
 app.include_router(uploads_router, prefix="/api", tags=["uploads"])
 app.include_router(assets_router, prefix="/api/assets", tags=["assets"])

--- a/apps/control-server/app/services/class_progression.py
+++ b/apps/control-server/app/services/class_progression.py
@@ -123,6 +123,42 @@ _CLASS_MECHANICS_FAMILIES: dict[str, str] = {
     "guardian": "ranger",
 }
 
+# ── Cantrip progression (PHB) ─────────────────────────────────────────────────
+# Frontend counterpart: apps/control-web/src/entities/dnd-base/spellProgression.ts (CANTRIPS_BY_CLASS)
+_CANTRIPS_BY_CLASS: dict[str, dict[int, int]] = {
+    "bard":     {1:2,2:2,3:2,4:3,5:3,6:3,7:3,8:3,9:3,10:4,11:4,12:4,13:4,14:4,15:4,16:4,17:4,18:4,19:4,20:4},
+    "cleric":   {1:3,2:3,3:3,4:4,5:4,6:4,7:4,8:4,9:4,10:5,11:5,12:5,13:5,14:5,15:5,16:5,17:5,18:5,19:5,20:5},
+    "druid":    {1:2,2:2,3:2,4:3,5:3,6:3,7:3,8:3,9:3,10:4,11:4,12:4,13:4,14:4,15:4,16:4,17:4,18:4,19:4,20:4},
+    "sorcerer": {1:4,2:4,3:4,4:5,5:5,6:5,7:5,8:5,9:5,10:6,11:6,12:6,13:6,14:6,15:6,16:6,17:6,18:6,19:6,20:6},
+    "warlock":  {1:2,2:2,3:2,4:3,5:3,6:3,7:3,8:3,9:3,10:4,11:4,12:4,13:4,14:4,15:4,16:4,17:4,18:4,19:4,20:4},
+    "wizard":   {1:3,2:3,3:3,4:4,5:4,6:4,7:4,8:4,9:4,10:5,11:5,12:5,13:5,14:5,15:5,16:5,17:5,18:5,19:5,20:5},
+}
+
+# ── Leveled spells known — known-spell casters only (PHB) ─────────────────────
+# Frontend counterpart: apps/control-web/src/entities/dnd-base/spellProgression.ts (LEVELED_SPELLS_KNOWN_BY_CLASS)
+# Prepared casters (cleric, druid, paladin, wizard) are NOT in this table.
+_LEVELED_SPELLS_KNOWN_BY_CLASS: dict[str, dict[int, int]] = {
+    "bard":     {1:4,2:5,3:6,4:7,5:8,6:9,7:10,8:11,9:12,10:14,11:15,12:15,13:16,14:18,15:19,16:19,17:20,18:22,19:22,20:22},
+    "ranger":   {1:0,2:2,3:3,4:3,5:4,6:4,7:5,8:5,9:6,10:6,11:7,12:7,13:8,14:8,15:9,16:9,17:10,18:10,19:11,20:11},
+    "sorcerer": {1:2,2:3,3:4,4:5,5:6,6:7,7:8,8:9,9:10,10:11,11:12,12:12,13:13,14:13,15:14,16:14,17:15,18:15,19:15,20:15},
+    "warlock":  {1:2,2:3,3:4,4:5,5:6,6:7,7:8,8:9,9:10,10:10,11:11,12:11,13:12,14:12,15:13,16:13,17:14,18:14,19:15,20:15},
+}
+
+# ── Spellcasting type by class ─────────────────────────────────────────────────
+# "known"    — knows a fixed list of spells (bard, ranger, sorcerer, warlock)
+# "prepared" — prepares from full class list using level + modifier (cleric, druid, paladin)
+# "spellbook"— wizard: maintains a spellbook, prepares from it each day
+_SPELLCASTING_TYPE_BY_CLASS: dict[str, str] = {
+    "bard":     "known",
+    "cleric":   "prepared",
+    "druid":    "prepared",
+    "paladin":  "prepared",
+    "ranger":   "known",
+    "sorcerer": "known",
+    "warlock":  "known",
+    "wizard":   "spellbook",
+}
+
 # ── Public API ─────────────────────────────────────────────────────────────────
 
 
@@ -137,6 +173,44 @@ def get_spell_slots_for_class_level(class_id: str, level: int) -> dict[int, int]
     if table is None:
         return None
     return dict(table.get(max(1, min(level, 20)), {}))
+
+
+def get_class_spell_progression(class_id: str, level: int) -> dict | None:
+    """Return pure class spell progression data for a given class and character level.
+
+    Returns None for non-caster classes.
+    Does NOT include prepared spell counts (those depend on character ability scores).
+
+    Keys:
+      className         — normalized class id
+      level             — clamped character level (1–20)
+      slots             — {slot_level: count}, empty dict if no slots yet
+      maxSpellLevel     — highest slot level with count > 0 (0 if none)
+      cantrips          — cantrip count at this level, or 0 for non-cantrip classes
+      leveledSpellsKnown — spells known count for known-spell classes, None for prepared/spellbook
+      spellcastingType  — "known" | "prepared" | "spellbook", or None for non-casters
+    """
+    normalized = _normalize_class(class_id)
+    slots = get_spell_slots_for_class_level(normalized, level)
+    if slots is None:
+        return None
+
+    clamped_level = max(1, min(level, 20))
+    max_spell_level = max(slots.keys(), default=0)
+    cantrips = _CANTRIPS_BY_CLASS.get(normalized, {}).get(clamped_level, 0)
+    leveled_known_table = _LEVELED_SPELLS_KNOWN_BY_CLASS.get(normalized)
+    leveled_spells_known = leveled_known_table.get(clamped_level) if leveled_known_table else None
+    spellcasting_type = _SPELLCASTING_TYPE_BY_CLASS.get(normalized)
+
+    return {
+        "className": normalized,
+        "level": clamped_level,
+        "slots": slots,
+        "maxSpellLevel": max_spell_level,
+        "cantrips": cantrips,
+        "leveledSpellsKnown": leveled_spells_known,
+        "spellcastingType": spellcasting_type,
+    }
 
 
 def get_hp_gain_per_level(class_id: str, constitution_score: int = 10) -> int:

--- a/apps/control-web/src/entities/dnd-base/index.ts
+++ b/apps/control-web/src/entities/dnd-base/index.ts
@@ -38,7 +38,10 @@ export {
   CANTRIPS_BY_CLASS,
   LEVELED_SPELLS_KNOWN_BY_CLASS,
   PREPARED_SPELL_LEVEL_DIVISOR_BY_CLASS,
+  SPELLCASTING_TYPE_BY_CLASS,
   getSlotProgressionForLevel,
   getMaxUnlockedSpellLevel,
   getCantripCountForClassLevel,
 } from "./spellProgression";
+export type { ClassSpellProgression } from "./spellProgressionBackendAdapter";
+export { fetchClassSpellProgression } from "./spellProgressionBackendAdapter";

--- a/apps/control-web/src/entities/dnd-base/spellProgression.ts
+++ b/apps/control-web/src/entities/dnd-base/spellProgression.ts
@@ -135,6 +135,18 @@ export const PREPARED_SPELL_LEVEL_DIVISOR_BY_CLASS: Record<string, number> = {
   wizard: 1,
 };
 
+export const SPELLCASTING_TYPE_BY_CLASS: Record<string, "known" | "prepared" | "spellbook"> = {
+  bard:     "known",
+  cleric:   "prepared",
+  druid:    "prepared",
+  guardian: "known",
+  paladin:  "prepared",
+  ranger:   "known",
+  sorcerer: "known",
+  warlock:  "known",
+  wizard:   "spellbook",
+};
+
 // ── Private helpers ───────────────────────────────────────────────────────────
 
 const clampCharacterLevel = (level: number) => Math.max(1, Math.min(20, level));

--- a/apps/control-web/src/entities/dnd-base/spellProgressionBackendAdapter.ts
+++ b/apps/control-web/src/entities/dnd-base/spellProgressionBackendAdapter.ts
@@ -37,6 +37,13 @@ async function fetchFromBackend(
     const response = await fetch(`/api/rules/spell-progression?${params}`);
     if (!response.ok) return null;
     const data = await response.json();
+    // JSON serializes dict[int, int] with string keys ("1", "2").
+    // Normalize to numeric keys so the shape matches getSlotProgressionForLevel.
+    if (data?.slots && typeof data.slots === "object") {
+      data.slots = Object.fromEntries(
+        Object.entries(data.slots).map(([k, v]) => [Number(k), v])
+      );
+    }
     return data as ClassSpellProgression;
   } catch {
     return null;
@@ -84,15 +91,20 @@ function fromLocalTables(
 }
 
 /**
- * Fetch class spell progression data.
+ * Fetch class spell progression data (optional async source).
  *
- * When VITE_USE_BACKEND_PROGRESSION=true: queries the backend API with
- * fallback to local tables on failure.
- * Otherwise: returns local tables directly (synchronous path wrapped in Promise).
+ * ## When to use this
+ * Async contexts only: debug panels, admin UIs, optional validation, prefetch hooks.
  *
- * Does NOT replace the synchronous creation flow — use getSlotProgressionForLevel
- * and related functions from spellProgression.ts for that.
- * This adapter is for components or hooks that can tolerate async loading.
+ * ## When NOT to use this
+ * The synchronous creation flow. That flow uses spellProgression.ts directly:
+ *   getSlotProgressionForLevel / getMaxUnlockedSpellLevel / getCantripCountForClassLevel
+ * This adapter does NOT replace those calls and must not be inserted into that path.
+ *
+ * ## Behavior by flag
+ * - VITE_USE_BACKEND_PROGRESSION=true  → fetch from /api/rules/spell-progression,
+ *                                         fall back to local tables on any error
+ * - flag off (default)                 → local tables only, no network request made
  */
 export async function fetchClassSpellProgression(
   className: string,

--- a/apps/control-web/src/entities/dnd-base/spellProgressionBackendAdapter.ts
+++ b/apps/control-web/src/entities/dnd-base/spellProgressionBackendAdapter.ts
@@ -1,0 +1,106 @@
+import {
+  getCantripCountForClassLevel,
+  getMaxUnlockedSpellLevel,
+  getSlotProgressionForLevel,
+  LEVELED_SPELLS_KNOWN_BY_CLASS,
+  SPELLCASTING_TYPE_BY_CLASS,
+} from "./spellProgression";
+
+/**
+ * Pure class spell progression as returned by GET /api/rules/spell-progression.
+ * Does NOT include preparedSpells — that depends on character ability scores
+ * and is computed on the frontend via getLeveledSpellCountForClassLevel.
+ */
+export type ClassSpellProgression = {
+  className: string;
+  level: number;
+  slots: Record<number, number>;
+  maxSpellLevel: number;
+  cantrips: number;
+  leveledSpellsKnown: number | null;
+  spellcastingType: "known" | "prepared" | "spellbook" | null;
+};
+
+const USE_BACKEND = import.meta.env.VITE_USE_BACKEND_PROGRESSION === "true";
+
+/**
+ * Fetch spell progression from the backend API.
+ * Only called when VITE_USE_BACKEND_PROGRESSION=true.
+ * Returns null on any error so callers can fall back to local tables.
+ */
+async function fetchFromBackend(
+  className: string,
+  level: number
+): Promise<ClassSpellProgression | null> {
+  try {
+    const params = new URLSearchParams({ class: className, level: String(level) });
+    const response = await fetch(`/api/rules/spell-progression?${params}`);
+    if (!response.ok) return null;
+    const data = await response.json();
+    return data as ClassSpellProgression;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build progression from local spellProgression.ts tables.
+ * Guaranteed synchronous and offline-safe.
+ */
+function fromLocalTables(
+  className: string,
+  level: number
+): ClassSpellProgression | null {
+  const slots = getSlotProgressionForLevel(className, level);
+  const maxSpellLevel = getMaxUnlockedSpellLevel(className, level);
+  const isKnownCaster = Object.keys(LEVELED_SPELLS_KNOWN_BY_CLASS).includes(
+    className.toLowerCase()
+  );
+
+  if (maxSpellLevel === 0 && Object.keys(slots).length === 0) {
+    const table = getSlotProgressionForLevel(className, 20);
+    if (Object.keys(table).length === 0) return null;
+  }
+
+  const cantrips = getCantripCountForClassLevel(className, level) ?? 0;
+  const leveledSpellsKnown = isKnownCaster
+    ? (LEVELED_SPELLS_KNOWN_BY_CLASS[
+        className.toLowerCase() as keyof typeof LEVELED_SPELLS_KNOWN_BY_CLASS
+      ]?.[Math.max(1, Math.min(20, level))] ?? null)
+    : null;
+  const spellcastingType =
+    (SPELLCASTING_TYPE_BY_CLASS[className.toLowerCase()] as ClassSpellProgression["spellcastingType"]) ??
+    null;
+
+  return {
+    className: className.toLowerCase(),
+    level: Math.max(1, Math.min(20, level)),
+    slots,
+    maxSpellLevel,
+    cantrips,
+    leveledSpellsKnown,
+    spellcastingType,
+  };
+}
+
+/**
+ * Fetch class spell progression data.
+ *
+ * When VITE_USE_BACKEND_PROGRESSION=true: queries the backend API with
+ * fallback to local tables on failure.
+ * Otherwise: returns local tables directly (synchronous path wrapped in Promise).
+ *
+ * Does NOT replace the synchronous creation flow — use getSlotProgressionForLevel
+ * and related functions from spellProgression.ts for that.
+ * This adapter is for components or hooks that can tolerate async loading.
+ */
+export async function fetchClassSpellProgression(
+  className: string,
+  level: number
+): Promise<ClassSpellProgression | null> {
+  if (USE_BACKEND) {
+    const result = await fetchFromBackend(className, level);
+    if (result !== null) return result;
+  }
+  return fromLocalTables(className, level);
+}


### PR DESCRIPTION
## Contexto

Após a extração das tabelas de progressão para \`spellProgression.ts\` e os testes de contrato FE/BE, o próximo passo é permitir que o frontend consuma progressão diretamente do backend — eliminando drift em runtime quando habilitado.

## Backend

**Novo endpoint:** \`GET /api/rules/spell-progression?class=sorcerer&level=3\`

\`\`\`json
{
  "className": "sorcerer",
  "level": 3,
  "slots": {"1": 4, "2": 2},
  "maxSpellLevel": 2,
  "cantrips": 4,
  "leveledSpellsKnown": 4,
  "spellcastingType": "known"
}
\`\`\`

\`preparedSpells\` está **fora do escopo** do endpoint — depende de ability scores do personagem e continua sendo calculado no frontend via \`getLeveledSpellCountForClassLevel\`.

Novas tabelas adicionadas a \`class_progression.py\`:
- \`_CANTRIPS_BY_CLASS\` — espelho do \`CANTRIPS_BY_CLASS\` do TS
- \`_LEVELED_SPELLS_KNOWN_BY_CLASS\` — espelho do \`LEVELED_SPELLS_KNOWN_BY_CLASS\` do TS
- \`_SPELLCASTING_TYPE_BY_CLASS\` — "known" | "prepared" | "spellbook"

## Frontend

**\`SPELLCASTING_TYPE_BY_CLASS\`** adicionado a \`spellProgression.ts\`.

**\`spellProgressionBackendAdapter.ts\`** — adapter opcional:
- \`fetchClassSpellProgression(className, level): Promise<ClassSpellProgression | null>\`
- Gated behind \`VITE_USE_BACKEND_PROGRESSION=true\`
- Normaliza \`slots\` de string keys JSON (\`"1"\`, \`"2"\`) para numeric keys, consistente com \`getSlotProgressionForLevel\`
- Fallback automático para \`spellProgression.ts\` em caso de erro ou flag desligada

## Observação importante

**O adapter não deve ser usado pelo fluxo síncrono de criação de fichas.**

A criação continua usando \`spellProgression.ts\` diretamente:
- \`getSlotProgressionForLevel\`
- \`getMaxUnlockedSpellLevel\`
- \`getCantripCountForClassLevel\`

\`fetchClassSpellProgression(...)\` existe para usos assíncronos: debug, painéis administrativos, validações opcionais — qualquer contexto que tolere \`await\`.

## Comportamento por flag

| Flag | Comportamento |
|---|---|
| Off (padrão) | Tabelas locais, zero request de rede |
| On + backend OK | Dados do backend, slots normalizados |
| On + backend erro | Fallback para tabelas locais, null nunca vazado |

## Testes

- 78 testes FE passando
- 72 testes BE passando
- Fluxo de criação: inalterado

🤖 Generated with [Claude Code](https://claude.com/claude-code)