### PR TITLE
feat(encumbrance): implement movement penalty calculations and UI upd…

### DIFF
--- a/apps/control-web/src/features/character-sheet/utils/calculations.test.ts
+++ b/apps/control-web/src/features/character-sheet/utils/calculations.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyEncumbranceMovementPenalty,
   computeAbilityScoreTotal,
   computeCarryingCapacity,
   computeCarryingCapacityMultiplier,
@@ -640,6 +641,44 @@ describe("computeEncumbranceTier", () => {
     expect(justBelow.tier).toBe("normal");
     const justAbove = computeEncumbranceTier({ strengthScore: 10, totalWeightKg: thresholdKg + 0.01 });
     expect(justAbove.tier).toBe("encumbered");
+  });
+});
+
+describe("applyEncumbranceMovementPenalty", () => {
+  it("normal → sem alteração", () => {
+    expect(applyEncumbranceMovementPenalty(9, "normal")).toBe(9);
+  });
+
+  it("encumbered → -3", () => {
+    expect(applyEncumbranceMovementPenalty(9, "encumbered")).toBe(6);
+  });
+
+  it("heavily_encumbered → -6", () => {
+    expect(applyEncumbranceMovementPenalty(9, "heavily_encumbered")).toBe(3);
+  });
+
+  it("overloaded → 0", () => {
+    expect(applyEncumbranceMovementPenalty(9, "overloaded")).toBe(0);
+  });
+
+  it("nunca negativo", () => {
+    expect(applyEncumbranceMovementPenalty(2, "heavily_encumbered")).toBe(0);
+    expect(applyEncumbranceMovementPenalty(1, "encumbered")).toBe(0);
+  });
+
+  it("speed 0 → 0 em qualquer tier", () => {
+    expect(applyEncumbranceMovementPenalty(0, "normal")).toBe(0);
+    expect(applyEncumbranceMovementPenalty(0, "encumbered")).toBe(0);
+    expect(applyEncumbranceMovementPenalty(0, "heavily_encumbered")).toBe(0);
+    expect(applyEncumbranceMovementPenalty(0, "overloaded")).toBe(0);
+  });
+
+  it("anões (8m) encumbered → 5m", () => {
+    expect(applyEncumbranceMovementPenalty(8, "encumbered")).toBe(5);
+  });
+
+  it("wood elf (11m) heavily_encumbered → 5m", () => {
+    expect(applyEncumbranceMovementPenalty(11, "heavily_encumbered")).toBe(5);
   });
 });
 

--- a/apps/control-web/src/features/character-sheet/utils/calculations.ts
+++ b/apps/control-web/src/features/character-sheet/utils/calculations.ts
@@ -251,6 +251,16 @@ export const computeEncumbranceTier = ({
   };
 };
 
