### PR TITLE
feat(combat): apply Cat’s Grace fall damage prevention

### DIFF
--- a/apps/control-server/app/services/combat_service/condition_effects_predicates.py
+++ b/apps/control-server/app/services/combat_service/condition_effects_predicates.py
@@ -92,6 +92,32 @@ def has_condition(participant: dict, condition_type: str) -> bool:
     return False
 
 
+def is_incapacitated(participant: dict) -> bool:
+    return any(has_condition(participant, c) for c in _INCAPACITATING_CONDITIONS)
+
+
+def get_fall_damage_immunity_threshold(participant: dict) -> tuple[float | None, str | None]:
+    best: float | None = None
+    label: str | None = None
+    for effect in participant.get("active_effects") or []:
+        if effect.get("kind") != "spell_effect":
+            continue
+        metadata = effect.get("metadata") or {}
+        declarative = metadata.get("declarative_effect")
+        if not isinstance(declarative, dict):
+            continue
+        if declarative.get("type") != "fall_damage_immunity_threshold":
+            continue
+        params = declarative.get("params") or {}
+        threshold = params.get("max_distance_meters")
+        if not isinstance(threshold, (int, float)):
+            continue
+        if best is None or float(threshold) > best:
+            best = float(threshold)
+            label = effect.get("display_label") or metadata.get("source_spell_name") or "Graça do Gato"
+    return best, label
+
+
 def is_action_blocked(participant: dict) -> bool:
     for effect in participant.get("active_effects") or []:
         if effect.get("kind") == "condition" and effect.get("condition_type") in _INCAPACITATING_CONDITIONS:

--- a/apps/control-server/app/services/combat_service/damage_admin.py
+++ b/apps/control-server/app/services/combat_service/damage_admin.py
@@ -5,6 +5,7 @@ from sqlmodel import Session
 
 from app.services.session_state_finalize import finalize_session_state_data
 
+from .condition_effects_predicates import get_fall_damage_immunity_threshold, is_incapacitated
 from .damage_core import CombatDamageCoreMixin
 from .exceptions import CombatServiceError, _roll_dice_expression
 from .fall_damage import FallDamageResolution, compute_fall_damage
@@ -149,6 +150,45 @@ class CombatDamageAdminMixin(CombatDamageCoreMixin):
                     "participantId": participant_id,
                     "heightMeters": height_meters,
                     "causesDamage": False,
+                },
+            )
+            return {"resolution": resolution.model_dump(mode="json"), "new_hp": None, "concentration_check": None}
+        immunity_threshold, immunity_label = get_fall_damage_immunity_threshold(participant)
+        if (
+            immunity_threshold is not None
+            and computation.effective_height_meters <= immunity_threshold
+            and not is_incapacitated(participant)
+        ):
+            resolution = FallDamageResolution(
+                participant_id=participant_id,
+                height_meters=computation.height_meters,
+                effective_height_meters=computation.effective_height_meters,
+                dice_count=computation.dice_count,
+                dice_sides=computation.dice_sides,
+                damage_formula=computation.damage_formula,
+                damage_type=computation.damage_type,
+                damage_total=0,
+                causes_damage=True,
+                applied_damage=False,
+                prevented=True,
+                prevention_sources=[immunity_label],
+            )
+            db.commit()
+            await cls._emit_state(session_id, state)
+            await cls._emit_and_persist_log(
+                db,
+                session_id,
+                actor_user_id,
+                None,
+                {
+                    "message": f"{display_name} cai {height_meters}m e não sofre dano por {immunity_label}.",
+                    "source": "environmental_fall",
+                    "actorUserId": actor_user_id,
+                    "participantId": participant_id,
+                    "heightMeters": height_meters,
+                    "causesDamage": False,
+                    "prevented": True,
+                    "preventionSources": [immunity_label],
                 },
             )
             return {"resolution": resolution.model_dump(mode="json"), "new_hp": None, "concentration_check": None}

--- a/apps/control-server/tests/test_fall_damage.py
+++ b/apps/control-server/tests/test_fall_damage.py
@@ -301,5 +301,159 @@ class TestResolveFallDamage(unittest.IsolatedAsyncioTestCase):
         )
 
 
