### PR TITLE
feat(character-sheet): show passive perception bonus breakdown

### DIFF
--- a/apps/control-web/src/features/character-sheet/components/CharacterHeader.test.tsx
+++ b/apps/control-web/src/features/character-sheet/components/CharacterHeader.test.tsx
@@ -1,0 +1,158 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { CharacterHeader } from "./CharacterHeader";
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => () => {},
+}));
+
+vi.mock("../../../shared/hooks/useLocale", () => ({
+  useLocale: () => ({
+    t: (key: string) =>
+      ({
+        "sheet.header.unnamed": "Sem nome",
+        "sheet.header.reset": "Resetar",
+        "sheet.header.exportJson": "Exportar",
+        "sheet.header.importJson": "Importar",
+      }[key] ?? key),
+  }),
+}));
+
+vi.mock("../../../shared/lib/navigation", () => ({
+  canNavigateBack: () => false,
+  navigateBackOrFallback: () => {},
+}));
+
+vi.mock("../data/classes", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../data/classes")>();
+  return {
+    ...actual,
+    formatClassDisplayName: () => "Guerreiro",
+  };
+});
+
+vi.mock("../constants", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../constants")>();
+  return {
+    ...actual,
+    CONDITION_LABELS: {},
+    CONDITION_NAMES: [],
+  };
+});
+
+const BASE_SHEET: Record<string, unknown> = {
+  name: "Teste",
+  class: "fighter",
+  subclass: null,
+  subclassConfig: null,
+  level: 1,
+  currentHP: 10,
+  maxHP: 10,
+  tempHP: 0,
+  inspiration: false,
+  conditions: {},
+};
+
+const noop = () => {};
+const importRef = { current: null };
+
+describe("CharacterHeader", () => {
+  it("renders PP chip without helper when no bonus", () => {
+    const markup = renderToStaticMarkup(
+      <CharacterHeader
+        sheet={BASE_SHEET as any}
+        mode="play"
+        canSave={false}
+        showResetImport={false}
+        ac={12}
+        initiative={1}
+        profBonus={2}
+        passivePerception={13}
+        spellSaveDC={null}
+        spellAttack={null}
+        hpTextColor="text-emerald-400"
+        isDirty={false}
+        saving={false}
+        saveError={null}
+        importRef={importRef as any}
+        importError={null}
+        onSave={noop}
+        onExport={noop}
+        onImport={noop}
+        onReset={noop}
+      />,
+    );
+
+    expect(markup).toContain("PP");
+    expect(markup).toContain(">13<");
+    expect(markup).not.toContain("Sabedoria");
+  });
+
+  it("renders PP chip with helper when bonus sources provided", () => {
+    const markup = renderToStaticMarkup(
+      <CharacterHeader
+        sheet={BASE_SHEET as any}
+        mode="play"
+        canSave={false}
+        showResetImport={false}
+        ac={12}
+        initiative={1}
+        profBonus={2}
+        passivePerception={17}
+        passivePerceptionBonus={5}
+        passivePerceptionBonusSources={[
+          { label: "Sabedoria da Coruja", value: 5, groupKey: "a" },
+        ]}
+        spellSaveDC={null}
+        spellAttack={null}
+        hpTextColor="text-emerald-400"
+        isDirty={false}
+        saving={false}
+        saveError={null}
+        importRef={importRef as any}
+        importError={null}
+        onSave={noop}
+        onExport={noop}
+        onImport={noop}
+        onReset={noop}
+      />,
+    );
+
+    expect(markup).toContain(">17<");
+    expect(markup).toContain("Base 12 + Sabedoria da Coruja +5");
+  });
+
+  it("includes aria-label with breakdown when bonus exists", () => {
+    const markup = renderToStaticMarkup(
+      <CharacterHeader
+        sheet={BASE_SHEET as any}
+        mode="play"
+        canSave={false}
+        showResetImport={false}
+        ac={12}
+        initiative={1}
+        profBonus={2}
+        passivePerception={17}
+        passivePerceptionBonus={5}
+        passivePerceptionBonusSources={[
+          { label: "Sabedoria da Coruja", value: 5, groupKey: "a" },
+        ]}
+        spellSaveDC={null}
+        spellAttack={null}
+        hpTextColor="text-emerald-400"
+        isDirty={false}
+        saving={false}
+        saveError={null}
+        importRef={importRef as any}
+        importError={null}
+        onSave={noop}
+        onExport={noop}
+        onImport={noop}
+        onReset={noop}
+      />,
+    );
+
+    expect(markup).toContain("aria-label");
+    expect(markup).toContain("PP 17. Base 12 + Sabedoria da Coruja +5");
+  });
+});

