### PR TITLE
feat(encumbrance): recompute encumbrance tier after shop

### DIFF
--- a/apps/control-server/app/api/routes/sessions/rewards_service.py
+++ b/apps/control-server/app/api/routes/sessions/rewards_service.py
@@ -17,6 +17,7 @@ from app.schemas.session_reward import (
     SessionGrantXpRequest,
 )
 from app.services.character_progression import build_progression_snapshot, grant_experience
+from app.services.combat import CombatService
 from app.services.magic_item_effects import inventory_item_supports_stacking
 from app.services.money import normalize_money
 from app.services.session_state_finalize import finalize_session_state_data
@@ -192,9 +193,15 @@ async def grant_session_item_service(
         created_at=issued_at,
     )
 
+    _cs_grant, _tier_grant = CombatService.get_state_and_recompute_encumbrance(
+        session, session_id, payload.playerUserId
+    )
     session.commit()
     session.refresh(state)
     session.refresh(inventory_entry)
+    if _tier_grant and _cs_grant:
+        session.refresh(_cs_grant)
+        await CombatService._emit_state(session_id, _cs_grant)
 
     inventory_version = inventory_entry.updated_at or inventory_entry.created_at
     event_payload = {

--- a/apps/control-server/app/api/routes/sessions/shop_service.py
+++ b/apps/control-server/app/api/routes/sessions/shop_service.py
@@ -33,6 +33,7 @@ from .shop_common import (
     to_item_read,
 )
 from app.models.inventory import InventoryItem
+from app.services.combat import CombatService
 from app.services.magic_item_effects import inventory_item_supports_stacking
 from app.services.money import normalize_money
 from app.services.session_state_finalize import finalize_session_state_data
@@ -161,10 +162,14 @@ async def buy_session_shop_item_service(
     if existing and inventory_item_supports_stacking(item):
         existing.quantity += payload.quantity
         session.add(existing)
+        _cs_buy, _tier_buy = CombatService.get_state_and_recompute_encumbrance(session, session_id, user.id)
         session.commit()
         session.refresh(purchase_event)
         session.refresh(existing)
         session.refresh(state)
+        if _tier_buy and _cs_buy:
+            session.refresh(_cs_buy)
+            await CombatService._emit_state(session_id, _cs_buy)
         await publish_purchase_realtime(entry, purchase_event, member.display_name)
         await _publish_session_state_realtime(
             entry,
@@ -181,10 +186,14 @@ async def buy_session_shop_item_service(
         quantity=payload.quantity,
     )
     session.add(new_entry)
+    _cs_buy, _tier_buy = CombatService.get_state_and_recompute_encumbrance(session, session_id, user.id)
     session.commit()
     session.refresh(purchase_event)
     session.refresh(new_entry)
     session.refresh(state)
+    if _tier_buy and _cs_buy:
+        session.refresh(_cs_buy)
+        await CombatService._emit_state(session_id, _cs_buy)
     await publish_purchase_realtime(entry, purchase_event, member.display_name)
     await _publish_session_state_realtime(
         entry,
@@ -242,10 +251,14 @@ async def sell_session_shop_item_service(
         updated_inventory_entry = None
         session.delete(inventory_entry)
 
+    _cs_sell, _tier_sell = CombatService.get_state_and_recompute_encumbrance(session, session_id, user.id)
     session.commit()
     session.refresh(state)
     if updated_inventory_entry:
         session.refresh(updated_inventory_entry)
+    if _tier_sell and _cs_sell:
+        session.refresh(_cs_sell)
+        await CombatService._emit_state(session_id, _cs_sell)
 
     refund_currency = {"copperValue": refund_cp}
     refund_label = _format_cp_label(refund_cp)

--- a/apps/control-server/app/services/combat_service/lifecycle_initiative.py
+++ b/apps/control-server/app/services/combat_service/lifecycle_initiative.py
@@ -28,6 +28,42 @@ def maybe_project_combat_start_to_limiar_map(db, session_id: str, state) -> None
         return
     _project_combat_start_to_limiar_map(db, session_id, state)
 
+def get_player_total_inventory_weight_lb(db, session_id: str, player_user_id: str) -> float:
+    from sqlalchemy import func
+    from app.models.campaign_member import CampaignMember
+    from app.models.inventory import InventoryItem
+    from app.models.item import Item
+
+    session_entry = db.exec(
+        select(CampaignSession).where(CampaignSession.id == session_id)
+    ).first()
+    if not session_entry:
+        return 0.0
+
+    member = db.exec(
+        select(CampaignMember).where(
+            CampaignMember.campaign_id == session_entry.campaign_id,
+            CampaignMember.user_id == player_user_id,
+        )
+    ).first()
+    if not member:
+        return 0.0
+
+    result = db.exec(
+        select(func.coalesce(
+            func.sum(func.coalesce(Item.weight, 0.0) * InventoryItem.quantity),
+            0.0,
+        ))
+        .select_from(InventoryItem)
+        .join(Item, InventoryItem.item_id == Item.id)
+        .where(
+            InventoryItem.campaign_id == session_entry.campaign_id,
+            InventoryItem.member_id == member.id,
+        )
+    ).scalar()
+    return float(result or 0.0)
+
+
 def _encumbrance_tier_for_player(db, session_id: str, player_user_id: str) -> str:
     from app.models.session_state import SessionState
 
@@ -41,12 +77,7 @@ def _encumbrance_tier_for_player(db, session_id: str, player_user_id: str) -> st
         return "normal"
     sj = entry.state_json or {}
     strength = float((sj.get("abilities") or {}).get("strength") or 10)
-    inventory = sj.get("inventory") or []
-    total_lb = sum(
-        float(item.get("weight") or 0) * max(1, int(item.get("quantity") or 1))
-        for item in inventory
-        if isinstance(item, dict)
-    )
+    total_lb = get_player_total_inventory_weight_lb(db, session_id, player_user_id)
     return compute_encumbrance_tier_from_lb(strength, total_lb)
 
 
@@ -175,6 +206,29 @@ class CombatLifecycleInitiativeMixin:
             return False
         participant["encumbrance_tier"] = new_tier
         return True
+
+    @classmethod
+    def get_state_and_recompute_encumbrance(
+        cls,
+        db,
+        session_id: str,
+        player_user_id: str,
+    ):
+        """Recomputa encumbrance_tier e marca o CombatState para o próximo commit.
+
+        Retorna (state, changed). Caller deve fazer session.commit() e, se changed,
+        session.refresh(state) + await _emit_state(session_id, state).
+        """
+        from sqlalchemy.orm.attributes import flag_modified
+
+        state = cls.get_state(db, session_id)
+        if not state:
+            return None, False
+        changed = cls.recompute_participant_encumbrance_tier(db, session_id, state, player_user_id)
+        if changed:
+            flag_modified(state, "participants")
+            db.add(state)
+        return state, changed
 
     @classmethod
     def _resolve_map_selection(cls, db, session_id: str, req) -> dict:

--- a/apps/control-server/tests/test_combat_state_encumbrance_sync.py
+++ b/apps/control-server/tests/test_combat_state_encumbrance_sync.py
@@ -3,6 +3,10 @@
 Validates _encumbrance_tier_for_player and compute_encumbrance_tier_from_lb.
 STR 10 thresholds (in lb): normal ≤ 50, encumbered ≤ 100, heavily ≤ 150, overloaded > 150.
 Uses `>` (strict), not `>=`.
+
+_encumbrance_tier_for_player now calls get_player_total_inventory_weight_lb which
+makes 4 sequential db.exec calls: SessionState, CampaignSession, CampaignMember,
+weight sum (scalar). The _make_db helper mocks all 4 via side_effect.
 """
 
 import unittest
@@ -22,52 +26,51 @@ def _kg_to_lb(kg: float) -> float:
     return kg / _LB_TO_KG
 
 
-def _make_db(state_json: dict | None) -> MagicMock:
+def _make_db(strength: int = 10, weight_lb: float = 0.0) -> MagicMock:
     db = MagicMock()
-    if state_json is None:
-        db.exec.return_value.first.return_value = None
-    else:
-        entry = MagicMock()
-        entry.state_json = state_json
-        db.exec.return_value.first.return_value = entry
+    session_state = MagicMock()
+    session_state.state_json = {"abilities": {"strength": strength}}
+    campaign_session = MagicMock()
+    campaign_session.campaign_id = "camp-1"
+    member = MagicMock()
+    member.id = "member-1"
+
+    db.exec.side_effect = [
+        MagicMock(first=MagicMock(return_value=session_state)),
+        MagicMock(first=MagicMock(return_value=campaign_session)),
+        MagicMock(first=MagicMock(return_value=member)),
+        MagicMock(scalar=MagicMock(return_value=weight_lb)),
+    ]
     return db
 
 
-def _state_json(strength: int = 10, items: list[dict] | None = None) -> dict:
-    return {
-        "abilities": {"strength": strength},
-        "inventory": items or [],
-    }
-
-
-def _item(weight_lb: float, quantity: int = 1) -> dict:
-    return {"weight": weight_lb, "quantity": quantity}
+def _make_db_no_state() -> MagicMock:
+    db = MagicMock()
+    db.exec.side_effect = [
+        MagicMock(first=MagicMock(return_value=None)),
+    ]
+    return db
 
 
 class TestComputeEncumbranceTierFromLb(unittest.TestCase):
     """Unit tests for the shared computation helper."""
 
     def test_normal(self):
-        # STR 10 → normal max = 50 lb
         self.assertEqual(compute_encumbrance_tier_from_lb(10, 30), "normal")
 
     def test_exact_normal_boundary(self):
-        # 50 lb == normal threshold → still normal (uses >)
         self.assertEqual(compute_encumbrance_tier_from_lb(10, 50), "normal")
 
     def test_just_above_normal_boundary(self):
         self.assertEqual(compute_encumbrance_tier_from_lb(10, 50.1), "encumbered")
 
     def test_encumbered(self):
-        # 25 kg ≈ 55 lb → encumbered
         self.assertEqual(compute_encumbrance_tier_from_lb(10, _kg_to_lb(25)), "encumbered")
 
     def test_heavily_encumbered(self):
-        # 50 kg ≈ 110 lb → heavily_encumbered
         self.assertEqual(compute_encumbrance_tier_from_lb(10, _kg_to_lb(50)), "heavily_encumbered")
 
     def test_overloaded(self):
-        # 70 kg ≈ 154 lb → overloaded
         self.assertEqual(compute_encumbrance_tier_from_lb(10, _kg_to_lb(70)), "overloaded")
 
     def test_zero_weight(self):
@@ -78,53 +81,53 @@ class TestEncumbranceTierForPlayer(unittest.TestCase):
     """Tests for _encumbrance_tier_for_player helper."""
 
     def test_normal_load(self):
-        db = _make_db(_state_json(10, [_item(20)]))
+        db = _make_db(strength=10, weight_lb=20.0)
         self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "normal")
 
     def test_encumbered(self):
-        # 25 kg ≈ 55.1 lb > 50 lb (STR 10 × 5)
-        db = _make_db(_state_json(10, [_item(_kg_to_lb(25))]))
+        db = _make_db(strength=10, weight_lb=_kg_to_lb(25))
         self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "encumbered")
 
     def test_heavily_encumbered(self):
-        # 50 kg ≈ 110 lb → between 100 and 150 lb
-        db = _make_db(_state_json(10, [_item(_kg_to_lb(50))]))
+        db = _make_db(strength=10, weight_lb=_kg_to_lb(50))
         self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "heavily_encumbered")
 
     def test_overloaded(self):
-        # 70 kg ≈ 154 lb > 150 lb (STR 10 × 15)
-        db = _make_db(_state_json(10, [_item(_kg_to_lb(70))]))
+        db = _make_db(strength=10, weight_lb=_kg_to_lb(70))
         self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "overloaded")
 
     def test_no_session_state_fallback(self):
-        """No SessionState found → safe fallback to normal."""
-        db = _make_db(None)
+        db = _make_db_no_state()
         self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "normal")
 
     def test_missing_abilities_field(self):
-        """state_json without abilities → defaults to STR 10."""
-        db = _make_db({"inventory": []})
+        db = MagicMock()
+        session_state = MagicMock()
+        session_state.state_json = {}
+        campaign_session = MagicMock()
+        campaign_session.campaign_id = "camp-1"
+        member = MagicMock()
+        member.id = "member-1"
+        db.exec.side_effect = [
+            MagicMock(first=MagicMock(return_value=session_state)),
+            MagicMock(first=MagicMock(return_value=campaign_session)),
+            MagicMock(first=MagicMock(return_value=member)),
+            MagicMock(scalar=MagicMock(return_value=0.0)),
+        ]
         self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "normal")
 
     def test_missing_inventory_field(self):
-        """state_json without inventory → zero weight → normal."""
-        db = _make_db({"abilities": {"strength": 10}})
+        db = _make_db(strength=10, weight_lb=0.0)
         self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "normal")
 
     def test_quantity_multiplied(self):
-        """Items with quantity > 1 have their weight multiplied."""
-        # STR 10 → heavily max = 150 lb. 3 × 40 lb = 120 lb → heavily_encumbered
-        db = _make_db(_state_json(10, [_item(40, quantity=3)]))
+        db = _make_db(strength=10, weight_lb=120.0)
         self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "heavily_encumbered")
 
     def test_multiple_items_summed(self):
-        """Multiple items are summed."""
-        # 30 + 30 = 60 lb → encumbered (STR 10 normal max = 50 lb)
-        db = _make_db(_state_json(10, [_item(30), _item(30)]))
+        db = _make_db(strength=10, weight_lb=60.0)
         self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "encumbered")
 
     def test_high_strength_stays_normal(self):
-        """High STR raises all thresholds."""
-        # STR 20 → normal max = 100 lb. 25 kg ≈ 55 lb → still normal
-        db = _make_db(_state_json(20, [_item(_kg_to_lb(25))]))
+        db = _make_db(strength=20, weight_lb=_kg_to_lb(25))
         self.assertEqual(_encumbrance_tier_for_player(db, "s1", "u1"), "normal")

--- a/apps/control-server/tests/test_encumbrance_inventory_sync.py
+++ b/apps/control-server/tests/test_encumbrance_inventory_sync.py
@@ -1,0 +1,83 @@
+"""Test: get_player_total_inventory_weight_lb reads weight from InventoryItem + Item.
+
+Validates the single-source-of-truth weight function that replaced state_json["inventory"]
+weight computation. All scenarios mock 3 sequential db.exec calls:
+  1. CampaignSession lookup (first)
+  2. CampaignMember lookup (first)
+  3. Weight sum query (scalar)
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from app.services.combat_service.lifecycle_initiative import (
+    get_player_total_inventory_weight_lb,
+)
+
+
+def _make_db(campaign_id="camp-1", member_id="member-1", weight_lb=0.0, no_session=False, no_member=False):
+    db = MagicMock()
+
+    if no_session:
+        db.exec.side_effect = [
+            MagicMock(first=MagicMock(return_value=None)),
+        ]
+        return db
+
+    campaign_session = MagicMock()
+    campaign_session.campaign_id = campaign_id
+
+    if no_member:
+        db.exec.side_effect = [
+            MagicMock(first=MagicMock(return_value=campaign_session)),
+            MagicMock(first=MagicMock(return_value=None)),
+        ]
+        return db
+
+    member = MagicMock()
+    member.id = member_id
+
+    db.exec.side_effect = [
+        MagicMock(first=MagicMock(return_value=campaign_session)),
+        MagicMock(first=MagicMock(return_value=member)),
+        MagicMock(scalar=MagicMock(return_value=weight_lb)),
+    ]
+    return db
+
+
+class TestGetPlayerTotalInventoryWeightLb(unittest.TestCase):
+
+    def test_single_item_weight(self):
+        db = _make_db(weight_lb=10.0)
+        result = get_player_total_inventory_weight_lb(db, "s1", "u1")
+        self.assertAlmostEqual(result, 10.0)
+
+    def test_null_weight_coalesces_to_zero(self):
+        db = _make_db(weight_lb=0.0)
+        result = get_player_total_inventory_weight_lb(db, "s1", "u1")
+        self.assertAlmostEqual(result, 0.0)
+
+    def test_multiple_items_summed(self):
+        db = _make_db(weight_lb=75.5)
+        result = get_player_total_inventory_weight_lb(db, "s1", "u1")
+        self.assertAlmostEqual(result, 75.5)
+
+    def test_empty_inventory(self):
+        db = _make_db(weight_lb=0.0)
+        result = get_player_total_inventory_weight_lb(db, "s1", "u1")
+        self.assertAlmostEqual(result, 0.0)
+
+    def test_no_session_returns_zero(self):
+        db = _make_db(no_session=True)
+        result = get_player_total_inventory_weight_lb(db, "s1", "u1")
+        self.assertAlmostEqual(result, 0.0)
+
+    def test_no_member_returns_zero(self):
+        db = _make_db(no_member=True)
+        result = get_player_total_inventory_weight_lb(db, "s1", "u1")
+        self.assertAlmostEqual(result, 0.0)
+
+    def test_none_scalar_returns_zero(self):
+        db = _make_db(weight_lb=None)
+        result = get_player_total_inventory_weight_lb(db, "s1", "u1")
+        self.assertAlmostEqual(result, 0.0)

--- a/apps/control-server/tests/test_encumbrance_recompute.py
+++ b/apps/control-server/tests/test_encumbrance_recompute.py
@@ -2,6 +2,10 @@
 
 Validates that the method correctly updates encumbrance_tier in the participant
 dict when the player's inventory changes, and that it respects combat phase guards.
+
+_encumbrance_tier_for_player now calls get_player_total_inventory_weight_lb which
+makes 4 sequential db.exec calls: SessionState, CampaignSession, CampaignMember,
+weight sum (scalar). The _make_db helper mocks all 4 via side_effect.
 """
 
 import unittest
@@ -22,12 +26,19 @@ def _kg_to_lb(kg: float) -> float:
 
 def _make_db(strength: int = 10, weight_lb: float = 0.0) -> MagicMock:
     db = MagicMock()
-    entry = MagicMock()
-    entry.state_json = {
-        "abilities": {"strength": strength},
-        "inventory": [{"weight": weight_lb, "quantity": 1}] if weight_lb > 0 else [],
-    }
-    db.exec.return_value.first.return_value = entry
+    session_state = MagicMock()
+    session_state.state_json = {"abilities": {"strength": strength}}
+    campaign_session = MagicMock()
+    campaign_session.campaign_id = "camp-1"
+    member = MagicMock()
+    member.id = "member-1"
+
+    db.exec.side_effect = [
+        MagicMock(first=MagicMock(return_value=session_state)),
+        MagicMock(first=MagicMock(return_value=campaign_session)),
+        MagicMock(first=MagicMock(return_value=member)),
+        MagicMock(scalar=MagicMock(return_value=weight_lb)),
+    ]
     return db
 
 
@@ -60,39 +71,33 @@ def _recompute(db, state, player_user_id="user-1") -> bool:
 class TestRecomputeParticipantEncumbranceTier(unittest.TestCase):
 
     def test_tier_rises_when_inventory_gets_heavier(self):
-        """After adding heavy items, tier goes from normal to heavily_encumbered."""
-        # STR 10 → normal max = 50 lb. 55 lb → encumbered
-        db = _make_db(strength=10, weight_lb=_kg_to_lb(50))  # ≈110 lb → heavily
+        db = _make_db(strength=10, weight_lb=_kg_to_lb(50))
         state = _state(encumbrance_tier="normal")
         changed = _recompute(db, state)
         self.assertTrue(changed)
         self.assertEqual(state.participants[0]["encumbrance_tier"], "heavily_encumbered")
 
     def test_tier_drops_when_item_removed(self):
-        """After removing items, tier goes from encumbered to normal."""
-        db = _make_db(strength=10, weight_lb=10.0)  # 10 lb → normal
+        db = _make_db(strength=10, weight_lb=10.0)
         state = _state(encumbrance_tier="encumbered")
         changed = _recompute(db, state)
         self.assertTrue(changed)
         self.assertEqual(state.participants[0]["encumbrance_tier"], "normal")
 
     def test_no_change_when_tier_unchanged(self):
-        """Returns False and leaves participant untouched if tier is the same."""
-        db = _make_db(strength=10, weight_lb=10.0)  # normal
+        db = _make_db(strength=10, weight_lb=10.0)
         state = _state(encumbrance_tier="normal")
         changed = _recompute(db, state)
         self.assertFalse(changed)
         self.assertEqual(state.participants[0]["encumbrance_tier"], "normal")
 
     def test_participant_not_found_returns_false(self):
-        """Returns False without error when player is not in combat."""
         db = _make_db(strength=10, weight_lb=_kg_to_lb(50))
         state = _state()
         changed = _recompute(db, state, player_user_id="unknown-user")
         self.assertFalse(changed)
 
     def test_phase_ended_returns_false(self):
-        """Does not update participants when combat is ended."""
         db = _make_db(strength=10, weight_lb=_kg_to_lb(50))
         state = _state(encumbrance_tier="normal", phase=CombatPhase.ended)
         changed = _recompute(db, state)
@@ -100,14 +105,12 @@ class TestRecomputeParticipantEncumbranceTier(unittest.TestCase):
         self.assertEqual(state.participants[0]["encumbrance_tier"], "normal")
 
     def test_phase_initiative_returns_false(self):
-        """Does not update during initiative phase — guard only allows active."""
         db = _make_db(strength=10, weight_lb=_kg_to_lb(50))
         state = _state(encumbrance_tier="normal", phase=CombatPhase.initiative)
         changed = _recompute(db, state)
         self.assertFalse(changed)
 
     def test_phase_string_active_accepted(self):
-        """Accepts 'active' as a string for robustness."""
         db = _make_db(strength=10, weight_lb=_kg_to_lb(50))
         state = _state(encumbrance_tier="normal")
         state.phase = "active"


### PR DESCRIPTION
## Summary

Closes #178.

Keeps `CombatState.participants[].encumbrance_tier` in sync after shop and inventory mutations.

## Changes

- Uses inventory DB data as the source of truth for total carried weight
- Recomputes encumbrance after:
  - shop buy stacking
  - shop buy new entry
  - shop sell
  - GM grant item
- Emits updated combat state when the tier changes
- Updates encumbrance sync/recompute tests for the new DB lookup flow
- Adds unit tests for `get_player_total_inventory_weight_lb`

## Validation

- 60/60 tests passing