### PR TITLE
feat(fall-damage): implement fall damage computation and associated t…

### DIFF
--- a/apps/control-server/app/services/combat_service/fall_damage.py
+++ b/apps/control-server/app/services/combat_service/fall_damage.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import math
+
+from pydantic import BaseModel
+
+FALL_DAMAGE_METERS_PER_DIE = 3
+FALL_DAMAGE_DIE_SIDES = 6
+MAX_FALL_DAMAGE_DICE = 20
+# TODO: align with canonical damage-type enum/registry when established
+FALL_DAMAGE_TYPE = "bludgeoning"
+
+
+class FallDamageComputation(BaseModel):
+    height_meters: float
+    effective_height_meters: float
+    dice_count: int
+    dice_sides: int
+    damage_type: str
+    damage_formula: str | None
+    causes_damage: bool
+
+
+def compute_fall_damage(height_meters: float) -> FallDamageComputation:
+    effective_height_meters = max(0.0, height_meters)
+    causes_damage = effective_height_meters >= FALL_DAMAGE_METERS_PER_DIE
+    if causes_damage:
+        dice_count = min(
+            MAX_FALL_DAMAGE_DICE,
+            math.floor(effective_height_meters / FALL_DAMAGE_METERS_PER_DIE),
+        )
+    else:
+        dice_count = 0
+    return FallDamageComputation(
+        height_meters=height_meters,
+        effective_height_meters=effective_height_meters,
+        dice_count=dice_count,
+        dice_sides=FALL_DAMAGE_DIE_SIDES,
+        damage_type=FALL_DAMAGE_TYPE,
+        damage_formula=f"{dice_count}d{FALL_DAMAGE_DIE_SIDES}" if causes_damage else None,
+        causes_damage=causes_damage,
+    )

--- a/apps/control-server/tests/test_fall_damage.py
+++ b/apps/control-server/tests/test_fall_damage.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import unittest
+
+from app.services.combat_service.fall_damage import (
+    FALL_DAMAGE_DIE_SIDES,
+    FALL_DAMAGE_METERS_PER_DIE,
+    FALL_DAMAGE_TYPE,
+    MAX_FALL_DAMAGE_DICE,
+    FallDamageComputation,
+    compute_fall_damage,
+)
+
+
+class TestComputeFallDamage(unittest.TestCase):
+    def _assert_no_damage(self, result: FallDamageComputation, original_height: float) -> None:
+        self.assertFalse(result.causes_damage)
+        self.assertEqual(result.dice_count, 0)
+        self.assertIsNone(result.damage_formula)
+        self.assertEqual(result.height_meters, original_height)
+        self.assertEqual(result.effective_height_meters, max(0, original_height))
+
+    def _assert_damage(self, result: FallDamageComputation, expected_dice: int, original_height: float) -> None:
+        self.assertTrue(result.causes_damage)
+        self.assertEqual(result.dice_count, expected_dice)
+        self.assertEqual(result.damage_formula, f"{expected_dice}d{FALL_DAMAGE_DIE_SIDES}")
+        self.assertEqual(result.dice_sides, FALL_DAMAGE_DIE_SIDES)
+        self.assertEqual(result.damage_type, FALL_DAMAGE_TYPE)
+        self.assertEqual(result.height_meters, original_height)
+        self.assertEqual(result.effective_height_meters, max(0, original_height))
+
+    def test_zero_height(self):
+        self._assert_no_damage(compute_fall_damage(0), 0)
+
+    def test_below_threshold_1_5(self):
+        self._assert_no_damage(compute_fall_damage(1.5), 1.5)
+
+    def test_below_threshold_2_99(self):
+        self._assert_no_damage(compute_fall_damage(2.99), 2.99)
+
+    def test_exactly_3m_is_1d6(self):
+        self._assert_damage(compute_fall_damage(3), 1, 3)
+
+    def test_5_99m_still_1d6(self):
+        self._assert_damage(compute_fall_damage(5.99), 1, 5.99)
+
+    def test_6m_is_2d6(self):
+        self._assert_damage(compute_fall_damage(6), 2, 6)
+
+    def test_9m_is_3d6(self):
+        self._assert_damage(compute_fall_damage(9), 3, 9)
+
+    def test_60m_hits_cap_20d6(self):
+        self._assert_damage(compute_fall_damage(60), 20, 60)
+
+    def test_90m_capped_at_20d6(self):
+        self._assert_damage(compute_fall_damage(90), 20, 90)
+
+    def test_negative_height_normalizes_to_zero(self):
+        result = compute_fall_damage(-1)
+        self._assert_no_damage(result, -1)
+        self.assertEqual(result.effective_height_meters, 0)
+
+    def test_constants_are_correct(self):
+        self.assertEqual(FALL_DAMAGE_METERS_PER_DIE, 3)
+        self.assertEqual(FALL_DAMAGE_DIE_SIDES, 6)
+        self.assertEqual(MAX_FALL_DAMAGE_DICE, 20)
+        self.assertEqual(FALL_DAMAGE_TYPE, "bludgeoning")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# feat(combat): add fall damage calculation foundation

