### PR TITLE
fix(spells): use Cat’s Grace variant label for fall prevention logs

### DIFF
--- a/Base/base_spells.seed.json
+++ b/Base/base_spells.seed.json
@@ -1654,7 +1654,7 @@
         },
         {
           "key": "cats_grace",
-          "labelPt": "Agilidade do Gato",
+          "labelPt": "Graça do Gato",
           "labelEn": "Cat's Grace",
           "descriptionPt": "Vantagem em testes de Destreza.",
           "descriptionEn": "Advantage on Dexterity checks.",

--- a/apps/control-server/app/services/combat_service/condition_effects_predicates.py
+++ b/apps/control-server/app/services/combat_service/condition_effects_predicates.py
@@ -114,7 +114,12 @@ def get_fall_damage_immunity_threshold(participant: dict) -> tuple[float | None,
             continue
         if best is None or float(threshold) > best:
             best = float(threshold)
-            label = effect.get("display_label") or metadata.get("source_spell_name") or "Graça do Gato"
+            label = (
+                metadata.get("selected_variant_label")
+                or effect.get("display_label")
+                or metadata.get("source_spell_name")
+                or "Graça do Gato"
+            )
     return best, label
 
 

--- a/apps/control-server/tests/test_fall_damage.py
+++ b/apps/control-server/tests/test_fall_damage.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.models.combat import CombatPhase, CombatState
 from app.services.combat import CombatService, CombatServiceError
+from app.services.combat_service.condition_effects_predicates import get_fall_damage_immunity_threshold
 from app.services.combat_service.fall_damage import (
     FALL_DAMAGE_DIE_SIDES,
     FALL_DAMAGE_METERS_PER_DIE,
@@ -670,6 +671,82 @@ class TestFallLogPayloads(unittest.IsolatedAsyncioTestCase):
         await CombatService.resolve_fall(MagicMock(), "session-1", "entity-e1", 6.0, "user-1", is_gm=True)
         payload = mock_emit_log.call_args[0][4]
         self.assertEqual(payload["appliedConditions"], [])
+
+
+def _make_realistic_cats_grace_effect(
+    threshold_m: float = 6.0,
+    variant_label: str | None = "Graça do Gato",
+    display_label: str | None = None,
+) -> dict:
+    return {
+        "id": "effect-cg-prod-1",
+        "kind": "spell_effect",
+        "source_participant_id": "caster-1",
+        "duration_type": "manual",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "display_label": display_label,
+        "metadata": {
+            "source_spell_name": "Melhorar Habilidade",
+            "source_spell_key": "enhance_ability",
+            "selected_variant_key": "cats_grace",
+            "selected_variant_label": variant_label,
+            "declarative_effect": {
+                "type": "fall_damage_immunity_threshold",
+                "params": {"max_distance_meters": threshold_m},
+            },
+        },
+    }
+
+
+class TestFallImmunityLabelResolution(unittest.TestCase):
+    def _participant_with_effects(self, *effects: dict) -> dict:
+        return {"active_effects": list(effects)}
+
+    def test_label_from_selected_variant_label(self):
+        effect = _make_realistic_cats_grace_effect(variant_label="Graça do Gato", display_label=None)
+        participant = self._participant_with_effects(effect)
+        threshold, label = get_fall_damage_immunity_threshold(participant)
+        self.assertEqual(threshold, 6.0)
+        self.assertEqual(label, "Graça do Gato")
+
+    def test_label_prefers_variant_over_display(self):
+        effect = _make_realistic_cats_grace_effect(
+            variant_label="Graça do Gato", display_label="Melhorar Habilidade",
+        )
+        participant = self._participant_with_effects(effect)
+        _, label = get_fall_damage_immunity_threshold(participant)
+        self.assertEqual(label, "Graça do Gato")
+
+    def test_label_falls_back_to_display_label(self):
+        effect = _make_realistic_cats_grace_effect(variant_label=None, display_label="Melhorar Habilidade")
+        participant = self._participant_with_effects(effect)
+        _, label = get_fall_damage_immunity_threshold(participant)
+        self.assertEqual(label, "Melhorar Habilidade")
+
+    def test_label_falls_back_to_source_spell_name(self):
+        effect = _make_realistic_cats_grace_effect(variant_label=None, display_label=None)
+        participant = self._participant_with_effects(effect)
+        _, label = get_fall_damage_immunity_threshold(participant)
+        self.assertEqual(label, "Melhorar Habilidade")
+
+    def test_label_hardcoded_fallback(self):
+        effect = {
+            "id": "effect-minimal",
+            "kind": "spell_effect",
+            "source_participant_id": "caster-1",
+            "duration_type": "manual",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "display_label": None,
+            "metadata": {
+                "declarative_effect": {
+                    "type": "fall_damage_immunity_threshold",
+                    "params": {"max_distance_meters": 6.0},
+                },
+            },
+        }
+        participant = self._participant_with_effects(effect)
+        _, label = get_fall_damage_immunity_threshold(participant)
+        self.assertEqual(label, "Graça do Gato")
 
 
 if __name__ == "__main__":

--- a/apps/control-server/tests/test_spell_declarative_effects.py
+++ b/apps/control-server/tests/test_spell_declarative_effects.py
@@ -602,6 +602,132 @@ class TestSpellDeclarativeEffectRuntime(unittest.TestCase):
         self.assertEqual(declarative["type"], "fall_damage_immunity_threshold")
         self.assertEqual(declarative["params"]["max_distance_meters"], 6.0)
 
+    def test_cats_grace_creates_fall_immunity_with_variant_label(self):
+        state = self._make_state()
+        attacker = state.participants[0]
+        target = state.participants[1]
+        spell_context = {
+            "spell_name": "Melhorar Habilidade",
+            "spell_canonical_key": "enhance_ability",
+            "concentration": True,
+            "selected_variant_key": "cats_grace",
+            "selected_variant_label": "Graça do Gato",
+            "effects": [
+                {
+                    "type": "advantage_on_checks",
+                    "target": "selected_target",
+                    "duration": {"type": "manual"},
+                    "params": {"ability": "dexterity", "against": "any"},
+                    "stacking": "replace",
+                },
+                {
+                    "type": "fall_damage_immunity_threshold",
+                    "target": "selected_target",
+                    "duration": {"type": "manual"},
+                    "params": {"max_distance_meters": 6.0},
+                },
+            ],
+            "on_end_effects": [],
+        }
+
+        CombatService._apply_declarative_spell_effects(
+            state=state,
+            attacker=attacker,
+            target_participant=target,
+            spell_context=spell_context,
+        )
+
+        fall_effect = next(
+            e for e in target["active_effects"]
+            if e["metadata"]["declarative_effect"]["type"] == "fall_damage_immunity_threshold"
+        )
+        self.assertEqual(fall_effect["metadata"]["selected_variant_label"], "Graça do Gato")
+        self.assertEqual(
+            fall_effect["metadata"]["declarative_effect"]["params"]["max_distance_meters"], 6.0,
+        )
+
+    def test_cats_grace_creates_dexterity_advantage(self):
+        state = self._make_state()
+        attacker = state.participants[0]
+        target = state.participants[1]
+        spell_context = {
+            "spell_name": "Melhorar Habilidade",
+            "spell_canonical_key": "enhance_ability",
+            "concentration": True,
+            "selected_variant_key": "cats_grace",
+            "selected_variant_label": "Graça do Gato",
+            "effects": [
+                {
+                    "type": "advantage_on_checks",
+                    "target": "selected_target",
+                    "duration": {"type": "manual"},
+                    "params": {"ability": "dexterity", "against": "any"},
+                    "stacking": "replace",
+                },
+                {
+                    "type": "fall_damage_immunity_threshold",
+                    "target": "selected_target",
+                    "duration": {"type": "manual"},
+                    "params": {"max_distance_meters": 6.0},
+                },
+            ],
+            "on_end_effects": [],
+        }
+
+        CombatService._apply_declarative_spell_effects(
+            state=state,
+            attacker=attacker,
+            target_participant=target,
+            spell_context=spell_context,
+        )
+
+        dex_effect = next(
+            e for e in target["active_effects"]
+            if e["metadata"]["declarative_effect"]["type"] == "advantage_on_checks"
+        )
+        self.assertEqual(dex_effect["metadata"]["declarative_effect"]["params"]["ability"], "dexterity")
+
+    def test_other_variant_no_fall_immunity(self):
+        state = self._make_state()
+        attacker = state.participants[0]
+        target = state.participants[1]
+        spell_context = {
+            "spell_name": "Melhorar Habilidade",
+            "spell_canonical_key": "enhance_ability",
+            "concentration": True,
+            "selected_variant_key": "bulls_strength",
+            "selected_variant_label": "Força do Touro",
+            "effects": [
+                {
+                    "type": "advantage_on_checks",
+                    "target": "selected_target",
+                    "duration": {"type": "manual"},
+                    "params": {"ability": "strength", "against": "any"},
+                    "stacking": "replace",
+                },
+                {
+                    "type": "carrying_capacity_multiplier",
+                    "target": "selected_target",
+                    "duration": {"type": "manual"},
+                    "params": {"multiplier": 2.0},
+                },
+            ],
+            "on_end_effects": [],
+        }
+
+        CombatService._apply_declarative_spell_effects(
+            state=state,
+            attacker=attacker,
+            target_participant=target,
+            spell_context=spell_context,
+        )
+
+        fall_effects = [
+            e for e in target["active_effects"]
+            if e["metadata"]["declarative_effect"]["type"] == "fall_damage_immunity_threshold"
+        ]
+        self.assertEqual(fall_effects, [])
+
     def test_builds_applied_declarative_effects_summary_by_target(self):
         state = self._make_state()
         attacker = state.participants[0]


### PR DESCRIPTION
# fix(spells): use Cat’s Grace variant label for fall prevention logs

## Summary

Fixes Cat’s Grace / Graça do Gato labeling for fall damage prevention.

The fall prevention effect was already working mechanically, but production active effects used the base spell name as `display_label`, causing fall prevention logs to say the damage was prevented by `Melhorar Habilidade` instead of the selected variant `Graça do Gato`.

This PR updates label resolution to prefer `selected_variant_label` and fixes the Cat’s Grace PT-BR seed label.

## Context

Cat’s Grace fall prevention is implemented through the declarative effect:

```json
{
  "type": "fall_damage_immunity_threshold",
  "params": {
    "max_distance_meters": 6.0
  }
}
````

However, production effect metadata stores:

```text
display_label = "Melhorar Habilidade"
metadata.selected_variant_label = "Graça do Gato"
```

The fall prevention predicate previously resolved labels using `display_label` first, so logs could incorrectly say:

```text
por Melhorar Habilidade
```

instead of:

```text
por Graça do Gato
```

This PR fixes that.

## What changed

### Seed label

Updated:

```text
Base/base_spells.seed.json
```

Changed Cat’s Grace PT-BR label:

```diff
- "Agilidade do Gato"
+ "Graça do Gato"
```

### Fall immunity label resolution

Updated:

```text
condition_effects_predicates.py
```

`get_fall_damage_immunity_threshold()` now resolves prevention labels with this priority:

```text
selected_variant_label
→ display_label
→ source_spell_name
→ "Graça do Gato"
```

This preserves compatibility for effects without variants while correctly using the selected Enhance Ability variant label when available.

### Tests

Updated:

```text
test_fall_damage.py
test_spell_declarative_effects.py
```

Added 5 label resolution tests covering:

* label from `selected_variant_label`
* variant label preferred over `display_label`
* fallback to `display_label`
* fallback to `source_spell_name`
* hardcoded final fallback

Added 3 Cat’s Grace e2e declarative effect tests covering:

* Cat’s Grace creates fall immunity with the variant label
* Cat’s Grace creates Dexterity-check advantage
* other Enhance Ability variants do not create fall immunity

## Validation

```bash
cd apps/control-server
.venv/bin/pytest tests/test_fall_damage.py tests/test_spell_declarative_effects.py -v
```

Result:

```text
98 passed, 0 failed
```

## Notes for reviewers

The behavior change is intentionally small.

This does not change fall damage rules. It only fixes the label used by fall prevention sources so the combat log credits the specific Enhance Ability variant instead of the base spell name.

Before:

```text
Aelar cai 6m e não sofre dano por Melhorar Habilidade.
```

After:

```text
Aelar cai 6m e não sofre dano por Graça do Gato.
```

The cat has reclaimed intellectual property rights.