### PR TITLE
feat(encumbrance): sync encumbrance_tier into CombatState participants at combat start

### DIFF
--- a/apps/control-server/app/services/combat_service/condition_effects_predicates.py
+++ b/apps/control-server/app/services/combat_service/condition_effects_predicates.py
@@ -145,6 +145,16 @@ def is_lightly_obscured(participant: dict) -> bool:
     return has_condition(participant, "lightly_obscured")
 
 
+def compute_encumbrance_tier_from_lb(strength_score: float, weight_lb: float) -> str:
+    if weight_lb > strength_score * 15:
+        return "overloaded"
+    if weight_lb > strength_score * 10:
+        return "heavily_encumbered"
+    if weight_lb > strength_score * 5:
+        return "encumbered"
+    return "normal"
+
+
 def _get_encumbrance_tier_for_participant(participant: dict) -> str:
     tier = participant.get("encumbrance_tier")
     if isinstance(tier, str) and tier in ("normal", "encumbered", "heavily_encumbered", "overloaded"):
@@ -154,13 +164,7 @@ def _get_encumbrance_tier_for_participant(participant: dict) -> str:
     weight_kg = participant.get("total_weight_kg")
     if isinstance(strength, (int, float)) and isinstance(weight_kg, (int, float)) and strength > 0:
         weight_lb = weight_kg / _LB_TO_KG
-        if weight_lb > strength * 15:
-            return "overloaded"
-        if weight_lb > strength * 10:
-            return "heavily_encumbered"
-        if weight_lb > strength * 5:
-            return "encumbered"
-        return "normal"
+        return compute_encumbrance_tier_from_lb(strength, weight_lb)
 
     return "normal"
 

--- a/apps/control-server/app/services/combat_service/lifecycle_initiative.py
+++ b/apps/control-server/app/services/combat_service/lifecycle_initiative.py
@@ -8,6 +8,7 @@ from app.models.session import Session as CampaignSession
 from app.schemas.campaign import decode_blocked_cells, decode_edge_obstacles, decode_obstacles
 from app.schemas.combat import CombatMapSelection
 
