### PR TITLE
feat(fall-damage): apply prone condition after damaging falls and upd…

### DIFF
--- a/apps/control-server/app/services/combat_service/damage_admin.py
+++ b/apps/control-server/app/services/combat_service/damage_admin.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from uuid import uuid4
+
 from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import Session
 
 from app.services.session_state_finalize import finalize_session_state_data
 
-from .condition_effects_predicates import get_fall_damage_immunity_threshold, is_incapacitated
+from .condition_effects_predicates import get_fall_damage_immunity_threshold, has_condition, is_incapacitated
 from .damage_core import CombatDamageCoreMixin
 from .exceptions import CombatServiceError, _roll_dice_expression
 from .fall_damage import FallDamageResolution, compute_fall_damage
@@ -202,6 +205,27 @@ class CombatDamageAdminMixin(CombatDamageCoreMixin):
             is_crit=False,
             state=state,
         )
+        prone_applied = False
+        if damage_total > 0 and not has_condition(participant, "prone"):
+            prone_effect = {
+                "id": str(uuid4()),
+                "source_participant_id": None,
+                "kind": "condition",
+                "condition_type": "prone",
+                "numeric_value": None,
+                "duration_type": "manual",
+                "remaining_rounds": None,
+                "expires_on": None,
+                "expires_at_participant_id": participant_id,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "metadata": {"source": "environmental_fall"},
+                "display_label": None,
+            }
+            effects = cls._get_participant_effects(participant)
+            effects.append(prone_effect)
+            cls._set_participant_effects(participant, effects)
+            flag_modified(state, "participants")
+            prone_applied = True
         db.commit()
         if kind == "player":
             target_state, *_ = cls._get_stats(db, ref_id, kind, session_id)
@@ -210,13 +234,14 @@ class CombatDamageAdminMixin(CombatDamageCoreMixin):
             await cls._emit_entity_hp_update(db, session_id, ref_id, previous_hp)
         if state:
             await cls._emit_state(session_id, state)
+        prone_suffix = " e fica caído" if prone_applied else ""
         await cls._emit_and_persist_log(
             db,
             session_id,
             actor_user_id,
             None,
             {
-                "message": f"{display_name} falls {height_meters}m and takes {damage_total} {computation.damage_type} damage.{effect_msg}",
+                "message": f"{display_name} cai {height_meters}m, sofre {damage_total} de dano contundente{prone_suffix}.{effect_msg}",
                 "source": "environmental_fall",
                 "actorUserId": actor_user_id,
                 "participantId": participant_id,
@@ -226,6 +251,7 @@ class CombatDamageAdminMixin(CombatDamageCoreMixin):
                 "damageFormula": computation.damage_formula,
                 "diceCount": computation.dice_count,
                 "causesDamage": True,
+                "proneApplied": prone_applied,
             },
         )
         resolution = FallDamageResolution(
@@ -239,5 +265,6 @@ class CombatDamageAdminMixin(CombatDamageCoreMixin):
             damage_total=damage_total,
             causes_damage=True,
             applied_damage=True,
+            applied_conditions=["prone"] if prone_applied else [],
         )
         return {"resolution": resolution.model_dump(mode="json"), "new_hp": new_hp, "concentration_check": concentration_check}

--- a/apps/control-server/app/services/combat_service/fall_damage.py
+++ b/apps/control-server/app/services/combat_service/fall_damage.py
@@ -55,3 +55,4 @@ class FallDamageResolution(BaseModel):
     applied_damage: bool
     prevented: bool = False
     prevention_sources: list[str] = Field(default_factory=list)
+    applied_conditions: list[str] = Field(default_factory=list)

--- a/apps/control-server/tests/test_fall_damage.py
+++ b/apps/control-server/tests/test_fall_damage.py
@@ -270,8 +270,8 @@ class TestResolveFallDamage(unittest.IsolatedAsyncioTestCase):
         )
 
         log_payload = mock_emit_log.call_args[0][4]
-        self.assertIn("falls 6.0m and takes", log_payload["message"])
-        self.assertIn("7 bludgeoning damage", log_payload["message"])
+        self.assertIn("cai 6.0m", log_payload["message"])
+        self.assertIn("sofre 7 de dano contundente", log_payload["message"])
         self.assertEqual(log_payload["source"], "environmental_fall")
 
     @patch("app.services.combat_service.damage_admin._roll_dice_expression", return_value=5)
