### PR TITLE
fix(effects): enforce single persisted concentration group

### DIFF
--- a/.opencode/plans/1778029821863-enforce-single-concentration.md
+++ b/.opencode/plans/1778029821863-enforce-single-concentration.md
@@ -1,0 +1,181 @@
+# Plan: Enforce single out-of-combat concentration group (#213)
+
+## Problem
+
+Multiple concentration groups can coexist in `state_json.active_spell_effects` after combat ends. The backend derives one active concentration but never prevents multiple groups from being persisted simultaneously.
+
+## Solution
+
+Add a pure helper and wire it into persist + restore paths.
+
+---
+
+## Step 1 — Add `enforce_single_persisted_concentration_group` helper
+
+**File:** `apps/control-server/app/services/combat_service/persistent_effects.py`
+
+Add after `clear_persisted_concentration_effects` (after line 207):
+
+```python
+def enforce_single_persisted_concentration_group(
+    effects: list[dict],
+) -> list[dict]:
+    """Keep only the newest concentration group; preserve non-concentration effects.
+
+    Selection rule: highest valid ``created_at`` among concentration groups.
+    Fallback (missing/invalid timestamps): last concentration group encountered.
+    """
+    non_concentration: list[dict] = []
+    groups: dict[str, list[dict]] = {}           # group_key → [effect, ...]
+    group_order: list[str] = []                  # insertion order for fallback
+
+    for effect in effects:
+        metadata = effect.get("metadata") or {}
+        if not metadata.get("concentration"):
+            non_concentration.append(effect)
+            continue
+        group_key = metadata.get("concentration_group") or _solo_group_key(effect)
+        groups.setdefault(group_key, []).append(effect)
+        if group_key not in group_order:
+            group_order.append(group_key)
+
+    if len(groups) <= 1:
+        return list(effects)
+
+    winning = _pick_winning_concentration_group(groups, group_order)
+    winning_effects = groups[winning]
+
+    # preserve original order: non-concentration first, then winning group effects
+    return non_concentration + winning_effects
+
+
+def _solo_group_key(effect: dict) -> str:
+    """Synthetic key for concentration effects without a concentration_group."""
+    return f"__solo__:{effect.get('id', id(effect))}"
+
+
+def _pick_winning_concentration_group(
+    groups: dict[str, list[dict]],
+    group_order: list[str],
+) -> str:
+    best_group: str | None = None
+    best_ts: str | None = None
+    for gkey in group_order:
+        ts = _max_created_at(groups[gkey])
+        if ts is None:
+            continue
+        if best_ts is None or ts > best_ts:
+            best_ts = ts
+            best_group = gkey
+    if best_group is not None:
+        return best_group
+    # fallback: last group in list order
+    return group_order[-1]
+
+
+def _max_created_at(effects: list[dict]) -> str | None:
+    best: str | None = None
+    for e in effects:
+        ts = e.get("created_at")
+        if isinstance(ts, str) and ts:
+            if best is None or ts > best:
+                best = ts
+    return best
+```
+
+---
+
+## Step 2 — Wire into `persist_surviving_spell_effects`
+
+**File:** `apps/control-server/app/services/combat_service/persistent_effects.py`
+
+After the `surviving` list comprehension (line 44), normalize before writing:
+
+```python
+        surviving = enforce_single_persisted_concentration_group(surviving)
+```
+
+Insert between current lines 44 and 45 (after building `surviving`, before `if not surviving`).
+
+---
+
+## Step 3 — Wire into `restore_persisted_effects`
+
+**File:** `apps/control-server/app/services/combat_service/persistent_effects.py`
+
+After reading `persisted` and before the deduplication loop (around line 89), normalize:
+
+```python
+    persisted = enforce_single_persisted_concentration_group(persisted)
+    if not persisted:
+        return
+```
+
+Additionally, if normalization changed the list, sync back to `state_json`:
+
+```python
+    original_persisted = (session_state.state_json or {}).get("active_spell_effects")
+    if isinstance(original_persisted, list) and persisted != original_persisted:
+        data = dict(session_state.state_json)
+        if persisted:
+            data["active_spell_effects"] = persisted
+        else:
+            data.pop("active_spell_effects", None)
+        session_state.state_json = finalize_session_state_data(data)
+        flag_modified(session_state, "state_json")
+        db.add(session_state)
+```
+
+---
+
+## Step 4 — Tests
+
+**File:** `apps/control-server/tests/test_persistent_effects.py`
+
+### 4a. Add import
+
+```python
+from app.services.combat_service.persistent_effects import (
+    ...,
+    enforce_single_persisted_concentration_group,
+)
+```
+
+### 4b. Add `TestEnforceSinglePersistedConcentrationGroup` class
+
+- `test_no_concentration_effects_unchanged` — all non-conc → returned as-is
+- `test_single_concentration_group_unchanged` — one group → returned as-is
+- `test_two_groups_keeps_newest_by_created_at` — group A (older ts), group B (newer ts) → only group B
+- `test_multiple_effects_in_winning_group_all_kept` — winning group has 3 effects → all 3 returned
+- `test_non_concentration_effects_survive` — non-conc effects preserved alongside winning group
+- `test_invalid_created_at_falls_back_to_last_group` — no valid timestamps → last group in list order wins
+- `test_preserves_original_ordering` — non-conc first, then winning group in original order
+- `test_solo_concentration_without_group_key` — concentration effect with no `concentration_group` gets synthetic key, still works
+
+### 4c. Add persist integration tests
+
+- `test_persist_surviving_keeps_only_newest_concentration_group` — two conc groups in surviving → only newest persisted
+- `test_persist_surviving_preserves_non_concentration` — conc + non-conc → both in state_json
+
+### 4d. Add restore integration tests
+
+- `test_restore_normalizes_multiple_concentration_groups` — state_json has two groups → only one restored into participant
+- `test_restore_syncs_back_to_state_json` — state_json updated when normalization changes list
+
+### 4e. Verify existing clear tests pass unchanged
+
+- `clear_persisted_concentration_effects` tests already verify non-conc survive — no changes needed
+
+---
+
+## Verification
+
+```bash
+cd apps/control-server
+.venv/bin/pytest tests/test_persistent_effects.py -v
+```
+
+## Files changed
+
+- `apps/control-server/app/services/combat_service/persistent_effects.py` — add helper + wire into persist/restore
+- `apps/control-server/tests/test_persistent_effects.py` — add ~12 new tests

