### PR TITLE
feat(encumbrance): apply encumbrance disadvantage to ability checks

### DIFF
--- a/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
+++ b/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
@@ -226,9 +226,10 @@ export const PlayerCombatModeShell = ({
       ability: (pendingRoll.ability ?? null) as AbilityName | null,
       skill: (pendingRoll.skill ?? null) as SkillName | null,
       targetParticipantId: pendingRoll.targetParticipantId ?? null,
+      encumbranceTier: playerStatus?.encumbranceTier,
     });
     return preview.length > 0 ? preview : undefined;
-  }, [myParticipant, pendingRoll]);
+  }, [myParticipant, pendingRoll, playerStatus?.encumbranceTier]);
   const movementEnabled =
     movementMode &&
     combat.state?.use_map !== false &&

--- a/apps/control-web/src/features/rolls/checkModifierSources.test.ts
+++ b/apps/control-web/src/features/rolls/checkModifierSources.test.ts
@@ -131,3 +131,110 @@ describe("deriveCheckModifierPreviewSources", () => {
     expect(preview[1]?.applied).toBe(true);
   });
 });
+
+describe("deriveCheckModifierPreviewSources — encumbrance disadvantage", () => {
+  it("heavily_encumbered + STR → disadvantage aplicada", () => {
+    const preview = deriveCheckModifierPreviewSources([], {
+      rollType: "ability",
+      ability: "strength",
+      encumbranceTier: "heavily_encumbered",
+    });
+
+    expect(preview).toHaveLength(1);
+    expect(preview[0]?.applied).toBe(true);
+    expect(preview[0]?.modifier_type).toBe("disadvantage");
+    expect(preview[0]?.source_label).toBe("Carga");
+    expect(preview[0]?.ability).toBe("strength");
+  });
+
+  it("heavily_encumbered + INT → nenhuma entry de encumbrance", () => {
+    const preview = deriveCheckModifierPreviewSources([], {
+      rollType: "ability",
+      ability: "intelligence",
+      encumbranceTier: "heavily_encumbered",
+    });
+
+    expect(preview).toHaveLength(0);
+  });
+
+  it("overloaded + DEX → disadvantage aplicada", () => {
+    const preview = deriveCheckModifierPreviewSources([], {
+      rollType: "ability",
+      ability: "dexterity",
+      encumbranceTier: "overloaded",
+    });
+
+    expect(preview).toHaveLength(1);
+    expect(preview[0]?.applied).toBe(true);
+    expect(preview[0]?.modifier_type).toBe("disadvantage");
+  });
+
+  it("encumbered + STR → nenhuma entry de encumbrance", () => {
+    const preview = deriveCheckModifierPreviewSources([], {
+      rollType: "ability",
+      ability: "strength",
+      encumbranceTier: "encumbered",
+    });
+
+    expect(preview).toHaveLength(0);
+  });
+
+  it("normal + STR → nenhuma entry de encumbrance", () => {
+    const preview = deriveCheckModifierPreviewSources([], {
+      rollType: "ability",
+      ability: "strength",
+      encumbranceTier: "normal",
+    });
+
+    expect(preview).toHaveLength(0);
+  });
+
+  it("sem encumbranceTier → funciona como antes", () => {
+    const preview = deriveCheckModifierPreviewSources([], {
+      rollType: "ability",
+      ability: "strength",
+    });
+
+    expect(preview).toHaveLength(0);
+  });
+
+  it("advantage (effect) + encumbrance disadvantage → ambas aplicadas", () => {
+    const owlsWisdomEffect = {
+      id: "effect-1",
+      kind: "spell_effect" as const,
+      duration_type: "manual" as const,
+      created_at: "2026-05-02T00:00:00Z",
+      metadata: {
+        source_spell_name: "Bless",
+        declarative_effect: {
+          type: "advantage_on_checks",
+          params: { ability: "strength", against: "any" },
+        },
+      },
+    };
+    const preview = deriveCheckModifierPreviewSources([owlsWisdomEffect], {
+      rollType: "ability",
+      ability: "strength",
+      encumbranceTier: "heavily_encumbered",
+    });
+
+    expect(preview).toHaveLength(2);
+    expect(preview[0]?.modifier_type).toBe("advantage");
+    expect(preview[0]?.applied).toBe(true);
+    expect(preview[1]?.modifier_type).toBe("disadvantage");
+    expect(preview[1]?.applied).toBe(true);
+    expect(preview[1]?.source_label).toBe("Carga");
+  });
+
+  it("heavily_encumbered + CON → disadvantage aplicada", () => {
+    const preview = deriveCheckModifierPreviewSources([], {
+      rollType: "ability",
+      ability: "constitution",
+      encumbranceTier: "heavily_encumbered",
+    });
+
+    expect(preview).toHaveLength(1);
+    expect(preview[0]?.modifier_type).toBe("disadvantage");
+    expect(preview[0]?.ability).toBe("constitution");
+  });
+});

