### PR TITLE
feat(dnd-base): useClassSpellProgression hook com backend opcional

### DIFF
--- a/apps/control-web/src/entities/dnd-base/index.ts
+++ b/apps/control-web/src/entities/dnd-base/index.ts
@@ -44,4 +44,6 @@ export {
   getCantripCountForClassLevel,
 } from "./spellProgression";
 export type { ClassSpellProgression } from "./spellProgressionBackendAdapter";
-export { fetchClassSpellProgression } from "./spellProgressionBackendAdapter";
+export { fetchClassSpellProgression, fromLocalTables } from "./spellProgressionBackendAdapter";
+export { useClassSpellProgression } from "./useClassSpellProgression";
+export type { SpellProgressionResult } from "./useClassSpellProgression";

--- a/apps/control-web/src/entities/dnd-base/spellProgressionBackendAdapter.ts
+++ b/apps/control-web/src/entities/dnd-base/spellProgressionBackendAdapter.ts
@@ -28,7 +28,7 @@ const USE_BACKEND = import.meta.env.VITE_USE_BACKEND_PROGRESSION === "true";
  * Only called when VITE_USE_BACKEND_PROGRESSION=true.
  * Returns null on any error so callers can fall back to local tables.
  */
-async function fetchFromBackend(
+export async function fetchFromBackend(
   className: string,
   level: number
 ): Promise<ClassSpellProgression | null> {
@@ -54,7 +54,7 @@ async function fetchFromBackend(
  * Build progression from local spellProgression.ts tables.
  * Guaranteed synchronous and offline-safe.
  */
-function fromLocalTables(
+export function fromLocalTables(
   className: string,
   level: number
 ): ClassSpellProgression | null {

--- a/apps/control-web/src/entities/dnd-base/useClassSpellProgression.test.ts
+++ b/apps/control-web/src/entities/dnd-base/useClassSpellProgression.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { fromLocalTables } from "./spellProgressionBackendAdapter";
+import { resolveProgressionState } from "./useClassSpellProgression";
+
+const WIZARD_L5_LOCAL = {
+  className: "wizard",
+  level: 5,
+  slots: { 1: 4, 2: 3, 3: 2 },
+  maxSpellLevel: 3,
+  cantrips: 4,
+  leveledSpellsKnown: null,
+  spellcastingType: "spellbook" as const,
+};
+
+describe("fromLocalTables", () => {
+  it("returns correct progression for wizard level 5", () => {
+    expect(fromLocalTables("wizard", 5)).toEqual(WIZARD_L5_LOCAL);
+  });
+
+  it("returns null for non-caster class", () => {
+    expect(fromLocalTables("fighter", 5)).toBeNull();
+  });
+
+  it("clamps level to 1–20 range", () => {
+    const result = fromLocalTables("wizard", 0);
+    expect(result).not.toBeNull();
+    expect(result!.level).toBe(1);
+  });
+
+  it("returns spells-known for known caster classes", () => {
+    const result = fromLocalTables("bard", 1);
+    expect(result).not.toBeNull();
+    expect(result!.leveledSpellsKnown).toBe(4);
+    expect(result!.spellcastingType).toBe("known");
+  });
+});
+
+describe("resolveProgressionState", () => {
+  it("returns local data when backend flag is off", () => {
+    const result = resolveProgressionState(WIZARD_L5_LOCAL, null, null, false, false);
+
+    expect(result.progression).toBe(WIZARD_L5_LOCAL);
+    expect(result.source).toBe("local");
+    expect(result.isLoading).toBe(false);
+    expect(result.error).toBeNull();
+  });
+
+  it("returns loading state with local fallback when backend flag is on and loading", () => {
+    const result = resolveProgressionState(WIZARD_L5_LOCAL, null, null, true, true);
+
+    expect(result.progression).toBe(WIZARD_L5_LOCAL);
+    expect(result.source).toBe("local");
+    expect(result.isLoading).toBe(true);
+    expect(result.error).toBeNull();
+  });
+
+  it("returns backend data when backend flag is on and fetch succeeded", () => {
+    const backendData = { ...WIZARD_L5_LOCAL, maxSpellLevel: 3 };
+    const result = resolveProgressionState(WIZARD_L5_LOCAL, backendData, null, true, false);
+
+    expect(result.progression).toBe(backendData);
+    expect(result.source).toBe("backend");
+    expect(result.isLoading).toBe(false);
+    expect(result.error).toBeNull();
+  });
+
+  it("returns local data when backend flag is on and fetch returned null", () => {
+    const result = resolveProgressionState(WIZARD_L5_LOCAL, null, null, true, false);
+
+    expect(result.progression).toBe(WIZARD_L5_LOCAL);
+    expect(result.source).toBe("local");
+    expect(result.isLoading).toBe(false);
+    expect(result.error).toBeNull();
+  });
+
+  it("returns local data with error when backend flag is on and fetch threw", () => {
+    const err = new Error("network failure");
+    const result = resolveProgressionState(WIZARD_L5_LOCAL, null, err, true, false);
+
+    expect(result.progression).toBe(WIZARD_L5_LOCAL);
+    expect(result.source).toBe("local");
+    expect(result.isLoading).toBe(false);
+    expect(result.error).toBe(err);
+  });
+});

--- a/apps/control-web/src/entities/dnd-base/useClassSpellProgression.ts
+++ b/apps/control-web/src/entities/dnd-base/useClassSpellProgression.ts
@@ -1,0 +1,83 @@
+import { useEffect, useMemo, useState } from "react";
+
+import type { ClassSpellProgression } from "./spellProgressionBackendAdapter";
+import { fetchFromBackend, fromLocalTables } from "./spellProgressionBackendAdapter";
+
+const USE_BACKEND = import.meta.env.VITE_USE_BACKEND_PROGRESSION === "true";
+
+export type SpellProgressionResult = {
+  progression: ClassSpellProgression | null;
+  source: "local" | "backend";
+  isLoading: boolean;
+  error: Error | null;
+};
+
+export function resolveProgressionState(
+  localData: ClassSpellProgression | null,
+  backendData: ClassSpellProgression | null,
+  backendError: Error | null,
+  useBackend: boolean,
+  isLoading: boolean
+): SpellProgressionResult {
+  if (!useBackend) {
+    return { progression: localData, source: "local", isLoading: false, error: null };
+  }
+
+  if (isLoading) {
+    return { progression: localData, source: "local", isLoading: true, error: null };
+  }
+
+  if (backendError) {
+    return { progression: localData, source: "local", isLoading: false, error: backendError };
+  }
+
+  if (backendData !== null) {
+    return { progression: backendData, source: "backend", isLoading: false, error: null };
+  }
+
+  return { progression: localData, source: "local", isLoading: false, error: null };
+}
+
+export function useClassSpellProgression(
+  className: string,
+  level: number
+): SpellProgressionResult {
+  const localData = useMemo(
+    () => fromLocalTables(className, level),
+    [className, level]
+  );
+
+  const [backendData, setBackendData] = useState<ClassSpellProgression | null>(null);
+  const [backendError, setBackendError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState(USE_BACKEND);
+
+  useEffect(() => {
+    if (!USE_BACKEND) return;
+
+    setBackendData(null);
+    setBackendError(null);
+    setIsLoading(true);
+
+    let cancelled = false;
+
+    fetchFromBackend(className, level)
+      .then((data) => {
+        if (cancelled) return;
+        setBackendData(data);
+        setBackendError(null);
+        setIsLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setBackendData(null);
+        setBackendError(err instanceof Error ? err : new Error(String(err)));
+        setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [className, level]);
+
+  return resolveProgressionState(localData, backendData, backendError, USE_BACKEND, isLoading);
+}


### PR DESCRIPTION
## Summary

- **Novo hook `useClassSpellProgression`** que retorna progressão de spellcasting com fallback local garantido e source backend opcional via flag `VITE_USE_BACKEND_PROGRESSION`
- **Função pura `resolveProgressionState`** exportada para testabilidade — decide `source`/`isLoading`/`error` a partir de `(localData, backendData, backendError, useBackend, isLoading)`
- **Adapter atualizado** — `fromLocalTables` e `fetchFromBackend` agora são exportadas do arquivo (sem re-exportar `fetchFromBackend` no barrel público)

## Comportamento

| Flag | Comportamento |
|------|--------------|
| off (default) | Retorna dados locais imediatamente, sem request |
| on + sucesso | Retorna local inicial, depois overlay com dados do backend (`source: "backend"`) |
| on + falha | Mantém dados locais (`source: "local"`), sem quebrar UI |

## Fora do escopo

- Fluxo síncrono de criação de ficha inalterado
- `spellProgression.ts` inalterado
- Nenhum loading adicionado ao picker de magias

## Testes

- 9 novos testes cobrindo `fromLocalTables` e todos os branches de `resolveProgressionState`
- 33 testes existentes na pasta continuam passando