### PR TITLE
feat(effects): track concentration outside combat

### DIFF
--- a/apps/control-server/app/api/routes/sessions/state_common.py
+++ b/apps/control-server/app/api/routes/sessions/state_common.py
@@ -18,6 +18,7 @@ from app.models.session_state import SessionState
 from app.schemas.session_state import SessionStateRead
 from app.services.centrifugo import centrifugo
 from app.services.realtime import build_event, campaign_channel, event_version
+from app.services.combat_service.persistent_effects import derive_active_concentration
 from app.services.session_rest import ensure_rest_state
 from app.services.session_state_finalize import finalize_session_state_data
 from app.services.session_state_merge import merge_session_state_data
@@ -43,6 +44,7 @@ REQUIRED_SHEET_KEYS = {
 
 
 def to_state_read(entry: SessionState) -> SessionStateRead:
+    state_json = entry.state_json or {}
     return SessionStateRead(
         id=require_identifier(entry.id, "Session state is missing an id"),
         sessionId=entry.session_id,
@@ -50,7 +52,8 @@ def to_state_read(entry: SessionState) -> SessionStateRead:
         state=entry.state_json,
         createdAt=entry.created_at,
         updatedAt=entry.updated_at,
-        activeSpellEffects=(entry.state_json or {}).get("active_spell_effects"),
+        activeSpellEffects=state_json.get("active_spell_effects"),
+        activeConcentration=derive_active_concentration(state_json),
     )
 
 

--- a/apps/control-server/app/schemas/session_state.py
+++ b/apps/control-server/app/schemas/session_state.py
@@ -11,6 +11,7 @@ class SessionStateRead(BaseModel):
     createdAt: datetime
     updatedAt: datetime | None
     activeSpellEffects: list[dict] | None = None
+    activeConcentration: dict | None = None
 
 
 class SessionStateUpdate(BaseModel):

--- a/apps/control-server/app/services/combat_service/persistent_effects.py
+++ b/apps/control-server/app/services/combat_service/persistent_effects.py
@@ -4,8 +4,8 @@
 non-combat spell effects.  Only effects with:
   - kind in {"spell_effect", "temp_ac_bonus"}
   - duration_type == "manual"
-  - concentration == False
-are persisted.  Round-based and turn-based effects expire naturally during combat.
+are persisted (including concentration effects).  Round-based and turn-based
+effects expire naturally during combat.
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ _PERSISTABLE_KINDS = {"spell_effect", "temp_ac_bonus"}
 
 
 def persist_surviving_spell_effects(db: DbSession, state: CombatState) -> None:
-    """Transfer manual-duration, non-concentration spell effects to state_json.
+    """Transfer manual-duration spell effects (including concentration) to state_json.
 
     Called during end_combat() AFTER concentration has been cleared but BEFORE
     remaining participant effects are wiped.
@@ -41,7 +41,6 @@ def persist_surviving_spell_effects(db: DbSession, state: CombatState) -> None:
             e for e in effects
             if e.get("kind") in _PERSISTABLE_KINDS
             and e.get("duration_type") == "manual"
-            and not (e.get("metadata") or {}).get("concentration")
         ]
         if not surviving:
             continue
