### PR TITLE
feat(combat): harden fall result UX and combat logs

### DIFF
--- a/apps/control-server/app/schemas/combat_spells.py
+++ b/apps/control-server/app/schemas/combat_spells.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -328,6 +328,9 @@ class CombatMovementPreviewResponse(BaseModel):
     movement_speed_cells: int = Field(ge=1)
     remaining_budget: int = Field(ge=0)
     map_version: int | None = None
+    fall_result: dict[str, Any] | None = None
+    source_elevation_meters: float | None = None
+    destination_elevation_meters: float | None = None
 
 
 class EffectInstanceOutcome(BaseModel):

--- a/apps/control-server/app/services/combat_service/damage_admin.py
+++ b/apps/control-server/app/services/combat_service/damage_admin.py
@@ -11,10 +11,41 @@ from app.services.session_state_finalize import finalize_session_state_data
 from .condition_effects_predicates import get_fall_damage_immunity_threshold, has_condition, is_incapacitated
 from .damage_core import CombatDamageCoreMixin
 from .exceptions import CombatServiceError, _roll_dice_expression
-from .fall_damage import FallDamageResolution, compute_fall_damage
+from .fall_damage import FallDamageComputation, FallDamageResolution, compute_fall_damage
 
 
 class CombatDamageAdminMixin(CombatDamageCoreMixin):
+    @staticmethod
+    def _build_fall_log_payload(
+        *,
+        message: str,
+        actor_user_id: str,
+        participant_id: str,
+        computation: FallDamageComputation,
+        damage_total: int,
+        applied_damage: bool,
+        prevented: bool,
+        prevention_sources: list[str],
+        applied_conditions: list[str],
+    ) -> dict:
+        return {
+            "message": message,
+            "source": "environmental_fall",
+            "actorUserId": actor_user_id,
+            "participantId": participant_id,
+            "heightMeters": computation.height_meters,
+            "effectiveHeightMeters": computation.effective_height_meters,
+            "damageType": computation.damage_type,
+            "damageTotal": damage_total,
+            "damageFormula": computation.damage_formula,
+            "diceCount": computation.dice_count,
+            "causesDamage": computation.causes_damage,
+            "appliedDamage": applied_damage,
+            "prevented": prevented,
+            "preventionSources": prevention_sources,
+            "appliedConditions": applied_conditions,
+        }
+
     @classmethod
     async def revive_player(
         cls,
@@ -146,14 +177,17 @@ class CombatDamageAdminMixin(CombatDamageCoreMixin):
                 session_id,
                 actor_user_id,
                 None,
-                {
-                    "message": f"{display_name} falls {height_meters}m and takes no damage.",
-                    "source": "environmental_fall",
-                    "actorUserId": actor_user_id,
-                    "participantId": participant_id,
-                    "heightMeters": height_meters,
-                    "causesDamage": False,
-                },
+                cls._build_fall_log_payload(
+                    message=f"{display_name} cai {height_meters}m e não sofre dano.",
+                    actor_user_id=actor_user_id,
+                    participant_id=participant_id,
+                    computation=computation,
+                    damage_total=0,
+                    applied_damage=False,
+                    prevented=False,
+                    prevention_sources=[],
+                    applied_conditions=[],
+                ),
             )
             return {"resolution": resolution.model_dump(mode="json"), "new_hp": None, "concentration_check": None}
         immunity_threshold, immunity_label = get_fall_damage_immunity_threshold(participant)
@@ -183,16 +217,17 @@ class CombatDamageAdminMixin(CombatDamageCoreMixin):
                 session_id,
                 actor_user_id,
                 None,
-                {
-                    "message": f"{display_name} cai {height_meters}m e não sofre dano por {immunity_label}.",
-                    "source": "environmental_fall",
-                    "actorUserId": actor_user_id,
-                    "participantId": participant_id,
-                    "heightMeters": height_meters,
-                    "causesDamage": False,
-                    "prevented": True,
-                    "preventionSources": [immunity_label],
-                },
+                cls._build_fall_log_payload(
+                    message=f"{display_name} cai {height_meters}m e não sofre dano por {immunity_label}.",
+                    actor_user_id=actor_user_id,
+                    participant_id=participant_id,
+                    computation=computation,
+                    damage_total=0,
+                    applied_damage=False,
+                    prevented=True,
+                    prevention_sources=[immunity_label],
+                    applied_conditions=[],
+                ),
             )
             return {"resolution": resolution.model_dump(mode="json"), "new_hp": None, "concentration_check": None}
         damage_total = _roll_dice_expression(computation.damage_formula)