+from .condition_effects_predicates import compute_encumbrance_tier_from_lb
 from .exceptions import CombatServiceError
 from .limiar_map_projection import (
     maybe_project_combat_start_to_limiar_map as _project_combat_start_to_limiar_map,
@@ -26,6 +27,28 @@ def maybe_project_combat_start_to_limiar_map(db, session_id: str, state) -> None
         projection(db, session_id, state)
         return
     _project_combat_start_to_limiar_map(db, session_id, state)
+
+def _encumbrance_tier_for_player(db, session_id: str, player_user_id: str) -> str:
+    from app.models.session_state import SessionState
+
+    entry = db.exec(
+        select(SessionState).where(
+            SessionState.session_id == session_id,
+            SessionState.player_user_id == player_user_id,
+        )
+    ).first()
+    if not entry:
+        return "normal"
+    sj = entry.state_json or {}
+    strength = float((sj.get("abilities") or {}).get("strength") or 10)
+    inventory = sj.get("inventory") or []
+    total_lb = sum(
+        float(item.get("weight") or 0) * max(1, int(item.get("quantity") or 1))
+        for item in inventory
+        if isinstance(item, dict)
+    )
+    return compute_encumbrance_tier_from_lb(strength, total_lb)
+
 
 class CombatLifecycleInitiativeMixin:
     @classmethod
@@ -97,12 +120,22 @@ class CombatLifecycleInitiativeMixin:
         map_selection = cls._resolve_map_selection(db, session_id, req)
         from app.models.combat import CombatState
 
+        built_participants = []
+        for p in req.participants:
+            entry = {
+                **p.model_dump(),
+                "status": "active" if p.kind == "player" else ("active" if not getattr(p, "is_defeated", False) else "defeated"),
+            }
+            if p.kind == "player":
+                entry["encumbrance_tier"] = _encumbrance_tier_for_player(db, session_id, p.ref_id)
+            built_participants.append(entry)
+
         new_state = CombatState(
             session_id=session_id,
             phase=CombatPhase.initiative,
             round=1,
             current_turn_index=0,
-            participants=[{**participant.model_dump(), "status": "active" if participant.kind == "player" else ("active" if not getattr(participant, "is_defeated", False) else "defeated")} for participant in req.participants],
+            participants=built_participants,
             map_selection=map_selection,
             use_map=req.useMap,
         )

--- a/apps/control-server/tests/test_combat_state_encumbrance_sync.py
+++ b/apps/control-server/tests/test_combat_state_encumbrance_sync.py
@@ -1,0 +1,130 @@
+"""Test: encumbrance_tier sync into CombatState participants at combat start.
+
+Validates _encumbrance_tier_for_player and compute_encumbrance_tier_from_lb.
+STR 10 thresholds (in lb): normal ≤ 50, encumbered ≤ 100, heavily ≤ 150, overloaded > 150.
+Uses `>` (strict), not `>=`.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from app.services.combat_service.condition_effects_predicates import (
+    compute_encumbrance_tier_from_lb,
+)
+from app.services.combat_service.lifecycle_initiative import (
+    _encumbrance_tier_for_player,
+)
+
+_LB_TO_KG = 0.45359237
+
+
+def _kg_to_lb(kg: float) -> float:
+    return kg / _LB_TO_KG
+
+
+def _make_db(state_json: dict | None) -> MagicMock:
+    db = MagicMock()
+    if state_json is None:
+        db.exec.return_value.first.return_value = None
+    else:
+        entry = MagicMock()
+        entry.state_json = state_json
+        db.exec.return_value.first.return_value = entry
+    return db
+
+
+def _state_json(strength: int = 10, items: list[dict] | None = None) -> dict:
+    return {
+        "abilities": {"strength": strength},
+        "inventory": items or [],
+    }
+
+
+def _item(weight_lb: float, quantity: int = 1) -> dict:
+    return {"weight": weight_lb, "quantity": quantity}
+
+
+class TestComputeEncumbranceTierFromLb(unittest.TestCase):
+    """Unit tests for the shared computation helper."""
+
+    def test_normal(self):
+        # STR 10 → normal max = 50 lb
+        self.assertEqual(compute_encumbrance_tier_from_lb(10, 30), "normal")
+
+    def test_exact_normal_boundary(self):
+        # 50 lb == normal threshold → still normal (uses >)
+        self.assertEqual(compute_encumbrance_tier_from_lb(10, 50), "normal")
+
+    def test_just_above_normal_boundary(self):
+        self.assertEqual(compute_encumbrance_tier_from_lb(10, 50.1), "encumbered")
+
+    def test_encumbered(self):
+        # 25 kg ≈ 55 lb → encumbered
+        self.assertEqual(compute_encumbrance_tier_from_lb(10, _kg_to_lb(25)), "encumbered")
+
+    def test_heavily_encumbered(self):
+        # 50 kg ≈ 110 lb → heavily_encumbered
+        self.assertEqual(compute_encumbrance_tier_from_lb(10, _kg_to_lb(50)), "heavily_encumbered")
+
+    def test_overloaded(self):
+        # 70 kg ≈ 154 lb → overloaded
+        self.assertEqual(compute_encumbrance_tier_from_lb(10, _kg_to_lb(70)), "overloaded")
+
+    def test_zero_weight(self):
+        self.assertEqual(compute_encumbrance_tier_from_lb(10, 0), "normal")
+
+
+class TestEncumbranceTierForPlayer(unittest.TestCase):
+    """Tests for _encumbrance_tier_for_player helper."""
+
+    def test_normal_load(self):
+        db = _make_db(_state_json(10, [_item(20)]))
+        self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "normal")
+
+    def test_encumbered(self):
+        # 25 kg ≈ 55.1 lb > 50 lb (STR 10 × 5)
+        db = _make_db(_state_json(10, [_item(_kg_to_lb(25))]))
+        self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "encumbered")
+
+    def test_heavily_encumbered(self):
+        # 50 kg ≈ 110 lb → between 100 and 150 lb
+        db = _make_db(_state_json(10, [_item(_kg_to_lb(50))]))
+        self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "heavily_encumbered")
+
+    def test_overloaded(self):
+        # 70 kg ≈ 154 lb > 150 lb (STR 10 × 15)
+        db = _make_db(_state_json(10, [_item(_kg_to_lb(70))]))
+        self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "overloaded")
+
+    def test_no_session_state_fallback(self):
+        """No SessionState found → safe fallback to normal."""
+        db = _make_db(None)
+        self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "normal")
+
+    def test_missing_abilities_field(self):
+        """state_json without abilities → defaults to STR 10."""
+        db = _make_db({"inventory": []})
+        self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "normal")
+
+    def test_missing_inventory_field(self):
+        """state_json without inventory → zero weight → normal."""
+        db = _make_db({"abilities": {"strength": 10}})
+        self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "normal")
+
+    def test_quantity_multiplied(self):
+        """Items with quantity > 1 have their weight multiplied."""
+        # STR 10 → heavily max = 150 lb. 3 × 40 lb = 120 lb → heavily_encumbered
+        db = _make_db(_state_json(10, [_item(40, quantity=3)]))
+        self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "heavily_encumbered")
+
+    def test_multiple_items_summed(self):
+        """Multiple items are summed."""
+        # 30 + 30 = 60 lb → encumbered (STR 10 normal max = 50 lb)
+        db = _make_db(_state_json(10, [_item(30), _item(30)]))
+        self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "encumbered")
+
+    def test_high_strength_stays_normal(self):
+        """High STR raises all thresholds."""
+        # STR 20 → normal max = 100 lb. 25 kg ≈ 55 lb → still normal
+        db = _make_db(_state_json(20, [_item(_kg_to_lb(25))]))
+        self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "normal")


### PR DESCRIPTION
## Summary

- Extrai `compute_encumbrance_tier_from_lb(strength, weight_lb)` como função pública reutilizável em `condition_effects_predicates.py`
- Adiciona `_encumbrance_tier_for_player(db, session_id, player_user_id)` em `lifecycle_initiative.py` — lê `SessionState` da DB, soma pesos do inventário em lb e deriva o tier
- Modifica `start_combat` para enriquecer cada participante player com `encumbrance_tier` antes do `db.add` (sem necessidade de `flag_modified`)
- A partir desta issue, a #170 para de cair no fallback `"normal"` em produção

Closes #172

## Test plan

- [x] 17 novos testes em `test_combat_state_encumbrance_sync.py` — todos passando
- [x] `compute_encumbrance_tier_from_lb`: normal, encumbered, heavily, overloaded, limite exato com `>` vs `>=`
- [x] `_encumbrance_tier_for_player`: todos os tiers via kg→lb, fallback sem SessionState, campos ausentes, `quantity > 1`, múltiplos itens, STR alta
- [x] 122 testes de regressão passando (`test_encumbrance_disadvantage`, `test_condition_effects`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)