@@ -135,3 +134,74 @@ def sync_effect_removal_to_state_json(
     session_state.state_json = finalize_session_state_data(data)
     flag_modified(session_state, "state_json")
     db.add(session_state)
+
+
+def derive_active_concentration(state_json: dict | None) -> dict | None:
+    persisted = (state_json or {}).get("active_spell_effects")
+    if not isinstance(persisted, list):
+        return None
+
+    first_group: str | None = None
+    first_metadata: dict | None = None
+    for effect in persisted:
+        metadata = effect.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        if not metadata.get("concentration"):
+            continue
+        first_group = metadata.get("concentration_group")
+        first_metadata = metadata
+        break
+
+    if first_metadata is None:
+        return None
+
+    if isinstance(first_group, str) and first_group:
+        grouped = [
+            e for e in persisted
+            if (e.get("metadata") or {}).get("concentration_group") == first_group
+        ]
+        effect_ids = [e.get("id") for e in grouped if e.get("id")]
+    else:
+        effect_ids = [e.get("id") for e in persisted
+                      if (e.get("metadata") or {}).get("concentration")
+                      and e.get("id")][:1]
+
+    return {
+        "spellKey": first_metadata.get("source_spell_key"),
+        "spellName": first_metadata.get("source_spell_name"),
+        "variantKey": first_metadata.get("selected_variant_key"),
+        "variantLabel": first_metadata.get("selected_variant_label"),
+        "concentrationGroup": first_group,
+        "effectIds": effect_ids,
+    }
+
+
+def clear_persisted_concentration_effects(
+    state_json: dict | None,
+    *,
+    concentration_group: str | None = None,
+) -> dict:
+    data = dict(state_json or {})
+    persisted = data.get("active_spell_effects")
+    if not isinstance(persisted, list):
+        return data
+
+    if concentration_group is not None:
+        filtered = [
+            e for e in persisted
+            if (e.get("metadata") or {}).get("concentration_group") != concentration_group
+        ]
+    else:
+        filtered = [
+            e for e in persisted
+            if not (e.get("metadata") or {}).get("concentration")
+        ]
+
+    if len(filtered) == len(persisted):
+        return data
+    if filtered:
+        data["active_spell_effects"] = filtered
+    else:
+        data.pop("active_spell_effects", None)
+    return data

--- a/apps/control-server/tests/test_persistent_effects.py
+++ b/apps/control-server/tests/test_persistent_effects.py
@@ -14,6 +14,8 @@ from unittest.mock import MagicMock, patch
 from app.models.combat import CombatPhase, CombatState
 from app.models.session_state import SessionState
 from app.services.combat_service.persistent_effects import (
+    clear_persisted_concentration_effects,
+    derive_active_concentration,
     persist_surviving_spell_effects,
     restore_persisted_effects,
     sync_effect_removal_to_state_json,
@@ -151,7 +153,7 @@ class TestPersistSurvivingSpellEffects(unittest.TestCase):
         self.assertEqual(len(persisted), 1)
         self.assertEqual(persisted[0]["id"], "eff-1")
 
-    def test_discards_concentration_effect(self):
+    def test_persists_concentration_effect(self):
         effect = _manual_spell_effect("eff-1", concentration=True)
         state = _make_state_with_participants([effect])
         db = MagicMock()
@@ -160,7 +162,10 @@ class TestPersistSurvivingSpellEffects(unittest.TestCase):
 
         persist_surviving_spell_effects(db, state)
 
-        self.assertNotIn("active_spell_effects", session_state.state_json)
+        persisted = session_state.state_json["active_spell_effects"]
+        self.assertEqual(len(persisted), 1)
+        self.assertEqual(persisted[0]["id"], "eff-1")
+        self.assertTrue(persisted[0]["metadata"]["concentration"])
 
     def test_discards_condition_effect(self):
         effect = _condition_effect("eff-cond")
@@ -279,6 +284,211 @@ class TestSyncEffectRemovalToStateJson(unittest.TestCase):
         sync_effect_removal_to_state_json(db, "session-1", participant, "eff-1")
 
         db.exec.assert_not_called()
+
+
+class TestPersistSurvivingConcentrationEffects(unittest.TestCase):
+    def test_persists_concentration_and_non_concentration_together(self):
+        conc = _manual_spell_effect("eff-conc", concentration=True)
+        non_conc = _manual_spell_effect("eff-non")
+        state = _make_state_with_participants([conc, non_conc])
+        db = MagicMock()
+        session_state = _make_session_state({})
+        db.exec.return_value.first.return_value = session_state
+
+        persist_surviving_spell_effects(db, state)
+
+        persisted = session_state.state_json["active_spell_effects"]
+        self.assertEqual(len(persisted), 2)
+        ids = {e["id"] for e in persisted}
+        self.assertEqual(ids, {"eff-conc", "eff-non"})
+
+
+class TestDeriveActiveConcentration(unittest.TestCase):
+    def test_returns_none_when_no_effects(self):
+        self.assertIsNone(derive_active_concentration({}))
+        self.assertIsNone(derive_active_concentration(None))
+
+    def test_returns_none_when_only_non_concentration_effects(self):
+        effect = _manual_spell_effect("eff-1", concentration=False)
+        result = derive_active_concentration({"active_spell_effects": [effect]})
+        self.assertIsNone(result)
+
+    def test_returns_concentration_info_for_single_effect(self):
+        effect = _manual_spell_effect("eff-1", concentration=True)
+        result = derive_active_concentration({"active_spell_effects": [effect]})
+        self.assertIsNotNone(result)
+        self.assertEqual(result["spellName"], "Owl's Wisdom")
+        self.assertEqual(result["effectIds"], ["eff-1"])
+        self.assertEqual(result["concentrationGroup"], "group-1")
+
+    def test_groups_effects_by_concentration_group(self):
+        eff1 = {
+            "id": "eff-a",
+            "kind": "spell_effect",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-bless",
+                "source_spell_key": "bless",
+                "source_spell_name": "Bless",
+            },
+        }
+        eff2 = {
+            "id": "eff-b",
+            "kind": "spell_effect",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-bless",
+                "source_spell_key": "bless",
+                "source_spell_name": "Bless",
+            },
+        }
+        non_conc = _manual_spell_effect("eff-other")
+        result = derive_active_concentration({
+            "active_spell_effects": [eff1, eff2, non_conc],
+        })
+        self.assertIsNotNone(result)
+        self.assertEqual(result["concentrationGroup"], "grp-bless")
+        self.assertIn("eff-a", result["effectIds"])
+        self.assertIn("eff-b", result["effectIds"])
+        self.assertEqual(len(result["effectIds"]), 2)
+
+    def test_returns_first_group_when_multiple_groups(self):
+        eff1 = {
+            "id": "eff-1",
+            "kind": "spell_effect",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-first",
+                "source_spell_name": "Spell A",
+            },
+        }
+        eff2 = {
+            "id": "eff-2",
+            "kind": "spell_effect",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-second",
+                "source_spell_name": "Spell B",
+            },
+        }
+        result = derive_active_concentration({
+            "active_spell_effects": [eff2, eff1],
+        })
+        self.assertIsNotNone(result)
+        self.assertEqual(result["concentrationGroup"], "grp-second")
+        self.assertEqual(result["effectIds"], ["eff-2"])
+
+    def test_handles_effect_without_concentration_group(self):
+        eff = {
+            "id": "eff-solo",
+            "kind": "spell_effect",
+            "metadata": {
+                "concentration": True,
+                "source_spell_name": "Solo Spell",
+            },
+        }
+        result = derive_active_concentration({"active_spell_effects": [eff]})
+        self.assertIsNotNone(result)
+        self.assertIsNone(result["concentrationGroup"])
+        self.assertEqual(result["effectIds"], ["eff-solo"])
+
+
+class TestClearPersistedConcentrationEffects(unittest.TestCase):
+    def test_removes_all_concentration_effects_by_default(self):
+        conc = _manual_spell_effect("eff-conc", concentration=True)
+        non_conc = _manual_spell_effect("eff-other")
+        state_json = {"active_spell_effects": [conc, non_conc]}
+
+        result = clear_persisted_concentration_effects(state_json)
+
+        persisted = result["active_spell_effects"]
+        self.assertEqual(len(persisted), 1)
+        self.assertEqual(persisted[0]["id"], "eff-other")
+
+    def test_removes_only_targeted_group_when_concentration_group_given(self):
+        eff_a = {
+            "id": "eff-a",
+            "kind": "spell_effect",
+            "metadata": {"concentration": True, "concentration_group": "grp-a"},
+        }
+        eff_b = {
+            "id": "eff-b",
+            "kind": "spell_effect",
+            "metadata": {"concentration": True, "concentration_group": "grp-b"},
+        }
+        state_json = {"active_spell_effects": [eff_a, eff_b]}
+
+        result = clear_persisted_concentration_effects(state_json, concentration_group="grp-a")
+
+        persisted = result["active_spell_effects"]
+        self.assertEqual(len(persisted), 1)
+        self.assertEqual(persisted[0]["id"], "eff-b")
+
+    def test_preserves_non_concentration_effects(self):
+        conc = _manual_spell_effect("eff-conc", concentration=True)
+        non_conc = _manual_spell_effect("eff-other")
+        state_json = {"active_spell_effects": [conc, non_conc]}
+
+        result = clear_persisted_concentration_effects(state_json)
+
+        self.assertEqual(len(result["active_spell_effects"]), 1)
+        self.assertEqual(result["active_spell_effects"][0]["id"], "eff-other")
+
+    def test_removes_all_when_only_concentration_effects(self):
+        conc = _manual_spell_effect("eff-conc", concentration=True)
+        state_json = {"active_spell_effects": [conc]}
+
+        result = clear_persisted_concentration_effects(state_json)
+
+        self.assertNotIn("active_spell_effects", result)
+
+    def test_safe_when_no_effects(self):
+        result = clear_persisted_concentration_effects({})
+        self.assertNotIn("active_spell_effects", result)
+
+    def test_safe_when_no_concentration_effects(self):
+        non_conc = _manual_spell_effect("eff-1")
+        state_json = {"active_spell_effects": [non_conc]}
+
+        result = clear_persisted_concentration_effects(state_json)
+
+        self.assertEqual(len(result["active_spell_effects"]), 1)
+
+
+class TestToStateReadActiveConcentration(unittest.TestCase):
+    def test_active_concentration_derived_in_response(self):
+        from app.api.routes.sessions.state_common import to_state_read
+
+        conc = _manual_spell_effect("eff-conc", concentration=True)
+        mock = MagicMock(spec=SessionState)
+        mock.id = "ss-1"
+        mock.session_id = "session-1"
+        mock.player_user_id = "player-1"
+        mock.state_json = {"active_spell_effects": [conc]}
+        mock.created_at = "2026-01-01T00:00:00+00:00"
+        mock.updated_at = None
+
+        result = to_state_read(mock)
+
+        self.assertIsNotNone(result.activeConcentration)
+        self.assertEqual(result.activeConcentration["spellName"], "Owl's Wisdom")
+        self.assertIn("eff-conc", result.activeConcentration["effectIds"])
+
+    def test_active_concentration_none_when_no_concentration(self):
+        from app.api.routes.sessions.state_common import to_state_read
+
+        non_conc = _manual_spell_effect("eff-1")
+        mock = MagicMock(spec=SessionState)
+        mock.id = "ss-1"
+        mock.session_id = "session-1"
+        mock.player_user_id = "player-1"
+        mock.state_json = {"active_spell_effects": [non_conc]}
+        mock.created_at = "2026-01-01T00:00:00+00:00"
+        mock.updated_at = None
+
+        result = to_state_read(mock)
+
+        self.assertIsNone(result.activeConcentration)
 
 
 if __name__ == "__main__":

