### PR TITLE
fix(effects): persist manual active effects outside combat

### DIFF
--- a/apps/control-server/app/api/routes/sessions/state_common.py
+++ b/apps/control-server/app/api/routes/sessions/state_common.py
@@ -50,6 +50,7 @@ def to_state_read(entry: SessionState) -> SessionStateRead:
         state=entry.state_json,
         createdAt=entry.created_at,
         updatedAt=entry.updated_at,
+        activeSpellEffects=(entry.state_json or {}).get("active_spell_effects"),
     )
 
 

--- a/apps/control-server/app/schemas/session_state.py
+++ b/apps/control-server/app/schemas/session_state.py
@@ -10,6 +10,7 @@ class SessionStateRead(BaseModel):
     state: dict
     createdAt: datetime
     updatedAt: datetime | None
+    activeSpellEffects: list[dict] | None = None
 
 
 class SessionStateUpdate(BaseModel):

--- a/apps/control-server/app/services/combat_service/effects_actions.py
+++ b/apps/control-server/app/services/combat_service/effects_actions.py
@@ -111,6 +111,9 @@ class CombatEffectsActionsMixin(CombatEffectsCoreMixin):
         db.refresh(state)
         await cls._emit_state(session_id, state)
         await cls._emit_log(session_id, {"message": f"Effect '{cls._effect_label(removed)}' removed from {target['display_name']}.", "source": "effect_removed"})
+        if target.get("kind") == "player":
+            from .persistent_effects import sync_effect_removal_to_state_json
+            sync_effect_removal_to_state_json(db, session_id, target, removed.get("id"))
         return state
 
     @classmethod

--- a/apps/control-server/app/services/combat_service/lifecycle_initiative.py
+++ b/apps/control-server/app/services/combat_service/lifecycle_initiative.py
@@ -159,6 +159,8 @@ class CombatLifecycleInitiativeMixin:
             }
             if p.kind == "player":
                 entry["encumbrance_tier"] = _encumbrance_tier_for_player(db, session_id, p.ref_id)
