### PR TITLE
feat(map): add elevation layer support to LimiarMap grid cells

### DIFF
--- a/apps/control-web/src/entities/campaign/campaign.types.ts
+++ b/apps/control-web/src/entities/campaign/campaign.types.ts
@@ -82,6 +82,12 @@ export type CampaignEdgeObstacle = {
   cover: ObstacleCover;
 };
 
+export type CampaignCellElevation = {
+  x: number;
+  y: number;
+  elevationMeters: number;
+};
+
 export type ObstaclePresetId =
   | "solid_wall"
   | "dense_obstacle"
@@ -288,6 +294,8 @@ export type CampaignMapConfig = {
   obstacles?: CampaignObstacle[] | null;
   /** Canonical semantic edge obstacles authored between adjacent cells. */
   edgeObstacles?: CampaignEdgeObstacle[] | null;
+  /** Per-cell elevation metadata for fall detection. */
+  cellElevations?: CampaignCellElevation[] | null;
   /** @deprecated Legacy movement-only blocked cells for pre-semantic maps. */
   blockedCells?: BlockedCell[] | null;
   createdAt: string;

--- a/apps/map-server/src/modules/encounters/elevation-paint-service.ts
+++ b/apps/map-server/src/modules/encounters/elevation-paint-service.ts
@@ -1,0 +1,107 @@
+import type {
+  CellElevation,
+  ControllerType,
+  Coordinate
+} from "@limiarmap/shared-contracts";
+import {
+  chebyshevDistance,
+  coordinateKey,
+  isInsideMap,
+  nextEncounterVersion
+} from "@limiarmap/tactical-engine";
+import type { InMemoryEncounterRepository } from "./encounter-repository";
+
+function buildCircleCells(
+  centerCell: Coordinate,
+  radius: number,
+  map: ReturnType<InMemoryEncounterRepository["requireEncounter"]>["battleMap"]
+): Coordinate[] {
+  const cells: Coordinate[] = [];
+
+  for (let x = centerCell.x - radius; x <= centerCell.x + radius; x += 1) {
+    for (let y = centerCell.y - radius; y <= centerCell.y + radius; y += 1) {
+      const coordinate = { x, y };
+      if (
+        chebyshevDistance(centerCell, coordinate) > radius ||
+        !isInsideMap({ map, obstacles: [], edgeObstacles: [], tokens: [] }, coordinate)
+      ) {
+        continue;
+      }
+
+      cells.push(coordinate);
+    }
+  }
+
+  return cells;
+}
+
+export class ElevationPaintService {
+  constructor(private readonly repository: InMemoryEncounterRepository) {}
+
+  paintElevation(
+    sessionId: string,
+    actorType: ControllerType,
+    centerCell: Coordinate,
+    radius: number,
+    mode: "paint" | "erase",
+    elevationMeters: number | undefined,
+    actionId: string
+  ) {
+    const encounter = this.repository.requireEncounter(sessionId);
+    if (encounter.actionTracker.has(actionId)) {
+      return { accepted: false, rejectionReason: "duplicate_action", encounter };
+    }
+
+    if (actorType !== "gm") {
+      return { accepted: false, rejectionReason: "not_gm", encounter };
+    }
+
+    if ((mode !== "paint" && mode !== "erase") || !Number.isInteger(radius) || radius < 0 || radius > 12) {
+      return { accepted: false, rejectionReason: "invalid_elevation_brush", encounter };
+    }
+
+    if (!isInsideMap({ map: encounter.battleMap, obstacles: [], edgeObstacles: [], tokens: [] }, centerCell)) {
+      return { accepted: false, rejectionReason: "outside_map", encounter };
+    }
+
+    const targetCells = buildCircleCells(centerCell, radius, encounter.battleMap);
+    if (targetCells.length === 0) {
+      return { accepted: false, rejectionReason: "invalid_elevation_brush", encounter };
+    }
+
+    const targetKeys = new Set(targetCells.map((cell) => coordinateKey(cell)));
+
+    let nextElevations: CellElevation[];
+
+    if (mode === "paint" && elevationMeters !== undefined && elevationMeters > 0) {
+      // Merge: keep existing entries not in target, add/update target entries
+      const existing = encounter.cellElevations.filter(
+        (e) => !targetKeys.has(coordinateKey(e.cell))
+      );
+      const painted = targetCells.map((cell) => ({
+        cell,
+        elevationMeters,
+      }));
+      nextElevations = [...existing, ...painted];
+    } else {
+      // Erase (or paint with 0): remove elevation from target cells
+      nextElevations = encounter.cellElevations.filter(
+        (e) => !targetKeys.has(coordinateKey(e.cell))
+      );
+    }
+
+    encounter.actionTracker.record(actionId);
+    encounter.combatState = {
+      ...encounter.combatState,
+      version: nextEncounterVersion(encounter.combatState.version)
+    };
+
+    this.repository.setCellElevations(sessionId, nextElevations);
+    this.repository.updateCombatState(sessionId, encounter.combatState);
+
+    return {
+      accepted: true,
+      encounter: this.repository.requireEncounter(sessionId)
+    };
+  }
+}

--- a/apps/map-server/src/modules/encounters/encounter-repository.ts
+++ b/apps/map-server/src/modules/encounters/encounter-repository.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type {
   ActiveAreaEffect,
   BattleMap,
+  CellElevation,
   CombatState,
   Coordinate,
   EdgeObstacle,
@@ -19,6 +20,7 @@ export interface EncounterState {
   obstacles: Obstacle[];
   edgeObstacles: EdgeObstacle[];
   activeAreaEffects: ActiveAreaEffect[];
+  cellElevations: CellElevation[];
   combatState: CombatState;
   actionTracker: ActionIdempotencyTracker;
 }
@@ -128,6 +130,7 @@ function createDemoEncounter(
     obstacles,
     edgeObstacles: [], // Phase 10: Initialize empty edge obstacles for backward compatibility
     activeAreaEffects: [],
+    cellElevations: [],
     combatState,
     actionTracker: new ActionIdempotencyTracker()
   };
@@ -233,6 +236,12 @@ export class InMemoryEncounterRepository {
   setEdgeObstacles(sessionId: string, edgeObstacles: EdgeObstacle[]): EncounterState {
     const encounter = this.requireEncounter(sessionId);
     encounter.edgeObstacles = edgeObstacles;
+    return this.saveEncounter(encounter);
+  }
+
+  setCellElevations(sessionId: string, cellElevations: CellElevation[]): EncounterState {
+    const encounter = this.requireEncounter(sessionId);
+    encounter.cellElevations = cellElevations;
     return this.saveEncounter(encounter);
   }
 

--- a/apps/map-server/src/modules/encounters/encounter-snapshot.ts
+++ b/apps/map-server/src/modules/encounters/encounter-snapshot.ts
@@ -14,7 +14,8 @@ export function toEncounterSnapshot(
     tokens: encounter.tokens,
     obstacles: encounter.obstacles,
     edgeObstacles: encounter.edgeObstacles,
-    activeAreaEffects: encounter.activeAreaEffects
+    activeAreaEffects: encounter.activeAreaEffects,
+    cellElevations: encounter.cellElevations
   };
 }
 
@@ -34,6 +35,7 @@ export function toIntegrationSnapshot(
     tokens: encounter.tokens,
     obstacles: encounter.obstacles,
     edgeObstacles: encounter.edgeObstacles,
-    activeAreaEffects: encounter.activeAreaEffects
+    activeAreaEffects: encounter.activeAreaEffects,
+    cellElevations: encounter.cellElevations
   };
 }

--- a/apps/map-server/src/routes/integration/state.routes.ts
+++ b/apps/map-server/src/routes/integration/state.routes.ts
@@ -195,6 +195,25 @@ export function registerStateRoutes(app: FastifyInstance, repository: InMemoryEn
       } else {
         repository.setEdgeObstacles(sessionId, []);
       }
+
+      if (parse.data.battleMap?.cellElevations?.length) {
+        const seenElevations = new Set<string>();
+        const validElevations = parse.data.battleMap.cellElevations
+          .filter((entry) => {
+            if (entry.cell.x < 0 || entry.cell.y < 0 || entry.cell.x >= gridWidth || entry.cell.y >= gridHeight) {
+              return false;
+            }
+            const key = `${entry.cell.x}:${entry.cell.y}`;
+            if (seenElevations.has(key)) return false;
+            seenElevations.add(key);
+            return true;
+          })
+          .map((entry) => ({
+            cell: { x: entry.cell.x, y: entry.cell.y },
+            elevationMeters: entry.elevationMeters,
+          }));
+        repository.setCellElevations(sessionId, validElevations);
+      }
     }
 
     request.log.info(

--- a/apps/map-server/src/routes/realtime-helpers.ts
+++ b/apps/map-server/src/routes/realtime-helpers.ts
@@ -153,6 +153,21 @@ function getEdgeObstaclePaintRejectionDetails(reason: string): string {
   }
 }
 