--- a/apps/control-server/app/services/combat_service/persistent_effects.py
+++ b/apps/control-server/app/services/combat_service/persistent_effects.py
@@ -42,6 +42,7 @@ def persist_surviving_spell_effects(db: DbSession, state: CombatState) -> None:
             if e.get("kind") in _PERSISTABLE_KINDS
             and e.get("duration_type") == "manual"
         ]
+        surviving = enforce_single_persisted_concentration_group(surviving)
         if not surviving:
             continue
         ref_id = participant.get("ref_id")
@@ -87,6 +88,21 @@ def restore_persisted_effects(
     persisted = (session_state.state_json or {}).get("active_spell_effects")
     if not isinstance(persisted, list) or not persisted:
         return
+    original_persisted = list(persisted)
+    persisted = enforce_single_persisted_concentration_group(persisted)
+    if not persisted:
+        data = dict(session_state.state_json)
+        data.pop("active_spell_effects", None)
+        session_state.state_json = finalize_session_state_data(data)
+        flag_modified(session_state, "state_json")
+        db.add(session_state)
+        return
+    if persisted != original_persisted:
+        data = dict(session_state.state_json)
+        data["active_spell_effects"] = persisted
+        session_state.state_json = finalize_session_state_data(data)
+        flag_modified(session_state, "state_json")
+        db.add(session_state)
     existing = participant.get("active_effects")
     if not isinstance(existing, list):
         existing = []
@@ -205,3 +221,69 @@ def clear_persisted_concentration_effects(
     else:
         data.pop("active_spell_effects", None)
     return data
+
+
+def enforce_single_persisted_concentration_group(
+    effects: list[dict],
+) -> list[dict]:
+    """Keep only the newest concentration group; preserve non-concentration effects.
+
+    Selection rule: highest valid ``created_at`` among concentration groups.
+    Fallback (missing/invalid timestamps): last concentration group encountered.
+    """
+    non_concentration: list[dict] = []
+    groups: dict[str, list[dict]] = {}           # group_key → [effect, ...]
+    group_order: list[str] = []                  # insertion order for fallback
+
+    for effect in effects:
+        metadata = effect.get("metadata") or {}
+        if not metadata.get("concentration"):
+            non_concentration.append(effect)
+            continue
+        group_key = metadata.get("concentration_group") or _solo_group_key(effect)
+        groups.setdefault(group_key, []).append(effect)
+        if group_key not in group_order:
+            group_order.append(group_key)
+
+    if not groups:
+        return list(effects)
+
+    winning = _pick_winning_concentration_group(groups, group_order)
+    winning_effects = groups[winning]
+
+    # preserve original order: non-concentration first, then winning group effects
+    return non_concentration + winning_effects
+
+
+def _solo_group_key(effect: dict) -> str:
+    """Synthetic key for concentration effects without a concentration_group."""
+    return f"__solo__:{effect.get('id', id(effect))}"
+
+
+def _pick_winning_concentration_group(
+    groups: dict[str, list[dict]],
+    group_order: list[str],
+) -> str:
+    best_group: str | None = None
+    best_ts: str | None = None
+    for gkey in group_order:
+        ts = _max_created_at(groups[gkey])
+        if ts is None:
+            continue
+        if best_ts is None or ts > best_ts:
+            best_ts = ts
+            best_group = gkey
+    if best_group is not None:
+        return best_group
+    # fallback: last group in list order
+    return group_order[-1]
+
+
+def _max_created_at(effects: list[dict]) -> str | None:
+    best: str | None = None
+    for e in effects:
+        ts = e.get("created_at")
+        if isinstance(ts, str) and ts:
+            if best is None or ts > best:
+                best = ts
+    return best

--- a/apps/control-server/tests/test_persistent_effects.py
+++ b/apps/control-server/tests/test_persistent_effects.py
@@ -16,6 +16,7 @@ from app.models.session_state import SessionState
 from app.services.combat_service.persistent_effects import (
     clear_persisted_concentration_effects,
     derive_active_concentration,
+    enforce_single_persisted_concentration_group,
     persist_surviving_spell_effects,
     restore_persisted_effects,
     sync_effect_removal_to_state_json,
@@ -489,6 +490,281 @@ class TestToStateReadActiveConcentration(unittest.TestCase):
         result = to_state_read(mock)
 
         self.assertIsNone(result.activeConcentration)
+
+
+class TestEnforceSinglePersistedConcentrationGroup(unittest.TestCase):
+    def test_no_concentration_effects_unchanged(self):
+        effects = [_manual_spell_effect("eff-1"), _temp_ac_bonus_effect("eff-ac")]
+        result = enforce_single_persisted_concentration_group(effects)
+        self.assertEqual(result, effects)
+
+    def test_single_concentration_group_unchanged(self):
+        effects = [
+            _manual_spell_effect("eff-a", concentration=True),
+            _manual_spell_effect("eff-b", concentration=True),
+        ]
+        result = enforce_single_persisted_concentration_group(effects)
+        self.assertEqual(len(result), 2)
+        self.assertEqual({e["id"] for e in result}, {"eff-a", "eff-b"})
+
+    def test_two_groups_keeps_newest_by_created_at(self):
+        older = {
+            "id": "eff-old",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-old",
+                "source_spell_name": "Old Spell",
+            },
+        }
+        newer = {
+            "id": "eff-new",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "created_at": "2026-01-02T00:00:00+00:00",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-new",
+                "source_spell_name": "New Spell",
+            },
+        }
+        result = enforce_single_persisted_concentration_group([older, newer])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], "eff-new")
+
+    def test_multiple_effects_in_winning_group_all_kept(self):
+        older = {
+            "id": "eff-old",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-old",
+                "source_spell_name": "Old Spell",
+            },
+        }
+        new_a = {
+            "id": "eff-new-a",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "created_at": "2026-01-02T00:00:00+00:00",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-new",
+                "source_spell_name": "New Spell",
+            },
+        }
+        new_b = {
+            "id": "eff-new-b",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "created_at": "2026-01-02T00:00:00+00:00",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-new",
+                "source_spell_name": "New Spell",
+            },
+        }
+        result = enforce_single_persisted_concentration_group([older, new_a, new_b])
+        self.assertEqual(len(result), 2)
+        ids = {e["id"] for e in result}
+        self.assertEqual(ids, {"eff-new-a", "eff-new-b"})
+
+    def test_non_concentration_effects_survive(self):
+        non_conc = _manual_spell_effect("eff-non")
+        conc = _manual_spell_effect("eff-conc", concentration=True)
+        result = enforce_single_persisted_concentration_group([non_conc, conc])
+        self.assertEqual(len(result), 2)
+        ids = {e["id"] for e in result}
+        self.assertEqual(ids, {"eff-non", "eff-conc"})
+
+    def test_invalid_created_at_falls_back_to_last_group(self):
+        first = {
+            "id": "eff-first",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-first",
+            },
+        }
+        second = {
+            "id": "eff-second",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-second",
+            },
+        }
+        result = enforce_single_persisted_concentration_group([first, second])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], "eff-second")
+
+    def test_preserves_original_ordering(self):
+        non1 = _manual_spell_effect("eff-non-1")
+        non2 = _temp_ac_bonus_effect("eff-ac")
+        conc = {
+            "id": "eff-conc",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-1",
+            },
+        }
+        result = enforce_single_persisted_concentration_group([non1, conc, non2])
+        self.assertEqual([e["id"] for e in result], ["eff-non-1", "eff-ac", "eff-conc"])
+
+    def test_solo_concentration_without_group_key(self):
+        solo = {
+            "id": "eff-solo",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "metadata": {
+                "concentration": True,
+                "source_spell_name": "Solo Spell",
+            },
+        }
+        result = enforce_single_persisted_concentration_group([solo])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], "eff-solo")
+
+
+class TestPersistSurvivingConcentrationNormalization(unittest.TestCase):
+    def test_persist_surviving_keeps_only_newest_concentration_group(self):
+        older = {
+            "id": "eff-old",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-old",
+                "source_spell_name": "Old Spell",
+            },
+        }
+        newer = {
+            "id": "eff-new",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "created_at": "2026-01-02T00:00:00+00:00",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-new",
+                "source_spell_name": "New Spell",
+            },
+        }
+        state = _make_state_with_participants([older, newer])
+        db = MagicMock()
+        session_state = _make_session_state({})
+        db.exec.return_value.first.return_value = session_state
+
+        persist_surviving_spell_effects(db, state)
+
+        persisted = session_state.state_json["active_spell_effects"]
+        self.assertEqual(len(persisted), 1)
+        self.assertEqual(persisted[0]["id"], "eff-new")
+
+    def test_persist_surviving_preserves_non_concentration(self):
+        non_conc = _manual_spell_effect("eff-non")
+        conc = {
+            "id": "eff-conc",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "created_at": "2026-01-02T00:00:00+00:00",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-1",
+                "source_spell_name": "Conc Spell",
+            },
+        }
+        state = _make_state_with_participants([non_conc, conc])
+        db = MagicMock()
+        session_state = _make_session_state({})
+        db.exec.return_value.first.return_value = session_state
+
+        persist_surviving_spell_effects(db, state)
+
+        persisted = session_state.state_json["active_spell_effects"]
+        self.assertEqual(len(persisted), 2)
+        ids = {e["id"] for e in persisted}
+        self.assertEqual(ids, {"eff-non", "eff-conc"})
+
+
+class TestRestorePersistedConcentrationNormalization(unittest.TestCase):
+    def test_restore_normalizes_multiple_concentration_groups(self):
+        older = {
+            "id": "eff-old",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-old",
+                "source_spell_name": "Old Spell",
+            },
+        }
+        newer = {
+            "id": "eff-new",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "created_at": "2026-01-02T00:00:00+00:00",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-new",
+                "source_spell_name": "New Spell",
+            },
+        }
+        participant = {"kind": "player", "ref_id": "player-1", "active_effects": []}
+        db = MagicMock()
+        session_state = _make_session_state({"active_spell_effects": [older, newer]})
+        db.exec.return_value.first.return_value = session_state
+
+        restore_persisted_effects(db, "session-1", participant)
+
+        self.assertEqual(len(participant["active_effects"]), 1)
+        self.assertEqual(participant["active_effects"][0]["id"], "eff-new")
+
+    def test_restore_syncs_back_to_state_json(self):
+        older = {
+            "id": "eff-old",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-old",
+                "source_spell_name": "Old Spell",
+            },
+        }
+        newer = {
+            "id": "eff-new",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "created_at": "2026-01-02T00:00:00+00:00",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-new",
+                "source_spell_name": "New Spell",
+            },
+        }
+        participant = {"kind": "player", "ref_id": "player-1", "active_effects": []}
+        db = MagicMock()
+        session_state = _make_session_state({"active_spell_effects": [older, newer]})
+        db.exec.return_value.first.return_value = session_state
+
+        restore_persisted_effects(db, "session-1", participant)
+
+        # state_json should be normalized too
+        persisted = session_state.state_json["active_spell_effects"]
+        self.assertEqual(len(persisted), 1)
+        self.assertEqual(persisted[0]["id"], "eff-new")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Enforces a single persisted concentration group for out-of-combat active effects.

