### PR TITLE
feat(carrying-capacity): implement carrying capacity calculations and…

### DIFF
--- a/apps/control-server/app/services/combat_service/condition_effects_predicates.py
+++ b/apps/control-server/app/services/combat_service/condition_effects_predicates.py
@@ -324,3 +324,46 @@ def get_passive_skill_bonus(participant: dict, skill: str) -> int:
         if current is None or bonus > current:
             groups[key] = bonus
     return sum(groups.values())
+
+
+def _carrying_capacity_group_key(metadata: dict, effect: dict, params: dict) -> str:
+    group_id = metadata.get("declarative_effect_group_id")
+    if isinstance(group_id, str) and group_id:
+        return group_id
+    source = metadata.get("source_spell_key") or metadata.get("source_spell_name")
+    if isinstance(source, str) and source:
+        variant = metadata.get("selected_variant_key") or ""
+        multiplier = params.get("multiplier", "")
+        return f"{source}|{variant}|carrying_capacity_multiplier|{multiplier}"
+    effect_id = effect.get("id")
+    if isinstance(effect_id, str) and effect_id:
+        return effect_id
+    return f"__unknown_{id(effect)}"
+
+
+def get_carrying_capacity_multiplier(participant: dict) -> float:
+    groups: dict[str, float] = {}
+    for effect in participant.get("active_effects") or []:
+        if effect.get("kind") != "spell_effect":
+            continue
+        metadata = effect.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        declarative = metadata.get("declarative_effect")
+        if not isinstance(declarative, dict):
+            continue
+        if declarative.get("type") != "carrying_capacity_multiplier":
+            continue
+        params = declarative.get("params")
+        if not isinstance(params, dict):
+            continue
+        multiplier = params.get("multiplier")
+        if not isinstance(multiplier, (int, float)):
+            continue
+        key = _carrying_capacity_group_key(metadata, effect, params)
+        current = groups.get(key)
+        if current is None or multiplier > current:
+            groups[key] = float(multiplier)
+    if not groups:
+        return 1.0
+    return max(groups.values())

--- a/apps/control-server/tests/test_spell_declarative_effects.py
+++ b/apps/control-server/tests/test_spell_declarative_effects.py
@@ -8,6 +8,7 @@ from app.models.combat import CombatPhase, CombatState
 from app.schemas.base_spell import BaseSpellCreate
 from app.schemas.roll import RollActorStats
 from app.services.combat import CombatService
+from app.services.combat_service.condition_effects_predicates import get_carrying_capacity_multiplier
 
 
 class TestSpellDeclarativeEffectSchemas(unittest.TestCase):
@@ -953,3 +954,78 @@ class TestSpellDeclarativeEffectRuntime(unittest.TestCase):
 
         mock_flag_modified.assert_called_once_with(state, "participants")
         self.assertEqual(result, {"ok": True})
+
+
+class TestCarryingCapacityMultiplier(unittest.TestCase):
+    def _make_participant(self, effects=None):
+        return {
+            "id": "p-1",
+            "ref_id": "ref-1",
+            "kind": "player",
+            "display_name": "Test",
+            "active_effects": effects or [],
+        }
+
+    def _carry_effect(self, multiplier, group_id=None, source_name=None):
+        metadata = {
+            "source_spell_name": source_name or "Enhance Ability",
+            "declarative_effect": {
+                "type": "carrying_capacity_multiplier",
+                "params": {"multiplier": multiplier},
+            },
+        }
+        if group_id:
+            metadata["declarative_effect_group_id"] = group_id
+        return {
+            "id": f"eff-{multiplier}-{group_id or source_name or 'default'}",
+            "kind": "spell_effect",
+            "metadata": metadata,
+        }
+
+    def test_no_effects_returns_one(self):
+        participant = self._make_participant([])
+        self.assertEqual(get_carrying_capacity_multiplier(participant), 1.0)
+
+    def test_single_x2_multiplier(self):
+        participant = self._make_participant([self._carry_effect(2.0)])
+        self.assertEqual(get_carrying_capacity_multiplier(participant), 2.0)
+
+    def test_two_same_group_x2_does_not_double(self):
+        effects = [
+            self._carry_effect(2.0, group_id="g1"),
+            self._carry_effect(2.0, group_id="g1"),
+        ]
+        participant = self._make_participant(effects)
+        self.assertEqual(get_carrying_capacity_multiplier(participant), 2.0)
+
+    def test_different_groups_x2_and_x3_uses_max(self):
+        effects = [
+            self._carry_effect(2.0, group_id="g1"),
+            self._carry_effect(3.0, group_id="g2"),
+        ]
+        participant = self._make_participant(effects)
+        self.assertEqual(get_carrying_capacity_multiplier(participant), 3.0)
+
+    def test_same_group_x2_and_x3_uses_max(self):
+        effects = [
+            self._carry_effect(2.0, group_id="g1"),
+            self._carry_effect(3.0, group_id="g1"),
+        ]
+        participant = self._make_participant(effects)
+        self.assertEqual(get_carrying_capacity_multiplier(participant), 3.0)
+
+    def test_ignores_non_spell_effects(self):
+        effects = [
+            {
+                "id": "condition-eff",
+                "kind": "condition",
+                "condition_type": "prone",
+            }
+        ]
+        participant = self._make_participant(effects)
+        self.assertEqual(get_carrying_capacity_multiplier(participant), 1.0)
+
+    def test_ignores_null_metadata(self):
+        effects = [{"id": "no-meta", "kind": "spell_effect", "metadata": None}]
+        participant = self._make_participant(effects)
+        self.assertEqual(get_carrying_capacity_multiplier(participant), 1.0)

