### PR TITLE
fix(effects): clear persisted active effects on long rest

### DIFF
--- a/apps/control-server/app/services/session_rest.py
+++ b/apps/control-server/app/services/session_rest.py
@@ -227,6 +227,9 @@ def apply_long_rest(data: dict | None) -> dict:
     next_data = _force_revert_wild_shape_inline(next_data)
     next_data = _recharge_wild_shape_inline(next_data)
     next_data = _recharge_dragonborn_breath_weapon_inline(next_data)
+
+    next_data.pop("active_spell_effects", None)
+
     return next_data
 
 

--- a/apps/control-server/tests/test_session_rest.py
+++ b/apps/control-server/tests/test_session_rest.py
@@ -138,6 +138,57 @@ class SessionRestTests(unittest.TestCase):
             ],
         )
 
+    def test_long_rest_clears_persisted_active_spell_effects(self):
+        owl_wisdom = {
+            "id": "eff-1",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "metadata": {
+                "source_spell_name": "Owl's Wisdom",
+                "declarative_effect": {
+                    "type": "passive_skill_bonus",
+                    "params": {"skill": "perception", "bonus": 5},
+                },
+            },
+        }
+        next_data = apply_long_rest(
+            {
+                "restState": "long_rest",
+                "currentHP": 4,
+                "maxHP": 8,
+                "active_spell_effects": [owl_wisdom],
+            }
+        )
+
+        self.assertNotIn("active_spell_effects", next_data)
+        self.assertEqual(next_data["currentHP"], 8)
+
+    def test_long_rest_with_no_active_spell_effects_is_safe(self):
+        next_data = apply_long_rest(
+            {
+                "restState": "long_rest",
+                "currentHP": 4,
+                "maxHP": 8,
+            }
+        )
+
+        self.assertNotIn("active_spell_effects", next_data)
+        self.assertEqual(next_data["currentHP"], 8)
+
+    def test_long_rest_preserves_other_state_json_fields(self):
+        next_data = apply_long_rest(
+            {
+                "restState": "long_rest",
+                "currentHP": 4,
+                "maxHP": 8,
+                "active_spell_effects": [{"id": "eff-1"}],
+                "customField": "should survive",
+            }
+        )
+
+        self.assertNotIn("active_spell_effects", next_data)
+        self.assertEqual(next_data["customField"], "should survive")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Clears persisted out-of-combat active spell effects when a character takes a long rest.

This prevents manual persisted effects such as Enhance Ability / Owl’s Wisdom from surviving indefinitely through `state_json.active_spell_effects`.

## Context

Issue #147 introduced persisted manual effects outside combat using:

```text
state_json.active_spell_effects
````

That allows long-lived effects to keep affecting the character sheet and player board after combat ends.

However, long rest did not clear this persisted effects bucket, which meant effects like Owl’s Wisdom could survive longer than intended and behave like permanent buffs.

The Coruja was getting tenure. Absolutely not.

## What changed

Updated:

```text
apps/control-server/app/services/session_rest.py
```

`apply_long_rest()` now removes the persisted effects bucket:

```py
next_data.pop("active_spell_effects", None)
```

This clears all persisted out-of-combat active spell effects on long rest.

Updated:

```text
apps/control-server/tests/test_session_rest.py
```

Added 3 tests covering:

* long rest clears persisted active spell effects
* long rest is safe when no persisted effects exist
* long rest preserves unrelated `state_json` fields

## Behavior

Before:

```text
Owl’s Wisdom active
→ end combat
→ active_spell_effects persists
→ long rest
→ active_spell_effects still present
→ Passive Perception bonus could remain
```

After:

```text
Owl’s Wisdom active
→ end combat
→ active_spell_effects persists
→ long rest
→ active_spell_effects removed
→ Passive Perception returns to base
```

This applies to the whole persisted effects bucket, not only Owl’s Wisdom.

## Validation

```bash
cd apps/control-server
.venv/bin/pytest tests/test_session_rest.py -v
```

Result:

```text
29/29 passed
```

## Out of scope

This PR intentionally does not implement:

* short rest cleanup
* duration-based expiration
* concentration lifecycle
* frontend changes
* generic persistent effect model