+                from .persistent_effects import restore_persisted_effects
+                restore_persisted_effects(db, session_id, entry)
             built_participants.append(entry)
 
         new_state = CombatState(

--- a/apps/control-server/app/services/combat_service/lifecycle_turns.py
+++ b/apps/control-server/app/services/combat_service/lifecycle_turns.py
@@ -7,6 +7,7 @@ from .limiar_map_projection import (
     maybe_project_combat_advance_to_limiar_map as _project_combat_advance_to_limiar_map,
     maybe_project_combat_end_to_limiar_map as _project_combat_end_to_limiar_map,
 )
+from .persistent_effects import persist_surviving_spell_effects
 
 
 def maybe_project_combat_advance_to_limiar_map(session_id: str, state) -> None:
@@ -128,6 +129,8 @@ class CombatLifecycleTurnsMixin:
         for source_id in concentration_source_ids:
             result = cls._clear_concentration_for_source(state, source_participant_id=source_id)
             all_removed.extend(result["removed_effects"])
+
+        persist_surviving_spell_effects(db, state)
 
         for participant in state.participants:
             remaining = cls._get_participant_effects(participant)

--- a/apps/control-server/app/services/combat_service/persistent_effects.py
+++ b/apps/control-server/app/services/combat_service/persistent_effects.py
@@ -1,0 +1,137 @@
+"""Persist and restore manual-duration spell effects across combat boundaries.
+
+`active_spell_effects` in SessionState.state_json is the canonical store for
+non-combat spell effects.  Only effects with:
+  - kind in {"spell_effect", "temp_ac_bonus"}
+  - duration_type == "manual"
+  - concentration == False
+are persisted.  Round-based and turn-based effects expire naturally during combat.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select as sa_select
+from sqlalchemy.orm.attributes import flag_modified
+
+from app.models.session_state import SessionState
+from app.services.session_state_finalize import finalize_session_state_data
+
+if TYPE_CHECKING:
+    from app.models.combat import CombatState
+    from sqlmodel import Session as DbSession
+
+_PERSISTABLE_KINDS = {"spell_effect", "temp_ac_bonus"}
+
+
+def persist_surviving_spell_effects(db: DbSession, state: CombatState) -> None:
+    """Transfer manual-duration, non-concentration spell effects to state_json.
+
+    Called during end_combat() AFTER concentration has been cleared but BEFORE
+    remaining participant effects are wiped.
+    """
+    for participant in state.participants:
+        if participant.get("kind") != "player":
+            continue
+        effects = participant.get("active_effects")
+        if not isinstance(effects, list):
+            continue
+        surviving = [
+            e for e in effects
+            if e.get("kind") in _PERSISTABLE_KINDS
+            and e.get("duration_type") == "manual"
+            and not (e.get("metadata") or {}).get("concentration")
+        ]
+        if not surviving:
+            continue
+        ref_id = participant.get("ref_id")
+        if not ref_id:
+            continue
+        session_state = db.exec(
+            sa_select(SessionState).where(
+                SessionState.session_id == state.session_id,
+                SessionState.player_user_id == ref_id,
+            )
+        ).first()
+        if not session_state:
+            continue
+        data = dict(session_state.state_json or {})
+        data["active_spell_effects"] = surviving
+        session_state.state_json = finalize_session_state_data(data)
+        flag_modified(session_state, "state_json")
+        db.add(session_state)
+
+
+def restore_persisted_effects(
+    db: DbSession,
+    session_id: str,
+    participant: dict,
+) -> None:
+    """Restore persisted spell effects from state_json into a combat participant.
+
+    Called during start_combat() for each player participant.
+    """
+    if participant.get("kind") != "player":
+        return
+    ref_id = participant.get("ref_id")
+    if not ref_id:
+        return
+    session_state = db.exec(
+        sa_select(SessionState).where(
+            SessionState.session_id == session_id,
+            SessionState.player_user_id == ref_id,
+        )
+    ).first()
+    if not session_state:
+        return
+    persisted = (session_state.state_json or {}).get("active_spell_effects")
+    if not isinstance(persisted, list) or not persisted:
+        return
+    existing = participant.get("active_effects")
+    if not isinstance(existing, list):
+        existing = []
+        participant["active_effects"] = existing
+    existing_ids = {e.get("id") for e in existing}
+    for effect in persisted:
+        if effect.get("id") not in existing_ids:
+            existing.append(effect)
+
+
+def sync_effect_removal_to_state_json(
+    db: DbSession,
+    session_id: str,
+    participant: dict,
+    removed_effect_id: str,
+) -> None:
+    """Remove an effect from state_json.active_spell_effects by id.
+
+    Called from remove_effect() when the target is a player participant.
+    """
+    if participant.get("kind") != "player":
+        return
+    ref_id = participant.get("ref_id")
+    if not ref_id:
+        return
+    session_state = db.exec(
+        sa_select(SessionState).where(
+            SessionState.session_id == session_id,
+            SessionState.player_user_id == ref_id,
+        )
+    ).first()
+    if not session_state:
+        return
+    data = dict(session_state.state_json or {})
+    persisted = data.get("active_spell_effects")
+    if not isinstance(persisted, list):
+        return
+    filtered = [e for e in persisted if e.get("id") != removed_effect_id]
+    if len(filtered) == len(persisted):
+        return
+    if filtered:
+        data["active_spell_effects"] = filtered
+    else:
+        data.pop("active_spell_effects", None)
+    session_state.state_json = finalize_session_state_data(data)
+    flag_modified(session_state, "state_json")
+    db.add(session_state)

--- a/apps/control-server/tests/_combat_test_flow.py
+++ b/apps/control-server/tests/_combat_test_flow.py
@@ -146,7 +146,17 @@ class CombatFlowTestsMixin:
             calibration_width=0.7,
             calibration_height=0.6,
         )
-        self.db.exec.side_effect = [session_result, campaign_map_result]
+        call_count = 0
+        side_effect_results = [session_result, campaign_map_result]
+        def exec_side_effect(*args, **kwargs):
+            nonlocal call_count
+            if call_count < len(side_effect_results):
+                result = side_effect_results[call_count]
+                call_count += 1
+                return result
+            call_count += 1
+            return MagicMock(first=MagicMock(return_value=None))
+        self.db.exec.side_effect = exec_side_effect
 
         req = CombatStartRequest(
             participants=[

--- a/apps/control-server/tests/test_persistent_effects.py
+++ b/apps/control-server/tests/test_persistent_effects.py
@@ -1,0 +1,285 @@
+"""Tests for persistent spell effects across combat boundaries.
+
+Covers:
+- persist_surviving_spell_effects (end_combat → state_json)
+- restore_persisted_effects (combat start ← state_json)
+- sync_effect_removal_to_state_json (remove_effect → state_json)
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.models.combat import CombatPhase, CombatState
+from app.models.session_state import SessionState
+from app.services.combat_service.persistent_effects import (
+    persist_surviving_spell_effects,
+    restore_persisted_effects,
+    sync_effect_removal_to_state_json,
+)
+
+
+def _manual_spell_effect(effect_id: str = "eff-1", concentration: bool = False) -> dict:
+    return {
+        "id": effect_id,
+        "kind": "spell_effect",
+        "source_participant_id": "caster-1",
+        "duration_type": "manual",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "display_label": "Owl's Wisdom",
+        "metadata": {
+            "source_spell_name": "Owl's Wisdom",
+            "concentration": concentration,
+            "concentration_group": "group-1" if concentration else None,
+            "declarative_effect": {
+                "type": "passive_skill_bonus",
+                "params": {"skill": "perception", "bonus": 5},
+            },
+        },
+    }
+
+
+def _rounds_spell_effect(effect_id: str = "eff-rounds") -> dict:
+    return {
+        "id": effect_id,
+        "kind": "spell_effect",
+        "source_participant_id": "caster-1",
+        "duration_type": "rounds",
+        "remaining_rounds": 5,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "metadata": {"source_spell_name": "Friends"},
+    }
+
+
+def _condition_effect(effect_id: str = "eff-cond") -> dict:
+    return {
+        "id": effect_id,
+        "kind": "condition",
+        "condition_type": "frightened",
+        "duration_type": "manual",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "metadata": {},
+    }
+
+
+def _temp_ac_bonus_effect(effect_id: str = "eff-ac") -> dict:
+    return {
+        "id": effect_id,
+        "kind": "temp_ac_bonus",
+        "numeric_value": 2,
+        "duration_type": "manual",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "metadata": {},
+    }
+
+
+def _make_state_with_participants(effects: list[dict] | None = None) -> CombatState:
+    return CombatState(
+        id="combat-1",
+        session_id="session-1",
+        phase=CombatPhase.active,
+        round=3,
+        current_turn_index=0,
+        participants=[
+            {
+                "id": "p1",
+                "ref_id": "player-1",
+                "kind": "player",
+                "display_name": "Hero",
+                "status": "active",
+                "team": "players",
+                "active_effects": list(effects or []),
+            },
+            {
+                "id": "e1",
+                "ref_id": "enemy-1",
+                "kind": "session_entity",
+                "display_name": "Goblin",
+                "status": "active",
+                "team": "enemies",
+                "active_effects": [],
+            },
+        ],
+    )
+
+
+def _make_session_state(state_json: dict | None = None) -> SessionState:
+    mock = MagicMock(spec=SessionState)
+    mock.state_json = state_json or {}
+    mock._sa_instance_state = MagicMock()
+    return mock
+
+
+class TestPersistSurvivingSpellEffects(unittest.TestCase):
+    def test_persists_manual_spell_effect(self):
+        effect = _manual_spell_effect("eff-1")
+        state = _make_state_with_participants([effect])
+        db = MagicMock()
+        session_state = _make_session_state({})
+        db.exec.return_value.first.return_value = session_state
+
+        persist_surviving_spell_effects(db, state)
+
+        persisted = session_state.state_json["active_spell_effects"]
+        self.assertEqual(len(persisted), 1)
+        self.assertEqual(persisted[0]["id"], "eff-1")
+
+    def test_persists_manual_temp_ac_bonus(self):
+        effect = _temp_ac_bonus_effect("eff-ac")
+        state = _make_state_with_participants([effect])
+        db = MagicMock()
+        session_state = _make_session_state({})
+        db.exec.return_value.first.return_value = session_state
+
+        persist_surviving_spell_effects(db, state)
+
+        persisted = session_state.state_json["active_spell_effects"]
+        self.assertEqual(len(persisted), 1)
+        self.assertEqual(persisted[0]["kind"], "temp_ac_bonus")
+
+    def test_discards_rounds_based_effect(self):
+        effects = [_manual_spell_effect("eff-1"), _rounds_spell_effect("eff-rounds")]
+        state = _make_state_with_participants(effects)
+        db = MagicMock()
+        session_state = _make_session_state({})
+        db.exec.return_value.first.return_value = session_state
+
+        persist_surviving_spell_effects(db, state)
+
+        persisted = session_state.state_json["active_spell_effects"]
+        self.assertEqual(len(persisted), 1)
+        self.assertEqual(persisted[0]["id"], "eff-1")
+
+    def test_discards_concentration_effect(self):
+        effect = _manual_spell_effect("eff-1", concentration=True)
+        state = _make_state_with_participants([effect])
+        db = MagicMock()
+        session_state = _make_session_state({})
+        db.exec.return_value.first.return_value = session_state
+
+        persist_surviving_spell_effects(db, state)
+
+        self.assertNotIn("active_spell_effects", session_state.state_json)
+
+    def test_discards_condition_effect(self):
+        effect = _condition_effect("eff-cond")
+        state = _make_state_with_participants([effect])
+        db = MagicMock()
+        session_state = _make_session_state({})
+        db.exec.return_value.first.return_value = session_state
+
+        persist_surviving_spell_effects(db, state)
+
+        self.assertNotIn("active_spell_effects", session_state.state_json)
+
+    def test_skips_entity_participants(self):
+        state = _make_state_with_participants()
+        state.participants[1]["active_effects"] = [_manual_spell_effect("eff-1")]
+        db = MagicMock()
+
+        persist_surviving_spell_effects(db, state)
+
+        db.exec.assert_not_called()
+
+    def test_no_persist_when_no_surviving(self):
+        state = _make_state_with_participants([_rounds_spell_effect()])
+        db = MagicMock()
+
+        persist_surviving_spell_effects(db, state)
+
+        db.exec.assert_not_called()
+
+
+class TestRestorePersistedEffects(unittest.TestCase):
+    def test_restores_persisted_effects(self):
+        effect = _manual_spell_effect("eff-1")
+        participant = {"kind": "player", "ref_id": "player-1", "active_effects": []}
+        db = MagicMock()
+        session_state = _make_session_state({"active_spell_effects": [effect]})
+        db.exec.return_value.first.return_value = session_state
+
+        restore_persisted_effects(db, "session-1", participant)
+
+        self.assertEqual(len(participant["active_effects"]), 1)
+        self.assertEqual(participant["active_effects"][0]["id"], "eff-1")
+
+    def test_does_not_duplicate_existing(self):
+        effect = _manual_spell_effect("eff-1")
+        participant = {"kind": "player", "ref_id": "player-1", "active_effects": [effect]}
+        db = MagicMock()
+        session_state = _make_session_state({"active_spell_effects": [effect]})
+        db.exec.return_value.first.return_value = session_state
+
+        restore_persisted_effects(db, "session-1", participant)
+
+        self.assertEqual(len(participant["active_effects"]), 1)
+
+    def test_skips_non_player(self):
+        participant = {"kind": "session_entity", "ref_id": "enemy-1", "active_effects": []}
+        db = MagicMock()
+
+        restore_persisted_effects(db, "session-1", participant)
+
+        db.exec.assert_not_called()
+        self.assertEqual(participant["active_effects"], [])
+
+    def test_handles_empty_persisted(self):
+        participant = {"kind": "player", "ref_id": "player-1", "active_effects": []}
+        db = MagicMock()
+        session_state = _make_session_state({"active_spell_effects": []})
+        db.exec.return_value.first.return_value = session_state
+
+        restore_persisted_effects(db, "session-1", participant)
+
+        self.assertEqual(participant["active_effects"], [])
+
+
+class TestSyncEffectRemovalToStateJson(unittest.TestCase):
+    def test_removes_effect_from_state_json(self):
+        effect = _manual_spell_effect("eff-1")
+        participant = {"kind": "player", "ref_id": "player-1"}
+        db = MagicMock()
+        session_state = _make_session_state({"active_spell_effects": [effect]})
+        db.exec.return_value.first.return_value = session_state
+
+        sync_effect_removal_to_state_json(db, "session-1", participant, "eff-1")
+
+        self.assertNotIn("active_spell_effects", session_state.state_json)
+
+    def test_removes_only_matching_effect(self):
+        eff1 = _manual_spell_effect("eff-1")
+        eff2 = _manual_spell_effect("eff-2")
+        participant = {"kind": "player", "ref_id": "player-1"}
+        db = MagicMock()
+        session_state = _make_session_state({"active_spell_effects": [eff1, eff2]})
+        db.exec.return_value.first.return_value = session_state
+
+        sync_effect_removal_to_state_json(db, "session-1", participant, "eff-1")
+
+        remaining = session_state.state_json["active_spell_effects"]
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0]["id"], "eff-2")
+
+    def test_noop_when_effect_not_persisted(self):
+        effect = _manual_spell_effect("eff-1")
+        participant = {"kind": "player", "ref_id": "player-1"}
+        db = MagicMock()
+        session_state = _make_session_state({"active_spell_effects": [effect]})
+        db.exec.return_value.first.return_value = session_state
+
+        sync_effect_removal_to_state_json(db, "session-1", participant, "eff-other")
+
+        self.assertEqual(len(session_state.state_json["active_spell_effects"]), 1)
+
+    def test_skips_non_player(self):
+        participant = {"kind": "session_entity", "ref_id": "enemy-1"}
+        db = MagicMock()
+
+        sync_effect_removal_to_state_json(db, "session-1", participant, "eff-1")
+
+        db.exec.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/control-web/src/features/character-sheet/components/CharacterSheet.tsx
+++ b/apps/control-web/src/features/character-sheet/components/CharacterSheet.tsx
@@ -67,7 +67,7 @@ export const CharacterSheet = ({
     canEditPlay,
     campaignId,
   });