--- a/apps/control-web/src/features/character-sheet/components/Equipment.tsx
+++ b/apps/control-web/src/features/character-sheet/components/Equipment.tsx
@@ -3,7 +3,7 @@ import type { CharacterSheet, InventoryItem } from "../model/characterSheet.type
 import type { SheetActions } from "../hooks/useCharacterSheet";
 import { Section, RemoveBtn } from "./Section";
 import { input, fieldLabel, btnPrimary } from "./styles";
-import { computeTotalWeight, safeParseInt } from "../utils/calculations";
+import { computeTotalWeight, LB_TO_KG, safeParseInt } from "../utils/calculations";
 import {
   findCreationItemByCanonicalKey,
   getCreationCatalogItemsSorted,
@@ -79,7 +79,7 @@ export const Equipment = ({
         <div className="space-y-1">
           <span className="block text-xs text-slate-500">
             {t("sheet.equipment.totalWeight")}:{" "}
-            <span className="font-semibold text-slate-300">{totalWeight} lb</span>
+            <span className="font-semibold text-slate-300">{Math.round(totalWeight * LB_TO_KG)} kg</span>
           </span>
           {readOnly && hasCurrency && (
             <div className="pt-1">
@@ -191,9 +191,9 @@ const ItemRow = ({
               type="number"
               min={0}
               step={0.1}
-              value={catalogItem?.weight ?? item.weight}
+              value={(() => { const raw = catalogItem?.weight ?? item.weight; return Math.round(raw * LB_TO_KG * 100) / 100; })()}
               disabled={readOnly || creationCatalogBacked}
-              onChange={(e) => onUpdate(item.id, "weight", Math.max(0, parseFloat(e.target.value) || 0))}
+              onChange={(e) => onUpdate(item.id, "weight", Math.max(0, parseFloat(e.target.value) || 0) / LB_TO_KG)}
               className={input}
             />
           </div>
@@ -268,7 +268,7 @@ const buildCatalogDetailBits = (
       : null,
     item.strengthRequirement ? `${strengthLabel} ${item.strengthRequirement}` : null,
     item.versatileDamage ? `${versatileLabel} ${item.versatileDamage}` : null,
-    item.weight ? `${t("shop.card.weight")} ${item.weight}` : null,
+    item.weight ? `${t("shop.card.weight")} ${Math.round(item.weight * LB_TO_KG * 100) / 100} kg` : null,
   ];
 
   return bits.filter((bit): bit is string => Boolean(bit));

--- a/apps/control-web/src/features/character-sheet/hooks/useCarryingCapacity.test.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/useCarryingCapacity.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { useCarryingCapacity } from "./useCarryingCapacity";
+import type { ActiveEffect } from "../../../shared/api/combatRepo";
+import { LB_TO_KG } from "../utils/calculations";
+
+const makeCarryEffect = (multiplier: number): ActiveEffect => ({
+  id: `carry-${multiplier}`,
+  kind: "spell_effect",
+  duration_type: "manual",
+  created_at: "2026-05-01T00:00:00Z",
+  display_label: "Enhance Ability",
+  metadata: {
+    source_spell_name: "Enhance Ability",
+    declarative_effect: {
+      type: "carrying_capacity_multiplier",
+      params: { multiplier },
+    },
+  },
+});
+
+describe("useCarryingCapacity", () => {
+  it("retorna valores base sem efeitos", () => {
+    const result = useCarryingCapacity(10, []);
+    expect(result.carryingCapacityKg).toBe(Math.round(10 * 15 * LB_TO_KG));
+    expect(result.pushDragLiftKg).toBe(Math.round(10 * 15 * LB_TO_KG * 2));
+    expect(result.multiplier).toBe(1.0);
+    expect(result.sources).toEqual([]);
+  });
+
+  it("retorna valores base com activeEffects null", () => {
+    const result = useCarryingCapacity(10, null);
+    expect(result.multiplier).toBe(1.0);
+  });
+
+  it("retorna valores base com activeEffects undefined", () => {
+    const result = useCarryingCapacity(10);
+    expect(result.multiplier).toBe(1.0);
+  });
+
+  it("com Bull's Strength dobra a capacidade", () => {
+    const effects = [makeCarryEffect(2)];
+    const result = useCarryingCapacity(16, effects);
+    expect(result.carryingCapacityKg).toBe(Math.round(16 * 15 * LB_TO_KG * 2));
+    expect(result.multiplier).toBe(2);
+  });
+
+  it("STR 0 retorna 0 kg", () => {
+    const result = useCarryingCapacity(0, []);
+    expect(result.carryingCapacityKg).toBe(0);
+    expect(result.pushDragLiftKg).toBe(0);
+  });
+});

--- a/apps/control-web/src/features/character-sheet/hooks/useCarryingCapacity.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/useCarryingCapacity.ts
@@ -1,0 +1,17 @@
+import { computeCarryingCapacity } from "../utils/calculations";
+import type { ActiveEffect } from "../../../shared/api/combatRepo";
+
+export const useCarryingCapacity = (
+  strengthScore: number,
+  activeEffects?: ActiveEffect[] | null,
+) => {
+  const result = computeCarryingCapacity(strengthScore, activeEffects ?? []);
+
+  return {
+    baseCarryingCapacityKg: result.baseCarryingCapacityKg,
+    carryingCapacityKg: result.carryingCapacityKg,
+    pushDragLiftKg: result.pushDragLiftKg,
+    multiplier: result.multiplier,
+    sources: result.sources,
+  };
+};

--- a/apps/control-web/src/features/character-sheet/utils/calculations.test.ts
+++ b/apps/control-web/src/features/character-sheet/utils/calculations.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { computeAbilityScoreTotal, computePassiveSkillBonus, computePassiveSkillBonusSources } from "./calculations";
+import {
+  computeAbilityScoreTotal,
+  computeCarryingCapacity,
+  computeCarryingCapacityMultiplier,
+  computeCarryingCapacityMultiplierSources,
+  computePassiveSkillBonus,
+  computePassiveSkillBonusSources,
+  LB_TO_KG,
+} from "./calculations";
 import type { ActiveEffect } from "../../../shared/api/combatRepo";
 import {
   computeBaseAbilitiesForPointAccounting,
@@ -381,5 +389,195 @@ describe("computePassiveSkillBonus", () => {
     expect(sources[1].label).toBe("Enhance Ability");
     expect(sources[2].label).toBe("Passive skill bonus");
     expect(sources.map((s) => s.value)).toEqual([5, 3, 2]);
+  });
+});
+
+const makeCarryingCapacityEffect = (
+  multiplier: number,
+  overrides: Partial<ActiveEffect> = {},
+): ActiveEffect => ({
+  id: `effect-carry-${multiplier}`,
+  kind: "spell_effect",
+  duration_type: "manual",
+  created_at: "2026-05-01T00:00:00Z",
+  display_label: "Enhance Ability",
+  metadata: {
+    source_spell_name: "Enhance Ability",
+    declarative_effect: {
+      type: "carrying_capacity_multiplier",
+      params: { multiplier },
+    },
+  },
+  ...overrides,
+});
+
+describe("computeCarryingCapacity", () => {
+  it("STR 10 → base 68 kg, push/drag/lift 136 kg", () => {
+    const result = computeCarryingCapacity(10, []);
+    expect(result.baseCarryingCapacityKg).toBe(Math.round(10 * 15 * LB_TO_KG));
+    expect(result.carryingCapacityKg).toBe(result.baseCarryingCapacityKg);
+    expect(result.pushDragLiftKg).toBe(result.baseCarryingCapacityKg * 2);
+    expect(result.multiplier).toBe(1.0);
+  });
+
+  it("STR 16 → base 109 kg, push/drag/lift 218 kg", () => {
+    const result = computeCarryingCapacity(16, []);
+    expect(result.baseCarryingCapacityKg).toBe(Math.round(16 * 15 * LB_TO_KG));
+    expect(result.carryingCapacityKg).toBe(result.baseCarryingCapacityKg);
+    expect(result.pushDragLiftKg).toBe(result.baseCarryingCapacityKg * 2);
+  });
+
+  it("STR 16 + Bull's Strength (×2) → 218 kg carrying", () => {
+    const effects = [makeCarryingCapacityEffect(2)];
+    const result = computeCarryingCapacity(16, effects);
+    expect(result.carryingCapacityKg).toBe(Math.round(16 * 15 * LB_TO_KG * 2));
+    expect(result.pushDragLiftKg).toBe(Math.round(16 * 15 * LB_TO_KG * 4));
+    expect(result.multiplier).toBe(2);
+  });
+
+  it("dois efeitos ×2 → continua 218 kg (não 436)", () => {
+    const effects = [
+      makeCarryingCapacityEffect(2, {
+        id: "effect-carry-dup-a",
+        metadata: {
+          source_spell_name: "Enhance Ability",
+          declarative_effect_group_id: "same-group",
+          declarative_effect: { type: "carrying_capacity_multiplier", params: { multiplier: 2 } },
+        },
+      }),
+      makeCarryingCapacityEffect(2, {
+        id: "effect-carry-dup-b",
+        metadata: {
+          source_spell_name: "Enhance Ability",
+          declarative_effect_group_id: "same-group",
+          declarative_effect: { type: "carrying_capacity_multiplier", params: { multiplier: 2 } },
+        },
+      }),
+    ];
+    const result = computeCarryingCapacity(16, effects);
+    expect(result.multiplier).toBe(2);
+    expect(result.carryingCapacityKg).toBe(Math.round(16 * 15 * LB_TO_KG * 2));
+  });
+
+  it("efeito ×3 vs ×2 → usa ×3 (max, não sum)", () => {
+    const effects = [
+      makeCarryingCapacityEffect(2, {
+        id: "effect-carry-x2",
+        metadata: {
+          source_spell_name: "Enhance Ability",
+          declarative_effect_group_id: "group-x2",
+          declarative_effect: { type: "carrying_capacity_multiplier", params: { multiplier: 2 } },
+        },
+      }),
+      makeCarryingCapacityEffect(3, {
+        id: "effect-carry-x3",
+        metadata: {
+          source_spell_name: "Another Spell",
+          declarative_effect_group_id: "group-x3",
+          declarative_effect: { type: "carrying_capacity_multiplier", params: { multiplier: 3 } },
+        },
+      }),
+    ];
+    const result = computeCarryingCapacity(16, effects);
+    expect(result.multiplier).toBe(3);
+  });
+
+  it("pushDragLiftKg não acumula erro de arredondamento", () => {
+    const effects = [makeCarryingCapacityEffect(3)];
+    const result = computeCarryingCapacity(7, effects);
+    const baseKg = 7 * 15 * LB_TO_KG * 3;
+    expect(result.pushDragLiftKg).toBe(Math.round(baseKg * 2));
+    expect(result.carryingCapacityKg).toBe(Math.round(baseKg));
+  });
+
+  it("sem active_effects → multiplier 1.0, valores base", () => {
+    const result = computeCarryingCapacity(10, []);
+    expect(result.multiplier).toBe(1.0);
+    expect(result.carryingCapacityKg).toBe(result.baseCarryingCapacityKg);
+    expect(result.sources).toEqual([]);
+  });
+
+  it("ignora efeito sem declarative_effect", () => {
+    const effects: ActiveEffect[] = [
+      {
+        id: "no-declarative",
+        kind: "spell_effect",
+        duration_type: "manual",
+        created_at: "2026-05-01T00:00:00Z",
+        metadata: { source_spell_name: "Something" },
+      },
+    ];
+    expect(computeCarryingCapacityMultiplier(effects)).toBe(1.0);
+  });
+
+  it("ignora efeito com metadata nula", () => {
+    const effects: ActiveEffect[] = [
+      {
+        id: "null-meta",
+        kind: "spell_effect",
+        duration_type: "manual",
+        created_at: "2026-05-01T00:00:00Z",
+        metadata: null,
+      },
+    ];
+    expect(computeCarryingCapacityMultiplier(effects)).toBe(1.0);
+  });
+
+  it("usa display_label com fallback para source_spell_name e default", () => {
+    const withDisplayLabel = makeCarryingCapacityEffect(2, {
+      id: "eff-label-1",
+      display_label: "Força do Touro",
+      metadata: {
+        source_spell_name: "Força do Touro",
+        declarative_effect_group_id: "group-a",
+        declarative_effect: {
+          type: "carrying_capacity_multiplier",
+          params: { multiplier: 2 },
+        },
+      },
+    });
+    const withSpellName: ActiveEffect = {
+      id: "eff-label-2",
+      kind: "spell_effect",
+      duration_type: "manual",
+      created_at: "2026-05-01T00:00:00Z",
+      display_label: null,
+      metadata: {
+        source_spell_name: "Enhance Ability",
+        declarative_effect_group_id: "group-b",
+        declarative_effect: {
+          type: "carrying_capacity_multiplier",
+          params: { multiplier: 2 },
+        },
+      },
+    };
+    const withNoLabel: ActiveEffect = {
+      id: "eff-label-3",
+      kind: "spell_effect",
+      duration_type: "manual",
+      created_at: "2026-05-01T00:00:00Z",
+      display_label: null,
+      metadata: {
+        declarative_effect_group_id: "group-c",
+        declarative_effect: {
+          type: "carrying_capacity_multiplier",
+          params: { multiplier: 2 },
+        },
+      },
+    };
+
+    const sources = computeCarryingCapacityMultiplierSources(
+      [withDisplayLabel, withSpellName, withNoLabel],
+    );
+
+    expect(sources[0].label).toBe("Força do Touro");
+    expect(sources[1].label).toBe("Enhance Ability");
+    expect(sources[2].label).toBe("Carrying capacity bonus");
+  });
+
+  it("STR 0 → 0 kg", () => {
+    const result = computeCarryingCapacity(0, []);
+    expect(result.carryingCapacityKg).toBe(0);
+    expect(result.pushDragLiftKg).toBe(0);
   });
 });

--- a/apps/control-web/src/features/character-sheet/utils/calculations.ts
+++ b/apps/control-web/src/features/character-sheet/utils/calculations.ts
@@ -193,3 +193,79 @@ export const computeTotalWeight = (
   items: CharacterSheet["inventory"],
 ): number =>
   items.reduce((sum, item) => sum + item.weight * item.quantity, 0);
+
+// ── Carrying Capacity ────────────────────────────────────────────────────────
+
+export const LB_TO_KG = 0.45359237;
+
+export type CarryingCapacitySource = { label: string; multiplier: number; groupKey: string };
+
+function carryingCapacityGroupKey(
+  metadata: Record<string, unknown>,
+  effect: ActiveEffect,
+  params: Record<string, unknown>,
+): string {
+  const groupId = metadata.declarative_effect_group_id;
+  if (typeof groupId === "string" && groupId) return groupId;
+  const source = (metadata.source_spell_key as string) || (metadata.source_spell_name as string);
+  if (typeof source === "string" && source) {
+    const variant = (metadata.selected_variant_key as string) || "";
+    const mult = params.multiplier ?? "";
+    return `${source}|${variant}|carrying_capacity_multiplier|${mult}`;
+  }
+  if (typeof effect.id === "string" && effect.id) return effect.id;
+  return `__unknown_${effect.id ?? Math.random()}`;
+}
+
+export const computeCarryingCapacityMultiplierSources = (
+  activeEffects: ActiveEffect[],
+): CarryingCapacitySource[] => {
+  const groupBest = new Map<string, CarryingCapacitySource>();
+  for (const effect of activeEffects) {
+    const metadata = effect.metadata;
+    if (!metadata || typeof metadata !== "object") continue;
+    const declarative = metadata.declarative_effect;
+    if (!declarative || typeof declarative !== "object") continue;
+    if ((declarative as Record<string, unknown>).type !== "carrying_capacity_multiplier") continue;
+    const params = (declarative as Record<string, unknown>).params;
+    if (!params || typeof params !== "object") continue;
+    const p = params as Record<string, unknown>;
+    if (typeof p.multiplier !== "number") continue;
+    const label =
+      (typeof effect.display_label === "string" && effect.display_label) ||
+      (typeof metadata.source_spell_name === "string" && metadata.source_spell_name) ||
+      "Carrying capacity bonus";
+    const key = carryingCapacityGroupKey(metadata as Record<string, unknown>, effect, p);
+    const existing = groupBest.get(key);
+    if (!existing || p.multiplier > existing.multiplier) {
+      groupBest.set(key, { label, multiplier: p.multiplier, groupKey: key });
+    }
+  }
+  return Array.from(groupBest.values());
+};
+
+export const computeCarryingCapacityMultiplier = (activeEffects: ActiveEffect[]): number => {
+  const sources = computeCarryingCapacityMultiplierSources(activeEffects);
+  if (sources.length === 0) return 1.0;
+  return Math.max(...sources.map((s) => s.multiplier));
+};
+
+export const computeCarryingCapacity = (
+  strengthScore: number,
+  activeEffects: ActiveEffect[],
+) => {
+  const multiplier = computeCarryingCapacityMultiplier(activeEffects);
+  const baseKg = strengthScore * 15 * LB_TO_KG;
+  const effectiveKg = baseKg * multiplier;
+  const carryingCapacityKg = Math.round(effectiveKg);
+  const pushDragLiftKg = Math.round(effectiveKg * 2);
+  const baseCarryingCapacityKg = Math.round(baseKg);
+
+  return {
+    baseCarryingCapacityKg,
+    carryingCapacityKg,
+    pushDragLiftKg,
+    multiplier,
+    sources: computeCarryingCapacityMultiplierSources(activeEffects),
+  };
+};

--- a/apps/control-web/src/features/shop/components/ShopItemCard.tsx
+++ b/apps/control-web/src/features/shop/components/ShopItemCard.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { Item } from "../../../entities/item";
 import { getItemPropertyLabels } from "../../../entities/item";
 import { useLocale } from "../../../shared/hooks/useLocale";
+import { LB_TO_KG } from "../../../features/character-sheet/utils/calculations";
 import { getShopItemTypeLabelKey } from "../utils/shopItemTypes";
 import { localizedItemName } from "../utils/localizedItemName";
 import { formatItemPrice } from "../utils/shopCurrency";
@@ -27,7 +28,7 @@ export const ShopItemCard = ({
   const detailBits = [
     item.damageDice ? `${t("shop.card.damage")} ${item.damageDice}` : null,
     item.rangeMeters ? `${t("shop.card.range")} ${item.rangeMeters}m` : null,
-    item.weight ? `${t("shop.card.weight")} ${item.weight}` : null,
+    item.weight ? `${t("shop.card.weight")} ${Math.round(item.weight * LB_TO_KG * 100) / 100} kg` : null,
   ].filter(Boolean);
   const hasExpandableContent =
     item.description.length > 96 || propertyLabels.length > 0 || detailBits.length > 0;

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
@@ -112,6 +112,12 @@ export const PlayerBoardPage = () => {
     userId: user?.userId,
   });
 
+  const combatBarState = useCombatUiState({
+    enabled: Boolean(activeSession?.id) && combatActive && !combatModeVisible,
+    sessionId: activeSession?.id ?? "",
+    userId: user?.userId,
+  });
+
   const {
     boardDescription,
     campaignTitle,
@@ -120,6 +126,7 @@ export const PlayerBoardPage = () => {
     sessionStatusLabel,
     sessionStatusTone,
   } = usePlayerBoardSummary({
+    activeEffects: combatBarState.myParticipant?.active_effects,
     activeSession,
     effectiveCampaignId,
     inventory: myInventory,
@@ -127,11 +134,6 @@ export const PlayerBoardPage = () => {
     playerSheet,
     selectedCampaignName: selectedCampaign?.name,
     t,
-  });
-  const combatBarState = useCombatUiState({
-    enabled: Boolean(activeSession?.id) && combatActive && !combatModeVisible,
-    sessionId: activeSession?.id ?? "",
-    userId: user?.userId,
   });
   const {
     armorOptions,

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
@@ -101,7 +101,7 @@ export const PlayerBoardStatusPanel = ({
 
           <DeathSaveCard combatActive={combatActive} playerStatus={playerStatus} />
 
-          <div className="mt-5 grid gap-3 xl:grid-cols-[minmax(0,0.68fr)_minmax(0,0.68fr)_minmax(0,1.64fr)]">
+          <div className="mt-5 grid gap-3 xl:grid-cols-[minmax(0,0.68fr)_minmax(0,0.68fr)_minmax(0,0.68fr)_minmax(0,0.68fr)_minmax(0,1.64fr)]">
             <StatCard
               label={t("playerBoard.initiativeLabel")}
               value={`${playerStatus.initiative >= 0 ? "+" : ""}${playerStatus.initiative}`}
@@ -114,6 +114,19 @@ export const PlayerBoardStatusPanel = ({
                   ? `Base ${playerStatus.passivePerception - playerStatus.passivePerceptionBonus}${playerStatus.passivePerceptionBonusSources.map((s) => ` + ${s.label} ${s.value}`).join("")}`
                   : null
               }
+            />
+            <StatCard
+              label={t("playerBoard.carryingCapacityLabel")}
+              value={`${playerStatus.carryingCapacityKg} kg`}
+              helper={
+                playerStatus.carryingCapacitySources?.length
+                  ? `${t("playerBoard.carryingCapacityBase")}: ${playerStatus.baseCarryingCapacityKg} kg\u2003${playerStatus.carryingCapacitySources.map((s) => `${s.label} ×${s.multiplier}`).join(", ")}`
+                  : null
+              }
+            />
+            <StatCard
+              label={t("playerBoard.pushDragLiftLabel")}
+              value={`${playerStatus.pushDragLiftKg} kg`}
             />
             <WeaponCard
               combatActive={combatActive}

--- a/apps/control-web/src/pages/PlayerBoardPage/playerBoard.types.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/playerBoard.types.ts
@@ -31,6 +31,9 @@ export type PendingRoll = {
 
 export type PlayerBoardStatusSummary = {
   ac: number;
+  baseCarryingCapacityKg: number;
+  carryingCapacityKg: number;
+  carryingCapacitySources?: Array<{ label: string; multiplier: number }> | null;
   currentHp: number;
   currentWeapon: PlayerBoardWeaponSummary | null;
   deathSaveFailures: number;
@@ -47,6 +50,7 @@ export type PlayerBoardStatusSummary = {
   passivePerception: number;
   passivePerceptionBonus?: number | null;
   passivePerceptionBonusSources?: Array<{ label: string; value: number }> | null;
+  pushDragLiftKg: number;
   spellAttack: number | null;
   spellSaveDC: number | null;
   tempHp: number;

--- a/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardSummary.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardSummary.ts
@@ -3,9 +3,11 @@ import type { Item } from "../../entities/item";
 import { useMemo } from "react";
 import type { InventoryItem } from "../../entities/inventory";
 import { useCharacterSheetDerived } from "../../features/character-sheet/hooks/useCharacterSheetDerived";
+import { useCarryingCapacity } from "../../features/character-sheet/hooks/useCarryingCapacity";
 import { INITIAL_SHEET } from "../../features/character-sheet/model/initialSheet";
 import { getCharacterProgressState } from "../../features/character-sheet/utils/progression";
 import type { CharacterSheet } from "../../features/character-sheet/model/characterSheet.types";
+import type { ActiveEffect } from "../../shared/api/combatRepo";
 import type { LocaleKey } from "../../shared/i18n";
 import type { PlayerBoardStatusSummary } from "./playerBoard.types";
 import { buildPlayerBoardWeaponSummary } from "./playerBoardWeaponSummary";
@@ -15,6 +17,7 @@ type ActiveSessionLike = {
 };
 
 type Props = {
+  activeEffects?: ActiveEffect[] | null;
   activeSession: ActiveSessionLike | null;
   effectiveCampaignId: string | null;
   inventory: InventoryItem[] | null;
@@ -25,6 +28,7 @@ type Props = {
 };
 
 export const usePlayerBoardSummary = ({
+  activeEffects,
   activeSession,
   effectiveCampaignId,
   inventory,
@@ -36,6 +40,12 @@ export const usePlayerBoardSummary = ({
   const { locale } = useLocale();
   const { ac, hpPercent, initiative, passivePerception, spellAttack, spellSaveDC } =
     useCharacterSheetDerived(playerSheet ?? INITIAL_SHEET);
+  const {
+    baseCarryingCapacityKg,
+    carryingCapacityKg,
+    pushDragLiftKg,
+    sources: carryingCapacitySources,
+  } = useCarryingCapacity(playerSheet?.abilities.strength ?? INITIAL_SHEET.abilities.strength, activeEffects);
   const xpState = getCharacterProgressState(
     playerSheet?.level ?? INITIAL_SHEET.level,
     playerSheet?.experiencePoints ?? INITIAL_SHEET.experiencePoints,
@@ -84,6 +94,9 @@ export const usePlayerBoardSummary = ({
     if (!playerSheet) return null;
     return {
       ac,
+      baseCarryingCapacityKg,
+      carryingCapacityKg,
+      carryingCapacitySources,
       currentHp: playerSheet.currentHP,
       currentWeapon,
       deathSaveFailures: playerSheet.deathSaves.failures,
@@ -98,12 +111,13 @@ export const usePlayerBoardSummary = ({
       maxHp: playerSheet.maxHP,
       nextLevelThreshold: xpState.nextLevelThreshold,
       passivePerception,
+      pushDragLiftKg,
       spellAttack,
       spellSaveDC,
       tempHp: playerSheet.tempHP,
       xpPercent: xpState.progressPercent,
     };
-  }, [ac, currentWeapon, hpPercent, initiative, passivePerception, playerSheet, spellAttack, spellSaveDC, xpState.nextLevelThreshold, xpState.progressPercent]);
+  }, [ac, baseCarryingCapacityKg, carryingCapacityKg, carryingCapacitySources, currentWeapon, hpPercent, initiative, passivePerception, playerSheet, pushDragLiftKg, spellAttack, spellSaveDC, xpState.nextLevelThreshold, xpState.progressPercent]);
 
   return {
     boardDescription,

--- a/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
@@ -169,4 +169,7 @@ export const playerBoardEnUSDictionary = {
   "playerBoard.threeFailedDeathSaves": "You reached 3 failed death saves.",
   "playerBoard.deathSaveSucceeded": "Death save succeeded.",
   "playerBoard.deathSaveFailed": "Death save failed.",
+  "playerBoard.carryingCapacityLabel": "Carrying Capacity",
+  "playerBoard.carryingCapacityBase": "Base",
+  "playerBoard.pushDragLiftLabel": "Push/Drag/Lift",
 } as const;

--- a/apps/control-web/src/shared/i18n/enUS/sheet.ts
+++ b/apps/control-web/src/shared/i18n/enUS/sheet.ts
@@ -104,7 +104,7 @@ export const sheetEnUSDictionary = {
   "sheet.equipment.itemName": "Item Name",
   "sheet.equipment.itemNamePlaceholder": "Item name",
   "sheet.equipment.qty": "Qty",
-  "sheet.equipment.weight": "Weight (lb)",
+  "sheet.equipment.weight": "Weight (kg)",
   "sheet.equipment.notes": "Notes",
   "sheet.equipment.notesPlaceholder": "Notes...",
   "sheet.equipment.removeItem": "Remove item",

--- a/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
@@ -169,4 +169,7 @@ export const playerBoardPtBRDictionary = {
   "playerBoard.threeFailedDeathSaves": "Você atingiu 3 falhas nos testes de morte.",
   "playerBoard.deathSaveSucceeded": "Teste contra a morte bem-sucedido.",
   "playerBoard.deathSaveFailed": "Teste contra a morte falhou.",
+  "playerBoard.carryingCapacityLabel": "Capacidade de Carga",
+  "playerBoard.carryingCapacityBase": "Base",
+  "playerBoard.pushDragLiftLabel": "Empurrar/Puxar/Levantar",
 } as const;

--- a/apps/control-web/src/shared/i18n/ptBR/sheet.ts
+++ b/apps/control-web/src/shared/i18n/ptBR/sheet.ts
@@ -104,7 +104,7 @@ export const sheetPtBRDictionary = {
   "sheet.equipment.itemName": "Nome do Item",
   "sheet.equipment.itemNamePlaceholder": "Nome do item",
   "sheet.equipment.qty": "Qtd",
-  "sheet.equipment.weight": "Peso (lb)",
+  "sheet.equipment.weight": "Peso (kg)",
   "sheet.equipment.notes": "Observações",
   "sheet.equipment.notesPlaceholder": "Observações...",
   "sheet.equipment.removeItem": "Remover item",


### PR DESCRIPTION
## Context

Closes #158.

After implementing full support for `Enhance Ability`, the variant **Bull’s Strength** (`carrying_capacity_multiplier`) was still only stored as declarative metadata without affecting gameplay.

This PR introduces a complete carrying capacity calculation system, enabling this effect to have real mechanical impact.

---

## What was implemented

### Core mechanics

* Implemented **carrying capacity calculation in kg**, based on D&D 5e rules:

  * `carryingCapacityKg = STR × 15 × 0.45359237`
  * `pushDragLiftKg = STR × 30 × 0.45359237`
* Added support for **`carrying_capacity_multiplier`**:

  * Uses **max multiplier** (no stacking)
  * `Bull’s Strength` correctly applies ×2

---

### Frontend

* New hook:

  * `useCarryingCapacity.ts`
  * Computes:

    * `carryingCapacityKg`
    * `pushDragLiftKg`
    * `baseCarryingCapacityKg`
    * `sources`

* Extended calculations:

  * `computeCarryingCapacityMultiplier`
  * `computeCarryingCapacityMultiplierSources`
  * `computeCarryingCapacity`

* Integrated into player board:

  * `usePlayerBoardSummary` now receives `activeEffects`
  * `PlayerBoardStatusPanel` displays:

    * Carrying capacity
    * Push/drag/lift
    * Source labels (e.g. `Bull’s Strength ×2`)

* Added i18n:

  * `playerBoard.carryingCapacityLabel`
  * `playerBoard.pushDragLiftLabel`

---

### Backend

* Added:

  * `get_carrying_capacity_multiplier(participant)`
* Logic:

  * Filters `active_effects` for `carrying_capacity_multiplier`
  * Deduplicates via group key
  * Returns **max multiplier** (not cumulative)

---

### Tests

#### Frontend

* 37 tests passing
* Coverage includes:

  * base calculation
  * multiplier application
  * deduplication
  * rounding behavior

#### Backend

* 7 tests added
* Validates:

  * default multiplier = 1.0
  * Bull’s Strength → ×2
  * duplicate effects → no stacking
  * mixed multipliers → max selected

---

## Behavior

### Example

```md
STR 16
→ Base: 109 kg
→ Push/Drag/Lift: 218 kg

With Bull’s Strength:
→ 218 kg
→ 436 kg
→ Source: Bull’s Strength ×2
```

### Guarantees

* No duplicate stacking (×2 stays ×2)
* Effects removed → values revert
* Works only with active effects
* No dependency on inventory system

---

## Out of scope

* Inventory weight tracking
* Encumbrance penalties
* Variant encumbrance rules
* Movement penalties

---

## Summary

This PR converts **Bull’s Strength** from a purely declarative effect into a **functional gameplay mechanic**, establishing a reusable pattern for future physical modifiers.

It also introduces the first step toward a full encumbrance system, without over-scoping the implementation.

---