This PR adds normalization for `state_json.active_spell_effects` so persisted effects cannot contain multiple active concentration groups at the same time.

The normalization runs both when effects are persisted after combat and when persisted effects are restored into a new combat.

## Context

Out-of-combat active effects now support concentration:

- manual concentration effects can persist in `state_json.active_spell_effects`
- `activeConcentration` is derived from persisted effects
- PlayerBoard can show and clear out-of-combat concentration

However, nothing prevented multiple concentration groups from coexisting in the persisted effects bucket.

That violates the D&D concentration rule:

```text
A creature can concentrate on only one spell at a time.
````

This PR enforces that rule at the persisted-effect layer.

## What changed

### Concentration normalization helper

Updated:

```text
apps/control-server/app/services/combat_service/persistent_effects.py
```

Added:

```py
enforce_single_persisted_concentration_group(effects)
```

This pure helper:

* splits effects into non-concentration effects and concentration groups
* groups concentration effects by `metadata.concentration_group`
* uses a synthetic `__solo__:{id}` group key for concentration effects without a group
* selects the winning concentration group by the highest valid `created_at` within the group
* falls back to the last group in list order when timestamps are missing or invalid
* returns non-concentration effects plus the winning concentration group
* preserves relative ordering within returned effects

This keeps all effects from the winning concentration package while removing older concentration groups.

### Persist flow

Updated `persist_surviving_spell_effects()`.

Before writing to:

```text
state_json.active_spell_effects
```

the surviving effects are normalized so `end_combat()` cannot persist multiple concentration groups.

### Restore flow

Updated `restore_persisted_effects()`.

Persisted effects are normalized after being read from `state_json`.

If normalization changes the list:

* `state_json.active_spell_effects` is updated
* the key is removed if the normalized list is empty
* `finalize_session_state_data` is applied
* `flag_modified(session_state, "state_json")` is called
* the session state is added back to the DB session

This prevents stale multi-concentration persisted state from being restored into combat.

## Bug caught during implementation

The first version used an early return:

```py
if len(groups) <= 1:
    return list(effects)