+def _make_cats_grace_effect(threshold_m: float = 6.0, label: str = "Graça do Gato") -> dict:
+    return {
+        "id": "effect-cg-1",
+        "kind": "spell_effect",
+        "source_participant_id": "caster-1",
+        "duration_type": "manual",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "display_label": label,
+        "metadata": {
+            "source_spell_name": label,
+            "declarative_effect": {
+                "type": "fall_damage_immunity_threshold",
+                "params": {"max_distance_meters": threshold_m},
+            },
+        },
+    }
+
+
+def _make_incapacitated_effect() -> dict:
+    return {
+        "id": "cond-1",
+        "kind": "condition",
+        "condition_type": "incapacitated",
+        "duration_type": "manual",
+        "created_at": "2026-01-01T00:00:00+00:00",
+    }
+
+
+def _make_state_with_effects(effects: list) -> CombatState:
+    state = _make_active_state()
+    state.participants[1]["active_effects"] = effects
+    return state
+
+
+@patch.object(CombatService, "_emit_and_persist_log", new_callable=AsyncMock)
+@patch.object(CombatService, "_emit_state", new_callable=AsyncMock)
+@patch.object(CombatService, "get_state")
+class TestResolveFallDamagePrevention(unittest.IsolatedAsyncioTestCase):
+    async def test_cats_grace_prevents_6m_fall(self, mock_get_state, mock_emit_state, mock_emit_log):
+        mock_get_state.return_value = _make_state_with_effects([_make_cats_grace_effect(6.0)])
+        result = await CombatService.resolve_fall(
+            MagicMock(), "session-1", "entity-e1", 6.0, "user-1", is_gm=True,
+        )
+        resolution = result["resolution"]
+        self.assertTrue(resolution["prevented"])
+        self.assertFalse(resolution["applied_damage"])
+        self.assertEqual(resolution["damage_total"], 0)
+        self.assertEqual(resolution["prevention_sources"], ["Graça do Gato"])
+        self.assertIsNone(result["new_hp"])
+
+    async def test_cats_grace_prevents_3m_fall(self, mock_get_state, mock_emit_state, mock_emit_log):
+        mock_get_state.return_value = _make_state_with_effects([_make_cats_grace_effect(6.0)])
+        result = await CombatService.resolve_fall(
+            MagicMock(), "session-1", "entity-e1", 3.0, "user-1", is_gm=True,
+        )
+        resolution = result["resolution"]
+        self.assertTrue(resolution["prevented"])
+        self.assertFalse(resolution["applied_damage"])
+        self.assertEqual(resolution["damage_total"], 0)
+
+    @patch("app.services.combat_service.damage_admin._roll_dice_expression", return_value=9)
+    @patch.object(CombatService, "_emit_entity_hp_update", new_callable=AsyncMock)
+    @patch.object(CombatService, "_apply_damage_to_target")
+    async def test_cats_grace_does_not_prevent_9m_fall(
+        self, mock_apply_damage, mock_emit_hp, mock_roll, mock_get_state, mock_emit_state, mock_emit_log,
+    ):
+        mock_get_state.return_value = _make_state_with_effects([_make_cats_grace_effect(6.0)])
+        mock_apply_damage.return_value = (5, "", 14, None)
+        result = await CombatService.resolve_fall(
+            MagicMock(), "session-1", "entity-e1", 9.0, "user-1", is_gm=True,
+        )
+        resolution = result["resolution"]
+        self.assertFalse(resolution["prevented"])
+        self.assertTrue(resolution["applied_damage"])
+        self.assertEqual(resolution["damage_total"], 9)
+
+    @patch("app.services.combat_service.damage_admin._roll_dice_expression", return_value=7)
+    @patch.object(CombatService, "_emit_entity_hp_update", new_callable=AsyncMock)
+    @patch.object(CombatService, "_apply_damage_to_target")
+    async def test_no_cats_grace_6m_fall_takes_damage(
+        self, mock_apply_damage, mock_emit_hp, mock_roll, mock_get_state, mock_emit_state, mock_emit_log,
+    ):
+        mock_get_state.return_value = _make_state_with_effects([])
+        mock_apply_damage.return_value = (3, "", 10, None)
+        result = await CombatService.resolve_fall(
+            MagicMock(), "session-1", "entity-e1", 6.0, "user-1", is_gm=True,
+        )
+        resolution = result["resolution"]
+        self.assertFalse(resolution["prevented"])
+        self.assertTrue(resolution["applied_damage"])
+
+    @patch("app.services.combat_service.damage_admin._roll_dice_expression", return_value=7)
+    @patch.object(CombatService, "_emit_entity_hp_update", new_callable=AsyncMock)
+    @patch.object(CombatService, "_apply_damage_to_target")
+    async def test_cats_grace_incapacitated_6m_takes_damage(
+        self, mock_apply_damage, mock_emit_hp, mock_roll, mock_get_state, mock_emit_state, mock_emit_log,
+    ):
+        mock_get_state.return_value = _make_state_with_effects(
+            [_make_cats_grace_effect(6.0), _make_incapacitated_effect()]
+        )
+        mock_apply_damage.return_value = (3, "", 10, None)
+        result = await CombatService.resolve_fall(
+            MagicMock(), "session-1", "entity-e1", 6.0, "user-1", is_gm=True,
+        )
+        resolution = result["resolution"]
+        self.assertFalse(resolution["prevented"])
+        self.assertTrue(resolution["applied_damage"])
+
+    @patch("app.services.combat_service.damage_admin._roll_dice_expression")
+    async def test_prevented_fall_does_not_call_dice_roller(
+        self, mock_roll, mock_get_state, mock_emit_state, mock_emit_log,
+    ):
+        mock_get_state.return_value = _make_state_with_effects([_make_cats_grace_effect(6.0)])
+        await CombatService.resolve_fall(
+            MagicMock(), "session-1", "entity-e1", 6.0, "user-1", is_gm=True,
+        )
+        mock_roll.assert_not_called()
+
+    @patch.object(CombatService, "_apply_damage_to_target")
+    async def test_prevented_fall_does_not_call_apply_damage(
+        self, mock_apply_damage, mock_get_state, mock_emit_state, mock_emit_log,
+    ):
+        mock_get_state.return_value = _make_state_with_effects([_make_cats_grace_effect(6.0)])
+        await CombatService.resolve_fall(
+            MagicMock(), "session-1", "entity-e1", 6.0, "user-1", is_gm=True,
+        )
+        mock_apply_damage.assert_not_called()
+
+    async def test_prevented_fall_log_message_contains_label(self, mock_get_state, mock_emit_state, mock_emit_log):
+        mock_get_state.return_value = _make_state_with_effects([_make_cats_grace_effect(6.0)])
+        await CombatService.resolve_fall(
+            MagicMock(), "session-1", "entity-e1", 6.0, "user-1", is_gm=True,
+        )
+        log_payload = mock_emit_log.call_args[0][4]
+        self.assertIn("Graça do Gato", log_payload["message"])
+        self.assertTrue(log_payload["prevented"])
+        self.assertEqual(log_payload["source"], "environmental_fall")
+
+    async def test_multiple_immunity_effects_uses_highest_threshold(
+        self, mock_get_state, mock_emit_state, mock_emit_log,
+    ):
+        effects = [
+            _make_cats_grace_effect(5.0, "Efeito A"),
+            {**_make_cats_grace_effect(8.0, "Efeito B"), "id": "effect-cg-2"},
+        ]
+        mock_get_state.return_value = _make_state_with_effects(effects)
+        result = await CombatService.resolve_fall(
+            MagicMock(), "session-1", "entity-e1", 7.0, "user-1", is_gm=True,
+        )
+        resolution = result["resolution"]
+        self.assertTrue(resolution["prevented"])
+        self.assertEqual(resolution["prevention_sources"], ["Efeito B"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# feat(combat): apply Cat’s Grace fall damage prevention

## Summary

Adds Cat’s Grace fall damage prevention to fall resolution.

This PR wires the existing declarative `fall_damage_immunity_threshold` effect into `resolve_fall()`, allowing Cat’s Grace / Graça do Gato to prevent fall damage for falls up to and including `6m`.

The prevention works for both explicit/manual fall resolution and movement-triggered fall resolution, because map movement already delegates fall damage to `resolve_fall()`.

No map movement code was changed.

## Context

Previous fall-damage work added:

- pure fall damage calculation
- explicit/manual fall resolution
- automatic fall detection from map elevation movement

Cat’s Grace already applied a declarative effect with:

```json
{
  "type": "fall_damage_immunity_threshold",
  "params": {
    "max_distance_meters": 6.0
  }
}
````

However, `resolve_fall()` did not consume that effect yet.

This PR connects the declarative effect to fall resolution.

In other words: the cat was already wearing the crown, the backend just finally acknowledged the monarchy.

## What changed

### Effect predicates

Updated:

```text
apps/control-server/app/services/combat_service/condition_effects_predicates.py
```

Added:

```py
is_incapacitated(participant)
```

Checks whether the participant has any incapacitating condition using the existing condition predicate patterns.

Added:

```py
get_fall_damage_immunity_threshold(participant)
```

This helper:

* scans active effects
* finds declarative spell effects of type `fall_damage_immunity_threshold`
* reads `params.max_distance_meters`
* ignores malformed thresholds safely
* uses the highest available threshold when multiple effects exist
* returns the associated label/source for logging
* falls back safely when no label is available

### Fall resolution prevention

Updated:

```text
apps/control-server/app/services/combat_service/damage_admin.py
```

`resolve_fall()` now checks for fall prevention after the no-damage early return and before dice rolling.

The flow is now:

```text
compute fall damage
→ if fall does not cause damage, return/log no damage
→ check fall damage immunity threshold
→ if fall height is within threshold and participant is not incapacitated, prevent damage
→ otherwise roll and apply damage normally
```

The prevention check uses:

```py
computation.effective_height_meters <= immunity_threshold
```

rather than raw height, so it stays aligned with the fall damage calculation model.

When prevented:

* no dice are rolled
* HP is not mutated
* `_apply_damage_to_target()` is not called
* `prevented=True`
* `applied_damage=False`
* `damage_total=0`
* `prevention_sources` includes the effect label
* combat log explains the prevention in Portuguese

Example behavior:

```text
Graça do Gato + queda de 6m → sem dano
Graça do Gato + queda de 9m → dano normal
Graça do Gato + incapacitado + queda de 6m → dano normal
```

### Tests

Updated:

```text
apps/control-server/tests/test_fall_damage.py
```

Added `TestResolveFallDamagePrevention` with 9 new tests covering:

* Cat’s Grace prevents a `6m` fall
* Cat’s Grace prevents a `3m` fall
* Cat’s Grace does not prevent a `9m` fall
* no Cat’s Grace means normal `6m` fall damage
* incapacitated participants do not benefit from Cat’s Grace
* prevented fall does not call the dice roller
* prevented fall does not call `_apply_damage_to_target()`
* prevention log includes the effect label
* multiple immunity effects use the highest threshold

## Behavior

```text
fall < 3m
→ no damage by normal fall rules

fall <= 6m + Cat’s Grace + not incapacitated
→ damage prevented

fall > 6m + Cat’s Grace
→ normal fall damage

fall <= 6m + Cat’s Grace + incapacitated
→ normal fall damage
```

## Validation

```bash
cd apps/control-server
python -m pytest tests/test_fall_damage.py -v
```

Result:

```text
30/30 passed
```

All existing fall damage tests remain green, and all 9 new prevention tests pass.

## Out of scope

This PR intentionally does not implement:

* Feather Fall
* prone after falling
* fall damage reduction above 6m
* frontend fall preview
* fall warning UI
* map rendering changes
* movement code changes
* spell catalog redesign
* changes to Dexterity check advantage behavior

## Notes for reviewers

The important design choice is that Cat’s Grace is handled through the existing declarative effect system:

```text
fall_damage_immunity_threshold
```

rather than hardcoding the spell name in fall resolution.

This keeps fall prevention reusable for future effects while preserving Cat’s Grace behavior.

Movement-triggered falls already call `resolve_fall()`, so they automatically benefit from this prevention path without any additional movement integration.

## Follow-ups

Recommended next issues:

1. Add prone behavior after damaging falls
2. Add fall UX/log hardening
3. Add Feather Fall support
4. Add forced movement / falling hazards integration