### PR TITLE
feat(combat): detect fall damage from map elevation movement

### DIFF
--- a/apps/control-server/app/integrations/limiar_map_client_parsers.py
+++ b/apps/control-server/app/integrations/limiar_map_client_parsers.py
@@ -329,4 +329,14 @@ def parse_movement_response(
         movement_budget=int(payload.get("movementBudget") or 0),
         movement_speed_cells=max(1, int(payload.get("movementSpeedCells") or 1)),
         remaining_budget=int(payload.get("remainingBudget") or 0),
+        source_elevation_meters=(
+            float(payload["sourceElevationMeters"])
+            if isinstance(payload.get("sourceElevationMeters"), (int, float))
+            else None
+        ),
+        destination_elevation_meters=(
+            float(payload["destinationElevationMeters"])
+            if isinstance(payload.get("destinationElevationMeters"), (int, float))
+            else None
+        ),
     )

--- a/apps/control-server/app/integrations/limiar_map_client_types.py
+++ b/apps/control-server/app/integrations/limiar_map_client_types.py
@@ -103,6 +103,8 @@ class LimiarMapMovementResponse:
     movement_budget: int
     movement_speed_cells: int
     remaining_budget: int
+    source_elevation_meters: float | None = None
+    destination_elevation_meters: float | None = None
 
 
 @dataclass(frozen=True)

--- a/apps/control-server/app/services/combat_service/movement.py
+++ b/apps/control-server/app/services/combat_service/movement.py
@@ -11,6 +11,7 @@ from app.schemas.combat import (
     CombatMovementPreviewResponse,
 )
 from .exceptions import CombatServiceError
+from .fall_damage import FALL_DAMAGE_METERS_PER_DIE
 from .movement_hazards import compute_movement_hazard_outcomes
 from .spells.area_targeting import AreaTargetingMixin
 
@@ -78,6 +79,14 @@ class CombatMovementMixin(AreaTargetingMixin):
                 actor=actor,
                 response=response,
                 actor_user_id=actor_user_id,
+            )
+            await cls._apply_movement_fall(
+                db,
+                session_id=session_id,
+                actor=actor,
+                response=response,
+                actor_user_id=actor_user_id,
+                is_gm=is_gm,
             )
 
         return CombatMovementPreviewResponse(
@@ -185,6 +194,34 @@ class CombatMovementMixin(AreaTargetingMixin):
                     "metersTraversed": outcome.get("meters_inside"),
                 },
             )
