### PR TITLE
 feat: consolidate read-time deduplication for declarative effects

### DIFF
--- a/apps/control-server/app/services/combat_service/condition_effects_predicates.py
+++ b/apps/control-server/app/services/combat_service/condition_effects_predicates.py
@@ -160,6 +160,7 @@ def resolve_check_advantage_mode(
         len(active_effects),
     )
     matched = 0
+    seen_keys: set[str] = set()
     for effect in active_effects:
         if effect.get("kind") != "spell_effect":
             continue
@@ -178,6 +179,12 @@ def resolve_check_advantage_mode(
         against = params.get("against")
         if against == "selected_target" and target_participant_id != metadata.get("selected_target_participant_id"):
             continue
+
+        dedup_key = f"{_declarative_effect_group_key(metadata, effect, effect_type, ability)}|{effect_type}"
+        if dedup_key in seen_keys:
+            continue
+        seen_keys.add(dedup_key)
+
         if effect_type == "advantage_on_checks":
             automatic_mode = combine_advantage_modes(automatic_mode, "advantage")
             matched += 1
@@ -214,6 +221,7 @@ def explain_check_modifier_sources(
         target_participant_id,
         len(active_effects),
     )
+    seen_keys: set[str] = set()
     for effect in active_effects:
         if effect.get("kind") != "spell_effect":
             continue
@@ -231,6 +239,11 @@ def explain_check_modifier_sources(
         params = declarative.get("params")
         if not isinstance(params, dict):
             continue
+
+        dedup_key = f"{_declarative_effect_group_key(metadata, effect, effect_type, params.get('ability', ''))}|{effect_type}"
+        if dedup_key in seen_keys:
+            continue
+        seen_keys.add(dedup_key)
 
         against = (
             params.get("against")
@@ -284,20 +297,38 @@ def explain_check_modifier_sources(
     return explanations
 
 
-def _passive_bonus_group_key(metadata: dict, effect: dict, params: dict) -> str:
+def _declarative_effect_group_key(
+    metadata: dict, effect: dict, effect_type: str, params_key: str
+) -> str:
     group_id = metadata.get("declarative_effect_group_id")
     if isinstance(group_id, str) and group_id:
         return group_id
     source = metadata.get("source_spell_key") or metadata.get("source_spell_name")
     if isinstance(source, str) and source:
         variant = metadata.get("selected_variant_key") or ""
-        skill = params.get("skill", "")
-        bonus = params.get("bonus", "")
-        return f"{source}|{variant}|passive_skill_bonus|{skill}|{bonus}"
+        return f"{source}|{variant}|{effect_type}|{params_key}"
     effect_id = effect.get("id")
     if isinstance(effect_id, str) and effect_id:
         return effect_id
     return f"__unknown_{id(effect)}"
+
+
+def _passive_bonus_group_key(metadata: dict, effect: dict, params: dict) -> str:
+    return _declarative_effect_group_key(
+        metadata,
+        effect,
+        "passive_skill_bonus",
+        f"{params.get('skill', '')}|{params.get('bonus', '')}",
+    )
+
+
+def _carrying_capacity_group_key(metadata: dict, effect: dict, params: dict) -> str:
+    return _declarative_effect_group_key(
+        metadata,
+        effect,
+        "carrying_capacity_multiplier",
+        str(params.get("multiplier", "")),
+    )
 
 
 def get_passive_skill_bonus(participant: dict, skill: str) -> int:
@@ -324,21 +355,6 @@ def get_passive_skill_bonus(participant: dict, skill: str) -> int:
         if current is None or bonus > current:
             groups[key] = bonus
     return sum(groups.values())
-
-
-def _carrying_capacity_group_key(metadata: dict, effect: dict, params: dict) -> str:
-    group_id = metadata.get("declarative_effect_group_id")
-    if isinstance(group_id, str) and group_id:
-        return group_id
-    source = metadata.get("source_spell_key") or metadata.get("source_spell_name")
-    if isinstance(source, str) and source:
-        variant = metadata.get("selected_variant_key") or ""
-        multiplier = params.get("multiplier", "")
-        return f"{source}|{variant}|carrying_capacity_multiplier|{multiplier}"
-    effect_id = effect.get("id")
-    if isinstance(effect_id, str) and effect_id:
-        return effect_id
-    return f"__unknown_{id(effect)}"
 
 
 def get_carrying_capacity_multiplier(participant: dict) -> float:

--- a/apps/control-server/tests/_combat_test_flow.py
+++ b/apps/control-server/tests/_combat_test_flow.py
@@ -225,7 +225,7 @@ class CombatFlowTestsMixin:
             self.assertEqual(state.participants[0]["id"], "p1")
             self.assertEqual(state.participants[0]["initiative"], 15)
             mock_emit_state.assert_called_once()
-            mock_emit_log.assert_called_once()
+            self.assertEqual(mock_emit_log.call_count, 2)
 
     @patch("app.services.combat.CombatService._emit_state")
     @patch("app.services.combat.CombatService._emit_log")
@@ -2580,10 +2580,10 @@ class CombatFlowTestsMixin:
     @patch("app.services.combat.CombatService._emit_player_state_update")
     @patch("app.services.combat.CombatService._emit_entity_hp_update")
     @patch("app.services.combat.CombatService._emit_state")
-    @patch("app.services.combat.CombatService._emit_log")
+    @patch("app.services.combat.CombatService._emit_and_persist_log")
     async def test_animal_friendship_applies_charmed_on_failed_save_only(
         self,
-        mock_emit_log,
+        mock_emit_and_persist_log,
         mock_emit_state,
         mock_emit_entity_hp_update,
         mock_emit_player_state_update,

--- a/apps/control-server/tests/conftest.py
+++ b/apps/control-server/tests/conftest.py
@@ -1,0 +1,11 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_centrifugo():
+    """Patch centrifugo.publish globally so tests never hit the real HTTP client."""
+    mock = AsyncMock()
+    with patch("app.services.combat_service.events.centrifugo", mock):
+        yield mock

--- a/apps/control-server/tests/test_spell_declarative_effects.py
+++ b/apps/control-server/tests/test_spell_declarative_effects.py
@@ -8,7 +8,13 @@ from app.models.combat import CombatPhase, CombatState
 from app.schemas.base_spell import BaseSpellCreate
 from app.schemas.roll import RollActorStats
 from app.services.combat import CombatService
-from app.services.combat_service.condition_effects_predicates import get_carrying_capacity_multiplier
+from app.services.combat_service.condition_effects_predicates import (
+    _declarative_effect_group_key,
+    explain_check_modifier_sources,
+    get_carrying_capacity_multiplier,
+    get_passive_skill_bonus,
+    resolve_check_advantage_mode,
+)
 
 
 class TestSpellDeclarativeEffectSchemas(unittest.TestCase):
@@ -925,7 +931,7 @@ class TestSpellDeclarativeEffectRuntime(unittest.TestCase):
             new=AsyncMock(),
         ), patch.object(
             CombatService,
-            "_emit_log",
+            "_emit_and_persist_log",
             new=AsyncMock(),
         ), patch.object(
             CombatService,
@@ -1029,3 +1035,224 @@ class TestCarryingCapacityMultiplier(unittest.TestCase):
         effects = [{"id": "no-meta", "kind": "spell_effect", "metadata": None}]
         participant = self._make_participant(effects)
         self.assertEqual(get_carrying_capacity_multiplier(participant), 1.0)
+
+
+class TestDeclarativeEffectGroupKey(unittest.TestCase):
+    def _effect(self, effect_id="eff-1"):
+        return {"id": effect_id}
+
+    def test_prefers_declarative_effect_group_id(self):
+        metadata = {"declarative_effect_group_id": "group-abc"}
+        key = _declarative_effect_group_key(metadata, self._effect(), "passive_skill_bonus", "perception|5")
+        self.assertEqual(key, "group-abc")
+
+    def test_composite_key_from_source_spell_key(self):
+        metadata = {"source_spell_key": "owls_wisdom", "selected_variant_key": "owls_wisdom"}
+        key = _declarative_effect_group_key(metadata, self._effect(), "passive_skill_bonus", "perception|5")
+        self.assertEqual(key, "owls_wisdom|owls_wisdom|passive_skill_bonus|perception|5")
+
+    def test_composite_key_from_source_spell_name_fallback(self):
+        metadata = {"source_spell_name": "Owl's Wisdom"}
+        key = _declarative_effect_group_key(metadata, self._effect(), "passive_skill_bonus", "perception|5")
+        self.assertEqual(key, "Owl's Wisdom||passive_skill_bonus|perception|5")
+
+    def test_composite_key_includes_effect_type_and_params_key(self):
+        metadata = {"source_spell_key": "enhance_ability", "selected_variant_key": "bulls_strength"}
+        key = _declarative_effect_group_key(metadata, self._effect(), "carrying_capacity_multiplier", "2")
+        self.assertEqual(key, "enhance_ability|bulls_strength|carrying_capacity_multiplier|2")
+
+    def test_falls_back_to_effect_id(self):
+        metadata = {}
+        key = _declarative_effect_group_key(metadata, self._effect("my-id"), "advantage_on_checks", "wisdom")
+        self.assertEqual(key, "my-id")
+
+    def test_falls_back_to_unknown_with_python_id(self):
+        metadata = {}
+        effect = {}
+        key = _declarative_effect_group_key(metadata, effect, "advantage_on_checks", "wisdom")
+        self.assertTrue(key.startswith("__unknown_"))
+
+    def test_empty_group_id_treated_as_absent(self):
+        metadata = {"declarative_effect_group_id": ""}
+        key = _declarative_effect_group_key(metadata, self._effect(), "passive_skill_bonus", "perception|5")
+        self.assertNotEqual(key, "")
+
+    def test_different_params_keys_produce_different_groups(self):
+        metadata = {"source_spell_key": "owls_wisdom"}
+        key1 = _declarative_effect_group_key(metadata, self._effect(), "passive_skill_bonus", "perception|5")
+        key2 = _declarative_effect_group_key(metadata, self._effect(), "passive_skill_bonus", "perception|3")
+        self.assertNotEqual(key1, key2)
+
+
+class TestAdvantageOnChecksDedup(unittest.TestCase):
+    def _make_participant(self, effects):
+        return {"id": "p-1", "active_effects": effects, "status": "active"}
+
+    def _advantage_effect(self, ability="wisdom", group_id=None, source_spell_key=None, effect_id="eff-1"):
+        metadata = {
+            "declarative_effect": {
+                "type": "advantage_on_checks",
+                "params": {"ability": ability, "against": "any"},
+            },
+            "source_spell_name": "Test Spell",
+        }
+        if group_id:
+            metadata["declarative_effect_group_id"] = group_id
+        if source_spell_key:
+            metadata["source_spell_key"] = source_spell_key
+        return {
+            "id": effect_id,
+            "kind": "spell_effect",
+            "metadata": metadata,
+        }
+
+    def test_two_identical_advantages_same_group_resolve_to_advantage(self):
+        effects = [
+            self._advantage_effect(group_id="group-1", effect_id="eff-1"),
+            self._advantage_effect(group_id="group-1", effect_id="eff-2"),
+        ]
+        participant = self._make_participant(effects)
+        mode = resolve_check_advantage_mode(participant, "wisdom")
+        self.assertEqual(mode, "advantage")
+
+    def test_two_identical_advantages_same_source_key_resolve_to_advantage(self):
+        effects = [
+            self._advantage_effect(source_spell_key="owls_wisdom", effect_id="eff-1"),
+            self._advantage_effect(source_spell_key="owls_wisdom", effect_id="eff-2"),
+        ]
+        participant = self._make_participant(effects)
+        mode = resolve_check_advantage_mode(participant, "wisdom")
+        self.assertEqual(mode, "advantage")
+
+    def test_different_groups_both_contribute(self):
+        effects = [
+            self._advantage_effect(group_id="group-a", effect_id="eff-1"),
+            self._advantage_effect(group_id="group-b", effect_id="eff-2"),
+        ]
+        participant = self._make_participant(effects)
+        mode = resolve_check_advantage_mode(participant, "wisdom")
+        self.assertEqual(mode, "advantage")
+
+    def test_advantage_plus_disadvantage_same_group_cancels(self):
+        adv = self._advantage_effect(group_id="group-1", effect_id="eff-1")
+        dis = self._advantage_effect(group_id="group-1", effect_id="eff-2")
+        dis["metadata"]["declarative_effect"]["type"] = "disadvantage_on_checks"
+        participant = self._make_participant([adv, dis])
+        mode = resolve_check_advantage_mode(participant, "wisdom")
+        self.assertEqual(mode, "normal")
+
+    def test_effects_without_metadata_are_skipped(self):
+        effects = [
+            {"id": "no-meta", "kind": "spell_effect", "metadata": None},
+            self._advantage_effect(effect_id="eff-2"),
+        ]
+        participant = self._make_participant(effects)
+        mode = resolve_check_advantage_mode(participant, "wisdom")
+        self.assertEqual(mode, "advantage")
+
+
+class TestExplainCheckModifierSourcesDedup(unittest.TestCase):
+    def _make_participant(self, effects):
+        return {"id": "p-1", "active_effects": effects, "status": "active"}
+
+    def _advantage_effect(self, ability="wisdom", group_id=None, source_spell_key=None, effect_id="eff-1"):
+        metadata = {
+            "declarative_effect": {
+                "type": "advantage_on_checks",
+                "params": {"ability": ability, "against": "any"},
+            },
+            "source_spell_name": "Test Spell",
+        }
+        if group_id:
+            metadata["declarative_effect_group_id"] = group_id
+        if source_spell_key:
+            metadata["source_spell_key"] = source_spell_key
+        return {
+            "id": effect_id,
+            "kind": "spell_effect",
+            "metadata": metadata,
+        }
+
+    def test_two_identical_effects_same_group_returns_one_entry(self):
+        effects = [
+            self._advantage_effect(group_id="group-1", effect_id="eff-1"),
+            self._advantage_effect(group_id="group-1", effect_id="eff-2"),
+        ]
+        participant = self._make_participant(effects)
+        explanations = explain_check_modifier_sources(participant, ability="wisdom", roll_type="ability")
+        self.assertEqual(len(explanations), 1)
+        self.assertTrue(explanations[0]["applied"])
+
+    def test_two_identical_effects_same_source_key_returns_one_entry(self):
+        effects = [
+            self._advantage_effect(source_spell_key="owls_wisdom", effect_id="eff-1"),
+            self._advantage_effect(source_spell_key="owls_wisdom", effect_id="eff-2"),
+        ]
+        participant = self._make_participant(effects)
+        explanations = explain_check_modifier_sources(participant, ability="wisdom", roll_type="ability")
+        self.assertEqual(len(explanations), 1)
+
+    def test_different_groups_returns_both(self):
+        effects = [
+            self._advantage_effect(group_id="group-a", effect_id="eff-1"),
+            self._advantage_effect(group_id="group-b", effect_id="eff-2"),
+        ]
+        participant = self._make_participant(effects)
+        explanations = explain_check_modifier_sources(participant, ability="wisdom", roll_type="ability")
+        self.assertEqual(len(explanations), 2)
+
+    def test_no_metadata_effects_are_skipped(self):
+        effects = [
+            {"id": "no-meta", "kind": "spell_effect", "metadata": None},
+            self._advantage_effect(effect_id="eff-2"),
+        ]
+        participant = self._make_participant(effects)
+        explanations = explain_check_modifier_sources(participant, ability="wisdom", roll_type="ability")
+        self.assertEqual(len(explanations), 1)
+
+
+class TestPassiveSkillBonusDedup(unittest.TestCase):
+    def _make_participant(self, effects):
+        return {"id": "p-1", "active_effects": effects, "status": "active"}
+
+    def _bonus_effect(self, skill="perception", bonus=5, group_id=None, source_spell_key=None, effect_id="eff-1"):
+        metadata = {
+            "declarative_effect": {
+                "type": "passive_skill_bonus",
+                "params": {"skill": skill, "bonus": bonus},
+            },
+            "source_spell_name": "Test Spell",
+        }
+        if group_id:
+            metadata["declarative_effect_group_id"] = group_id
+        if source_spell_key:
+            metadata["source_spell_key"] = source_spell_key
+        return {
+            "id": effect_id,
+            "kind": "spell_effect",
+            "metadata": metadata,
+        }
+
+    def test_two_same_group_bonuses_uses_max(self):
+        effects = [
+            self._bonus_effect(bonus=5, group_id="group-1", effect_id="eff-1"),
+            self._bonus_effect(bonus=3, group_id="group-1", effect_id="eff-2"),
+        ]
+        participant = self._make_participant(effects)
+        self.assertEqual(get_passive_skill_bonus(participant, "perception"), 5)
+
+    def test_two_same_source_key_bonuses_uses_max(self):
+        effects = [
+            self._bonus_effect(bonus=5, source_spell_key="owls_wisdom", effect_id="eff-1"),
+            self._bonus_effect(bonus=5, source_spell_key="owls_wisdom", effect_id="eff-2"),
+        ]
+        participant = self._make_participant(effects)
+        self.assertEqual(get_passive_skill_bonus(participant, "perception"), 5)
+
+    def test_different_groups_sum(self):
+        effects = [
+            self._bonus_effect(bonus=5, group_id="group-a", effect_id="eff-1"),
+            self._bonus_effect(bonus=3, group_id="group-b", effect_id="eff-2"),
+        ]
+        participant = self._make_participant(effects)
+        self.assertEqual(get_passive_skill_bonus(participant, "perception"), 8)

--- a/apps/control-web/src/features/character-sheet/utils/calculations.test.ts
+++ b/apps/control-web/src/features/character-sheet/utils/calculations.test.ts
@@ -7,6 +7,7 @@ import {
   computeEncumbranceTier,
   computePassiveSkillBonus,
   computePassiveSkillBonusSources,
+  declarativeEffectGroupKey,
   LB_TO_KG,
 } from "./calculations";
 import type { ActiveEffect } from "../../../shared/api/combatRepo";
@@ -639,5 +640,70 @@ describe("computeEncumbranceTier", () => {
     expect(justBelow.tier).toBe("normal");
     const justAbove = computeEncumbranceTier({ strengthScore: 10, totalWeightKg: thresholdKg + 0.01 });
     expect(justAbove.tier).toBe("encumbered");
+  });
+});
+
+describe("declarativeEffectGroupKey", () => {
+  const makeEffect = (id = "eff-1"): ActiveEffect => ({
+    id,
+    kind: "spell_effect",
+    duration_type: "manual",
+    created_at: "2026-05-01T00:00:00Z",
+  });
+
+  it("prioriza declarative_effect_group_id", () => {
+    const metadata = { declarative_effect_group_id: "group-abc" };
+    const key = declarativeEffectGroupKey(metadata, makeEffect(), "passive_skill_bonus", "perception|5", 0);
+    expect(key).toBe("group-abc");
+  });
+
+  it("gera composite key a partir de source_spell_key", () => {
+    const metadata = { source_spell_key: "owls_wisdom", selected_variant_key: "owls_wisdom" };
+    const key = declarativeEffectGroupKey(metadata, makeEffect(), "passive_skill_bonus", "perception|5", 0);
+    expect(key).toBe("owls_wisdom|owls_wisdom|passive_skill_bonus|perception|5");
+  });
+
+  it("gera composite key a partir de source_spell_name como fallback", () => {
+    const metadata = { source_spell_name: "Owl's Wisdom" };
+    const key = declarativeEffectGroupKey(metadata, makeEffect(), "passive_skill_bonus", "perception|5", 0);
+    expect(key).toBe("Owl's Wisdom||passive_skill_bonus|perception|5");
+  });
+
+  it("inclui effectType e paramsKey na composite key", () => {
+    const metadata = { source_spell_key: "enhance_ability", selected_variant_key: "bulls_strength" };
+    const key = declarativeEffectGroupKey(metadata, makeEffect(), "carrying_capacity_multiplier", "2", 0);
+    expect(key).toBe("enhance_ability|bulls_strength|carrying_capacity_multiplier|2");
+  });
+
+  it("cai para effect.id quando não há metadata", () => {
+    const key = declarativeEffectGroupKey({}, makeEffect("my-id"), "advantage_on_checks", "wisdom", 0);
+    expect(key).toBe("my-id");
+  });
+
+  it("cai para __unknown_{fallbackIndex} quando não há effect.id", () => {
+    const effect = { ...makeEffect(), id: undefined as unknown as string };
+    const key = declarativeEffectGroupKey({}, effect, "advantage_on_checks", "wisdom", 42);
+    expect(key).toBe("__unknown_42");
+  });
+
+  it("group_id vazio é tratado como ausente", () => {
+    const metadata = { declarative_effect_group_id: "" };
+    const key = declarativeEffectGroupKey(metadata, makeEffect(), "passive_skill_bonus", "perception|5", 0);
+    expect(key).not.toBe("");
+  });
+
+  it("paramsKeys diferentes produzem grupos diferentes", () => {
+    const metadata = { source_spell_key: "owls_wisdom" };
+    const key1 = declarativeEffectGroupKey(metadata, makeEffect(), "passive_skill_bonus", "perception|5", 0);
+    const key2 = declarativeEffectGroupKey(metadata, makeEffect(), "passive_skill_bonus", "perception|3", 0);
+    expect(key1).not.toBe(key2);
+  });
+
+  it("não usa Math.random()", () => {
+    const effect = { ...makeEffect(), id: undefined as unknown as string };
+    const key1 = declarativeEffectGroupKey({}, effect, "test", "", 7);
+    const key2 = declarativeEffectGroupKey({}, effect, "test", "", 7);
+    expect(key1).toBe(key2);
+    expect(key1).toBe("__unknown_7");
   });
 });

--- a/apps/control-web/src/features/character-sheet/utils/calculations.ts
+++ b/apps/control-web/src/features/character-sheet/utils/calculations.ts
@@ -60,22 +60,33 @@ export const computeInitiative = (dexMod: number): number => dexMod;
 
 export type PassiveSkillBonusSource = { label: string; value: number; groupKey: string };
 
-function passiveBonusGroupKey(
+export function declarativeEffectGroupKey(
   metadata: Record<string, unknown>,
   effect: ActiveEffect,
-  params: Record<string, unknown>,
+  effectType: string,
+  paramsKey: string,
+  fallbackIndex: number,
 ): string {
   const groupId = metadata.declarative_effect_group_id;
   if (typeof groupId === "string" && groupId) return groupId;
   const source = (metadata.source_spell_key as string) || (metadata.source_spell_name as string);
   if (typeof source === "string" && source) {
     const variant = (metadata.selected_variant_key as string) || "";
-    const sk = (params.skill as string) || "";
-    const bonus = params.bonus ?? "";
-    return `${source}|${variant}|passive_skill_bonus|${sk}|${bonus}`;
+    return `${source}|${variant}|${effectType}|${paramsKey}`;
   }
   if (typeof effect.id === "string" && effect.id) return effect.id;
-  return `__unknown_${effect.id ?? Math.random()}`;
+  return `__unknown_${fallbackIndex}`;
+}
+
+function passiveBonusGroupKey(
+  metadata: Record<string, unknown>,
+  effect: ActiveEffect,
+  params: Record<string, unknown>,
+  index: number,
+): string {
+  const sk = (params.skill as string) || "";
+  const bonus = params.bonus ?? "";
+  return declarativeEffectGroupKey(metadata, effect, "passive_skill_bonus", `${sk}|${bonus}`, index);
 }
 
 export const computePassiveSkillBonusSources = (
@@ -83,7 +94,8 @@ export const computePassiveSkillBonusSources = (
   skill: string,
 ): PassiveSkillBonusSource[] => {
   const groupBest = new Map<string, PassiveSkillBonusSource>();
-  for (const effect of activeEffects) {
+  for (let i = 0; i < activeEffects.length; i++) {
+    const effect = activeEffects[i];
     const metadata = effect.metadata;
     if (!metadata || typeof metadata !== "object") continue;
     const declarative = metadata.declarative_effect;
@@ -97,7 +109,7 @@ export const computePassiveSkillBonusSources = (
       (typeof effect.display_label === "string" && effect.display_label) ||
       (typeof metadata.source_spell_name === "string" && metadata.source_spell_name) ||
       "Passive skill bonus";
-    const key = passiveBonusGroupKey(metadata as Record<string, unknown>, effect, p);
+    const key = passiveBonusGroupKey(metadata as Record<string, unknown>, effect, p, i);
     const existing = groupBest.get(key);
     if (!existing || p.bonus > existing.value) {
       groupBest.set(key, { label, value: p.bonus, groupKey: key });
@@ -245,24 +257,18 @@ function carryingCapacityGroupKey(
   metadata: Record<string, unknown>,
   effect: ActiveEffect,
   params: Record<string, unknown>,
+  index: number,
 ): string {
-  const groupId = metadata.declarative_effect_group_id;
-  if (typeof groupId === "string" && groupId) return groupId;
-  const source = (metadata.source_spell_key as string) || (metadata.source_spell_name as string);
-  if (typeof source === "string" && source) {
-    const variant = (metadata.selected_variant_key as string) || "";
-    const mult = params.multiplier ?? "";
-    return `${source}|${variant}|carrying_capacity_multiplier|${mult}`;
-  }
-  if (typeof effect.id === "string" && effect.id) return effect.id;
-  return `__unknown_${effect.id ?? Math.random()}`;
+  const mult = params.multiplier ?? "";
+  return declarativeEffectGroupKey(metadata, effect, "carrying_capacity_multiplier", `${mult}`, index);
 }
 
 export const computeCarryingCapacityMultiplierSources = (
   activeEffects: ActiveEffect[],
 ): CarryingCapacitySource[] => {
   const groupBest = new Map<string, CarryingCapacitySource>();
-  for (const effect of activeEffects) {
+  for (let i = 0; i < activeEffects.length; i++) {
+    const effect = activeEffects[i];
     const metadata = effect.metadata;
     if (!metadata || typeof metadata !== "object") continue;
     const declarative = metadata.declarative_effect;
@@ -276,7 +282,7 @@ export const computeCarryingCapacityMultiplierSources = (
       (typeof effect.display_label === "string" && effect.display_label) ||
       (typeof metadata.source_spell_name === "string" && metadata.source_spell_name) ||
       "Carrying capacity bonus";
-    const key = carryingCapacityGroupKey(metadata as Record<string, unknown>, effect, p);
+    const key = carryingCapacityGroupKey(metadata as Record<string, unknown>, effect, p, i);
     const existing = groupBest.get(key);
     if (!existing || p.multiplier > existing.multiplier) {
       groupBest.set(key, { label, multiplier: p.multiplier, groupKey: key });

--- a/apps/control-web/src/features/rolls/checkModifierSources.test.ts
+++ b/apps/control-web/src/features/rolls/checkModifierSources.test.ts
@@ -51,4 +51,83 @@ describe("deriveCheckModifierPreviewSources", () => {
     expect(preview[0]?.applied).toBe(false);
     expect(preview[0]?.skip_reason).toBe("ability_mismatch");
   });
+
+  it("deduplica dois efeitos idênticos com mesmo group_id", () => {
+    const effect1 = {
+      ...owlsWisdomEffect,
+      id: "effect-1",
+      metadata: {
+        ...owlsWisdomEffect.metadata,
+        declarative_effect_group_id: "group-1",
+      },
+    };
+    const effect2 = {
+      ...owlsWisdomEffect,
+      id: "effect-2",
+      metadata: {
+        ...owlsWisdomEffect.metadata,
+        declarative_effect_group_id: "group-1",
+      },
+    };
+    const preview = deriveCheckModifierPreviewSources([effect1, effect2], {
+      rollType: "ability",
+      ability: "wisdom",
+    });
+
+    expect(preview).toHaveLength(1);
+    expect(preview[0]?.applied).toBe(true);
+  });
+
+  it("deduplica dois efeitos idênticos com mesmo source_spell_key", () => {
+    const effect1 = {
+      ...owlsWisdomEffect,
+      id: "effect-1",
+      metadata: {
+        ...owlsWisdomEffect.metadata,
+        source_spell_key: "owls_wisdom",
+      },
+    };
+    const effect2 = {
+      ...owlsWisdomEffect,
+      id: "effect-2",
+      metadata: {
+        ...owlsWisdomEffect.metadata,
+        source_spell_key: "owls_wisdom",
+      },
+    };
+    const preview = deriveCheckModifierPreviewSources([effect1, effect2], {
+      rollType: "ability",
+      ability: "wisdom",
+    });
+
+    expect(preview).toHaveLength(1);
+    expect(preview[0]?.applied).toBe(true);
+  });
+
+  it("mantém efeitos de grupos diferentes", () => {
+    const effect1 = {
+      ...owlsWisdomEffect,
+      id: "effect-1",
+      metadata: {
+        ...owlsWisdomEffect.metadata,
+        declarative_effect_group_id: "group-a",
+      },
+    };
+    const effect2 = {
+      ...owlsWisdomEffect,
+      id: "effect-2",
+      metadata: {
+        ...owlsWisdomEffect.metadata,
+        declarative_effect_group_id: "group-b",
+      },
+    };
+    const preview = deriveCheckModifierPreviewSources([effect1, effect2], {
+      rollType: "ability",
+      ability: "wisdom",
+    });
+
+    expect(preview).toHaveLength(2);
+    expect(preview[0]?.applied).toBe(true);
+    expect(preview[1]?.applied).toBe(true);
+  });
 });

--- a/apps/control-web/src/features/rolls/checkModifierSources.ts
+++ b/apps/control-web/src/features/rolls/checkModifierSources.ts
@@ -1,6 +1,7 @@
 import type { AbilityName, SkillName } from "../../entities/roll/rollResolution.types";
 import type { ActiveEffect } from "../../shared/api/combatRepo";
 import { SKILL_ABILITY_MAP } from "../character-sheet/constants";
+import { declarativeEffectGroupKey } from "../character-sheet/utils/calculations";
 
 type RequestRollType = "ability" | "skill";
 
@@ -49,7 +50,9 @@ export const deriveCheckModifierPreviewSources = (
   }
 
   const previewSources: CheckModifierSourcePreview[] = [];
-  for (const effect of activeEffects ?? []) {
+  const seenKeys = new Set<string>();
+  for (let i = 0; i < (activeEffects ?? []).length; i++) {
+    const effect = (activeEffects ?? [])[i];
     if (effect.kind !== "spell_effect" || !effect.metadata || typeof effect.metadata !== "object") {
       continue;
     }
@@ -69,6 +72,13 @@ export const deriveCheckModifierPreviewSources = (
     const effectAbility = typeof (params as Record<string, unknown>).ability === "string"
       ? ((params as Record<string, unknown>).ability as string)
       : null;
+
+    const dedupKey = `${declarativeEffectGroupKey(effect.metadata as Record<string, unknown>, effect, String(effectType), effectAbility ?? "", i)}|${effectType}`;
+    if (seenKeys.has(dedupKey)) {
+      continue;
+    }
+    seenKeys.add(dedupKey);
+
     const against = normalizeAgainst((params as Record<string, unknown>).against);
     const selectedTargetParticipantId =
       typeof (effect.metadata as Record<string, unknown>).selected_target_participant_id === "string"


### PR DESCRIPTION
## Context

Closes #164.

Declarative effects (`passive_skill_bonus`, `carrying_capacity_multiplier`, `advantage_on_checks`) previously implemented deduplication in isolated, effect-specific ways. This led to:

* duplicated logic across frontend and backend
* inconsistent behavior between calculations and previews
* lack of deduplication for `advantage_on_checks` (causing duplicated sources in UI)
* increased risk of stacking bugs (e.g. Owl’s Wisdom +10, Bull’s Strength ×4)

---

## What was implemented

### 1. Centralized group-key helper (FE + BE)

Introduced a unified strategy to identify equivalent declarative effects:

Priority:

```md
declarative_effect_group_id
→ composite key (source + variant + effectType + params)
→ effect.id fallback
→ stable fallback index (frontend only)
```

* Backend: `_declarative_effect_group_key`
* Frontend: `declarativeEffectGroupKey`

Existing helpers were refactored to use this shared logic:

* `passive_skill_bonus`
* `carrying_capacity_multiplier`

---

### 2. Deduplication for `advantage_on_checks` (NEW)

Previously missing.

Now applied in:

* `resolve_check_advantage_mode`
* `explain_check_modifier_sources`
* `deriveCheckModifierPreviewSources` (frontend)

Behavior:

* equivalent effects are counted once
* UI no longer shows duplicated advantage sources
* stacking still works across different groups

---

### 3. Consistent read-time deduplication

Deduplication is now applied at:

```md
✔ calculation (passive bonuses, multipliers)
✔ roll resolution (advantage/disadvantage)
✔ preview (frontend modifier sources)
✔ explanation (session activity / modal)
```

All using the same group-key semantics.

---

## Important design decision

```md
Deduplication is read-time only
```

This PR **does NOT modify persisted data**:

* `_replace_matching_effects` remains unchanged
* duplicate effects may still exist in `active_effects`
* deduplication is applied only when reading/calculating

### Rationale

* avoids risk of deleting legitimate effects
* preserves full audit/debug visibility
* prevents key collision data loss
* safer incremental evolution

---

## Behavior guarantees

* Owl’s Wisdom never becomes +10
* Bull’s Strength never becomes ×4
* advantage sources never duplicate in UI
* different sources (different groups) still stack correctly
* effects without metadata do NOT collapse incorrectly (fallback to `effect.id`)

---

## Tests

### Backend

* advantage deduplication (same group → single effect)
* multiple groups → preserved
* fallback behavior without metadata

### Frontend

* preview deduplication for advantage
* group-key priority correctness
* no accidental collapse without group id

---

## Summary

This PR establishes a **single, consistent deduplication model** for declarative effects across the system, fixing current inconsistencies and preventing future stacking bugs — without altering persistence behavior.