+function getElevationPaintRejectionDetails(reason: string): string {
+  switch (reason) {
+    case "not_gm":
+      return "Only the GM can paint elevation";
+    case "outside_map":
+      return "Elevation brush center must stay inside the map";
+    case "invalid_elevation_brush":
+      return "Elevation brush did not cover any valid map cells";
+    case "duplicate_action":
+      return "Elevation paint action was already processed";
+    default:
+      return "Elevation paint rejected";
+  }
+}
+
 function getTargetingRejectionDetails(reason: string): string {
   switch (reason) {
     case "no_line_of_sight":
@@ -224,6 +239,7 @@ export {
   getMovementRejectionDetails,
   getObstaclePaintRejectionDetails,
   getEdgeObstaclePaintRejectionDetails,
+  getElevationPaintRejectionDetails,
   getTargetingRejectionDetails,
   emitRejection,
   ensureEncounter

--- a/apps/map-server/src/routes/realtime-paint-routes.ts
+++ b/apps/map-server/src/routes/realtime-paint-routes.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import {
   edgeObstaclePaintRequestSchema,
+  elevationPaintRequestSchema,
   gridCalibrationRequestSchema,
   obstaclePaintRequestSchema
 } from "@limiarmap/shared-contracts";
@@ -10,6 +11,7 @@ import { broadcastAuthoritativeEvent } from "../modules/realtime/broadcast";
 import { GridCalibrationService } from "../modules/encounters/grid-calibration-service";
 import { ObstaclePaintService } from "../modules/encounters/obstacle-paint-service";
 import { EdgeObstaclePaintService } from "../modules/encounters/edge-obstacle-paint-service";
+import { ElevationPaintService } from "../modules/encounters/elevation-paint-service";
 import { toEncounterSnapshot } from "../modules/encounters/encounter-snapshot";
 import {
   LOG_PREFIX,
@@ -18,6 +20,7 @@ import {
   getGridCalibrationRejectionDetails,
   getObstaclePaintRejectionDetails,
   getEdgeObstaclePaintRejectionDetails,
+  getElevationPaintRejectionDetails,
   emitRejection,
   ensureEncounter
 } from "./realtime-helpers";
@@ -30,6 +33,7 @@ export function registerRealtimePaintRoutes(
   const gridCalibrationService = new GridCalibrationService(repository);
   const obstaclePaintService = new ObstaclePaintService(repository);
   const edgeObstaclePaintService = new EdgeObstaclePaintService(repository);
+  const elevationPaintService = new ElevationPaintService(repository);
 
   app.post(
     "/sessions/:sessionId/actions/grid-calibration",
@@ -217,6 +221,70 @@ export function registerRealtimePaintRoutes(
         payload: {
           battleMapId: result.encounter.battleMap.id,
           edgeObstacles: result.encounter.edgeObstacles
+        },
+        replaySafe: true
+      });
+
+      return reply.send(toEncounterSnapshot(result.encounter));
+    }
+  );
+
+  app.post(
+    "/sessions/:sessionId/actions/elevation",
+    async (request, reply) => {
+      const { sessionId } = request.params as { sessionId: string };
+      const encounter = ensureEncounter(repository, sessionId, reply);
+      if (!encounter) {
+        return;
+      }
+
+      const parse = elevationPaintRequestSchema.safeParse(request.body);
+      if (!parse.success) {
+        return err(reply, 400, "Invalid elevation paint request body");
+      }
+
+      const actor = getActor(request);
+      request.log.info(
+        {
+          sessionId,
+          actionId: parse.data.actionId,
+          actorId: actor.actorId,
+          actorType: actor.actorType
+        },
+        `${LOG_PREFIX} POST elevation`
+      );
+
+      const result = elevationPaintService.paintElevation(
+        sessionId,
+        actor.actorType,
+        parse.data.centerCell,
+        parse.data.radius,
+        parse.data.mode,
+        parse.data.elevationMeters,
+        parse.data.actionId
+      );
+
+      if (!result.accepted) {
+        emitRejection(
+          broadcaster,
+          sessionId,
+          result.encounter.combatState.version,
+          parse.data.actionId,
+          result.rejectionReason ?? "unknown",
+          getElevationPaintRejectionDetails(result.rejectionReason ?? "unknown")
+        );
+        return reply.send(toEncounterSnapshot(result.encounter));
+      }
+
+      broadcastAuthoritativeEvent(broadcaster, "elevation.updated", {
+        eventId: `elevation:${parse.data.actionId}`,
+        eventType: "elevation.updated",
+        encounterId: sessionId,
+        version: result.encounter.combatState.version,
+        actionId: parse.data.actionId,
+        payload: {
+          battleMapId: result.encounter.battleMap.id,
+          cellElevations: result.encounter.cellElevations
         },
         replaySafe: true
       });

--- a/apps/map-web/src/features/battle-map/battle-map-page.tsx
+++ b/apps/map-web/src/features/battle-map/battle-map-page.tsx
@@ -12,6 +12,7 @@ import { TokenPlacementBar } from "./token-placement-bar";
 import { battleMapStore } from "./battle-map-store";
 import { GridCalibrationPanel } from "./grid-calibration-panel";
 import { ObstacleEditorPanel } from "./obstacle-editor-panel";
+import { ElevationEditorPanel } from "./elevation-editor-panel";
 import { CombatPanel } from "../combat/combat-panel";
 import { DebugPanel } from "../debug/debug-panel";
 import { getMapSessionId, isEmbeddedMapView } from "../../services/map-runtime-config";
@@ -236,6 +237,7 @@ export function BattleMapPage(): React.JSX.Element {
         <DebugPanel />
         <GridCalibrationPanel />
         <ObstacleEditorPanel />
+        <ElevationEditorPanel />
 
         <div
           style={{

--- a/apps/map-web/src/features/battle-map/battle-map-pixi-runtime.ts
+++ b/apps/map-web/src/features/battle-map/battle-map-pixi-runtime.ts
@@ -5,12 +5,13 @@ import type { GridEditInteraction } from "./types";
 import { battleMapStore } from "./battle-map-store";
 import { submitMovement } from "./use-movement-actions";
 import { submitEdgeObstaclePaint, submitObstaclePaint } from "./use-obstacle-paint-actions";
+import { submitElevationPaint } from "./use-elevation-paint-actions";
 import { submitPlacement } from "./use-placement-actions";
 import { getEdgeBrushPreset, getObstacleBrushPreset } from "./obstacle-presets";
 import { HttpClient } from "../../services/http-client";
 import { postEmbeddedCellHovered, postEmbeddedCellSelected, postEmbeddedTokenSelected } from "../../services/embedded-map-bridge";
 import { buildFailureExplanation } from "../targeting/diagnostics-to-explanation";
-import { drawCellFills, drawEdgeObstacles, drawEditHandles, drawGrid, drawHUD, drawPreviewHint, drawReachAndAoe, drawSpellHighlightRings, drawTacticalTokenOverlay, drawTokenLayer } from "./canvas-renderers";
+import { drawCellFills, drawEdgeObstacles, drawCellElevationBadges, drawEditHandles, drawGrid, drawHUD, drawPreviewHint, drawReachAndAoe, drawSpellHighlightRings, drawTacticalTokenOverlay, drawTokenLayer } from "./canvas-renderers";
 import { canControlToken, canInteractWithToken, computePath, getSelectionBlockedMessage, pixelToGrid } from "./utils";
 
 type Snapshot = {
@@ -105,6 +106,12 @@ export function bindPixiStageEvents(
       if (currentActor.actorType === "gm" && !uiState.pendingObstaclePaintActionId && !uiState.pendingEdgePaintActionId) {
         if (uiState.obstaclePaintTarget === "edge") submitEdgeObstaclePaint(encounter.sessionId, coord, uiState.edgeDirection);
         else submitObstaclePaint(encounter.sessionId, coord);
+      }
+      return;
+    }
+    if (uiState.isElevationPaintMode) {
+      if (currentActor.actorType === "gm" && !uiState.pendingElevationPaintActionId) {
+        submitElevationPaint(encounter.sessionId, coord);
       }
       return;
     }
@@ -232,6 +239,7 @@ export function buildDrawFunction(
       drawCellFills(refs.cellFillsGfxRef.current, calibration, gridWidth, gridHeight, screen.width, screen.height, encounter.obstacles, uiState.movementPreview, uiState.targetingPreview, uiState.embeddedPreview, [...(encounter.activeAreaEffects ?? []), ...uiState.embeddedActiveAreaEffects], uiState.embeddedSelectedCell ?? null);
     }
     if (refs.edgeObstaclesGfxRef.current) drawEdgeObstacles(refs.edgeObstaclesGfxRef.current, calibration, gridWidth, gridHeight, screen.width, screen.height, encounter.edgeObstacles ?? []);
+    if (refs.edgeObstaclesGfxRef.current) drawCellElevationBadges(refs.edgeObstaclesGfxRef.current, calibration, gridWidth, gridHeight, screen.width, screen.height, encounter.cellElevations ?? []);
     if (refs.tokenContainerRef.current) drawTokenLayer(refs.tokenContainerRef.current, encounter.tokens, calibration, gridWidth, gridHeight, screen.width, screen.height, selectedTokenId, uiState.embeddedSelectedTargetRefId ?? null, encounter.combatState.activeCombatantId);
     if (refs.spellHighlightContainerRef.current) drawSpellHighlightRings(refs.spellHighlightContainerRef.current, encounter.tokens, calibration, gridWidth, gridHeight, screen.width, screen.height, uiState.embeddedSpellHighlights);
     if (refs.tacticalOverlayContainerRef.current) drawTacticalTokenOverlay(refs.tacticalOverlayContainerRef.current, encounter.tokens, calibration, gridWidth, gridHeight, screen.width, screen.height, uiState.tacticalPreview);

--- a/apps/map-web/src/features/battle-map/battle-map-store.ts
+++ b/apps/map-web/src/features/battle-map/battle-map-store.ts
@@ -66,7 +66,12 @@ class BattleMapStore {
     obstaclePaintTarget: "cell" as "cell" | "edge",
     edgeDirection: "E" as EdgeDirection,
     edgeBrushPresetId: "edge_wall" as EdgeBrushPresetId,
-    pendingEdgePaintActionId: undefined
+    pendingEdgePaintActionId: undefined,
+    isElevationPaintMode: false,
+    elevationBrushPresetMeters: 3,
+    elevationBrushRadius: 1,
+    elevationBrushMode: "paint" as "paint" | "erase",
+    pendingElevationPaintActionId: undefined
   };
   private readonly listeners = new Set<Listener>();
 
@@ -149,7 +154,7 @@ class BattleMapStore {
   }
 
   startGridEdit(cal: GridCalibration, gw: number, gh: number): void {
-    this.set({ isGridEditMode: true, isObstaclePaintMode: false, gridCalibrationDraft: cal, gridWidthDraft: gw, gridHeightDraft: gh, pendingGridCalibrationActionId: undefined, pendingObstaclePaintActionId: undefined, message: undefined });
+    this.set({ isGridEditMode: true, isObstaclePaintMode: false, isElevationPaintMode: false, gridCalibrationDraft: cal, gridWidthDraft: gw, gridHeightDraft: gh, pendingGridCalibrationActionId: undefined, pendingObstaclePaintActionId: undefined, pendingElevationPaintActionId: undefined, message: undefined });
   }
 
   updateGridCalibrationDraft(cal: GridCalibration): void { this.set({ gridCalibrationDraft: cal }); }
@@ -159,11 +164,11 @@ class BattleMapStore {
   }
 
   startObstaclePaint(): void {
-    this.set({ isObstaclePaintMode: true, isGridEditMode: false, gridCalibrationDraft: undefined, gridWidthDraft: undefined, gridHeightDraft: undefined, pendingGridCalibrationActionId: undefined, pendingObstaclePaintActionId: undefined, pendingEdgePaintActionId: undefined, message: undefined });
+    this.set({ isObstaclePaintMode: true, isElevationPaintMode: false, isGridEditMode: false, gridCalibrationDraft: undefined, gridWidthDraft: undefined, gridHeightDraft: undefined, pendingGridCalibrationActionId: undefined, pendingObstaclePaintActionId: undefined, pendingEdgePaintActionId: undefined, pendingElevationPaintActionId: undefined, message: undefined });
   }
 
   cancelObstaclePaint(): void {
-    this.set({ isObstaclePaintMode: false, pendingObstaclePaintActionId: undefined, pendingEdgePaintActionId: undefined });
+    this.set({ isObstaclePaintMode: false, pendingObstaclePaintActionId: undefined, pendingEdgePaintActionId: undefined, pendingElevationPaintActionId: undefined });
   }
 
   markObstaclePaintPending(id: string): void { this.set({ pendingObstaclePaintActionId: id }); }
@@ -187,6 +192,22 @@ class BattleMapStore {
   failObstaclePaintUpdate(id?: string): boolean { return this.completePending("pendingObstaclePaintActionId", id); }
   completeEdgePaintUpdate(id?: string): boolean { return this.completePending("pendingEdgePaintActionId", id); }
   failEdgePaintUpdate(id?: string): boolean { return this.completePending("pendingEdgePaintActionId", id); }
+
+  startElevationPaint(): void {
+    this.set({ isElevationPaintMode: true, isObstaclePaintMode: false, isGridEditMode: false, gridCalibrationDraft: undefined, gridWidthDraft: undefined, gridHeightDraft: undefined, pendingGridCalibrationActionId: undefined, pendingObstaclePaintActionId: undefined, pendingEdgePaintActionId: undefined, pendingElevationPaintActionId: undefined, message: undefined });
+  }
+
+  cancelElevationPaint(): void {
+    this.set({ isElevationPaintMode: false, pendingElevationPaintActionId: undefined });
+  }
+
+  setElevationBrushPreset(meters: number): void { this.set({ elevationBrushPresetMeters: meters }); }
+  setElevationBrushRadius(radius: number): void { this.set({ elevationBrushRadius: radius }); }
+  setElevationBrushMode(mode: "paint" | "erase"): void { this.set({ elevationBrushMode: mode }); }
+
+  markElevationPaintPending(id: string): void { this.set({ pendingElevationPaintActionId: id }); }
+  completeElevationPaintUpdate(id?: string): boolean { return this.completePending("pendingElevationPaintActionId", id); }
+  failElevationPaintUpdate(id?: string): boolean { return this.completePending("pendingElevationPaintActionId", id); }
 
   activateTacticalPreview(sourceTokenId: string, actionType: "move" | "attack" | "spell"): void {
     this.state = { ...this.state, tacticalPreview: { ...this.state.tacticalPreview, active: true, sourceTokenId, actionType } };

--- a/apps/map-web/src/features/battle-map/battle-map-store.types.ts
+++ b/apps/map-web/src/features/battle-map/battle-map-store.types.ts
@@ -76,6 +76,11 @@ export interface BattleMapUIState {
   edgeDirection: EdgeDirection;
   edgeBrushPresetId: EdgeBrushPresetId;
   pendingEdgePaintActionId?: string;
+  isElevationPaintMode: boolean;
+  elevationBrushPresetMeters: number;
+  elevationBrushRadius: number;
+  elevationBrushMode: "paint" | "erase";
+  pendingElevationPaintActionId?: string;
   mapImageAspectRatio: number;
   mapImageNaturalWidthPx: number;
   mapImageNaturalHeightPx: number;

--- a/apps/map-web/src/features/battle-map/canvas-renderers-grid.ts
+++ b/apps/map-web/src/features/battle-map/canvas-renderers-grid.ts
@@ -1,5 +1,6 @@
 import { Graphics } from "pixi.js";
 import type {
+  CellElevation,
   Coordinate,
   ActiveAreaEffect,
   EdgeDirection,
@@ -289,5 +290,48 @@ export function drawEdgeObstacles(
     }
 
     gfx.moveTo(x1, y1).lineTo(x2, y2).stroke({ width, color, alpha });
+  }
+}
+
+const ELEVATION_COLORS: Record<number, number> = {
+  0: 0x4b5563,
+  3: 0x3b82f6,
+  6: 0x8b5cf6,
+  9: 0xec4899,
+  12: 0xef4444,
+};
+
+function getElevationColor(meters: number): number {
+  // Find the closest preset color
+  const keys = Object.keys(ELEVATION_COLORS).map(Number).sort((a, b) => a - b);
+  let color = ELEVATION_COLORS[0];
+  for (const key of keys) {
+    if (meters >= key) {
+      color = ELEVATION_COLORS[key];
+    }
+  }
+  return color;
+}
+
+export function drawCellElevationBadges(
+  gfx: Graphics,
+  cal: GridCalibration,
+  gridW: number,
+  gridH: number,
+  canvasW: number,
+  canvasH: number,
+  cellElevations: CellElevation[]
+): void {
+  for (const entry of cellElevations) {
+    if (entry.elevationMeters <= 0) continue;
+
+    const { x, y, w, h } = cellRect(entry.cell.x, entry.cell.y, cal, gridW, gridH, canvasW, canvasH);
+    const badgeSize = Math.max(6, Math.min(w, h) * 0.25);
+    const color = getElevationColor(entry.elevationMeters);
+
+    // Small colored square in the top-right corner
+    gfx.rect(x + w - badgeSize - 2, y + 2, badgeSize, badgeSize)
+      .fill({ color, alpha: 0.85 })
+      .stroke({ width: 1, color: 0x000000, alpha: 0.4 });
   }
 }

--- a/apps/map-web/src/features/battle-map/canvas-renderers.ts
+++ b/apps/map-web/src/features/battle-map/canvas-renderers.ts
@@ -1,3 +1,3 @@
-export { drawGrid, drawCellFills, drawEdgeObstacles } from "./canvas-renderers-grid";
+export { drawGrid, drawCellFills, drawEdgeObstacles, drawCellElevationBadges } from "./canvas-renderers-grid";
 export { drawTokenLayer, drawEditHandles, drawHUD } from "./canvas-renderers-tokens";
 export { drawReachAndAoe, drawTacticalTokenOverlay, drawPreviewHint, drawSpellHighlightRings } from "./canvas-renderers-tactical";

--- a/apps/map-web/src/features/battle-map/elevation-editor-panel.tsx
+++ b/apps/map-web/src/features/battle-map/elevation-editor-panel.tsx
@@ -1,0 +1,257 @@
+import React, { useEffect, useSyncExternalStore } from "react";
+import { useCurrentActor } from "../../services/centrifugo-client";
+import { battleMapStore } from "./battle-map-store";
+import { ELEVATION_PRESETS, getElevationPreset } from "./elevation-presets";
+
+const panelStyle: React.CSSProperties = {
+  background: "#101725",
+  border: "1px solid #24324a",
+  borderRadius: 6,
+  padding: 12,
+  display: "flex",
+  flexDirection: "column",
+  gap: 8
+};
+
+const buttonStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "8px 10px",
+  borderRadius: 4,
+  border: "1px solid",
+  fontSize: 12,
+  fontWeight: 600,
+  cursor: "pointer"
+};
+
+export function ElevationEditorPanel(): React.JSX.Element | null {
+  const currentActor = useCurrentActor();
+  const uiState = useSyncExternalStore(
+    (listener) => battleMapStore.subscribe(listener),
+    () => battleMapStore.getState(),
+    () => battleMapStore.getState()
+  );
+
+  useEffect(() => {
+    if (currentActor.actorType !== "gm" && uiState.isElevationPaintMode) {
+      battleMapStore.cancelElevationPaint();
+    }
+  }, [currentActor.actorType, uiState.isElevationPaintMode]);
+
+  if (currentActor.actorType !== "gm") {
+    return null;
+  }
+
+  const selectedPreset = getElevationPreset(uiState.elevationBrushPresetMeters);
+  const isBusy = Boolean(uiState.pendingElevationPaintActionId);
+
+  return (
+    <section style={panelStyle}>
+      <div
+        style={{
+          fontSize: 9,
+          textTransform: "uppercase",
+          letterSpacing: "0.12em",
+          color: "#5f7ca3"
+        }}
+      >
+        Elevação
+      </div>
+
+      {!uiState.isElevationPaintMode ? (
+        <>
+          <button
+            type="button"
+            onClick={() => battleMapStore.startElevationPaint()}
+            style={{
+              ...buttonStyle,
+              background: "rgba(139,92,246,0.14)",
+              borderColor: "rgba(167,139,250,0.4)",
+              color: "#c4b5fd"
+            }}
+          >
+            Editar elevação
+          </button>
+
+          <div style={{ fontSize: 11, color: "#6f86a6", lineHeight: 1.5 }}>
+            Clique no mapa para pintar altura por célula.
+          </div>
+        </>
+      ) : (
+        <>
+          <div style={{ fontSize: 11, color: "#d9e7ff", lineHeight: 1.5 }}>
+            Clique em uma célula do mapa para aplicar a altura selecionada.
+          </div>
+
+          <div style={{ display: "flex", gap: 6 }}>
+            <button
+              type="button"
+              onClick={() => battleMapStore.setElevationBrushMode("paint")}
+              style={{
+                ...buttonStyle,
+                flex: 1,
+                background:
+                  uiState.elevationBrushMode === "paint"
+                    ? "rgba(139,92,246,0.24)"
+                    : "rgba(139,92,246,0.08)",
+                borderColor:
+                  uiState.elevationBrushMode === "paint"
+                    ? "rgba(167,139,250,0.52)"
+                    : "rgba(167,139,250,0.22)",
+                color: "#c4b5fd"
+              }}
+            >
+              Pintar
+            </button>
+
+            <button
+              type="button"
+              onClick={() => battleMapStore.setElevationBrushMode("erase")}
+              style={{
+                ...buttonStyle,
+                flex: 1,
+                background:
+                  uiState.elevationBrushMode === "erase"
+                    ? "rgba(210,84,84,0.24)"
+                    : "rgba(210,84,84,0.08)",
+                borderColor:
+                  uiState.elevationBrushMode === "erase"
+                    ? "rgba(255,120,120,0.48)"
+                    : "rgba(255,120,120,0.22)",
+                color: "#f0a0a0"
+              }}
+            >
+              Apagar
+            </button>
+          </div>
+
+          <label
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 4,
+              fontSize: 11,
+              color: "#8ba3c7"
+            }}
+          >
+            Altura
+            <select
+              disabled={isBusy || uiState.elevationBrushMode === "erase"}
+              value={uiState.elevationBrushPresetMeters}
+              onChange={(event) =>
+                battleMapStore.setElevationBrushPreset(
+                  Number(event.currentTarget.value)
+                )
+              }
+              style={{
+                height: 34,
+                borderRadius: 4,
+                border: "1px solid rgba(110,160,220,0.35)",
+                background: "rgba(8,16,28,0.9)",
+                color: "#d8e6ff",
+                padding: "0 10px"
+              }}
+            >
+              {ELEVATION_PRESETS.map((preset) => (
+                <option key={preset.meters} value={preset.meters}>
+                  {preset.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 4,
+              fontSize: 11,
+              color: "#8ba3c7"
+            }}
+          >
+            Raio do círculo
+            <input
+              type="number"
+              min="0"
+              max="6"
+              step="1"
+              disabled={isBusy}
+              value={uiState.elevationBrushRadius}
+              onChange={(event) => {
+                const parsed = Number(event.currentTarget.value);
+                if (!Number.isFinite(parsed)) {
+                  return;
+                }
+
+                battleMapStore.setElevationBrushRadius(
+                  Math.max(0, Math.min(6, Math.round(parsed)))
+                );
+              }}
+              style={{
+                height: 34,
+                borderRadius: 4,
+                border: "1px solid rgba(110,160,220,0.35)",
+                background: "rgba(8,16,28,0.9)",
+                color: "#d8e6ff",
+                padding: "0 10px"
+              }}
+            />
+          </label>
+
+          <div
+            style={{
+              background: "rgba(20,30,46,0.75)",
+              border: "1px solid rgba(55,82,116,0.6)",
+              borderRadius: 6,
+              padding: "8px 10px",
+              fontSize: 11,
+              lineHeight: 1.6,
+              color: "#d8e6ff"
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                marginBottom: 4
+              }}
+            >
+              <span
+                style={{
+                  display: "inline-block",
+                  width: 10,
+                  height: 10,
+                  borderRadius: 2,
+                  background: selectedPreset.swatchColor,
+                  opacity: 0.85,
+                  flexShrink: 0
+                }}
+              />
+              <strong style={{ color: "#c4b5fd" }}>
+                {selectedPreset.label}
+              </strong>
+            </div>
+            {uiState.elevationBrushMode === "erase"
+              ? "Remove a elevação das células selecionadas (volta para 0m)."
+              : `Aplica ${selectedPreset.label} nas células selecionadas.`}
+          </div>
+
+          <button
+            type="button"
+            disabled={isBusy}
+            onClick={() => battleMapStore.cancelElevationPaint()}
+            style={{
+              ...buttonStyle,
+              background: "rgba(180,60,60,0.12)",
+              borderColor: "rgba(220,100,100,0.3)",
+              color: "#e49a9a",
+              cursor: isBusy ? "not-allowed" : "pointer"
+            }}
+          >
+            Fechar modo de elevação
+          </button>
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/map-web/src/features/battle-map/elevation-presets.ts
+++ b/apps/map-web/src/features/battle-map/elevation-presets.ts
@@ -1,0 +1,37 @@
+/**
+ * Elevation brush presets — Issue #184.
+ *
+ * Presets are authoring conveniences only. The elevation value always relies
+ * on the explicit `elevationMeters` number. Preset IDs are never persisted.
+ *
+ * Preset set (5 tactically relevant heights):
+ *
+ * | meters | Label  | Color    | Use case                         |
+ * |--------|--------|----------|----------------------------------|
+ * | 0 m    | Ground | #4b5563  | Reset to ground level            |
+ * | 3 m    | Low    | #3b82f6  | Low platform, ledge              |
+ * | 6 m    | Medium | #8b5cf6  | Wall top, second floor           |
+ * | 9 m    | High   | #ec4899  | Tower, cliff                     |
+ * | 12 m   | Very   | #ef4444  | High cliff, tall structure       |
+ */
+
+export interface ElevationPreset {
+  meters: number;
+  label: string;
+  swatchColor: string;
+}
+
+export const ELEVATION_PRESETS: ElevationPreset[] = [
+  { meters: 0, label: "0 m", swatchColor: "#4b5563" },
+  { meters: 3, label: "3 m", swatchColor: "#3b82f6" },
+  { meters: 6, label: "6 m", swatchColor: "#8b5cf6" },
+  { meters: 9, label: "9 m", swatchColor: "#ec4899" },
+  { meters: 12, label: "12 m", swatchColor: "#ef4444" },
+];
+
+export function getElevationPreset(meters: number): ElevationPreset {
+  return (
+    ELEVATION_PRESETS.find((preset) => preset.meters === meters) ??
+    ELEVATION_PRESETS[0]
+  );
+}

--- a/apps/map-web/src/features/battle-map/use-battle-map-pixi.ts
+++ b/apps/map-web/src/features/battle-map/use-battle-map-pixi.ts
@@ -262,7 +262,7 @@ export function useBattleMapPixi(params: {
 
   useEffect(() => {
     if (
-      (uiState.isGridEditMode || uiState.isObstaclePaintMode) &&
+      (uiState.isGridEditMode || uiState.isObstaclePaintMode || uiState.isElevationPaintMode) &&
       selectedTokenId
     )
       setSelectedTokenId(null);
@@ -270,7 +270,8 @@ export function useBattleMapPixi(params: {
     selectedTokenId,
     setSelectedTokenId,
     uiState.isGridEditMode,
-    uiState.isObstaclePaintMode
+    uiState.isObstaclePaintMode,
+    uiState.isElevationPaintMode
   ]);
 
   useEffect(() => {

--- a/apps/map-web/src/features/battle-map/use-elevation-paint-actions.ts
+++ b/apps/map-web/src/features/battle-map/use-elevation-paint-actions.ts
@@ -1,0 +1,66 @@
+import type { Coordinate } from "@limiarmap/shared-contracts";
+import { HttpClient } from "../../services/http-client";
+import { recoverRealtimeState } from "../../services/realtime-recovery";
+import { battleMapStore } from "./battle-map-store";
+
+const ELEVATION_PAINT_RECOVERY_DELAY_MS = 1500;
+
+export function submitElevationPaint(
+  sessionId: string,
+  centerCell: Coordinate
+): void {
+  const state = battleMapStore.getState();
+  if (!state.isElevationPaintMode) {
+    return;
+  }
+
+  const actionId = `elevation:${Date.now()}`;
+
+  battleMapStore.markElevationPaintPending(actionId);
+  battleMapStore.setMessage(
+    state.elevationBrushMode === "erase"
+      ? "Removendo elevação..."
+      : `Aplicando elevação ${state.elevationBrushPresetMeters}m...`
+  );
+
+  void new HttpClient()
+    .submitElevationPaint(sessionId, {
+      actionId,
+      sessionId,
+      centerCell,
+      radius: state.elevationBrushRadius,
+      mode: state.elevationBrushMode,
+      elevationMeters: state.elevationBrushMode === "paint" ? state.elevationBrushPresetMeters : undefined,
+      knownVersion: battleMapStore.getEncounter()?.combatState.version ?? 0
+    })
+    .catch(() => {
+      if (battleMapStore.failElevationPaintUpdate(actionId)) {
+        battleMapStore.setMessage(
+          "Nao foi possivel aplicar a elevação. Tente novamente."
+        );
+      }
+    });
+
+  window.setTimeout(() => {
+    if (battleMapStore.getState().pendingElevationPaintActionId !== actionId) {
+      return;
+    }
+
+    void recoverRealtimeState(
+      sessionId,
+      battleMapStore.getEncounter()?.combatState.version ?? 0
+    )
+      .then(() => {
+        if (battleMapStore.failElevationPaintUpdate(actionId)) {
+          battleMapStore.setMessage(undefined);
+        }
+      })
+      .catch(() => {
+        if (battleMapStore.failElevationPaintUpdate(actionId)) {
+          battleMapStore.setMessage(
+            "Nao foi possivel confirmar a elevação. Recarregue a pagina."
+          );
+        }
+      });
+  }, ELEVATION_PAINT_RECOVERY_DELAY_MS);
+}

--- a/apps/map-web/src/features/battle-map/use-movement-actions.ts
+++ b/apps/map-web/src/features/battle-map/use-movement-actions.ts
@@ -13,6 +13,11 @@ export function submitMovement(sessionId: string, tokenId: string, path: Coordin
     return;
   }
 
+  if (battleMapStore.getState().isElevationPaintMode) {
+    battleMapStore.setMessage("Saia do modo de elevação antes de mover tokens.");
+    return;
+  }
+
   battleMapStore.setMovementPreview(path);
   void new HttpClient()
     .submitMovement(sessionId, {

--- a/apps/map-web/src/services/http-client.ts
+++ b/apps/map-web/src/services/http-client.ts
@@ -8,7 +8,8 @@ import type {
   ResyncResponse,
   TargetingSubmitRequest,
   ObstaclePaintRequest,
-  EdgeObstaclePaintRequest
+  EdgeObstaclePaintRequest,
+  ElevationPaintRequest
 } from "@limiarmap/shared-contracts";
 import type { TacticalDiagnostics } from "../features/battle-map/battle-map-store";
 
@@ -201,6 +202,17 @@ export class HttpClient {
   ): Promise<EncounterSnapshotResponse> {
     return this.postJson<EncounterSnapshotResponse>(
       `/sessions/${sessionId}/actions/edge-obstacles`,
+      payload,
+      true
+    );
+  }
+
+  async submitElevationPaint(
+    sessionId: string,
+    payload: ElevationPaintRequest
+  ): Promise<EncounterSnapshotResponse> {
+    return this.postJson<EncounterSnapshotResponse>(
+      `/sessions/${sessionId}/actions/elevation`,
       payload,
       true
     );

--- a/apps/map-web/src/services/realtime-events.ts
+++ b/apps/map-web/src/services/realtime-events.ts
@@ -245,12 +245,28 @@ export function handleRealtimePublication(data: unknown): void {
       }
       return;
     }
+    case "elevation.updated": {
+      const cellElevations = Array.isArray(event.payload.cellElevations)
+        ? event.payload.cellElevations
+        : null;
+      if (!cellElevations) return;
+      updateSnapshot((snapshot) => ({
+        ...snapshot,
+        cellElevations: cellElevations as typeof snapshot.cellElevations,
+        combatState: { ...snapshot.combatState, version: event.version }
+      }));
+      if (battleMapStore.completeElevationPaintUpdate(event.actionId)) {
+        battleMapStore.setMessage(undefined);
+      }
+      return;
+    }
     case "action.rejected": {
       battleMapStore.setMovementPreview([]);
       battleMapStore.setTargetingPreview([]);
       battleMapStore.failGridCalibrationUpdate(event.actionId);
       battleMapStore.failObstaclePaintUpdate(event.actionId);
       battleMapStore.failEdgePaintUpdate(event.actionId);
+      battleMapStore.failElevationPaintUpdate(event.actionId);
       const reason =
         typeof event.payload.reason === "string"
           ? event.payload.reason

--- a/packages/shared-contracts/src/domain.ts
+++ b/packages/shared-contracts/src/domain.ts
@@ -2,6 +2,9 @@ import { z } from "zod";
 
 export const MAX_GRID_DIMENSION = 150;
 
+/** Initial tactical ceiling for cell elevation in meters. Not a system rule — adjust as needed. */
+export const MAX_ELEVATION_METERS = 100;
+
 /**
  * Default map scale: 1.5 meters per cell.
  * Compatible with standard D&D 5e grids (5 ft ≈ 1.5 m per cell).
@@ -249,6 +252,11 @@ export const realtimeActionEventSchema = z.object({
   replaySafe: z.boolean().default(true)
 });
 
+export const cellElevationSchema = z.object({
+  cell: coordinateSchema,
+  elevationMeters: z.number().finite().min(0).max(MAX_ELEVATION_METERS),
+});
+
 export type Coordinate = z.infer<typeof coordinateSchema>;
 export type GridCalibration = z.infer<typeof gridCalibrationSchema>;
 export type GridDimensions = z.infer<typeof gridDimensionsSchema>;
@@ -267,3 +275,4 @@ export type MovementAction = z.infer<typeof movementActionSchema>;
 export type TargetingTemplate = z.infer<typeof targetingTemplateSchema>;
 export type ActiveAreaEffect = z.infer<typeof activeAreaEffectSchema>;
 export type RealtimeActionEvent = z.infer<typeof realtimeActionEventSchema>;
+export type CellElevation = z.infer<typeof cellElevationSchema>;

--- a/packages/shared-contracts/src/http.ts
+++ b/packages/shared-contracts/src/http.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   battleMapSchema,
   activeAreaEffectSchema,
+  cellElevationSchema,
   combatStateSchema,
   edgeObstacleSchema,
   obstacleSchema,
@@ -15,7 +16,8 @@ export const encounterSnapshotResponseSchema = z.object({
   tokens: z.array(tokenSchema),
   obstacles: z.array(obstacleSchema),
   edgeObstacles: z.array(edgeObstacleSchema).default([]),
-  activeAreaEffects: z.array(activeAreaEffectSchema).default([])
+  activeAreaEffects: z.array(activeAreaEffectSchema).default([]),
+  cellElevations: z.array(cellElevationSchema).default([])
 });
 
 export const resyncRequestSchema = z.object({

--- a/packages/shared-contracts/src/integration.combat.ts
+++ b/packages/shared-contracts/src/integration.combat.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   battleMapSchema,
   activeAreaEffectSchema,
+  cellElevationSchema,
   combatStateSchema,
   coordinateSchema,
   controllerTypeSchema,
@@ -51,6 +52,7 @@ export const integrationBattleMapSchema = z.object({
   obstacles: z.array(campaignObstacleInputSchema).optional(),
   edgeObstacles: z.array(campaignEdgeObstacleInputSchema).optional(),
   blockedCells: z.array(coordinateSchema).optional(),
+  cellElevations: z.array(cellElevationSchema).optional(),
 });
 
 export const startCombatRequestSchema = z.object({
@@ -101,6 +103,7 @@ export const integrationStateResponseSchema = z.object({
   obstacles: z.array(obstacleSchema),
   edgeObstacles: z.array(edgeObstacleSchema).default([]),
   activeAreaEffects: z.array(activeAreaEffectSchema).default([]),
+  cellElevations: z.array(cellElevationSchema).default([]),
 });
 
 export const movementPreviewRequestSchema = z.object({

--- a/packages/shared-contracts/src/integration.ts
+++ b/packages/shared-contracts/src/integration.ts
@@ -22,6 +22,7 @@ export const integrationSpatialEventTypeSchema = z.enum([
   "obstacles.updated",
   "edge_obstacles.updated",
   "grid.calibration.updated",
+  "elevation.updated",
 ]);
 
 export const integrationSpatialEventEnvelopeSchema = z.object({

--- a/packages/shared-contracts/src/realtime.ts
+++ b/packages/shared-contracts/src/realtime.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  cellElevationSchema,
   combatStateSchema,
   coordinateSchema,
   edgeDirectionSchema,
@@ -75,6 +76,16 @@ export const edgeObstaclePaintRequestSchema = z.object({
   style: obstacleStyleSchema.optional()
 });
 
+export const elevationPaintRequestSchema = z.object({
+  actionId: z.string(),
+  sessionId: z.string(),
+  knownVersion: z.number().int().nonnegative(),
+  mode: obstaclePaintModeSchema,
+  centerCell: coordinateSchema,
+  radius: z.number().int().nonnegative().max(12),
+  elevationMeters: z.number().finite().min(0).max(100).optional()
+});
+
 export const movementAppliedEventSchema = realtimeActionEventSchema.extend({
   payload: z.object({
     tokenId: z.string(),
@@ -126,6 +137,13 @@ export const edgeObstaclesUpdatedEventSchema = realtimeActionEventSchema.extend(
   }
 );
 
+export const elevationUpdatedEventSchema = realtimeActionEventSchema.extend({
+  payload: z.object({
+    battleMapId: z.string(),
+    cellElevations: z.array(cellElevationSchema)
+  })
+});
+
 export const actionRejectedEventSchema = realtimeActionEventSchema.extend({
   payload: z.object({
     reason: z.string(),
@@ -160,4 +178,6 @@ export type ObstaclesUpdatedEvent = z.infer<typeof obstaclesUpdatedEventSchema>;
 export type EdgeObstaclesUpdatedEvent = z.infer<
   typeof edgeObstaclesUpdatedEventSchema
 >;
+export type ElevationPaintRequest = z.infer<typeof elevationPaintRequestSchema>;
+export type ElevationUpdatedEvent = z.infer<typeof elevationUpdatedEventSchema>;
 export type ActionRejectedEvent = z.infer<typeof actionRejectedEventSchema>;

--- a/packages/tactical-engine/src/grid/grid-state.ts
+++ b/packages/tactical-engine/src/grid/grid-state.ts
@@ -1,6 +1,7 @@
 import type {
   ActiveAreaEffect,
   BattleMap,
+  CellElevation,
   Coordinate,
   EdgeObstacle,
   Obstacle,
@@ -19,6 +20,11 @@ export interface GridState {
    * lives on `obstacles`; these never mutate the campaign map.
    */
   activeAreaEffects?: ActiveAreaEffect[];
+  /**
+   * Per-cell elevation metadata for fall detection and vertical movement.
+   * Default elevation for missing cells is 0.
+   */
+  cellElevations?: CellElevation[];
 }
 
 export function isInsideMap(
@@ -140,4 +146,29 @@ export function getEdgeCover(
 ): "none" | "half" | "threeQuarters" | "full" {
   const edge = getEdgeBetweenCells(gridState, fromCell, toCell);
   return edge?.cover ?? "none";
+}
+
+/**
+ * Build a coordinate-keyed index from a CellElevation array.
+ * Construct once per context (e.g. before a path-cost loop) and reuse.
+ */
+export function buildElevationIndex(
+  cellElevations: CellElevation[] = []
+): Map<string, number> {
+  const index = new Map<string, number>();
+  for (const entry of cellElevations) {
+    index.set(coordinateKey(entry.cell), entry.elevationMeters);
+  }
+  return index;
+}
+
+/**
+ * Look up the elevation for a single cell using a pre-built index.
+ * Returns 0 for cells not in the index.
+ */
+export function getCellElevation(
+  elevationIndex: Map<string, number>,
+  cell: Coordinate
+): number {
+  return elevationIndex.get(coordinateKey(cell)) ?? 0;
 }


### PR DESCRIPTION
# Add elevation layer support to LimiarMap grid cells

## Summary

Adds the first foundation for fall damage support by introducing an elevation layer to LimiarMap grid cells.

This PR allows the tactical map to represent vertical height per cell through `cellElevations`, including shared contracts, map-server persistence/snapshots, GM painting tools in `map-web`, realtime synchronization, and campaign map config typing in `control-web`.

No fall damage is applied in this PR. This only makes elevation data available, editable, persisted, synchronized, and readable by runtime helpers.

## Context

This is the first step toward implementing fall damage and Cat’s Grace support.

Before Limiar can detect a fall, the map needs to know the elevation of the origin and destination cells. The chosen model follows the current map architecture: elevation is represented as a parallel cell metadata array, not as an obstacle field.

A cell can have elevation without being blocked, and an obstacle can exist at any elevation. So `cellElevations` stays orthogonal to `obstacles`, `edgeObstacles`, tokens, and active area effects.

## What changed

### Shared contracts

Added elevation to the shared API/realtime/integration contracts:

- Added `MAX_ELEVATION_METERS = 100`
- Added `cellElevationSchema`
- Added `CellElevation` type
- Added `cellElevations` to `encounterSnapshotResponseSchema`
- Added `elevationPaintRequestSchema`
- Added `elevationUpdatedEventSchema`
- Exported elevation realtime types
- Added `"elevation.updated"` to `integrationSpatialEventTypeSchema`
- Added `cellElevations` to integration battle map/state schemas

### Tactical engine

Added runtime support for reading cell elevation:

- Added optional `cellElevations` to `GridState`
- Added `buildElevationIndex()` for `Map<string, number>` lookup
- Added `getCellElevation(index, cell)` with O(1) lookup

This avoids repeatedly scanning the elevation array during movement/runtime flows. Tiny mercy. Rare thing in software.

### Map server

Added elevation persistence, snapshots, painting, and realtime sync:

- Added `cellElevations` to `EncounterState`
- Initialized encounter elevation state as `[]`
- Added `setCellElevations()`
- Included `cellElevations` in encounter and integration snapshots
- Added `ElevationPaintService`
  - GM validation
  - paint/erase modes
  - circular brush support
  - idempotency handling
- Added `POST .../elevation` paint route
- Broadcasts `elevation.updated`
- Added elevation rejection details helper
- Seeds `cellElevations` during combat start integration

### Map web

Added GM-facing elevation editing and rendering:

- Added elevation presets:
  - `0m`
  - `3m`
  - `6m`
  - `9m`
  - `12m`
- Added elevation paint state to the battle map store
- Added store actions for starting/canceling elevation paint mode, setting brush options, and handling pending/completed/failed updates
- Added `ElevationEditorPanel`
- Added `useElevationPaintActions()`
- Added `submitElevationPaint()` to the HTTP client
- Added realtime handler for `elevation.updated`
- Added failure handling for rejected elevation updates
- Added `drawCellElevationBadges()` to render elevation badges on cells
- Integrated elevation rendering into the Pixi runtime
- Added elevation paint click handling
- Added the elevation editor panel to the side panel
- Clear selected token when entering elevation paint mode
- Block movement actions while elevation paint mode is active

### Control web

Added campaign map config typing for persisted elevation data:

- Added `CampaignCellElevation`
- Added optional `cellElevations` to `CampaignMapConfig`

## Out of scope

This PR intentionally does not implement:

- fall damage calculation
- automatic fall detection from movement
- Cat’s Grace fall prevention
- HP damage application
- prone after falling
- forced movement / push into fall
- Feather Fall
- ramp/slope rules
- line of sight changes based on elevation
- cover changes based on elevation

Those are follow-up issues. One monster at a time, because we are professionals pretending not to suffer.

## Validation

- `packages/shared-contracts`
  - TypeScript check passed

- `packages/tactical-engine`
  - TypeScript check passed

- `apps/map-server`
  - TypeScript check passed

- `apps/map-web`
  - TypeScript check passed
  - Remaining TypeScript errors are pre-existing

- `apps/control-web`
  - TypeScript check passed
  - `804/804` tests passing

## Notes for reviewers

The main design choice is representing elevation as a separate `cellElevations` array rather than extending obstacles or tokens.

This keeps elevation as pure cell metadata and allows future fall detection to compare origin/destination elevations without coupling height to obstacle semantics.

The tactical-engine helper uses an indexed lookup:

```ts
buildElevationIndex(cellElevations)
getCellElevation(index, cell)
````

This avoids O(n) scans when movement/runtime logic needs repeated elevation reads.

## Follow-ups

Recommended next issues:

1. Fall damage calculation foundation
2. Explicit/manual fall event
3. Automatic fall detection from map movement
4. Cat’s Grace fall damage prevention
5. Fall log/UX and hardening