-  const { sheet } = actions;
+  const { sheet, activeSpellEffects } = actions;
   const { t } = useLocale();
   const isCreation = mode === "creation";
   const isCreationDraft = isCreation && creationDraftMode;
@@ -213,10 +213,11 @@ export const CharacterSheet = ({
     hpTextColor,
     initiative,
     passivePerception,
+    passivePerceptionBonus,
     profBonus,
     spellAttack,
     spellSaveDC,
-  } = useCharacterSheetDerived(sheet);
+  } = useCharacterSheetDerived(sheet, activeSpellEffects);
 
   if (actions.loading) {
     return <CharacterSheetStateScreen />;
@@ -439,6 +440,7 @@ export const CharacterSheet = ({
                 level={sheet.level}
                 onCycleProf={actions.cycleSkillProf}
                 readOnly={isCreation ? !isEditableCreationDraft : isPlayReadOnly || isSheetLocked}
+                passivePerceptionBonus={passivePerceptionBonus ?? 0}
               />
           </div>
         </div>

--- a/apps/control-web/src/features/character-sheet/hooks/useCharacterSheet.state.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/useCharacterSheet.state.ts
@@ -3,6 +3,7 @@ import type {
   PartyCharacterSheetDraftRecord,
 } from "../../../entities/character";
 import type { CharacterSheet } from "../model/characterSheet.types";
+import type { ActiveEffect } from "../../../shared/api/combatRepo";
 import { INITIAL_SHEET } from "../model/initialSheet";
 
 export type CharacterSheetHookState = {
@@ -19,6 +20,7 @@ export type CharacterSheetHookState = {
   playSessionId: string | null;
   playCampaignId: string | null;
   playPlayerUserId: string | null;
+  activeSpellEffects: ActiveEffect[];
 };
 
 export type CharacterSheetHookAction =
@@ -32,6 +34,7 @@ export type CharacterSheetHookAction =
       playSessionId?: string | null;
       playCampaignId?: string | null;
       playPlayerUserId?: string | null;
+      activeSpellEffects?: ActiveEffect[];
     }
   | { type: "load_fail"; error: string }
   | { type: "update_sheet"; updater: (sheet: CharacterSheet) => CharacterSheet }
@@ -62,6 +65,7 @@ export const initialCharacterSheetHookState: CharacterSheetHookState = {
   playSessionId: null,
   playCampaignId: null,
   playPlayerUserId: null,
+  activeSpellEffects: [],
 };
 
 export function characterSheetHookReducer(
@@ -83,6 +87,7 @@ export function characterSheetHookReducer(
         playSessionId: action.playSessionId ?? null,
         playCampaignId: action.playCampaignId ?? null,
         playPlayerUserId: action.playPlayerUserId ?? null,
+        activeSpellEffects: action.activeSpellEffects ?? [],
       };
     case "load_fail":
       return { ...state, loading: false, loadError: action.error };

--- a/apps/control-web/src/features/character-sheet/hooks/useCharacterSheet.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/useCharacterSheet.ts
@@ -190,6 +190,7 @@ export const useCharacterSheet = (
     loadError: state.loadError,
     saveError: state.saveError,
     remoteId: state.remoteId,
+    activeSpellEffects: state.activeSpellEffects,
     characterRecord: state.characterRecord,
     draftRecord: state.draftRecord,
     importError: state.importError,

--- a/apps/control-web/src/features/character-sheet/hooks/useCharacterSheetDerived.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/useCharacterSheetDerived.ts
@@ -1,6 +1,8 @@
 import {
   computeInitiative,
   computePassivePerception,
+  computePassiveSkillBonus,
+  computePassiveSkillBonusSources,
   computeSpellAttack,
   computeSpellSaveDC,
   getModifier,
@@ -12,20 +14,31 @@ import {
   getArmorClassBreakdownRows,
 } from "../utils/armorClass";
 import type { CharacterSheet } from "../model/characterSheet.types";
+import type { ActiveEffect } from "../../../shared/api/combatRepo";
 import {
   getDraconicLineageState,
   resolveElementalAffinityEligibility,
 } from "../data/draconicAncestry";
 import { resolveDragonbornLineageState } from "../data/dragonbornAncestries";
 
-export const useCharacterSheetDerived = (sheet: CharacterSheet) => {
+export const useCharacterSheetDerived = (
+  sheet: CharacterSheet,
+  activeEffects?: ActiveEffect[] | null,
+) => {
   const acResult = calculateArmorClass(buildCharacterAcStateFromSheet(sheet));
   const ac = acResult.total;
   const acBreakdown = getArmorClassBreakdownRows(acResult);
   const dexMod = getModifier(sheet.abilities.dexterity);
   const initiative = computeInitiative(dexMod);
   const profBonus = getProficiencyBonus(sheet.level);
-  const passivePerception = computePassivePerception(sheet);
+  const basePassivePerception = computePassivePerception(sheet);
+  const passivePerceptionBonus = activeEffects?.length
+    ? computePassiveSkillBonus(activeEffects, "perception")
+    : 0;
+  const passivePerception = basePassivePerception + passivePerceptionBonus;
+  const passivePerceptionBonusSources = activeEffects?.length
+    ? computePassiveSkillBonusSources(activeEffects, "perception")
+    : undefined;
 
   const spellAbilityScore = sheet.spellcasting
     ? sheet.abilities[sheet.spellcasting.ability]
@@ -69,6 +82,8 @@ export const useCharacterSheetDerived = (sheet: CharacterSheet) => {
     hpTextColor,
     initiative,
     passivePerception,
+    passivePerceptionBonus: passivePerceptionBonus || undefined,
+    passivePerceptionBonusSources,
     profBonus,
     dragonbornAncestry: dragonbornLineage.ancestry,
     dragonbornAncestryLabel: dragonbornLineage.ancestryLabel,

--- a/apps/control-web/src/features/character-sheet/hooks/useCharacterSheetLoader.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/useCharacterSheetLoader.ts
@@ -57,6 +57,7 @@ export function useCharacterSheetLoader(
           playSessionId: result.sessionId,
           playCampaignId: result.campaignId,
           playPlayerUserId: params.playPlayerUserId,
+          activeSpellEffects: result.activeSpellEffects as import("../../../shared/api/combatRepo").ActiveEffect[],
         });
         return;
       }

--- a/apps/control-web/src/features/character-sheet/services/characterSheet.service.ts
+++ b/apps/control-web/src/features/character-sheet/services/characterSheet.service.ts
@@ -154,7 +154,7 @@ export async function loadPlayCharacterSheet(
   partyId: string,
   playerUserId: string,
   useOwnState: boolean,
-): Promise<{ id: string | null; sheet: CharacterSheet; sessionId: string; campaignId: string }> {
+): Promise<{ id: string | null; sheet: CharacterSheet; sessionId: string; campaignId: string; activeSpellEffects: Record<string, unknown>[] }> {
   const activeSession = await partiesRepo.getPartyActiveSession(partyId);
   const record = useOwnState
     ? await sessionStatesRepo.getMine(activeSession.id)
@@ -165,6 +165,7 @@ export async function loadPlayCharacterSheet(
     sheet,
     sessionId: activeSession.id,
     campaignId: activeSession.campaignId,
+    activeSpellEffects: (record.state as Record<string, unknown>)?.active_spell_effects as Record<string, unknown>[] ?? [],
   };
 }
 

--- a/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
+++ b/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
@@ -14,7 +14,7 @@ import { CombatModeBar } from "../components/CombatModeBar";
 import { CombatParticipantRoster } from "../components/CombatParticipantRoster";
 import { ActiveEffectDebugPanel } from "../components/ActiveEffectDebugPanel";
 import { buildCombatParticipantViews, getCombatEffectLabel, getCombatStatusLabel } from "../combatUi.helpers";
-import { computePassiveSkillBonus, computePassiveSkillBonusSources } from "../../../features/character-sheet/utils/calculations";
+
 import { PlayerAttackRollDialog } from "../../../pages/PlayerBoardPage/player-combat-debug/PlayerAttackRollDialog";
 import { PlayerSpellCastDialog } from "../../../pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog";
 import { PlayerBoardRollDialog } from "../../../pages/PlayerBoardPage/PlayerBoardRollDialog";
@@ -185,18 +185,6 @@ export const PlayerCombatModeShell = ({
   );
 
   const myParticipant = combat.myParticipant;
-  const enrichedPlayerStatus = useMemo(() => {
-    if (!playerStatus) return null;
-    const activeEffects = myParticipant?.active_effects ?? [];
-    const bonus = computePassiveSkillBonus(activeEffects, "perception");
-    if (!bonus) return playerStatus;
-    return {
-      ...playerStatus,
-      passivePerception: playerStatus.passivePerception + bonus,
-      passivePerceptionBonus: bonus,
-      passivePerceptionBonusSources: computePassiveSkillBonusSources(activeEffects, "perception"),
-    };
-  }, [playerStatus, myParticipant?.active_effects]);
 
   const selectedSpellIsArea = requiresAreaTargetingSelection(selectedSpell?.selectionType, selectedSpell?.areaShape);
   const selectedSpellNeedsTarget = spellRequiresExternalTarget(selectedSpell?.selectionType, selectedSpell?.areaShape);
@@ -332,9 +320,9 @@ export const PlayerCombatModeShell = ({
       : null;
   const encumbranceMovementWarning =
     movementPreview.preview != null &&
-    enrichedPlayerStatus &&
-    enrichedPlayerStatus.baseSpeedMeters > 0 &&
-    pathCostUnitsToMeters(movementPreview.preview.path_cost_units) > enrichedPlayerStatus.effectiveSpeedMeters
+    playerStatus &&
+    playerStatus.baseSpeedMeters > 0 &&
+    pathCostUnitsToMeters(movementPreview.preview.path_cost_units) > playerStatus.effectiveSpeedMeters
       ? t("playerBoard.encumbranceMovementExceed")
       : null;
   const movementHintMessage = movementRejectionReason ?? movementPreview.error;
@@ -446,7 +434,7 @@ export const PlayerCombatModeShell = ({
             lastUseObjectResult={lastUseObjectResult}
             myParticipant={myParticipant}
             pendingRoll={pendingRoll}
-            playerStatus={enrichedPlayerStatus}
+            playerStatus={playerStatus}
             selectedConsumable={selectedConsumable}
             selectedSpell={selectedSpell}
             selectedSpellId={selectedSpellId}
@@ -486,43 +474,43 @@ export const PlayerCombatModeShell = ({
                 <div className="rounded-3xl border border-white/8 bg-white/4 px-4 py-4">
                   <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">{t("combatUi.hp")}</p>
                   <p className="mt-2 text-xl font-semibold text-white">
-                    {enrichedPlayerStatus ? `${enrichedPlayerStatus.currentHp}/${enrichedPlayerStatus.maxHp}` : "-"}
+                    {playerStatus ? `${playerStatus.currentHp}/${playerStatus.maxHp}` : "-"}
                   </p>
                 </div>
                 <div className="rounded-3xl border border-white/8 bg-white/4 px-4 py-4">
                   <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">{t("combatUi.armorClass")}</p>
-                  <p className="mt-2 text-xl font-semibold text-white">{enrichedPlayerStatus?.ac ?? "-"}</p>
+                  <p className="mt-2 text-xl font-semibold text-white">{playerStatus?.ac ?? "-"}</p>
                 </div>
                 <div className="rounded-3xl border border-white/8 bg-white/4 px-4 py-4">
                   <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">{t("playerBoard.speedLabel")}</p>
                   <p className="mt-2 text-xl font-semibold text-white">
-                    {enrichedPlayerStatus && enrichedPlayerStatus.baseSpeedMeters > 0
-                      ? `${enrichedPlayerStatus.effectiveSpeedMeters} m`
+                    {playerStatus && playerStatus.baseSpeedMeters > 0
+                      ? `${playerStatus.effectiveSpeedMeters} m`
                       : "-"}
                   </p>
-                  {enrichedPlayerStatus && enrichedPlayerStatus.effectiveSpeedMeters < enrichedPlayerStatus.baseSpeedMeters ? (
+                  {playerStatus && playerStatus.effectiveSpeedMeters < playerStatus.baseSpeedMeters ? (
                     <p className="mt-1 text-[10px] text-amber-400">
-                      {`${t("playerBoard.speedPenaltyHint")} (base ${enrichedPlayerStatus.baseSpeedMeters} m)`}
+                      {`${t("playerBoard.speedPenaltyHint")} (base ${playerStatus.baseSpeedMeters} m)`}
                     </p>
                   ) : null}
                 </div>
                 <div className="rounded-3xl border border-white/8 bg-white/4 px-4 py-4">
                   <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">{t("sheet.skills.passivePerception")}</p>
-                  <p className="mt-2 text-xl font-semibold text-white">{enrichedPlayerStatus?.passivePerception ?? "-"}</p>
-                  {enrichedPlayerStatus?.passivePerceptionBonus && enrichedPlayerStatus.passivePerceptionBonusSources?.length ? (
+                  <p className="mt-2 text-xl font-semibold text-white">{playerStatus?.passivePerception ?? "-"}</p>
+                  {playerStatus?.passivePerceptionBonus && playerStatus.passivePerceptionBonusSources?.length ? (
                     <p className="mt-1 text-[10px] text-sky-300">
-                      {`Base ${enrichedPlayerStatus.passivePerception - enrichedPlayerStatus.passivePerceptionBonus}${enrichedPlayerStatus.passivePerceptionBonusSources.map((s) => ` + ${s.label} ${s.value}`).join("")}`}
+                      {`Base ${playerStatus.passivePerception - playerStatus.passivePerceptionBonus}${playerStatus.passivePerceptionBonusSources.map((s) => ` + ${s.label} ${s.value}`).join("")}`}
                     </p>
                   ) : null}
                 </div>
                 <div className="rounded-3xl border border-white/8 bg-white/4 px-4 py-4 sm:col-span-2">
                   <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">{t("combatUi.currentWeapon")}</p>
                   <p className="mt-2 text-sm font-semibold text-white">
-                    {enrichedPlayerStatus?.currentWeapon?.name ?? t("combatUi.noWeapon")}
+                    {playerStatus?.currentWeapon?.name ?? t("combatUi.noWeapon")}
                   </p>
-                  {enrichedPlayerStatus?.currentWeapon ? (
+                  {playerStatus?.currentWeapon ? (
                     <p className="mt-2 text-xs text-slate-300">
-                      {enrichedPlayerStatus.currentWeapon.damageLabel}
+                      {playerStatus.currentWeapon.damageLabel}
                     </p>
                   ) : null}
                 </div>

--- a/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardSummary.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardSummary.ts
@@ -39,8 +39,9 @@ export const usePlayerBoardSummary = ({
   t,
 }: Props) => {
   const { locale } = useLocale();
-  const { ac, hpPercent, initiative, passivePerception, spellAttack, spellSaveDC } =
-    useCharacterSheetDerived(playerSheet ?? INITIAL_SHEET);
+  const { ac, hpPercent, initiative, passivePerception, passivePerceptionBonus,
+          passivePerceptionBonusSources, spellAttack, spellSaveDC } =
+    useCharacterSheetDerived(playerSheet ?? INITIAL_SHEET, activeEffects);
   const {
     baseCarryingCapacityKg,
     carryingCapacityKg,
@@ -136,6 +137,8 @@ export const usePlayerBoardSummary = ({
       maxHp: playerSheet.maxHP,
       nextLevelThreshold: xpState.nextLevelThreshold,
       passivePerception,
+      passivePerceptionBonus,
+      passivePerceptionBonusSources,
       pushDragLiftKg,
       spellAttack,
       spellSaveDC,


### PR DESCRIPTION
# fix(effects): persist manual active effects outside combat

## Summary

Fixes passive skill bonuses outside combat by persisting surviving manual active effects to session state and wiring those effects into character sheet and player board derived stats.

This closes the gap where effects such as Enhance Ability / Owl’s Wisdom applied correctly in combat, but disappeared from passive perception displays outside combat because `active_effects` only existed on combat participants.

## Context

Before this change, `passive_skill_bonus` effects were only available in combat through `CombatState.participants[*].active_effects`.

That meant Owl’s Wisdom / Sabedoria da Coruja could apply `+5 Passive Perception` correctly in `PlayerCombatModeShell`, but outside combat the following components showed the base value:

- `CharacterHeader`
- `Skills.tsx`
- `PlayerBoardStatusPanel`

The root cause was architectural: outside combat, the character/session state had no persisted active effect source.

## What changed

### Backend

Added persistent effect handling for manual-duration effects.

New/updated files:

```text
persistent_effects.py
lifecycle_turns.py
lifecycle_initiative.py
effects_actions.py
session_state.py
state_common.py
````

Implemented:

* `persist_surviving_spell_effects`
* `restore_persisted_effects`
* `sync_effect_removal_to_state_json`

Behavior:

* on `end_combat()`, surviving manual effects are persisted to `state_json.active_spell_effects`
* only appropriate surviving effects are persisted
* combat/round-based effects are not carried outside combat
* on `start_combat()`, persisted effects are restored into participant `active_effects`
* when an effect is removed, the persisted state is synchronized so removed effects do not reappear later
* `SessionStateRead` now exposes `activeSpellEffects`
* `to_state_read()` derives `activeSpellEffects` from `state_json`

This makes `state_json.active_spell_effects` the out-of-combat source for surviving manual effects.

### Frontend

Updated character sheet and player board derivation to consume active effects consistently.

Updated files:

```text
useCharacterSheetDerived.ts
usePlayerBoardSummary.ts
PlayerCombatModeShell.tsx
characterSheet.service.ts
useCharacterSheet.state.ts
CharacterSheet.tsx
```

Implemented:

* `useCharacterSheetDerived` now accepts optional `activeEffects`
* derived state now returns:

  * `passivePerceptionBonus`
  * `passivePerceptionBonusSources`
* `usePlayerBoardSummary` passes active effects into shared derivation
* removed duplicated `enrichedPlayerStatus` logic from `PlayerCombatModeShell`
* `loadPlayCharacterSheet` returns `activeSpellEffects`
* character sheet hook state stores `activeSpellEffects`
* `CharacterSheet` passes active effects into derived calculations and sends `passivePerceptionBonus` to `Skills`

## Behavior

Owl’s Wisdom / Sabedoria da Coruja now works consistently:

```text
during combat
→ active effect applies +5 Passive Perception

end combat
→ manual surviving effect persists into state_json.active_spell_effects

outside combat
→ character sheet and player board still show the +5 bonus

start combat again
→ persisted effect restores into participant active_effects

remove effect
→ persisted state is also cleaned
```

No more Coruja fantasma haunting the character sheet. She stays only while the effect actually exists. Revolutionary.

## Tests

Added:

```text
tests/test_persistent_effects.py
```

Coverage includes:

* persisting surviving manual spell effects
* ignoring non-manual/round-based effects
* restoring persisted effects on combat start
* syncing manual effect removal back to `state_json`
* preventing removed effects from reappearing

Updated:

```text
_combat_test_flow.py
```

Adjusted mock setup for the new `db.exec()` call.

## Validation

```bash
cd apps/control-server
.venv/bin/pytest tests/test_persistent_effects.py tests/test_combat.py -v
```

Result:

```text
260 passed, 0 failed
```

## Notes for reviewers

The important design choice is persisting only surviving manual-duration effects outside combat.

Round-based effects remain combat-scoped and are not converted into real time.

This avoids accidentally making short-duration effects permanent while still supporting long-lived/manual effects such as Enhance Ability variants.

Effect removal is synchronized back to `state_json.active_spell_effects`, preventing stale persisted effects from resurfacing after combat transitions.

## Out of scope

This PR intentionally does not implement:

* real-time duration conversion for round-based effects
* UI breakdown such as “Base 12 + Owl’s Wisdom 5”
* broader passive skill bonus UI beyond the existing passive perception paths
* redesigning the active effect lifecycle
* global non-session character effect storage

## Closes

Closes #147.