@@ -235,24 +270,23 @@ class CombatDamageAdminMixin(CombatDamageCoreMixin):
         if state:
             await cls._emit_state(session_id, state)
         prone_suffix = " e fica caído" if prone_applied else ""
+        applied_conditions = ["prone"] if prone_applied else []
         await cls._emit_and_persist_log(
             db,
             session_id,
             actor_user_id,
             None,
-            {
-                "message": f"{display_name} cai {height_meters}m, sofre {damage_total} de dano contundente{prone_suffix}.{effect_msg}",
-                "source": "environmental_fall",
-                "actorUserId": actor_user_id,
-                "participantId": participant_id,
-                "heightMeters": height_meters,
-                "damageTotal": damage_total,
-                "damageType": computation.damage_type,
-                "damageFormula": computation.damage_formula,
-                "diceCount": computation.dice_count,
-                "causesDamage": True,
-                "proneApplied": prone_applied,
-            },
+            cls._build_fall_log_payload(
+                message=f"{display_name} cai {height_meters}m, sofre {damage_total} de dano contundente{prone_suffix}.{effect_msg}",
+                actor_user_id=actor_user_id,
+                participant_id=participant_id,
+                computation=computation,
+                damage_total=damage_total,
+                applied_damage=True,
+                prevented=False,
+                prevention_sources=[],
+                applied_conditions=applied_conditions,
+            ),
         )
         resolution = FallDamageResolution(
             participant_id=participant_id,
@@ -265,6 +299,6 @@ class CombatDamageAdminMixin(CombatDamageCoreMixin):
             damage_total=damage_total,
             causes_damage=True,
             applied_damage=True,
-            applied_conditions=["prone"] if prone_applied else [],
+            applied_conditions=applied_conditions,
         )
         return {"resolution": resolution.model_dump(mode="json"), "new_hp": new_hp, "concentration_check": concentration_check}

--- a/apps/control-server/app/services/combat_service/movement.py
+++ b/apps/control-server/app/services/combat_service/movement.py
@@ -71,6 +71,7 @@ class CombatMovementMixin(AreaTargetingMixin):
                 503,
             ) from exc
 
+        fall_result: dict[str, Any] | None = None
         if confirm and response.is_valid:
             await cls._apply_movement_hazards(
                 db,
@@ -80,7 +81,7 @@ class CombatMovementMixin(AreaTargetingMixin):
                 response=response,
                 actor_user_id=actor_user_id,
             )
-            await cls._apply_movement_fall(
+            fall_result = await cls._apply_movement_fall(
                 db,
                 session_id=session_id,
                 actor=actor,
@@ -107,6 +108,9 @@ class CombatMovementMixin(AreaTargetingMixin):
             movement_speed_cells=response.movement_speed_cells,
             remaining_budget=response.remaining_budget,
             map_version=response.version,
+            fall_result=fall_result,
+            source_elevation_meters=response.source_elevation_meters,
+            destination_elevation_meters=response.destination_elevation_meters,
         )
 
     @classmethod
@@ -205,16 +209,16 @@ class CombatMovementMixin(AreaTargetingMixin):
         response: Any,
         actor_user_id: str,
         is_gm: bool,
-    ) -> None:
+    ) -> dict[str, Any] | None:
         source_elevation = response.source_elevation_meters if response.source_elevation_meters is not None else 0.0
         dest_elevation = response.destination_elevation_meters if response.destination_elevation_meters is not None else 0.0
         delta = dest_elevation - source_elevation
         if delta >= 0:
-            return
+            return None
         fall_height = abs(delta)
         if fall_height < FALL_DAMAGE_METERS_PER_DIE:
-            return
-        await cls.resolve_fall(
+            return None
+        result = await cls.resolve_fall(
             db,
             session_id,
             actor["id"],
@@ -222,6 +226,7 @@ class CombatMovementMixin(AreaTargetingMixin):
             actor_user_id,
             is_gm,
         )
+        return result["resolution"]
 
     @classmethod
     async def preview_movement(

--- a/apps/control-server/tests/test_combat_movement_preview.py
+++ b/apps/control-server/tests/test_combat_movement_preview.py
@@ -485,6 +485,7 @@ class TestConfirmMovementFallDetection(unittest.TestCase):
             source_elevation=6.0, dest_elevation=3.0,
         )
         mock_build_client.return_value = client
+        mock_resolve_fall.return_value = {"resolution": {}, "new_hp": None, "concentration_check": None}
 
         _run(CombatService.confirm_movement(
             db=MagicMock(), session_id="session-1",
@@ -516,6 +517,7 @@ class TestConfirmMovementFallDetection(unittest.TestCase):
             source_elevation=6.0, dest_elevation=0.0,
         )
         mock_build_client.return_value = client
+        mock_resolve_fall.return_value = {"resolution": {}, "new_hp": None, "concentration_check": None}
 
         _run(CombatService.confirm_movement(
             db=MagicMock(), session_id="session-1",
@@ -613,6 +615,126 @@ class TestConfirmMovementFallDetection(unittest.TestCase):
         ))
 
         mock_resolve_fall.assert_not_called()
+
+    @patch.object(CombatService, "_apply_movement_hazards")
+    @patch.object(CombatService, "resolve_fall")
+    @patch.object(CombatService, "_require_movement_capable")
+    @patch.object(CombatService, "_require_actor_status")
+    @patch.object(CombatService, "_require_active")
+    @patch.object(CombatService, "_resolve_actor_participant")
+    @patch.object(CombatService, "get_state")
+    @patch.object(CombatService, "_build_limiar_map_client")
+    def test_confirmed_fall_includes_fall_result_in_response(
+        self, mock_build_client, mock_get_state, mock_resolve_actor,
+        _mock_require_active, _mock_require_status, _mock_require_movement,
+        mock_resolve_fall, mock_hazards,
+    ):
+        mock_get_state.return_value = SimpleNamespace(use_map=True, active_area_effects=[])
+        mock_resolve_actor.return_value = {"id": "participant-1", "ref_id": "combatant-1", "status": "active"}
+        client = MagicMock()
+        client.move_combatant.return_value = _movement_response_with_elevation(
+            source_elevation=6.0, dest_elevation=0.0,
+        )
+        mock_build_client.return_value = client
+        fake_resolution = {"participant_id": "participant-1", "damage_total": 7, "prevented": False}
+        mock_resolve_fall.return_value = {"resolution": fake_resolution, "new_hp": 3, "concentration_check": None}
+
+        result = _run(CombatService.confirm_movement(
+            db=MagicMock(), session_id="session-1",
+            req=CombatMovementPreviewRequest(destination_cell={"x": 3, "y": 1}),
+            actor_user_id="user-1", is_gm=True,
+        ))
+
+        self.assertEqual(result.fall_result, fake_resolution)
+
+    @patch.object(CombatService, "_apply_movement_hazards")
+    @patch.object(CombatService, "resolve_fall")
+    @patch.object(CombatService, "_require_movement_capable")
+    @patch.object(CombatService, "_require_actor_status")
+    @patch.object(CombatService, "_require_active")
+    @patch.object(CombatService, "_resolve_actor_participant")
+    @patch.object(CombatService, "get_state")
+    @patch.object(CombatService, "_build_limiar_map_client")
+    def test_no_fall_movement_fall_result_is_none(
+        self, mock_build_client, mock_get_state, mock_resolve_actor,
+        _mock_require_active, _mock_require_status, _mock_require_movement,
+        mock_resolve_fall, mock_hazards,
+    ):
+        mock_get_state.return_value = SimpleNamespace(use_map=True, active_area_effects=[])
+        mock_resolve_actor.return_value = {"id": "participant-1", "ref_id": "combatant-1", "status": "active"}
+        client = MagicMock()
+        client.move_combatant.return_value = _movement_response_with_elevation(
+            source_elevation=3.0, dest_elevation=3.0,
+        )
+        mock_build_client.return_value = client
+
+        result = _run(CombatService.confirm_movement(
+            db=MagicMock(), session_id="session-1",
+            req=CombatMovementPreviewRequest(destination_cell={"x": 3, "y": 1}),
+            actor_user_id="user-1", is_gm=True,
+        ))
+
+        self.assertIsNone(result.fall_result)
+
+    @patch.object(CombatService, "_apply_movement_hazards")
+    @patch.object(CombatService, "resolve_fall")
+    @patch.object(CombatService, "_require_movement_capable")
+    @patch.object(CombatService, "_require_actor_status")
+    @patch.object(CombatService, "_require_active")
+    @patch.object(CombatService, "_resolve_actor_participant")
+    @patch.object(CombatService, "get_state")
+    @patch.object(CombatService, "_build_limiar_map_client")
+    def test_preview_fall_result_is_none(
+        self, mock_build_client, mock_get_state, mock_resolve_actor,
+        _mock_require_active, _mock_require_status, _mock_require_movement,
+        mock_resolve_fall, mock_hazards,
+    ):
+        mock_get_state.return_value = SimpleNamespace(use_map=True, active_area_effects=[])
+        mock_resolve_actor.return_value = {"id": "participant-1", "ref_id": "combatant-1", "status": "active"}
+        client = MagicMock()
+        client.preview_movement.return_value = _movement_response_with_elevation(
+            source_elevation=6.0, dest_elevation=0.0,
+        )
+        mock_build_client.return_value = client
+
+        result = _run(CombatService.preview_movement(
+            db=MagicMock(), session_id="session-1",
+            req=CombatMovementPreviewRequest(destination_cell={"x": 3, "y": 1}),
+            actor_user_id="user-1", is_gm=True,
+        ))
+
+        self.assertIsNone(result.fall_result)
+
+    @patch.object(CombatService, "_apply_movement_hazards")
+    @patch.object(CombatService, "resolve_fall")
+    @patch.object(CombatService, "_require_movement_capable")
+    @patch.object(CombatService, "_require_actor_status")
+    @patch.object(CombatService, "_require_active")
+    @patch.object(CombatService, "_resolve_actor_participant")
+    @patch.object(CombatService, "get_state")
+    @patch.object(CombatService, "_build_limiar_map_client")
+    def test_response_includes_elevation_data(
+        self, mock_build_client, mock_get_state, mock_resolve_actor,
+        _mock_require_active, _mock_require_status, _mock_require_movement,
+        mock_resolve_fall, mock_hazards,
+    ):
+        mock_get_state.return_value = SimpleNamespace(use_map=True, active_area_effects=[])
+        mock_resolve_actor.return_value = {"id": "participant-1", "ref_id": "combatant-1", "status": "active"}
+        client = MagicMock()
+        client.move_combatant.return_value = _movement_response_with_elevation(
+            source_elevation=9.0, dest_elevation=3.0,
+        )
+        mock_build_client.return_value = client
+        mock_resolve_fall.return_value = {"resolution": {}, "new_hp": None, "concentration_check": None}
+
+        result = _run(CombatService.confirm_movement(
+            db=MagicMock(), session_id="session-1",
+            req=CombatMovementPreviewRequest(destination_cell={"x": 3, "y": 1}),
+            actor_user_id="user-1", is_gm=True,
+        ))
+
+        self.assertEqual(result.source_elevation_meters, 9.0)
+        self.assertEqual(result.destination_elevation_meters, 3.0)
 
 
 if __name__ == "__main__":

--- a/apps/control-server/tests/test_fall_damage.py
+++ b/apps/control-server/tests/test_fall_damage.py
@@ -249,7 +249,8 @@ class TestResolveFallDamage(unittest.IsolatedAsyncioTestCase):
         )
 
         log_payload = mock_emit_log.call_args[0][4]
-        self.assertIn("takes no damage", log_payload["message"])
+        self.assertIn("não sofre dano", log_payload["message"])
+        self.assertNotIn("falls", log_payload["message"])
         self.assertEqual(log_payload["source"], "environmental_fall")
 
     @patch("app.services.combat_service.damage_admin._roll_dice_expression", return_value=7)
@@ -402,7 +403,7 @@ class TestResolveFallDamage(unittest.IsolatedAsyncioTestCase):
 
         log_payload = mock_emit_log.call_args[0][4]
         self.assertIn("fica caído", log_payload["message"])
-        self.assertTrue(log_payload["proneApplied"])
+        self.assertEqual(log_payload["appliedConditions"], ["prone"])
 
 
 def _get_active_effects_for(state: CombatState, participant_id: str) -> list:
@@ -598,6 +599,77 @@ class TestResolveFallDamagePrevention(unittest.IsolatedAsyncioTestCase):
         prone_effects = [e for e in effects if e.get("condition_type") == "prone"]
         self.assertEqual(len(prone_effects), 1)
         self.assertEqual(result["resolution"]["applied_conditions"], ["prone"])
+
+
+@patch.object(CombatService, "_emit_and_persist_log", new_callable=AsyncMock)
+@patch.object(CombatService, "_emit_state", new_callable=AsyncMock)
+@patch.object(CombatService, "get_state")
+class TestFallLogPayloads(unittest.IsolatedAsyncioTestCase):
+    _EXPECTED_KEYS = {
+        "message", "source", "actorUserId", "participantId",
+        "heightMeters", "effectiveHeightMeters", "damageType",
+        "damageTotal", "damageFormula", "diceCount", "causesDamage",
+        "appliedDamage", "prevented", "preventionSources", "appliedConditions",
+    }
+
+    async def test_no_damage_log_payload_has_all_fields(self, mock_get_state, mock_emit_state, mock_emit_log):
+        mock_get_state.return_value = _make_active_state()
+        await CombatService.resolve_fall(MagicMock(), "session-1", "entity-e1", 0.0, "user-1", is_gm=True)
+        payload = mock_emit_log.call_args[0][4]
+        self.assertTrue(self._EXPECTED_KEYS.issubset(payload.keys()))
+        self.assertEqual(payload["damageTotal"], 0)
+        self.assertFalse(payload["appliedDamage"])
+        self.assertFalse(payload["prevented"])
+        self.assertEqual(payload["preventionSources"], [])
+        self.assertEqual(payload["appliedConditions"], [])
+        self.assertIsNotNone(payload["effectiveHeightMeters"])
+        self.assertNotIn("proneApplied", payload)
+
+    async def test_prevented_fall_log_payload_has_all_fields(self, mock_get_state, mock_emit_state, mock_emit_log):
+        mock_get_state.return_value = _make_state_with_effects([_make_cats_grace_effect(6.0)])
+        await CombatService.resolve_fall(MagicMock(), "session-1", "entity-e1", 6.0, "user-1", is_gm=True)
+        payload = mock_emit_log.call_args[0][4]
+        self.assertTrue(self._EXPECTED_KEYS.issubset(payload.keys()))
+        self.assertTrue(payload["prevented"])
+        self.assertEqual(payload["preventionSources"], ["Graça do Gato"])
+        self.assertFalse(payload["appliedDamage"])
+        self.assertTrue(payload["causesDamage"])
+        self.assertEqual(payload["damageTotal"], 0)
+        self.assertEqual(payload["appliedConditions"], [])
+        self.assertNotIn("proneApplied", payload)
+
+    @patch("app.services.combat_service.damage_admin._roll_dice_expression", return_value=7)
+    @patch.object(CombatService, "_emit_entity_hp_update", new_callable=AsyncMock)
+    @patch.object(CombatService, "_apply_damage_to_target")
+    async def test_damaging_fall_log_payload_has_all_fields(
+        self, mock_apply_damage, mock_emit_hp, mock_roll, mock_get_state, mock_emit_state, mock_emit_log,
+    ):
+        mock_get_state.return_value = _make_active_state()
+        mock_apply_damage.return_value = (3, "", 10, None)
+        await CombatService.resolve_fall(MagicMock(), "session-1", "entity-e1", 6.0, "user-1", is_gm=True)
+        payload = mock_emit_log.call_args[0][4]
+        self.assertTrue(self._EXPECTED_KEYS.issubset(payload.keys()))
+        self.assertTrue(payload["causesDamage"])
+        self.assertTrue(payload["appliedDamage"])
+        self.assertEqual(payload["damageTotal"], 7)
+        self.assertFalse(payload["prevented"])
+        self.assertEqual(payload["preventionSources"], [])
+        self.assertEqual(payload["appliedConditions"], ["prone"])
+        self.assertNotIn("proneApplied", payload)
+
+    @patch("app.services.combat_service.damage_admin._roll_dice_expression", return_value=5)
+    @patch.object(CombatService, "_emit_entity_hp_update", new_callable=AsyncMock)
+    @patch.object(CombatService, "_apply_damage_to_target")
+    async def test_damaging_fall_already_prone_applied_conditions_empty(
+        self, mock_apply_damage, mock_emit_hp, mock_roll, mock_get_state, mock_emit_state, mock_emit_log,
+    ):
+        state = _make_active_state()
+        state.participants[1]["active_effects"] = [_make_prone_effect()]
+        mock_get_state.return_value = state
+        mock_apply_damage.return_value = (3, "", 10, None)
+        await CombatService.resolve_fall(MagicMock(), "session-1", "entity-e1", 6.0, "user-1", is_gm=True)
+        payload = mock_emit_log.call_args[0][4]
+        self.assertEqual(payload["appliedConditions"], [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# feat(combat): harden fall result UX and combat logs

## Summary

Hardens fall result output and combat log consistency.

This PR standardizes fall combat log payloads, exposes movement-triggered fall results in movement responses, and threads map elevation data through the final combat movement response.

No fall rules were changed.

## Context

Fall damage is already implemented end-to-end:

- map cells support elevation
- explicit/manual fall resolution exists
- map movement detects elevation drops
- Cat’s Grace prevents eligible fall damage
- damaging falls apply prone

This PR focuses on UX/debuggability and response consistency.

Before this change:

- fall log payloads differed between no-damage, prevented, and damaging branches
- the no-damage fall message still used English
- movement-triggered falls called `resolve_fall()`, but discarded the returned result
- elevation data existed in the map movement integration response, but was not exposed in the final combat movement response

Now the backend gives the UI and logs a clean receipt. Revolutionary technology: telling the truth clearly.

## What changed

### Fall log payloads

Updated:

```text
apps/control-server/app/services/combat_service/damage_admin.py
````

Added `_build_fall_log_payload()` to centralize fall log payload construction.

This removes duplicated payload assembly across the three fall branches:

* no-damage fall
* prevented fall
* damaging fall

Fall logs now share a consistent set of structured fields, including:

```py
source
actorUserId
participantId
heightMeters
effectiveHeightMeters
damageType
damageTotal
damageFormula
diceCount
causesDamage
appliedDamage
prevented
preventionSources
appliedConditions
```

The old isolated `proneApplied` style was removed in favor of `appliedConditions`.

### PT-BR fall messages

The no-damage fall message is now PT-BR.

Example:

```text
{name} cai {height}m e não sofre dano.
```

Fall logs are now consistent with the existing PT-BR fall/prevention/prone messages.

No more “falls/takes/lands prone” sneaking into the combat log like a badly localized goblin.

### Movement response fall result

Updated:

```text
apps/control-server/app/schemas/combat_spells.py
apps/control-server/app/services/combat_service/movement.py
```

`CombatMovementPreviewResponse` now includes:

```py
fall_result: dict[str, Any] | None
source_elevation_meters: float | None
destination_elevation_meters: float | None
```

`_apply_movement_fall()` now returns the fall resolution result when a confirmed movement causes a fall.

`_preview_or_confirm_movement()` captures that result and includes it in the response.

Behavior:

```text
confirmed movement with fall
→ fall_result contains resolve_fall()["resolution"]

confirmed movement without fall
→ fall_result = None

preview movement
→ fall_result = None
```

### Elevation data in movement response

The final combat movement response now exposes:

```py
source_elevation_meters
destination_elevation_meters
```

These values come from the map movement response and help explain why a movement did or did not trigger fall damage.

This makes the response easier to inspect without requiring the frontend to infer elevation from logs or refetch map state.

## Tests

Updated:

```text
apps/control-server/tests/test_fall_damage.py
apps/control-server/tests/test_combat_movement_preview.py
```

Added `TestFallLogPayloads` with 4 tests covering:

* no-damage fall payload has the unified field set
* prevented fall payload has the unified field set
* damaging fall payload has the unified field set
* already-prone damaging fall uses `appliedConditions=[]` and does not emit `proneApplied`

Updated the no-damage log message test to assert PT-BR text.

Added 4 movement response tests covering:

* confirmed fall includes `fall_result`
* movement without fall returns `fall_result=None`
* preview with elevation drop still returns `fall_result=None`
* response includes source/destination elevation data

## Validation

```bash
cd apps/control-server
.venv/bin/pytest tests/test_fall_damage.py tests/test_combat_movement_preview.py -v
```

Result:

```text
58/58 passed
```

## Out of scope

This PR intentionally does not implement:

* Feather Fall
* fall warning/preview UX
* frontend rendering changes
* forced movement
* falling into hazards
* rule changes to fall damage
* rule changes to Cat’s Grace
* rule changes to prone behavior

## Notes for reviewers

The key design change is centralizing fall log payload creation in `_build_fall_log_payload()`.

This keeps the three fall outcomes structurally aligned:

```text
no damage
prevented
damaging
```

and prevents future branches from drifting into slightly different payload shapes, which is how logs slowly become haunted furniture.

Movement-triggered falls now expose the same resolution object returned by `resolve_fall()`, so consumers no longer need to infer the fall outcome from combat logs.

## Follow-ups

Recommended next issues:

1. Feather Fall support
2. Fall preview / warning UX
3. Forced movement / falling hazards integration