--- a/apps/control-server/tests/test_session_rest.py
+++ b/apps/control-server/tests/test_session_rest.py
@@ -190,5 +190,31 @@ class SessionRestTests(unittest.TestCase):
         self.assertEqual(next_data["customField"], "should survive")
 
 
+    def test_long_rest_clears_concentration_from_active_spell_effects(self):
+        from app.services.combat_service.persistent_effects import derive_active_concentration
+
+        conc_effect = {
+            "id": "eff-conc",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-1",
+                "source_spell_name": "Bless",
+            },
+        }
+        next_data = apply_long_rest(
+            {
+                "restState": "long_rest",
+                "currentHP": 4,
+                "maxHP": 8,
+                "active_spell_effects": [conc_effect],
+            }
+        )
+
+        self.assertNotIn("active_spell_effects", next_data)
+        self.assertIsNone(derive_active_concentration(next_data))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds backend support for tracking concentration outside combat through persisted active spell effects.

This PR allows manual-duration concentration effects to survive outside combat, derives an `activeConcentration` summary from persisted effects, and adds helpers to clear persisted concentration effects safely.

No frontend UI changes are included.

## Context

Issue #147 introduced persisted manual active effects outside combat through:

```text
state_json.active_spell_effects
````

However, concentration effects were explicitly filtered out during persistence. That meant concentration-based effects could not be represented properly outside combat, even when their active spell effects otherwise needed to survive combat transitions.

This PR changes that lifecycle behavior: manual-duration concentration effects can now persist outside combat, and concentration state is derived from those persisted effects.

The important bit: concentration is derived, not duplicated. We are not creating a second little gremlin state that can drift and ruin everyone’s day.

## What changed

### Persist concentration effects

Updated:

```text
apps/control-server/app/services/combat_service/persistent_effects.py
```

Removed the filter that discarded effects with:

```py
metadata.concentration == True
```

`persist_surviving_spell_effects()` now persists manual-duration effects whether they are concentration-based or not.

Round/turn-based effects remain excluded according to the existing persistence rule.

### Active concentration derivation

Added:

```py
derive_active_concentration(state_json)
```

This helper derives concentration info from:

```text
state_json.active_spell_effects
```

Behavior:

* returns `None` when no persisted concentration exists
* detects concentration effects via metadata
* groups related effects by `concentration_group`
* collects all effect IDs in the active concentration group
* returns spell/variant metadata for the active concentration summary

This supports multi-effect concentration packages without pretending only one effect exists. Which is nice, because pretending is how bugs learn theater.

### Clear persisted concentration effects

Added:

```py
clear_persisted_concentration_effects(state_json, concentration_group=None)
```

Behavior:

* without `concentration_group`, clears all persisted concentration-linked effects
* with `concentration_group`, clears only effects from that group
* preserves unrelated non-concentration effects
* removes the `active_spell_effects` key when no effects remain
* is pure/testable and does not require DB access

### Session state API

Updated:

```text
apps/control-server/app/schemas/session_state.py
apps/control-server/app/api/routes/sessions/state_common.py
```

`SessionStateRead` now includes:

```py
activeConcentration: dict | None = None
```

`to_state_read()` derives this value from persisted active spell effects using `derive_active_concentration()`.

### Long rest interaction

Updated tests confirm long rest clears concentration naturally because long rest already clears the full persisted effects bucket:

```text
state_json.active_spell_effects
```

No production change to the long rest flow was needed.

## Tests

Updated:

```text
apps/control-server/tests/test_persistent_effects.py
apps/control-server/tests/test_session_rest.py
```

Coverage includes:

* concentration effects now persist
* concentration and non-concentration effects persist together
* `derive_active_concentration()` returns `None` when appropriate
* single concentration effect derivation
* grouped concentration effect derivation
* multiple concentration handling
* clearing all persisted concentration effects
* clearing a targeted concentration group
* preserving unrelated effects during concentration cleanup
* `to_state_read()` exposes `activeConcentration`
* long rest clears persisted concentration effects

## Validation

```bash
cd apps/control-server
.venv/bin/pytest tests/test_persistent_effects.py tests/test_session_rest.py -v
```

Result:

```text
45 passed
```

## Out of scope

This PR intentionally does not implement:

* frontend concentration UI
* concentration checks from damage outside combat
* automatic concentration breaking
* enforcing one concentration spell outside combat
* breaking previous concentration when casting another concentration spell
* duration metadata for persisted effects
* short rest rules

## Notes for reviewers

The main design choice is deriving `activeConcentration` from `state_json.active_spell_effects` instead of storing a separate concentration state.

This avoids duplicated state and keeps persisted effects as the source of truth.

`clear_persisted_concentration_effects()` supports both broad cleanup and targeted cleanup by `concentration_group`, which prepares the backend for future actions such as manually ending a specific concentration effect.