```

That broke ordering when a single concentration group was interleaved with non-concentration effects.

It was fixed to only short-circuit when there are zero concentration groups:

```py
if not groups:
    return list(effects)
```

Tiny optimization tried to be clever. It has been escorted from the building.

## Tests

Updated:

```text
apps/control-server/tests/test_persistent_effects.py
```

Added 12 tests.

### `TestEnforceSinglePersistedConcentrationGroup`

Covers:

* no concentration effects
* single concentration group
* two groups where newest wins
* multiple effects in the winning group
* non-concentration effects survive normalization
* invalid timestamp fallback behavior
* ordering preservation
* solo concentration effects without `concentration_group`

### `TestPersistSurvivingConcentrationNormalization`

Covers:

* persist keeps only newest concentration group
* persist preserves non-concentration effects

### `TestRestorePersistedConcentrationNormalization`

Covers:

* restore normalizes multiple concentration groups
* restore syncs normalized state back to `state_json`

## Validation

Targeted tests:

```bash
cd apps/control-server
.venv/bin/pytest tests/test_persistent_effects.py -v
```

Result:

```text
42 passed
```

Full backend suite:

```text
1832 passed, 1 skipped
```

## Out of scope

This PR intentionally does not implement:

* frontend warning when concentration is replaced
* out-of-combat casting workflow changes
* damage-triggered concentration checks outside combat
* concentration duration countdowns
* active effects management panel
* combat concentration behavior changes