+
+    @classmethod
+    async def _apply_movement_fall(
+        cls,
+        db: Session,
+        *,
+        session_id: str,
+        actor: dict[str, Any],
+        response: Any,
+        actor_user_id: str,
+        is_gm: bool,
+    ) -> None:
+        source_elevation = response.source_elevation_meters if response.source_elevation_meters is not None else 0.0
+        dest_elevation = response.destination_elevation_meters if response.destination_elevation_meters is not None else 0.0
+        delta = dest_elevation - source_elevation
+        if delta >= 0:
+            return
+        fall_height = abs(delta)
+        if fall_height < FALL_DAMAGE_METERS_PER_DIE:
+            return
+        await cls.resolve_fall(
+            db,
+            session_id,
+            actor["id"],
+            fall_height,
+            actor_user_id,
+            is_gm,
+        )
 
     @classmethod
     async def preview_movement(

--- a/apps/control-server/tests/test_combat_movement_preview.py
+++ b/apps/control-server/tests/test_combat_movement_preview.py
@@ -1,7 +1,7 @@
 import asyncio
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 from app.integrations.limiar_map_client import (
     LimiarMapMovementCell,
@@ -349,6 +349,270 @@ class TestConfirmMovementAppliesHazards(unittest.TestCase):
         )
 
         mock_apply_damage.assert_not_called()
+
+
+def _movement_response_with_elevation(
+    source_elevation: float | None = None,
+    dest_elevation: float | None = None,
+    is_valid: bool = True,
+    source_cell: LimiarMapMovementCell | None = LimiarMapMovementCell(x=1, y=1),
+) -> LimiarMapMovementResponse:
+    return LimiarMapMovementResponse(
+        is_valid=is_valid,
+        reason=None if is_valid else "rejected",
+        session_id="session-1",
+        action_id="move-1",
+        version=15,
+        token_id="token-1",
+        combatant_id="combatant-1",
+        source_cell=source_cell,
+        destination_cell=LimiarMapMovementCell(x=3, y=1),
+        path=(LimiarMapMovementCell(x=3, y=1),),
+        path_cost_units=5,
+        movement_budget=30,
+        movement_speed_cells=6,
+        remaining_budget=25,
+        source_elevation_meters=source_elevation,
+        destination_elevation_meters=dest_elevation,
+    )
+
+
+class TestConfirmMovementFallDetection(unittest.TestCase):
+    @patch.object(CombatService, "_apply_movement_hazards")
+    @patch.object(CombatService, "resolve_fall")
+    @patch.object(CombatService, "_require_movement_capable")
+    @patch.object(CombatService, "_require_actor_status")
+    @patch.object(CombatService, "_require_active")
+    @patch.object(CombatService, "_resolve_actor_participant")
+    @patch.object(CombatService, "get_state")
+    @patch.object(CombatService, "_build_limiar_map_client")
+    def test_same_elevation_no_fall(
+        self, mock_build_client, mock_get_state, mock_resolve_actor,
+        _mock_require_active, _mock_require_status, _mock_require_movement,
+        mock_resolve_fall, mock_hazards,
+    ):
+        mock_get_state.return_value = SimpleNamespace(use_map=True, active_area_effects=[])
+        mock_resolve_actor.return_value = {"id": "participant-1", "ref_id": "combatant-1", "status": "active"}
+        client = MagicMock()
+        client.move_combatant.return_value = _movement_response_with_elevation(
+            source_elevation=6.0, dest_elevation=6.0,
+        )
+        mock_build_client.return_value = client
+
+        _run(CombatService.confirm_movement(
+            db=MagicMock(), session_id="session-1",
+            req=CombatMovementPreviewRequest(destination_cell={"x": 3, "y": 1}),
+            actor_user_id="user-1", is_gm=True,
+        ))
+
+        mock_resolve_fall.assert_not_called()
+
+    @patch.object(CombatService, "_apply_movement_hazards")
+    @patch.object(CombatService, "resolve_fall")
+    @patch.object(CombatService, "_require_movement_capable")
+    @patch.object(CombatService, "_require_actor_status")
+    @patch.object(CombatService, "_require_active")
+    @patch.object(CombatService, "_resolve_actor_participant")
+    @patch.object(CombatService, "get_state")
+    @patch.object(CombatService, "_build_limiar_map_client")
+    def test_upward_movement_no_fall(
+        self, mock_build_client, mock_get_state, mock_resolve_actor,
+        _mock_require_active, _mock_require_status, _mock_require_movement,
+        mock_resolve_fall, mock_hazards,
+    ):
+        mock_get_state.return_value = SimpleNamespace(use_map=True, active_area_effects=[])
+        mock_resolve_actor.return_value = {"id": "participant-1", "ref_id": "combatant-1", "status": "active"}
+        client = MagicMock()
+        client.move_combatant.return_value = _movement_response_with_elevation(
+            source_elevation=0.0, dest_elevation=6.0,
+        )
+        mock_build_client.return_value = client
+
+        _run(CombatService.confirm_movement(
+            db=MagicMock(), session_id="session-1",
+            req=CombatMovementPreviewRequest(destination_cell={"x": 3, "y": 1}),
+            actor_user_id="user-1", is_gm=True,
+        ))
+
+        mock_resolve_fall.assert_not_called()
+
+    @patch.object(CombatService, "_apply_movement_hazards")
+    @patch.object(CombatService, "resolve_fall")
+    @patch.object(CombatService, "_require_movement_capable")
+    @patch.object(CombatService, "_require_actor_status")
+    @patch.object(CombatService, "_require_active")
+    @patch.object(CombatService, "_resolve_actor_participant")
+    @patch.object(CombatService, "get_state")
+    @patch.object(CombatService, "_build_limiar_map_client")
+    def test_small_drop_below_threshold_no_fall(
+        self, mock_build_client, mock_get_state, mock_resolve_actor,
+        _mock_require_active, _mock_require_status, _mock_require_movement,
+        mock_resolve_fall, mock_hazards,
+    ):
+        mock_get_state.return_value = SimpleNamespace(use_map=True, active_area_effects=[])
+        mock_resolve_actor.return_value = {"id": "participant-1", "ref_id": "combatant-1", "status": "active"}
+        client = MagicMock()
+        client.move_combatant.return_value = _movement_response_with_elevation(
+            source_elevation=3.0, dest_elevation=1.0,
+        )
+        mock_build_client.return_value = client
+
+        _run(CombatService.confirm_movement(
+            db=MagicMock(), session_id="session-1",
+            req=CombatMovementPreviewRequest(destination_cell={"x": 3, "y": 1}),
+            actor_user_id="user-1", is_gm=True,
+        ))
+
+        mock_resolve_fall.assert_not_called()
+
+    @patch.object(CombatService, "_apply_movement_hazards")
+    @patch.object(CombatService, "resolve_fall")
+    @patch.object(CombatService, "_require_movement_capable")
+    @patch.object(CombatService, "_require_actor_status")
+    @patch.object(CombatService, "_require_active")
+    @patch.object(CombatService, "_resolve_actor_participant")
+    @patch.object(CombatService, "get_state")
+    @patch.object(CombatService, "_build_limiar_map_client")
+    def test_threshold_drop_3m_calls_resolve_fall(
+        self, mock_build_client, mock_get_state, mock_resolve_actor,
+        _mock_require_active, _mock_require_status, _mock_require_movement,
+        mock_resolve_fall, mock_hazards,
+    ):
+        mock_get_state.return_value = SimpleNamespace(use_map=True, active_area_effects=[])
+        mock_resolve_actor.return_value = {"id": "participant-1", "ref_id": "combatant-1", "status": "active"}
+        client = MagicMock()
+        client.move_combatant.return_value = _movement_response_with_elevation(
+            source_elevation=6.0, dest_elevation=3.0,
+        )
+        mock_build_client.return_value = client
+
+        _run(CombatService.confirm_movement(
+            db=MagicMock(), session_id="session-1",
+            req=CombatMovementPreviewRequest(destination_cell={"x": 3, "y": 1}),
+            actor_user_id="user-1", is_gm=True,
+        ))
+
+        mock_resolve_fall.assert_called_once_with(
+            ANY, "session-1", "participant-1", 3.0, "user-1", True,
+        )
+
+    @patch.object(CombatService, "_apply_movement_hazards")
+    @patch.object(CombatService, "resolve_fall")
+    @patch.object(CombatService, "_require_movement_capable")
+    @patch.object(CombatService, "_require_actor_status")
+    @patch.object(CombatService, "_require_active")
+    @patch.object(CombatService, "_resolve_actor_participant")
+    @patch.object(CombatService, "get_state")
+    @patch.object(CombatService, "_build_limiar_map_client")
+    def test_larger_drop_6m_calls_resolve_fall(
+        self, mock_build_client, mock_get_state, mock_resolve_actor,
+        _mock_require_active, _mock_require_status, _mock_require_movement,
+        mock_resolve_fall, mock_hazards,
+    ):
+        mock_get_state.return_value = SimpleNamespace(use_map=True, active_area_effects=[])
+        mock_resolve_actor.return_value = {"id": "participant-1", "ref_id": "combatant-1", "status": "active"}
+        client = MagicMock()
+        client.move_combatant.return_value = _movement_response_with_elevation(
+            source_elevation=6.0, dest_elevation=0.0,
+        )
+        mock_build_client.return_value = client
+
+        _run(CombatService.confirm_movement(
+            db=MagicMock(), session_id="session-1",
+            req=CombatMovementPreviewRequest(destination_cell={"x": 3, "y": 1}),
+            actor_user_id="user-1", is_gm=True,
+        ))
+
+        mock_resolve_fall.assert_called_once_with(
+            ANY, "session-1", "participant-1", 6.0, "user-1", True,
+        )
+
+    @patch.object(CombatService, "_apply_movement_hazards")
+    @patch.object(CombatService, "resolve_fall")
+    @patch.object(CombatService, "_require_movement_capable")
+    @patch.object(CombatService, "_require_actor_status")
+    @patch.object(CombatService, "_require_active")
+    @patch.object(CombatService, "_resolve_actor_participant")
+    @patch.object(CombatService, "get_state")
+    @patch.object(CombatService, "_build_limiar_map_client")
+    def test_missing_elevation_defaults_to_zero_no_fall(
+        self, mock_build_client, mock_get_state, mock_resolve_actor,
+        _mock_require_active, _mock_require_status, _mock_require_movement,
+        mock_resolve_fall, mock_hazards,
+    ):
+        mock_get_state.return_value = SimpleNamespace(use_map=True, active_area_effects=[])
+        mock_resolve_actor.return_value = {"id": "participant-1", "ref_id": "combatant-1", "status": "active"}
+        client = MagicMock()
+        client.move_combatant.return_value = _movement_response_with_elevation(
+            source_elevation=None, dest_elevation=None,
+        )
+        mock_build_client.return_value = client
+
+        _run(CombatService.confirm_movement(
+            db=MagicMock(), session_id="session-1",
+            req=CombatMovementPreviewRequest(destination_cell={"x": 3, "y": 1}),
+            actor_user_id="user-1", is_gm=True,
+        ))
+
+        mock_resolve_fall.assert_not_called()
+
+    @patch.object(CombatService, "_apply_movement_hazards")
+    @patch.object(CombatService, "resolve_fall")
+    @patch.object(CombatService, "_require_movement_capable")
+    @patch.object(CombatService, "_require_actor_status")
+    @patch.object(CombatService, "_require_active")
+    @patch.object(CombatService, "_resolve_actor_participant")
+    @patch.object(CombatService, "get_state")
+    @patch.object(CombatService, "_build_limiar_map_client")
+    def test_failed_movement_no_fall(
+        self, mock_build_client, mock_get_state, mock_resolve_actor,
+        _mock_require_active, _mock_require_status, _mock_require_movement,
+        mock_resolve_fall, mock_hazards,
+    ):
+        mock_get_state.return_value = SimpleNamespace(use_map=True, active_area_effects=[])
+        mock_resolve_actor.return_value = {"id": "participant-1", "ref_id": "combatant-1", "status": "active"}
+        client = MagicMock()
+        client.move_combatant.return_value = _movement_response_with_elevation(
+            source_elevation=6.0, dest_elevation=0.0, is_valid=False,
+        )
+        mock_build_client.return_value = client
+
+        _run(CombatService.confirm_movement(
+            db=MagicMock(), session_id="session-1",
+            req=CombatMovementPreviewRequest(destination_cell={"x": 3, "y": 1}),
+            actor_user_id="user-1", is_gm=True,
+        ))
+
+        mock_resolve_fall.assert_not_called()
+
+    @patch.object(CombatService, "_apply_movement_hazards")
+    @patch.object(CombatService, "resolve_fall")
+    @patch.object(CombatService, "_require_movement_capable")
+    @patch.object(CombatService, "_require_actor_status")
+    @patch.object(CombatService, "_require_active")
+    @patch.object(CombatService, "_resolve_actor_participant")
+    @patch.object(CombatService, "get_state")
+    @patch.object(CombatService, "_build_limiar_map_client")
+    def test_preview_does_not_trigger_fall(
+        self, mock_build_client, mock_get_state, mock_resolve_actor,
+        _mock_require_active, _mock_require_status, _mock_require_movement,
+        mock_resolve_fall, mock_hazards,
+    ):
+        mock_get_state.return_value = SimpleNamespace(use_map=True, active_area_effects=[])
+        mock_resolve_actor.return_value = {"id": "participant-1", "ref_id": "combatant-1", "status": "active"}
+        client = MagicMock()
+        client.preview_movement.return_value = _movement_response_with_elevation(
+            source_elevation=6.0, dest_elevation=0.0,
+        )
+        mock_build_client.return_value = client
+
+        _run(CombatService.preview_movement(
+            db=MagicMock(), session_id="session-1",
+            req=CombatMovementPreviewRequest(destination_cell={"x": 3, "y": 1}),
+            actor_user_id="user-1", is_gm=True,
+        ))
+
+        mock_resolve_fall.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/apps/map-server/src/modules/encounters/encounter-repository.ts
+++ b/apps/map-server/src/modules/encounters/encounter-repository.ts
@@ -245,6 +245,15 @@ export class InMemoryEncounterRepository {
     return this.saveEncounter(encounter);
   }
 
+  getCellElevationMeters(sessionId: string, cell: { x: number; y: number }): number {
+    const encounter = this.getEncounter(sessionId);
+    if (!encounter) return 0;
+    const entry = encounter.cellElevations.find(
+      (e) => e.cell.x === cell.x && e.cell.y === cell.y
+    );
+    return entry?.elevationMeters ?? 0;
+  }
+
   setActiveAreaEffects(sessionId: string, activeAreaEffects: ActiveAreaEffect[]): EncounterState {
     const encounter = this.requireEncounter(sessionId);
     encounter.activeAreaEffects = activeAreaEffects;

--- a/apps/map-server/src/routes/integration/movement.routes.ts
+++ b/apps/map-server/src/routes/integration/movement.routes.ts
@@ -35,6 +35,8 @@ function toMovementResponse(
     movementBudget?: number;
     movementSpeedCells?: number;
     remainingBudget?: number;
+    sourceElevationMeters?: number | null;
+    destinationElevationMeters?: number | null;
   }
 ) {
   return movementPreviewResponseSchema.parse({
@@ -51,7 +53,9 @@ function toMovementResponse(
     pathCostUnits: result.pathCostUnits ?? 0,
     movementBudget: result.movementBudget ?? 0,
     movementSpeedCells: result.movementSpeedCells ?? 1,
-    remainingBudget: result.remainingBudget ?? result.movementBudget ?? 0
+    remainingBudget: result.remainingBudget ?? result.movementBudget ?? 0,
+    sourceElevationMeters: result.sourceElevationMeters ?? null,
+    destinationElevationMeters: result.destinationElevationMeters ?? null
   });
 }
 
@@ -81,8 +85,16 @@ export function registerMovementRoutes(
     );
 
     const result = movementService.previewMovement(sessionId, combatantId, destinationCell);
+    const sourceElevation = result.source
+      ? repository.getCellElevationMeters(sessionId, result.source)
+      : null;
+    const destinationElevation = repository.getCellElevationMeters(sessionId, destinationCell);
     return reply.status(200).send(
-      toMovementResponse(sessionId, actionId, encounter.combatState.version, result)
+      toMovementResponse(sessionId, actionId, encounter.combatState.version, {
+        ...result,
+        sourceElevationMeters: sourceElevation,
+        destinationElevationMeters: destinationElevation
+      })
     );
   });
 