@@ -299,6 +299,125 @@ class TestResolveFallDamage(unittest.IsolatedAsyncioTestCase):
             db, "player-ref-1", "player", 5,
             damage_type="bludgeoning", is_crit=False, state=mock_get_state.return_value,
         )
+
+    @patch("app.services.combat_service.damage_admin._roll_dice_expression", return_value=7)
+    @patch.object(CombatService, "_emit_and_persist_log", new_callable=AsyncMock)
+    @patch.object(CombatService, "_emit_state", new_callable=AsyncMock)
+    @patch.object(CombatService, "_emit_entity_hp_update", new_callable=AsyncMock)
+    @patch.object(CombatService, "_apply_damage_to_target")
+    @patch.object(CombatService, "get_state")
+    async def test_damaging_fall_applies_prone(
+        self, mock_get_state, mock_apply_damage, mock_emit_hp, mock_emit_state, mock_emit_log, mock_roll,
+    ):
+        mock_get_state.return_value = _make_active_state()
+        mock_apply_damage.return_value = (3, "", 10, None)
+        db = MagicMock()
+
+        result = await CombatService.resolve_fall(
+            db, "session-1", "entity-e1", 6.0, "user-1", is_gm=True,
+        )
+
+        effects = _get_active_effects_for(mock_get_state.return_value, "entity-e1")
+        prone_effects = [e for e in effects if e.get("condition_type") == "prone"]
+        self.assertEqual(len(prone_effects), 1)
+        self.assertEqual(result["resolution"]["applied_conditions"], ["prone"])
+
+    @patch.object(CombatService, "_emit_and_persist_log", new_callable=AsyncMock)
+    @patch.object(CombatService, "_emit_state", new_callable=AsyncMock)
+    @patch.object(CombatService, "get_state")
+    async def test_no_damage_fall_does_not_apply_prone(self, mock_get_state, mock_emit_state, mock_emit_log):
+        mock_get_state.return_value = _make_active_state()
+        db = MagicMock()
+
+        result = await CombatService.resolve_fall(
+            db, "session-1", "entity-e1", 2.0, "user-1", is_gm=True,
+        )
+
+        effects = _get_active_effects_for(mock_get_state.return_value, "entity-e1")
+        prone_effects = [e for e in effects if e.get("condition_type") == "prone"]
+        self.assertEqual(len(prone_effects), 0)
+        self.assertEqual(result["resolution"]["applied_conditions"], [])
+
+    @patch("app.services.combat_service.damage_admin._roll_dice_expression", return_value=5)
+    @patch.object(CombatService, "_emit_and_persist_log", new_callable=AsyncMock)
+    @patch.object(CombatService, "_emit_state", new_callable=AsyncMock)
+    @patch.object(CombatService, "_emit_entity_hp_update", new_callable=AsyncMock)
+    @patch.object(CombatService, "_apply_damage_to_target")
+    @patch.object(CombatService, "get_state")
+    async def test_damaging_fall_does_not_duplicate_prone(
+        self, mock_get_state, mock_apply_damage, mock_emit_hp, mock_emit_state, mock_emit_log, mock_roll,
+    ):
+        state = _make_active_state()
+        state.participants[1]["active_effects"] = [_make_prone_effect()]
+        mock_get_state.return_value = state
+        mock_apply_damage.return_value = (3, "", 10, None)
+        db = MagicMock()
+
+        await CombatService.resolve_fall(
+            db, "session-1", "entity-e1", 6.0, "user-1", is_gm=True,
+        )
+
+        effects = _get_active_effects_for(state, "entity-e1")
+        prone_effects = [e for e in effects if e.get("condition_type") == "prone"]
+        self.assertEqual(len(prone_effects), 1)
+
+    @patch("app.services.combat_service.damage_admin._roll_dice_expression", return_value=0)
+    @patch.object(CombatService, "_emit_and_persist_log", new_callable=AsyncMock)
+    @patch.object(CombatService, "_emit_state", new_callable=AsyncMock)
+    @patch.object(CombatService, "_emit_entity_hp_update", new_callable=AsyncMock)
+    @patch.object(CombatService, "_apply_damage_to_target")
+    @patch.object(CombatService, "get_state")
+    async def test_zero_damage_total_does_not_apply_prone(
+        self, mock_get_state, mock_apply_damage, mock_emit_hp, mock_emit_state, mock_emit_log, mock_roll,
+    ):
+        mock_get_state.return_value = _make_active_state()
+        mock_apply_damage.return_value = (10, "", 10, None)
+        db = MagicMock()
+
+        result = await CombatService.resolve_fall(
+            db, "session-1", "entity-e1", 3.0, "user-1", is_gm=True,
+        )
+
+        effects = _get_active_effects_for(mock_get_state.return_value, "entity-e1")
+        prone_effects = [e for e in effects if e.get("condition_type") == "prone"]
+        self.assertEqual(len(prone_effects), 0)
+        self.assertEqual(result["resolution"]["applied_conditions"], [])
+
+    @patch("app.services.combat_service.damage_admin._roll_dice_expression", return_value=7)
+    @patch.object(CombatService, "_emit_and_persist_log", new_callable=AsyncMock)
+    @patch.object(CombatService, "_emit_state", new_callable=AsyncMock)
+    @patch.object(CombatService, "_emit_entity_hp_update", new_callable=AsyncMock)
+    @patch.object(CombatService, "_apply_damage_to_target")
+    @patch.object(CombatService, "get_state")
+    async def test_damaging_fall_log_includes_prone(
+        self, mock_get_state, mock_apply_damage, mock_emit_hp, mock_emit_state, mock_emit_log, mock_roll,
+    ):
+        mock_get_state.return_value = _make_active_state()
+        mock_apply_damage.return_value = (3, "", 10, None)
+        db = MagicMock()
+
+        await CombatService.resolve_fall(
+            db, "session-1", "entity-e1", 6.0, "user-1", is_gm=True,
+        )
+
+        log_payload = mock_emit_log.call_args[0][4]
+        self.assertIn("fica caído", log_payload["message"])
+        self.assertTrue(log_payload["proneApplied"])
+
+
+def _get_active_effects_for(state: CombatState, participant_id: str) -> list:
+    p = next((p for p in state.participants if p["id"] == participant_id), None)
+    return (p.get("active_effects") or []) if p else []
+
+
+def _make_prone_effect() -> dict:
+    return {
+        "id": "prone-existing",
+        "kind": "condition",
+        "condition_type": "prone",
+        "duration_type": "manual",
+        "created_at": "2026-01-01T00:00:00+00:00",
+    }
 
 
 def _make_cats_grace_effect(threshold_m: float = 6.0, label: str = "Graça do Gato") -> dict:
@@ -453,6 +572,32 @@ class TestResolveFallDamagePrevention(unittest.IsolatedAsyncioTestCase):
         resolution = result["resolution"]
         self.assertTrue(resolution["prevented"])
         self.assertEqual(resolution["prevention_sources"], ["Efeito B"])
+
+    async def test_prevented_fall_does_not_apply_prone(self, mock_get_state, mock_emit_state, mock_emit_log):
+        mock_get_state.return_value = _make_state_with_effects([_make_cats_grace_effect(6.0)])
+        result = await CombatService.resolve_fall(
+            MagicMock(), "session-1", "entity-e1", 6.0, "user-1", is_gm=True,
+        )
+        effects = _get_active_effects_for(mock_get_state.return_value, "entity-e1")
+        prone_effects = [e for e in effects if e.get("condition_type") == "prone"]
+        self.assertEqual(len(prone_effects), 0)
+        self.assertEqual(result["resolution"]["applied_conditions"], [])
+
+    @patch("app.services.combat_service.damage_admin._roll_dice_expression", return_value=9)
+    @patch.object(CombatService, "_emit_entity_hp_update", new_callable=AsyncMock)
+    @patch.object(CombatService, "_apply_damage_to_target")
+    async def test_cats_grace_9m_fall_applies_prone(
+        self, mock_apply_damage, mock_emit_hp, mock_roll, mock_get_state, mock_emit_state, mock_emit_log,
+    ):
+        mock_get_state.return_value = _make_state_with_effects([_make_cats_grace_effect(6.0)])
+        mock_apply_damage.return_value = (5, "", 14, None)
+        result = await CombatService.resolve_fall(
+            MagicMock(), "session-1", "entity-e1", 9.0, "user-1", is_gm=True,
+        )
+        effects = _get_active_effects_for(mock_get_state.return_value, "entity-e1")
+        prone_effects = [e for e in effects if e.get("condition_type") == "prone"]
+        self.assertEqual(len(prone_effects), 1)
+        self.assertEqual(result["resolution"]["applied_conditions"], ["prone"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# feat(combat): apply prone after damaging falls

## Summary

Adds prone application after damaging fall resolution.

When a participant takes actual fall damage, `resolve_fall()` now applies the `prone` condition as part of the same fall resolution flow.

This works for both explicit/manual falls and movement-triggered falls, since both paths already delegate to `resolve_fall()`.

## Context

Fall damage support already included:

- pure fall damage calculation
- explicit/manual fall resolution
- automatic fall detection from map elevation movement
- Cat’s Grace fall damage prevention

This PR adds the remaining base-rule consequence: a creature that takes damage from a fall lands prone.

The floor now deals damage and handles crowd control. Terrible workplace culture, excellent rules fidelity.

## What changed

### Fall resolution result

Updated:

```text
apps/control-server/app/services/combat_service/fall_damage.py
````

`FallDamageResolution` now includes:

```py
applied_conditions: list[str]
```

This follows the same pattern as:

```py
prevention_sources: list[str]
```

The field is used to report conditions applied as part of fall resolution.

### Prone application

Updated:

```text
apps/control-server/app/services/combat_service/damage_admin.py
```

`resolve_fall()` now applies `prone` inline after `_apply_damage_to_target()` and before `db.commit()`.

Behavior:

* damaging fall applies `prone`
* no-damage fall does not apply `prone`
* Cat’s Grace-prevented fall does not apply `prone`
* zero-damage result does not apply `prone`
* already-prone participants do not receive duplicate prone effects

The prone condition is applied in the same transaction as fall damage, avoiding an extra action call, extra commit, extra emit, or duplicate “effect applied” log.

### Combat log

Fall damage logs are now unified in PT-BR.

When prone is applied, the log includes:

```text
e fica caído
```

This keeps the fall result clear without generating a separate condition log for an automatic consequence.

### Tests

Updated:

```text
apps/control-server/tests/test_fall_damage.py
```

Added 7 tests covering:

* damaging fall applies prone
* no-damage fall does not apply prone
* prevented Cat’s Grace fall does not apply prone
* Cat’s Grace fall above 6m applies damage and prone
* prone is not duplicated if already present
* zero damage total does not apply prone
* PT-BR fall log includes the prone suffix

## Behavior

```text
2m fall
→ no damage, no prone

6m fall without Cat’s Grace
→ damage applied, prone applied

6m fall with Cat’s Grace
→ damage prevented, no prone

9m fall with Cat’s Grace
→ damage applied, prone applied

damaging fall while already prone
→ damage applied, no duplicate prone condition
```

## Validation

```bash
cd apps/control-server
.venv/bin/pytest tests/test_fall_damage.py -v
```

Result:

```text
37/37 passed
```

## Out of scope

This PR intentionally does not implement:

* Feather Fall
* fall warning UI
* fall preview UX
* forced movement rules
* falling into hazards
* standing up movement cost
* prone UI polish
* condition duration redesign

## Notes for reviewers

The main design choice is applying `prone` inline inside `resolve_fall()` instead of calling the public/admin `apply_effect()` path.

That keeps fall damage and its automatic prone consequence atomic:

```text
fall damage → prone condition → commit → emit/log
```

and avoids duplicate commits, duplicate state emits, and unrelated effect-application log entries.

Movement-triggered falls already call `resolve_fall()`, so they automatically receive this prone behavior without movement-specific condition logic.

## Follow-ups

Recommended next issues:

1. Fall UX/log hardening
2. Feather Fall support
3. Forced movement / falling hazards integration