+export const applyEncumbranceMovementPenalty = (
+  baseSpeedMeters: number,
+  tier: EncumbranceTier,
+): number => {
+  if (tier === "overloaded") return 0;
+  if (tier === "heavily_encumbered") return Math.max(0, baseSpeedMeters - 6);
+  if (tier === "encumbered") return Math.max(0, baseSpeedMeters - 3);
+  return baseSpeedMeters;
+};
+
 export type CarryingCapacitySource = { label: string; multiplier: number; groupKey: string };
 
 function carryingCapacityGroupKey(

--- a/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
+++ b/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
@@ -329,6 +329,13 @@ export const PlayerCombatModeShell = ({
             ),
           )
       : null;
+  const encumbranceMovementWarning =
+    movementPreview.preview != null &&
+    enrichedPlayerStatus &&
+    enrichedPlayerStatus.baseSpeedMeters > 0 &&
+    pathCostUnitsToMeters(movementPreview.preview.path_cost_units) > enrichedPlayerStatus.effectiveSpeedMeters
+      ? t("playerBoard.encumbranceMovementExceed")
+      : null;
   const movementHintMessage = movementRejectionReason ?? movementPreview.error;
   const mapHint =
     movementEnabled && movementHintMessage
@@ -336,7 +343,9 @@ export const PlayerCombatModeShell = ({
       : movementEnabled && movementPreview.loading && movementSelectedCell
       ? t("combatUi.movementChecking")
       : movementEnabled && movementPreviewMessage
-      ? movementPreviewMessage
+      ? encumbranceMovementWarning
+        ? `${movementPreviewMessage}\n${encumbranceMovementWarning}`
+        : movementPreviewMessage
       : movementEnabled
       ? t("combatUi.mapHintMove")
       : activeActionPanel === "attack"
@@ -482,6 +491,19 @@ export const PlayerCombatModeShell = ({
                 <div className="rounded-3xl border border-white/8 bg-white/4 px-4 py-4">
                   <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">{t("combatUi.armorClass")}</p>
                   <p className="mt-2 text-xl font-semibold text-white">{enrichedPlayerStatus?.ac ?? "-"}</p>
+                </div>
+                <div className="rounded-3xl border border-white/8 bg-white/4 px-4 py-4">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">{t("playerBoard.speedLabel")}</p>
+                  <p className="mt-2 text-xl font-semibold text-white">
+                    {enrichedPlayerStatus && enrichedPlayerStatus.baseSpeedMeters > 0
+                      ? `${enrichedPlayerStatus.effectiveSpeedMeters} m`
+                      : "-"}
+                  </p>
+                  {enrichedPlayerStatus && enrichedPlayerStatus.effectiveSpeedMeters < enrichedPlayerStatus.baseSpeedMeters ? (
+                    <p className="mt-1 text-[10px] text-amber-400">
+                      {`${t("playerBoard.speedPenaltyHint")} (base ${enrichedPlayerStatus.baseSpeedMeters} m)`}
+                    </p>
+                  ) : null}
                 </div>
                 <div className="rounded-3xl border border-white/8 bg-white/4 px-4 py-4">
                   <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">{t("sheet.skills.passivePerception")}</p>

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
@@ -108,10 +108,22 @@ export const PlayerBoardStatusPanel = ({
 
           <DeathSaveCard combatActive={combatActive} playerStatus={playerStatus} />
 
-          <div className="mt-5 grid gap-3 xl:grid-cols-[minmax(0,0.68fr)_minmax(0,0.68fr)_minmax(0,0.68fr)_minmax(0,0.68fr)_minmax(0,1.64fr)]">
+          <div className="mt-5 grid gap-3 xl:grid-cols-[minmax(0,0.68fr)_minmax(0,0.68fr)_minmax(0,0.68fr)_minmax(0,0.68fr)_minmax(0,0.68fr)_minmax(0,1.64fr)]">
             <StatCard
               label={t("playerBoard.initiativeLabel")}
               value={`${playerStatus.initiative >= 0 ? "+" : ""}${playerStatus.initiative}`}
+            />
+            <StatCard
+              label={t("playerBoard.speedLabel")}
+              value={playerStatus.baseSpeedMeters > 0 ? `${playerStatus.effectiveSpeedMeters} m` : "-"}
+              accent={playerStatus.effectiveSpeedMeters < playerStatus.baseSpeedMeters
+                ? encumbranceAccentMap[playerStatus.encumbranceTier]
+                : undefined}
+              helper={
+                playerStatus.effectiveSpeedMeters < playerStatus.baseSpeedMeters
+                  ? `${t("playerBoard.speedPenaltyHint")} (base ${playerStatus.baseSpeedMeters} m)`
+                  : null
+              }
             />
             <StatCard
               label={t("sheet.skills.passivePerception")}

--- a/apps/control-web/src/pages/PlayerBoardPage/playerBoard.types.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/playerBoard.types.ts
@@ -42,6 +42,8 @@ export type PlayerBoardStatusSummary = {
   encumbranceNormalMaxKg: number;
   encumbranceEncumberedMaxKg: number;
   encumbranceHeavilyEncumberedMaxKg: number;
+  baseSpeedMeters: number;
+  effectiveSpeedMeters: number;
   experiencePoints: number;
   hitDiceRemaining: number;
   hitDiceTotal: number;

--- a/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardSummary.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardSummary.ts
@@ -6,7 +6,7 @@ import { useCharacterSheetDerived } from "../../features/character-sheet/hooks/u
 import { useCarryingCapacity } from "../../features/character-sheet/hooks/useCarryingCapacity";
 import { INITIAL_SHEET } from "../../features/character-sheet/model/initialSheet";
 import { getCharacterProgressState } from "../../features/character-sheet/utils/progression";
-import { computeTotalWeight, computeEncumbranceTier, LB_TO_KG } from "../../features/character-sheet/utils/calculations";
+import { computeTotalWeight, computeEncumbranceTier, applyEncumbranceMovementPenalty, LB_TO_KG } from "../../features/character-sheet/utils/calculations";
 import type { CharacterSheet } from "../../features/character-sheet/model/characterSheet.types";
 import type { ActiveEffect } from "../../shared/api/combatRepo";
 import type { LocaleKey } from "../../shared/i18n";
@@ -104,6 +104,11 @@ export const usePlayerBoardSummary = ({
     [playerSheet, totalWeightKg],
   );
 
+  const baseSpeedMeters = playerSheet?.speedMeters ?? 0;
+  const effectiveSpeedMeters = encumbrance
+    ? applyEncumbranceMovementPenalty(baseSpeedMeters, encumbrance.tier)
+    : baseSpeedMeters;
+
   const playerStatus = useMemo<PlayerBoardStatusSummary | null>(() => {
     if (!playerSheet) return null;
     return {
@@ -119,6 +124,8 @@ export const usePlayerBoardSummary = ({
       encumbranceNormalMaxKg: encumbrance?.normalMaxKg ?? 0,
       encumbranceEncumberedMaxKg: encumbrance?.encumberedMaxKg ?? 0,
       encumbranceHeavilyEncumberedMaxKg: encumbrance?.heavilyEncumberedMaxKg ?? 0,
+      baseSpeedMeters,
+      effectiveSpeedMeters,
       experiencePoints: playerSheet.experiencePoints,
       hitDiceRemaining: playerSheet.hitDiceRemaining,
       hitDiceTotal: playerSheet.hitDiceTotal,
@@ -136,7 +143,7 @@ export const usePlayerBoardSummary = ({
       totalWeightKg: Math.round(totalWeightKg),
       xpPercent: xpState.progressPercent,
     };
-  }, [ac, baseCarryingCapacityKg, carryingCapacityKg, carryingCapacitySources, currentWeapon, encumbrance, hpPercent, initiative, passivePerception, playerSheet, pushDragLiftKg, spellAttack, spellSaveDC, totalWeightKg, xpState.nextLevelThreshold, xpState.progressPercent]);
+  }, [ac, baseCarryingCapacityKg, baseSpeedMeters, carryingCapacityKg, carryingCapacitySources, currentWeapon, effectiveSpeedMeters, encumbrance, hpPercent, initiative, passivePerception, playerSheet, pushDragLiftKg, spellAttack, spellSaveDC, totalWeightKg, xpState.nextLevelThreshold, xpState.progressPercent]);
 
   return {
     boardDescription,

--- a/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
@@ -173,4 +173,7 @@ export const playerBoardEnUSDictionary = {
   "playerBoard.carryingCapacityBase": "Base",
   "playerBoard.pushDragLiftLabel": "Push/Drag/Lift",
   "playerBoard.encumbranceTierLabel": "Encumbrance",
+  "playerBoard.speedLabel": "Speed",
+  "playerBoard.speedPenaltyHint": "Penalized by encumbrance",
+  "playerBoard.encumbranceMovementExceed": "This path exceeds your effective speed due to encumbrance.",
 } as const;

--- a/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
@@ -173,4 +173,7 @@ export const playerBoardPtBRDictionary = {
   "playerBoard.carryingCapacityBase": "Base",
   "playerBoard.pushDragLiftLabel": "Empurrar/Puxar/Levantar",
   "playerBoard.encumbranceTierLabel": "Carga",
+  "playerBoard.speedLabel": "Velocidade",
+  "playerBoard.speedPenaltyHint": "Penalizado por carga",
+  "playerBoard.encumbranceMovementExceed": "Este trajeto excede sua velocidade efetiva por carga.",
 } as const;


### PR DESCRIPTION
## Summary

Implements frontend-only encumbrance movement penalty feedback.

## Changes

- Added `applyEncumbranceMovementPenalty`
- Added effective speed fields to player board summary
- Player Board now displays base vs effective speed
- Combat UI now displays effective speed
- Movement preview warns when path exceeds effective speed
- Added i18n labels for speed and encumbrance penalty

## Scope

This PR only calculates and displays penalties. It does not enforce movement limits and does not change backend logic.

## Validation

- Lint clean
- Typecheck clean/no new errors
- 1152 tests passing
- Existing unrelated `SpellAoeFootprintPreview` failures remain