--- a/apps/control-web/src/features/character-sheet/components/CharacterHeader.tsx
+++ b/apps/control-web/src/features/character-sheet/components/CharacterHeader.tsx
@@ -4,7 +4,8 @@ import type { CharacterSheet } from "../model/characterSheet.types";
 import type { CharacterSheetMode } from "../model/characterSheet.types";
 import type { SheetActions } from "../hooks/useCharacterSheet";
 import type { RequiredField } from "../utils/creationValidation";
-import { formatMod } from "../utils/calculations";
+import { formatMod, type PassiveSkillBonusSource } from "../utils/calculations";
+import { formatPassiveBonusBreakdown } from "../utils/passiveSkillBonusDisplay";
 import { CONDITION_LABELS, CONDITION_NAMES } from "../constants";
 import { formatClassDisplayName } from "../data/classes";
 import { useLocale } from "../../../shared/hooks/useLocale";
@@ -43,6 +44,8 @@ type Props = {
   initiative: number;
   profBonus: number;
   passivePerception: number;
+  passivePerceptionBonus?: number;
+  passivePerceptionBonusSources?: PassiveSkillBonusSource[];
   spellSaveDC: number | null;
   spellAttack: number | null;
   hpTextColor: string;
@@ -70,6 +73,7 @@ type Props = {
 
 export const CharacterHeader = ({
   sheet, mode, canSave, showResetImport, ac, initiative, profBonus, passivePerception,
+  passivePerceptionBonus, passivePerceptionBonusSources,
   spellSaveDC, spellAttack, hpTextColor,
   partyId, backHref, backLabel, isDirty, saving, saveError, saveDisabledReason, missingRequiredFields = [], onSave,
   draftName, draftNamePlaceholder, draftNameDisabled = false, onDraftNameChange,
@@ -188,7 +192,18 @@ export const CharacterHeader = ({
             <StatChip label="AC" value={String(ac)} />
             <StatChip label="Init" value={formatMod(initiative)} />
             <StatChip label="Prof" value={formatMod(profBonus)} className="text-limiar-400" />
-            <StatChip label="PP" value={String(passivePerception)} />
+            <StatChip
+              label="PP"
+              value={String(passivePerception)}
+              helper={
+                passivePerceptionBonus && passivePerceptionBonusSources?.length
+                  ? formatPassiveBonusBreakdown(
+                      passivePerception - passivePerceptionBonus,
+                      passivePerceptionBonusSources,
+                    )
+                  : undefined
+              }
+            />
             {spellSaveDC !== null && (
               <>
                 <StatChip label="Spell DC" value={String(spellSaveDC)} className="text-violet-400" />
@@ -279,9 +294,26 @@ const SaveStatus = ({
   return null;
 };
 
-const StatChip = ({ label, value, className = "text-slate-200" }: { label: string; value: string; className?: string }) => (
-  <div className="flex items-center gap-2 rounded-full border border-white/8 bg-white/3 px-3 py-1.5 text-xs">
+const StatChip = ({
+  label,
+  value,
+  className = "text-slate-200",
+  helper,
+}: {
+  label: string;
+  value: string;
+  className?: string;
+  helper?: string;
+}) => (
+  <div
+    className="flex items-center gap-2 rounded-full border border-white/8 bg-white/3 px-3 py-1.5 text-xs"
+    title={helper}
+    aria-label={helper ? `${label} ${value}. ${helper}` : undefined}
+  >
     <span className="font-bold uppercase tracking-[0.2em] text-slate-500">{label}</span>
     <span className={className}>{value}</span>
+    {helper && (
+      <span className="text-[10px] text-sky-300">{helper}</span>
+    )}
   </div>
 );

--- a/apps/control-web/src/features/character-sheet/components/CharacterSheet.tsx
+++ b/apps/control-web/src/features/character-sheet/components/CharacterSheet.tsx
@@ -214,6 +214,7 @@ export const CharacterSheet = ({
     initiative,
     passivePerception,
     passivePerceptionBonus,
+    passivePerceptionBonusSources,
     profBonus,
     spellAttack,
     spellSaveDC,
@@ -239,6 +240,8 @@ export const CharacterSheet = ({
         initiative={initiative}
         profBonus={profBonus}
         passivePerception={passivePerception}
+        passivePerceptionBonus={passivePerceptionBonus}
+        passivePerceptionBonusSources={passivePerceptionBonusSources}
         spellSaveDC={spellSaveDC}
         spellAttack={spellAttack}
         hpTextColor={hpTextColor}
@@ -441,6 +444,7 @@ export const CharacterSheet = ({
                 onCycleProf={actions.cycleSkillProf}
                 readOnly={isCreation ? !isEditableCreationDraft : isPlayReadOnly || isSheetLocked}
                 passivePerceptionBonus={passivePerceptionBonus ?? 0}
+                passivePerceptionBonusSources={passivePerceptionBonusSources}
               />
           </div>
         </div>

--- a/apps/control-web/src/features/character-sheet/components/Skills.test.tsx
+++ b/apps/control-web/src/features/character-sheet/components/Skills.test.tsx
@@ -1,0 +1,103 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { Skills } from "./Skills";
+
+vi.mock("../../../shared/hooks/useLocale", () => ({
+  useLocale: () => ({
+    t: (key: string) =>
+      ({
+        "sheet.skills.title": "Perícias",
+        "sheet.skills.passivePerception": "Percepção Passiva",
+        "sheet.skills.cycleProficiency": "Alternar proficiência",
+      }[key] ?? key),
+  }),
+}));
+
+vi.mock("./Section", () => ({
+  Section: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const BASE_ABILITIES = {
+  strength: 10,
+  dexterity: 10,
+  constitution: 10,
+  intelligence: 10,
+  wisdom: 14,
+  charisma: 10,
+};
+
+const BASE_PROFS: Record<string, number> = {
+  acrobatics: 0,
+  animalHandling: 0,
+  arcana: 0,
+  athletics: 0,
+  deception: 0,
+  history: 0,
+  insight: 0,
+  intimidation: 0,
+  investigation: 0,
+  medicine: 0,
+  nature: 0,
+  perception: 1,
+  performance: 0,
+  persuasion: 0,
+  religion: 0,
+  sleightOfHand: 0,
+  stealth: 0,
+  survival: 0,
+};
+
+const noop = () => {};
+
+describe("Skills", () => {
+  it("renders base passive perception with no bonus", () => {
+    const markup = renderToStaticMarkup(
+      <Skills
+        abilities={BASE_ABILITIES as any}
+        skillProficiencies={BASE_PROFS as any}
+        level={1}
+        onCycleProf={noop}
+      />,
+    );
+
+    expect(markup).toContain("Percepção Passiva:");
+    expect(markup).toContain(">14<");
+    expect(markup).not.toContain("Sabedoria");
+  });
+
+  it("renders bonus breakdown when sources provided", () => {
+    const markup = renderToStaticMarkup(
+      <Skills
+        abilities={BASE_ABILITIES as any}
+        skillProficiencies={BASE_PROFS as any}
+        level={1}
+        onCycleProf={noop}
+        passivePerceptionBonus={5}
+        passivePerceptionBonusSources={[
+          { label: "Sabedoria da Coruja", value: 5, groupKey: "a" },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Percepção Passiva:");
+    expect(markup).toContain(">19<");
+    expect(markup).toContain("Base 14 + Sabedoria da Coruja +5");
+  });
+
+  it("does not show bonus text when bonus is 0", () => {
+    const markup = renderToStaticMarkup(
+      <Skills
+        abilities={BASE_ABILITIES as any}
+        skillProficiencies={BASE_PROFS as any}
+        level={1}
+        onCycleProf={noop}
+        passivePerceptionBonus={0}
+        passivePerceptionBonusSources={[]}
+      />,
+    );
+
+    expect(markup).toContain("Percepção Passiva:");
+    expect(markup).toContain(">14<");
+    expect(markup).not.toContain("Base 14 +");
+  });
+});

--- a/apps/control-web/src/features/character-sheet/components/Skills.tsx
+++ b/apps/control-web/src/features/character-sheet/components/Skills.tsx
@@ -3,7 +3,8 @@ import type { SheetActions } from "../hooks/useCharacterSheet";
 import { Section } from "./Section";
 import { chk } from "./styles";
 import { ABILITY_SHORT, SKILL_ABILITY_MAP, SKILL_LABELS, SKILL_NAMES } from "../constants";
-import { computePassivePerception, computeSkillMod, formatMod } from "../utils/calculations";
+import { computePassivePerception, computeSkillMod, formatMod, type PassiveSkillBonusSource } from "../utils/calculations";
+import { formatPassiveBonusBreakdown } from "../utils/passiveSkillBonusDisplay";
 import { useLocale } from "../../../shared/hooks/useLocale";
 
 type Props = {
@@ -13,12 +14,17 @@ type Props = {
   level: number;
   onCycleProf: SheetActions["cycleSkillProf"];
   passivePerceptionBonus?: number;
+  passivePerceptionBonusSources?: PassiveSkillBonusSource[];
   readOnly?: boolean;
 };
 
-export const Skills = ({ className, abilities, skillProficiencies, level, onCycleProf, passivePerceptionBonus = 0, readOnly = false }: Props) => {
+export const Skills = ({ className, abilities, skillProficiencies, level, onCycleProf, passivePerceptionBonus = 0, passivePerceptionBonusSources, readOnly = false }: Props) => {
   const { t } = useLocale();
-  const passivePerception = computePassivePerception({ abilities, skillProficiencies, level } as CharacterSheet) + passivePerceptionBonus;
+  const basePassivePerception = computePassivePerception({ abilities, skillProficiencies, level } as CharacterSheet);
+  const passivePerception = basePassivePerception + passivePerceptionBonus;
+  const ppBreakdown = passivePerceptionBonus && passivePerceptionBonusSources?.length
+    ? formatPassiveBonusBreakdown(basePassivePerception, passivePerceptionBonusSources)
+    : null;
 
   return (
     <Section title={t("sheet.skills.title")} color="bg-cyan-500" className={className}>
@@ -40,9 +46,12 @@ export const Skills = ({ className, abilities, skillProficiencies, level, onCycl
           );
         })}
       </div>
-      <div className="mt-3 flex items-center gap-2 border-t border-white/6 pt-3 text-xs text-slate-400">
+      <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-white/6 pt-3 text-xs text-slate-400">
         <span className="font-bold">{t("sheet.skills.passivePerception")}:</span>
         <span className="text-sm font-bold text-slate-200">{passivePerception}</span>
+        {ppBreakdown && (
+          <span className="text-[10px] text-sky-300">{ppBreakdown}</span>
+        )}
       </div>
     </Section>
   );

--- a/apps/control-web/src/features/character-sheet/utils/passiveSkillBonusDisplay.test.ts
+++ b/apps/control-web/src/features/character-sheet/utils/passiveSkillBonusDisplay.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { formatPassiveBonusBreakdown } from "./passiveSkillBonusDisplay";
+
+describe("formatPassiveBonusBreakdown", () => {
+  it("returns empty string for empty sources", () => {
+    expect(formatPassiveBonusBreakdown(12, [])).toBe("");
+  });
+
+  it("formats a single source", () => {
+    const sources = [{ label: "Sabedoria da Coruja", value: 5, groupKey: "a" }];
+    expect(formatPassiveBonusBreakdown(12, sources)).toBe(
+      "Base 12 + Sabedoria da Coruja +5",
+    );
+  });
+
+  it("formats multiple sources", () => {
+    const sources = [
+      { label: "Sabedoria da Coruja", value: 5, groupKey: "a" },
+      { label: "Item X", value: 2, groupKey: "b" },
+    ];
+    expect(formatPassiveBonusBreakdown(12, sources)).toBe(
+      "Base 12 + Sabedoria da Coruja +5 + Item X +2",
+    );
+  });
+
+  it("handles negative bonus values", () => {
+    const sources = [{ label: "Maldição", value: -3, groupKey: "c" }];
+    expect(formatPassiveBonusBreakdown(15, sources)).toBe(
+      "Base 15 + Maldição -3",
+    );
+  });
+});

--- a/apps/control-web/src/features/character-sheet/utils/passiveSkillBonusDisplay.ts
+++ b/apps/control-web/src/features/character-sheet/utils/passiveSkillBonusDisplay.ts
@@ -1,0 +1,13 @@
+type BonusSource = { label: string; value: number };
+
+const formatSignedBonus = (value: number): string =>
+  value >= 0 ? `+${value}` : `${value}`;
+
+export const formatPassiveBonusBreakdown = (
+  baseValue: number,
+  sources: BonusSource[],
+): string => {
+  if (!sources.length) return "";
+  const parts = sources.map((s) => `${s.label} ${formatSignedBonus(s.value)}`);
+  return `Base ${baseValue} + ${parts.join(" + ")}`;
+};

--- a/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
+++ b/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
@@ -9,6 +9,7 @@ import { AuthoritativeRollDialog } from "../../../features/rolls/components/Auth
 import { deriveCheckModifierPreviewSources } from "../../../features/rolls/checkModifierSources";
 import { useLocale } from "../../../shared/hooks/useLocale";
 import { SpellSlotSummary } from "../../../shared/ui/SpellSlotSummary";
+import { formatPassiveBonusBreakdown } from "../../../features/character-sheet/utils/passiveSkillBonusDisplay";
 import { CombatLogPanel } from "../components/CombatLogPanel";
 import { CombatModeBar } from "../components/CombatModeBar";
 import { CombatParticipantRoster } from "../components/CombatParticipantRoster";
@@ -499,7 +500,10 @@ export const PlayerCombatModeShell = ({
                   <p className="mt-2 text-xl font-semibold text-white">{playerStatus?.passivePerception ?? "-"}</p>
                   {playerStatus?.passivePerceptionBonus && playerStatus.passivePerceptionBonusSources?.length ? (
                     <p className="mt-1 text-[10px] text-sky-300">
-                      {`Base ${playerStatus.passivePerception - playerStatus.passivePerceptionBonus}${playerStatus.passivePerceptionBonusSources.map((s) => ` + ${s.label} ${s.value}`).join("")}`}
+                      {formatPassiveBonusBreakdown(
+                        playerStatus.passivePerception - playerStatus.passivePerceptionBonus,
+                        playerStatus.passivePerceptionBonusSources,
+                      )}
                     </p>
                   ) : null}
                 </div>

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
@@ -136,7 +136,6 @@ describe("PlayerBoardStatusPanel", () => {
     );
 
     expect(markup).toContain("Percepção passiva:17");
-    expect(markup).toContain("Base 12");
-    expect(markup).toContain("Owl&#x27;s Wisdom 5");
+    expect(markup).toContain("Base 12 + Owl&#x27;s Wisdom +5");
   });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
@@ -1,6 +1,7 @@
 import type { CharacterSheet } from "../../features/character-sheet/model/characterSheet.types";
 import { useLocale } from "../../shared/hooks/useLocale";
 import { SpellSlotSummary } from "../../shared/ui/SpellSlotSummary";
+import { formatPassiveBonusBreakdown } from "../../features/character-sheet/utils/passiveSkillBonusDisplay";
 import type { PendingRoll, PlayerBoardStatusSummary } from "./playerBoard.types";
 import {
   DeathSaveCard,
@@ -130,7 +131,10 @@ export const PlayerBoardStatusPanel = ({
               value={String(playerStatus.passivePerception)}
               helper={
                 playerStatus.passivePerceptionBonus && playerStatus.passivePerceptionBonusSources?.length
-                  ? `Base ${playerStatus.passivePerception - playerStatus.passivePerceptionBonus}${playerStatus.passivePerceptionBonusSources.map((s) => ` + ${s.label} ${s.value}`).join("")}`
+                  ? formatPassiveBonusBreakdown(
+                      playerStatus.passivePerception - playerStatus.passivePerceptionBonus,
+                      playerStatus.passivePerceptionBonusSources,
+                    )
                   : null
               }
             />


### PR DESCRIPTION
## Summary

Adds Passive Perception bonus breakdowns to the character sheet UI and centralizes passive bonus formatting.

When Passive Perception is increased by an active effect such as **Sabedoria da Coruja**, the UI now shows where the bonus came from instead of only displaying the final value.

## Context

Issue #147 made manual active effects available outside combat through persisted `activeSpellEffects`.

That allowed effects like Owl’s Wisdom / Sabedoria da Coruja to correctly increase Passive Perception outside combat.

However, some UI surfaces still only showed the final Passive Perception number, without explaining the source of the bonus.

Before:

```text
Percepção Passiva: 17
````

After:

```text
Percepção Passiva: 17
Base 12 + Sabedoria da Coruja +5
```

The number is now legally obligated to explain itself.

## What changed

### Shared formatting helper

Added:

```text
apps/control-web/src/features/character-sheet/utils/passiveSkillBonusDisplay.ts
```

Introduces:

```ts
formatPassiveBonusBreakdown(baseValue, sources)
```

Example output:

```text
Base 12 + Sabedoria da Coruja +5
```

The helper handles:

* empty source lists
* single source
* multiple sources
* signed bonus values

This replaces duplicated inline formatting in multiple components.

### CharacterHeader

Updated:

```text
apps/control-web/src/features/character-sheet/components/CharacterHeader.tsx
```

Changes:

* `StatChip` now supports an optional `helper` prop
* Passive Perception chip can show the bonus breakdown
* added `title` / `aria-label` for accessibility
* added props:

  * `passivePerceptionBonus`
  * `passivePerceptionBonusSources`

When there is no bonus, the chip stays clean.

### CharacterSheet

Updated:

```text
apps/control-web/src/features/character-sheet/components/CharacterSheet.tsx
```

Changes:

* destructures `passivePerceptionBonusSources` from derived sheet data
* passes bonus data to `CharacterHeader`
* passes bonus source data to `Skills`

### Skills

Updated:

```text
apps/control-web/src/features/character-sheet/components/Skills.tsx
```

Changes:

* accepts `passivePerceptionBonusSources`
* shows Passive Perception breakdown under the Perception passive value when bonus sources exist
* hides breakdown when there is no bonus

### Player board / combat UI cleanup

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
```

Changes:

* removed duplicated inline breakdown formatting
* both now use `formatPassiveBonusBreakdown`

## Tests

Added:

```text
apps/control-web/src/features/character-sheet/utils/passiveSkillBonusDisplay.test.ts
apps/control-web/src/features/character-sheet/components/Skills.test.tsx
apps/control-web/src/features/character-sheet/components/CharacterHeader.test.tsx
```

Coverage includes:

* formatting helper with empty, single, multiple, and negative values
* Skills with no bonus
* Skills with bonus breakdown
* Skills with zero bonus
* CharacterHeader without helper
* CharacterHeader with helper
* CharacterHeader accessibility label

Updated existing player board expectations for the shared formatting output.

## Validation

```bash
cd apps/control-web
npx vitest run passiveSkillBonusDisplay Skills.test CharacterHeader.test PlayerBoardStatusPanel.test
```

Result:

```text
4 test files passed
13 tests passed
```

TypeScript check:

```bash
npx tsc --noEmit
```

Result:

```text
No new type errors from modified files
```

Existing unrelated type errors remain outside this change.

## Out of scope

This PR intentionally does not implement:

* backend changes
* new active effect persistence
* concentration lifecycle
* rest-based cleanup
* generic passive skill UI for Insight/Investigation
* active effects panel redesign
* passive perception rule changes

## Notes for reviewers

This PR is display-only.

It uses the already-derived values:

```ts
passivePerceptionBonus
passivePerceptionBonusSources
```

and avoids adding active-effect parsing inside visual components.

The goal is to make the existing derived result understandable across the character sheet, skills list, player board, and combat UI.