## Summary

Adds the backend foundation for D&D 5e fall damage calculation.

This PR introduces a pure `compute_fall_damage()` helper that converts a fall height in meters into a structured fall damage computation result.

No combat state is mutated in this PR. No HP damage is applied. No map movement integration is added. No Cat’s Grace behavior is implemented yet.

Just gravity doing math. Um absurdo, mas necessário.

## Context

This is part of the fall damage + Cat’s Grace implementation roadmap.

The previous map work introduced elevation metadata through `cellElevations`. Before movement can trigger fall damage, the combat backend needs an authoritative and testable way to calculate how much damage a fall should cause.

This PR adds that calculation as a standalone helper so future issues can reuse it from:

- explicit/manual fall resolution
- automatic fall detection from map movement
- Cat’s Grace fall prevention
- fall combat log/UX

## What changed

### Added fall damage calculation helper

Created:

```text
apps/control-server/app/services/combat_service/fall_damage.py
````

Includes:

* `FALL_DAMAGE_METERS_PER_DIE = 3`
* `FALL_DAMAGE_DIE_SIDES = 6`
* `MAX_FALL_DAMAGE_DICE = 20`
* `FALL_DAMAGE_TYPE = "bludgeoning"`
* `FallDamageComputation`
* `compute_fall_damage(height_meters)`

The helper:

* normalizes negative heights to `0`
* returns no damage below `3m`
* computes `1d6` per `3m`
* caps fall damage at `20d6`
* returns damage type as `bludgeoning`
* returns a formula like `2d6` when damage applies
* does not roll dice
* does not apply HP damage
* does not mutate combat state

## Examples

```text
0m    → no damage
1.5m  → no damage
2.99m → no damage
3m    → 1d6 bludgeoning
5.99m → 1d6 bludgeoning
6m    → 2d6 bludgeoning
9m    → 3d6 bludgeoning
60m   → 20d6 bludgeoning
90m   → 20d6 bludgeoning
-1m   → normalized to 0, no damage
```

## Tests

Created:

```text
apps/control-server/tests/test_fall_damage.py
```

Coverage includes:

* no damage below `3m`
* correct dice count at `3m`, `6m`, and `9m`
* floor-based calculation for partial intervals
* `20d6` maximum cap
* values above `60m` remain capped
* negative heights normalize to no damage
* damage type is `bludgeoning`
* die side is `d6`
* damage formula is present only when damage applies

## Validation

```bash
cd apps/control-server && .venv/bin/pytest tests/test_fall_damage.py -v
```

Result:

```text
11/11 tests passing
```

## Out of scope

This PR intentionally does not implement:

* dice rolling
* HP damage application
* combat log entries
* prone condition after falling
* explicit/manual fall event
* automatic fall detection from map movement
* Cat’s Grace fall prevention
* Feather Fall
* resistance/vulnerability handling
* death save or instant death interactions

## Follow-ups

Recommended next issues:

1. Add explicit/manual fall resolution event
2. Detect falls from map movement elevation changes
3. Apply Cat’s Grace fall damage prevention
4. Add fall log/UX and hardening