--- a/apps/control-web/src/features/rolls/checkModifierSources.ts
+++ b/apps/control-web/src/features/rolls/checkModifierSources.ts
@@ -1,7 +1,7 @@
 import type { AbilityName, SkillName } from "../../entities/roll/rollResolution.types";
 import type { ActiveEffect } from "../../shared/api/combatRepo";
 import { SKILL_ABILITY_MAP } from "../character-sheet/constants";
-import { declarativeEffectGroupKey } from "../character-sheet/utils/calculations";
+import { declarativeEffectGroupKey, type EncumbranceTier } from "../character-sheet/utils/calculations";
 
 type RequestRollType = "ability" | "skill";
 
@@ -23,6 +23,7 @@ type RollPreviewRequest = {
   ability?: AbilityName | null;
   skill?: SkillName | null;
   targetParticipantId?: string | null;
+  encumbranceTier?: EncumbranceTier | null;
 };
 
 const CHECK_MODIFIER_TYPES = new Set(["advantage_on_checks", "disadvantage_on_checks"]);
@@ -126,6 +127,22 @@ export const deriveCheckModifierPreviewSources = (
 
     entry.applied = true;
     previewSources.push(entry);
+  }
+
+  const ENCUMBRANCE_DISADVANTAGE_ABILITIES = new Set(["strength", "dexterity", "constitution"]);
+  const tier = request.encumbranceTier;
+  if (
+    (tier === "heavily_encumbered" || tier === "overloaded") &&
+    ENCUMBRANCE_DISADVANTAGE_ABILITIES.has(requestAbility)
+  ) {
+    previewSources.push({
+      source_label: "Carga",
+      modifier_type: "disadvantage",
+      roll_type: request.rollType,
+      ability: requestAbility,
+      skill: request.rollType === "skill" ? request.skill ?? null : null,
+      applied: true,
+    });
   }
 
   return previewSources;

--- a/apps/control-web/src/features/rolls/components/AuthoritativeRollDialog.tsx
+++ b/apps/control-web/src/features/rolls/components/AuthoritativeRollDialog.tsx
@@ -199,7 +199,15 @@ export const AuthoritativeRollDialog = ({
         {modifierSources.length > 0 ? (
           <div className="mt-4 rounded-2xl border border-emerald-500/25 bg-emerald-500/10 px-4 py-3">
             <p className="text-[11px] font-bold uppercase tracking-[0.24em] text-emerald-200">
-              {displayedResult ? "Vantagem automática" : "Contexto do efeito"}
+              {(() => {
+                if (!displayedResult) return "Contexto do efeito";
+                const applied = modifierSources.filter((s) => s.applied);
+                const hasAdv = applied.some((s) => s.modifier_type === "advantage");
+                const hasDis = applied.some((s) => s.modifier_type === "disadvantage");
+                if (hasAdv && hasDis) return "Modificadores automáticos";
+                if (hasDis) return "Desvantagem automática";
+                return "Vantagem automática";
+              })()}
             </p>
             <div className="mt-2 space-y-1 text-xs text-slate-100">
               {modifierSources.map((entry, index) => (

--- a/apps/control-web/src/features/sessions/components/sessionActivityRowUtils.test.ts
+++ b/apps/control-web/src/features/sessions/components/sessionActivityRowUtils.test.ts
@@ -59,6 +59,20 @@ describe("sessionActivityRowUtils", () => {
     ).toBe("Vantagem por Sabedoria da Coruja em perception");
   });
 
+  it("formats contextual disadvantage sources", () => {
+    expect(
+      formatCheckModifierSource({
+        source_label: "Carga",
+        modifier_type: "disadvantage",
+        roll_type: "ability",
+        ability: "strength",
+        against: "any",
+        applied: true,
+        skip_reason: null,
+      }),
+    ).toBe("Desvantagem por Carga em strength");
+  });
+
   it("includes contextual advantage sources in roll resolved toast text", () => {
     expect(
       formatRollResolvedToastDescription({

--- a/apps/control-web/src/features/sessions/components/sessionActivityRowUtils.ts
+++ b/apps/control-web/src/features/sessions/components/sessionActivityRowUtils.ts
@@ -114,6 +114,9 @@ export function formatCheckModifierSource(entry: NonNullable<RollResolvedActivit
   const source = entry.source_label || "efeito ativo";
 
   if (entry.applied) {
+    if (entry.modifier_type === "disadvantage") {
+      return `Desvantagem por ${source} em ${subject}`;
+    }
     return `Vantagem por ${source} em ${subject}`;
   }
   if (entry.skip_reason === "ability_mismatch") {


### PR DESCRIPTION
## Summary

Adds frontend-only preview for Variant Encumbrance disadvantage on STR/DEX/CON checks.

## Changes

- Adds `encumbranceTier` support to `deriveCheckModifierPreviewSources`
- Shows disadvantage preview for `heavily_encumbered` and `overloaded`
- Does not generate preview entries for unaffected abilities
- Passes encumbrance tier from combat UI into roll preview
- Fixes disadvantage text formatting in session activity utilities
- Makes `AuthoritativeRollDialog` header contextual:
  - Vantagem automática
  - Desvantagem automática
  - Modificadores automáticos

## Validation

- 1173 tests passing
- Lint clean
- No new TypeScript errors

## Scope

Frontend preview only. No backend enforcement yet.