@@ -106,6 +118,11 @@ export function registerMovementRoutes(
 
     const result = movementService.moveCombatant(sessionId, combatantId, destinationCell, actionId);
     const currentEncounter = "encounter" in result ? result.encounter : encounter;
+    const sourceForElevation = "source" in result ? result.source : currentEncounter.tokens.find((token) => token.combatantId === combatantId)?.position;
+    const sourceElevation = sourceForElevation
+      ? repository.getCellElevationMeters(sessionId, sourceForElevation)
+      : null;
+    const destinationElevation = repository.getCellElevationMeters(sessionId, destinationCell);
     const response = toMovementResponse(sessionId, actionId, currentEncounter.combatState.version, {
       accepted: result.accepted,
       rejectionReason: result.rejectionReason,
@@ -120,7 +137,9 @@ export function registerMovementRoutes(
         "movementSpeedCells" in result
           ? result.movementSpeedCells
           : currentEncounter.tokens.find((token) => token.combatantId === combatantId)?.movementSpeedCells,
-      remainingBudget: result.remainingBudget
+      remainingBudget: result.remainingBudget,
+      sourceElevationMeters: sourceElevation,
+      destinationElevationMeters: destinationElevation
     });
 
     if (result.accepted && response.tokenId && response.sourceCell) {

--- a/packages/shared-contracts/src/integration.combat.ts
+++ b/packages/shared-contracts/src/integration.combat.ts
@@ -127,6 +127,8 @@ export const movementPreviewResponseSchema = z.object({
   movementBudget: z.number().int().nonnegative(),
   movementSpeedCells: z.number().int().positive(),
   remainingBudget: z.number().int().nonnegative(),
+  sourceElevationMeters: z.number().nullable().optional(),
+  destinationElevationMeters: z.number().nullable().optional(),
 });
 
 export type InitiativeEntry = z.infer<typeof initiativeEntrySchema>;


### PR DESCRIPTION
# feat(combat): detect fall damage from map elevation movement

## Summary

Automatically detects fall damage when a combatant confirms movement from a higher map cell to a lower map cell.

This PR threads elevation data from `map-server` movement responses into `control-server`, then compares source/destination elevations after confirmed movement. When the vertical drop is at least `3m`, the backend calls the existing `resolve_fall()` action to apply fall damage through the established combat damage pipeline.

No Cat’s Grace behavior is added in this PR.

## Context

Previous fall-damage work added:

- `cellElevations` support in LimiarMap
- pure fall damage calculation via `compute_fall_damage()`
- explicit/manual fall resolution via `resolve_fall()`

This PR connects those pieces to map movement.

The frontend still does not calculate, roll, or apply fall damage. It merely receives the resulting state/log updates like a civilized citizen under backend authority.

## What changed

### Shared contracts

Updated:

```text
packages/shared-contracts/src/integration.combat.ts
````

Added optional nullable elevation fields to `movementPreviewResponseSchema`:

```ts
sourceElevationMeters?: number | null
destinationElevationMeters?: number | null
```

These fields are optional for backward compatibility with movement responses that do not include elevation data.

### Map server

Updated:

```text
apps/map-server/src/modules/encounters/encounter-repository.ts
apps/map-server/src/routes/integration/movement.routes.ts
```

Added `getCellElevationMeters()` to look up cell elevation from the encounter state.

Behavior:

* reads elevation from `cellElevations`
* defaults missing cells to `0`
* includes source/destination elevation in movement preview/confirm responses

Movement responses now carry enough data for `control-server` to detect vertical drops without making another map-state request.

### Control server integration parser

Updated:

```text
apps/control-server/app/integrations/limiar_map_client_types.py
apps/control-server/app/integrations/limiar_map_client_parsers.py
```

Added and parsed:

```py
source_elevation_meters: float | None
destination_elevation_meters: float | None
```

Missing elevation values default to `None`, and movement fall detection treats those as `0m`.

### Combat movement integration

Updated:

```text
apps/control-server/app/services/combat_service/movement.py
```

Added `_apply_movement_fall()`.

The new flow after confirmed valid movement is:

```text
movement confirmed
→ movement hazards resolve first
→ source/destination elevation are compared
→ if drop >= 3m, resolve_fall() is called
```

Fall detection logic:

```text
delta = destinationElevation - sourceElevation

delta >= 0      → no fall
abs(delta) < 3m → no fall damage
abs(delta) >= 3m → call resolve_fall()
```

Examples:

```text
0m → 0m   = no fall
0m → 6m   = upward movement, no fall
6m → 6m   = no fall
6m → 3m   = 3m fall
6m → 0m   = 6m fall
```

The implementation intentionally reuses `resolve_fall()` instead of duplicating fall damage logic. That keeps dice rolling, HP mutation, concentration checks, and logging centralized in the existing fall resolver.

### Tests

Updated:

```text
apps/control-server/tests/test_combat_movement_preview.py
```

Added `TestConfirmMovementFallDetection` coverage for:

* same elevation movement
* upward movement
* below-threshold drop
* threshold `3m` drop
* larger `6m` drop
* missing elevation defaults to `0`
* failed movement does not trigger fall
* preview-only movement does not trigger fall

## Ordering

Movement hazards resolve before fall damage.

This is intentional:

```text
1. movement is confirmed
2. movement hazards apply
3. elevation drop is checked
4. fall damage resolves
```

So if a creature walks through Spike Growth and then drops off a ledge, those are treated as separate consequences of the movement. Two damages, two possible logs/checks, one very bad day. 

## Validation

```bash
cd apps/control-server
.venv/bin/pytest tests/test_fall_damage.py tests/test_combat_movement_preview.py -v
```

Result:

```text
34/34 passing
```

TypeScript validation:

```bash
npx tsc --noEmit -p packages/shared-contracts/tsconfig.json
npx tsc --noEmit -p apps/map-server/tsconfig.json
```

Result:

```text
pass
```

## Out of scope

This PR intentionally does not implement:

* Cat’s Grace fall prevention
* Feather Fall
* prone after falling
* forced movement rules
* frontend fall preview
* fall confirmation UX
* path-based partial falling
* map-server HP mutation

## Notes for reviewers

The key design choice is passing only `sourceElevationMeters` and `destinationElevationMeters` through the movement response instead of syncing the full elevation layer into `control-server`.

This keeps ownership clean:

```text
map-server owns map/elevation lookup
control-server owns combat damage/HP/logs
```

The movement integration then simply compares the two elevation values and delegates damage to the existing `resolve_fall()` backend action.

## Follow-ups

Recommended next issues:

1. Apply Cat’s Grace fall damage prevention
2. Add prone behavior after damaging falls
3. Add fall UX/log hardening
4. Add forced movement / falling hazards integration