### PR TITLE
feat(effects): add out-of-combat active effects panel

### DIFF
--- a/apps/control-server/app/api/routes/sessions/state.py
+++ b/apps/control-server/app/api/routes/sessions/state.py
@@ -14,7 +14,10 @@ from app.schemas.session_state import (
     SessionStateUpdate,
 )
 from app.services.combat import CombatService
-from app.services.combat_service.persistent_effects import clear_persisted_concentration_effects
+from app.services.combat_service.persistent_effects import (
+    clear_persisted_concentration_effects,
+    remove_persisted_effect,
+)
 from app.services.session_rest import ensure_rest_state
 from app.services.session_state_finalize import finalize_session_state_data
 from ._shared import record_session_activity, require_identifier
@@ -238,6 +241,40 @@ async def clear_my_concentration(
         state.state_json,
         concentration_group=payload.concentrationGroup,
     )
+    state.state_json = finalize_session_state_data(updated)
+    session.add(state)
+    session.commit()
+    session.refresh(state)
+
+    await publish_state_update(
+        entry,
+        user.id,
+        state.updated_at or state.created_at,
+        state.state_json if isinstance(state.state_json, dict) else None,
+    )
+    return to_state_read(state)
+
+
+@router.delete("/sessions/{session_id}/state/me/effects/{effect_id}", response_model=SessionStateRead)
+async def remove_my_persisted_effect(
+    session_id: str,
+    effect_id: str,
+    user=Depends(get_current_user),
+    session: DbSession = Depends(get_session),
+):
+    entry = get_session_entry(session_id, session)
+    require_session_view_access(entry, user, session, user.id)
+    state = session.exec(
+        select(SessionState).where(
+            SessionState.session_id == session_id,
+            SessionState.player_user_id == user.id,
+        )
+    ).first()
+    state = ensure_session_state(state, session_id, user.id, entry.party_id, session)
+    if not state:
+        raise HTTPException(status_code=404, detail="Session state not found")
+
+    updated = remove_persisted_effect(state.state_json, effect_id)
     state.state_json = finalize_session_state_data(updated)
     session.add(state)
     session.commit()

--- a/apps/control-server/app/services/combat_service/persistent_effects.py
+++ b/apps/control-server/app/services/combat_service/persistent_effects.py
@@ -152,6 +152,44 @@ def sync_effect_removal_to_state_json(
     db.add(session_state)
 
 
+def remove_persisted_effect(
+    state_json: dict | None,
+    effect_id: str,
+) -> dict:
+    """Remove a persisted effect by id.
+
+    If the effect is part of a concentration group, the whole group is removed.
+    Idempotent: returns ``state_json`` unchanged if the effect is not found.
+    """
+    data = dict(state_json or {})
+    persisted = data.get("active_spell_effects")
+    if not isinstance(persisted, list):
+        return data
+
+    target: dict | None = None
+    for effect in persisted:
+        if effect.get("id") == effect_id:
+            target = effect
+            break
+
+    if target is None:
+        return data
+
+    metadata = target.get("metadata") or {}
+    concentration_group = metadata.get("concentration_group")
+    if metadata.get("concentration") and isinstance(concentration_group, str) and concentration_group:
+        return clear_persisted_concentration_effects(data, concentration_group=concentration_group)
+
+    filtered = [e for e in persisted if e.get("id") != effect_id]
+    if len(filtered) == len(persisted):
+        return data
+    if filtered:
+        data["active_spell_effects"] = filtered
+    else:
+        data.pop("active_spell_effects", None)
+    return data
+
+
 def derive_active_concentration(state_json: dict | None) -> dict | None:
     persisted = (state_json or {}).get("active_spell_effects")
     if not isinstance(persisted, list):

--- a/apps/control-server/tests/test_persistent_effects.py
+++ b/apps/control-server/tests/test_persistent_effects.py
@@ -18,6 +18,7 @@ from app.services.combat_service.persistent_effects import (
     derive_active_concentration,
     enforce_single_persisted_concentration_group,
     persist_surviving_spell_effects,
+    remove_persisted_effect,
     restore_persisted_effects,
     sync_effect_removal_to_state_json,
 )
@@ -490,6 +491,70 @@ class TestToStateReadActiveConcentration(unittest.TestCase):
         result = to_state_read(mock)
 
         self.assertIsNone(result.activeConcentration)
+
+
+class TestRemovePersistedEffect(unittest.TestCase):
+    def test_remove_non_concentration_effect(self):
+        eff_a = _manual_spell_effect("eff-a")
+        eff_b = _manual_spell_effect("eff-b")
+        state_json = {"active_spell_effects": [eff_a, eff_b]}
+        updated = remove_persisted_effect(state_json, "eff-a")
+        self.assertEqual(len(updated["active_spell_effects"]), 1)
+        self.assertEqual(updated["active_spell_effects"][0]["id"], "eff-b")
+
+    def test_remove_concentration_effect_clears_whole_group(self):
+        eff_a = _manual_spell_effect("eff-a", concentration=True)
+        eff_a["metadata"]["concentration_group"] = "grp-1"
+        eff_b = _manual_spell_effect("eff-b", concentration=True)
+        eff_b["metadata"]["concentration_group"] = "grp-1"
+        eff_c = _manual_spell_effect("eff-c")
+        state_json = {"active_spell_effects": [eff_a, eff_b, eff_c]}
+        updated = remove_persisted_effect(state_json, "eff-a")
+        self.assertEqual(len(updated["active_spell_effects"]), 1)
+        self.assertEqual(updated["active_spell_effects"][0]["id"], "eff-c")
+
+    def test_remove_concentration_preserves_unrelated_non_concentration(self):
+        eff_a = _manual_spell_effect("eff-a", concentration=True)
+        eff_a["metadata"]["concentration_group"] = "grp-1"
+        eff_b = _manual_spell_effect("eff-b")
+        eff_c = _manual_spell_effect("eff-c", concentration=True)
+        eff_c["metadata"]["concentration_group"] = "grp-2"
+        state_json = {"active_spell_effects": [eff_a, eff_b, eff_c]}
+        updated = remove_persisted_effect(state_json, "eff-a")
+        self.assertEqual(len(updated["active_spell_effects"]), 2)
+        self.assertEqual(updated["active_spell_effects"][0]["id"], "eff-b")
+        self.assertEqual(updated["active_spell_effects"][1]["id"], "eff-c")
+
+    def test_remove_unknown_effect_idempotent(self):
+        eff_a = _manual_spell_effect("eff-a")
+        state_json = {"active_spell_effects": [eff_a]}
+        updated = remove_persisted_effect(state_json, "eff-unknown")
+        self.assertEqual(updated["active_spell_effects"], [eff_a])
+
+    def test_remove_from_empty_state(self):
+        updated = remove_persisted_effect({}, "eff-x")
+        self.assertNotIn("active_spell_effects", updated)
+
+    def test_remove_from_missing_key(self):
+        updated = remove_persisted_effect({"currentHP": 10}, "eff-x")
+        self.assertEqual(updated["currentHP"], 10)
+        self.assertNotIn("active_spell_effects", updated)
+
+    def test_remove_last_effect_removes_key(self):
+        eff_a = _manual_spell_effect("eff-a")
+        state_json = {"active_spell_effects": [eff_a]}
+        updated = remove_persisted_effect(state_json, "eff-a")
+        self.assertNotIn("active_spell_effects", updated)
+
+    def test_remove_solo_concentration_without_group(self):
+        """Concentration effect without concentration_group is treated as non-concentration for removal."""
+        eff_a = _manual_spell_effect("eff-a", concentration=True)
+        del eff_a["metadata"]["concentration_group"]
+        eff_b = _manual_spell_effect("eff-b")
+        state_json = {"active_spell_effects": [eff_a, eff_b]}
+        updated = remove_persisted_effect(state_json, "eff-a")
+        self.assertEqual(len(updated["active_spell_effects"]), 1)
+        self.assertEqual(updated["active_spell_effects"][0]["id"], "eff-b")
 
 
 class TestEnforceSinglePersistedConcentrationGroup(unittest.TestCase):

--- a/apps/control-server/tests/test_session_concentration.py
+++ b/apps/control-server/tests/test_session_concentration.py
@@ -6,7 +6,7 @@ Covers route-level behavior of POST /sessions/{id}/state/me/concentration/clear.
 import unittest
 from unittest.mock import MagicMock, patch
 
-from app.api.routes.sessions.state import clear_my_concentration
+from app.api.routes.sessions.state import clear_my_concentration, remove_my_persisted_effect
 from app.schemas.session_state import ClearConcentrationRequest, SessionStateRead
 
 
@@ -307,6 +307,187 @@ class TestClearMyConcentration(unittest.IsolatedAsyncioTestCase):
 
         # The DB query filters by session_id + user.id. Verify the query params
         # contain the requesting user's id so the DB enforces ownership.
+        query_call = db.exec.call_args_list[0]
+        built_query = query_call[0][0]
+        self.assertEqual(
+            built_query.compile().params.get("player_user_id_1"),
+            "user-1",
+        )
+
+
+class TestRemoveMyPersistedEffect(unittest.IsolatedAsyncioTestCase):
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data")
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_removes_effect_and_returns_updated_state(
+        self,
+        mock_to_state_read,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_view,
+        mock_get_entry,
+    ):
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        db, state = _make_db_session(
+            {"active_spell_effects": [_non_concentration_effect("eff-a"), _non_concentration_effect("eff-b")]}
+        )
+        mock_ensure.return_value = state
+        mock_finalize.side_effect = lambda x: x
+        mock_to_state_read.return_value = SessionStateRead(
+            id="ss-1",
+            sessionId="session-1",
+            playerUserId="user-1",
+            state={},
+            createdAt="2026-01-01T00:00:00+00:00",
+            updatedAt=None,
+            activeSpellEffects=[_non_concentration_effect("eff-b")],
+            activeConcentration=None,
+        )
+
+        result = await remove_my_persisted_effect(
+            session_id="session-1",
+            effect_id="eff-a",
+            user=_make_user(),
+            session=db,
+        )
+
+        self.assertEqual(len(result.activeSpellEffects), 1)
+        self.assertEqual(result.activeSpellEffects[0]["id"], "eff-b")
+        mock_publish.assert_awaited_once()
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data")
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_concentration_effect_clears_group(
+        self,
+        mock_to_state_read,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_view,
+        mock_get_entry,
+    ):
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        eff_a = _concentration_effect("eff-a", "grp-1")
+        eff_b = _concentration_effect("eff-b", "grp-1")
+        eff_c = _non_concentration_effect("eff-c")
+        db, state = _make_db_session({"active_spell_effects": [eff_a, eff_b, eff_c]})
+        mock_ensure.return_value = state
+        mock_finalize.side_effect = lambda x: x
+        mock_to_state_read.return_value = SessionStateRead(
+            id="ss-1",
+            sessionId="session-1",
+            playerUserId="user-1",
+            state={},
+            createdAt="2026-01-01T00:00:00+00:00",
+            updatedAt=None,
+            activeSpellEffects=[eff_c],
+            activeConcentration=None,
+        )
+
+        result = await remove_my_persisted_effect(
+            session_id="session-1",
+            effect_id="eff-a",
+            user=_make_user(),
+            session=db,
+        )
+
+        self.assertEqual(len(result.activeSpellEffects), 1)
+        self.assertEqual(result.activeSpellEffects[0]["id"], "eff-c")
+        self.assertIsNone(result.activeConcentration)
+        mock_publish.assert_awaited_once()
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data")
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_unknown_effect_is_idempotent(
+        self,
+        mock_to_state_read,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_view,
+        mock_get_entry,
+    ):
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        db, state = _make_db_session(
+            {"active_spell_effects": [_non_concentration_effect("eff-a")]}
+        )
+        mock_ensure.return_value = state
+        mock_finalize.side_effect = lambda x: x
+        mock_to_state_read.return_value = SessionStateRead(
+            id="ss-1",
+            sessionId="session-1",
+            playerUserId="user-1",
+            state={},
+            createdAt="2026-01-01T00:00:00+00:00",
+            updatedAt=None,
+            activeSpellEffects=[_non_concentration_effect("eff-a")],
+            activeConcentration=None,
+        )
+
+        result = await remove_my_persisted_effect(
+            session_id="session-1",
+            effect_id="eff-unknown",
+            user=_make_user(),
+            session=db,
+        )
+
+        self.assertEqual(len(result.activeSpellEffects), 1)
+        self.assertEqual(result.activeSpellEffects[0]["id"], "eff-a")
+        mock_publish.assert_awaited_once()
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data")
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_non_owner_cannot_remove_another_players_effect(
+        self,
+        mock_to_state_read,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_view,
+        mock_get_entry,
+    ):
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        db, state = _make_db_session(
+            {"active_spell_effects": [_non_concentration_effect("eff-a")]}
+        )
+        state.player_user_id = "user-2"
+        mock_ensure.return_value = state
+        mock_finalize.side_effect = lambda x: x
+        mock_to_state_read.return_value = SessionStateRead(
+            id="ss-1",
+            sessionId="session-1",
+            playerUserId="user-2",
+            state={},
+            createdAt="2026-01-01T00:00:00+00:00",
+            updatedAt=None,
+            activeSpellEffects=[_non_concentration_effect("eff-a")],
+            activeConcentration=None,
+        )
+
+        user = _make_user("user-1")
+        result = await remove_my_persisted_effect(
+            session_id="session-1",
+            effect_id="eff-a",
+            user=user,
+            session=db,
+        )
+
         query_call = db.exec.call_args_list[0]
         built_query = query_call[0][0]
         self.assertEqual(

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
@@ -48,6 +48,7 @@ export const PlayerBoardPage = () => {
   const {
     activeConcentration,
     activeSession,
+    activeSpellEffects,
     catalogItems,
     clearCommand,
     clearSessionEnded,
@@ -66,6 +67,7 @@ export const PlayerBoardPage = () => {
     rollEvents,
     sessionEndedAt,
     setActiveConcentration,
+    setActiveSpellEffects,
     setMyInventory,
     setPlayerSheet,
     setPlayerWallet,
@@ -165,6 +167,7 @@ export const PlayerBoardPage = () => {
     t,
   });
   const [clearingConcentration, setClearingConcentration] = useState(false);
+  const [removingEffectId, setRemovingEffectId] = useState<string | null>(null);
 
   const handleClearConcentration = async () => {
     if (!activeSession?.id || clearingConcentration) return;
@@ -173,6 +176,9 @@ export const PlayerBoardPage = () => {
       const record = await sessionStatesRepo.clearConcentration(activeSession.id);
       setPlayerSheet(parseCharacterSheet(record.state));
       setActiveConcentration(record.activeConcentration ?? null);
+      setActiveSpellEffects(
+        (record.activeSpellEffects as import("../../shared/api/combatRepo").ActiveEffect[] | null | undefined) ?? null,
+      );
     } catch {
       showToast({
         variant: "error",
@@ -181,6 +187,27 @@ export const PlayerBoardPage = () => {
       });
     } finally {
       setClearingConcentration(false);
+    }
+  };
+
+  const handleRemoveEffect = async (effectId: string) => {
+    if (!activeSession?.id || removingEffectId) return;
+    setRemovingEffectId(effectId);
+    try {
+      const record = await sessionStatesRepo.removePersistedEffect(activeSession.id, effectId);
+      setPlayerSheet(parseCharacterSheet(record.state));
+      setActiveConcentration(record.activeConcentration ?? null);
+      setActiveSpellEffects(
+        (record.activeSpellEffects as import("../../shared/api/combatRepo").ActiveEffect[] | null | undefined) ?? null,
+      );
+    } catch {
+      showToast({
+        variant: "error",
+        title: t("playerBoard.removeEffectErrorTitle"),
+        description: t("playerBoard.removeEffectErrorDescription"),
+      });
+    } finally {
+      setRemovingEffectId(null);
     }
   };
 
@@ -297,16 +324,19 @@ export const PlayerBoardPage = () => {
         <div className="space-y-6">
       <PlayerBoardStatusPanel
         activeConcentration={activeConcentration}
+        activeSpellEffects={activeSpellEffects}
         clearingConcentration={clearingConcentration}
         combatActive={combatActive}
         onClearConcentration={handleClearConcentration}
+        onRemoveEffect={handleRemoveEffect}
         pendingRoll={pendingRoll}
         playerSheet={playerSheet}
         playerStatus={playerStatus}
+        removingEffectId={removingEffectId}
         restState={restState}
         usingHitDie={usingHitDie}
-            onUseHitDie={handleUseHitDie}
-          />
+        onUseHitDie={handleUseHitDie}
+      />
           {activeSession?.id && (
             <PlayerEntityList
               sessionId={activeSession.id}

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
@@ -25,6 +25,10 @@ vi.mock("../../shared/hooks/useLocale", () => ({
         "playerBoard.activeConcentrationLabel": "Concentração",
         "playerBoard.clearConcentration": "Encerrar concentração",
         "playerBoard.clearingConcentration": "Encerrando...",
+        "playerBoard.activeEffectsLabel": "Efeitos ativos",
+        "playerBoard.activeEffectFallback": "Efeito",
+        "playerBoard.removeEffect": "Remover",
+        "playerBoard.removingEffect": "Removendo...",
       }[key] ?? key),
   }),
 }));
@@ -75,6 +79,7 @@ describe("PlayerBoardStatusPanel", () => {
         usingHitDie={false}
         onUseHitDie={() => undefined}
         onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
       />,
     );
 
@@ -107,6 +112,7 @@ describe("PlayerBoardStatusPanel", () => {
         usingHitDie={false}
         onUseHitDie={() => undefined}
         onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
       />,
     );
 
@@ -138,6 +144,7 @@ describe("PlayerBoardStatusPanel", () => {
         usingHitDie={false}
         onUseHitDie={() => undefined}
         onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
       />,
     );
 
@@ -172,6 +179,7 @@ describe("PlayerBoardStatusPanel", () => {
         usingHitDie={false}
         onUseHitDie={() => undefined}
         onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
       />,
     );
 
@@ -208,6 +216,7 @@ describe("PlayerBoardStatusPanel", () => {
         usingHitDie={false}
         onUseHitDie={() => undefined}
         onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
       />,
     );
 
@@ -240,6 +249,7 @@ describe("PlayerBoardStatusPanel", () => {
         usingHitDie={false}
         onUseHitDie={() => undefined}
         onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
       />,
     );
 
@@ -273,6 +283,7 @@ describe("PlayerBoardStatusPanel", () => {
         usingHitDie={false}
         onUseHitDie={() => undefined}
         onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
       />,
     );
 
@@ -306,6 +317,7 @@ describe("PlayerBoardStatusPanel", () => {
         usingHitDie={false}
         onUseHitDie={() => undefined}
         onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
       />,
     );
 
@@ -336,6 +348,7 @@ describe("PlayerBoardStatusPanel", () => {
         usingHitDie={false}
         onUseHitDie={() => undefined}
         onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
       />,
     );
 
@@ -384,6 +397,7 @@ describe("PlayerBoardStatusPanel", () => {
         usingHitDie={false}
         onUseHitDie={() => undefined}
         onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
       />,
     );
 
@@ -400,10 +414,138 @@ describe("PlayerBoardStatusPanel", () => {
         usingHitDie={false}
         onUseHitDie={() => undefined}
         onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
       />,
     );
 
     expect(markupWithout).toContain("Percepção passiva:12");
     expect(markupWithout).not.toContain("Owl");
+  });
+
+  it("renderiza painel de efeitos ativos quando activeSpellEffects existem", () => {
+    const markup = renderToStaticMarkup(
+      <PlayerBoardStatusPanel
+        activeSpellEffects={[
+          {
+            id: "eff-1",
+            kind: "spell_effect",
+            duration_type: "manual",
+            created_at: "2026-01-01T00:00:00Z",
+            display_label: "Owl's Wisdom",
+            metadata: {
+              source_spell_name: "Owl's Wisdom",
+              concentration: true,
+              concentration_group: "grp-1",
+            },
+          },
+          {
+            id: "eff-2",
+            kind: "spell_effect",
+            duration_type: "manual",
+            created_at: "2026-01-01T00:00:00Z",
+            metadata: {
+              source_spell_name: "Shield of Faith",
+            },
+          },
+        ] as any}
+        combatActive={false}
+        pendingRoll={null}
+        playerStatus={{
+          level: 3,
+          currentHp: 20,
+          maxHp: 20,
+          hpPercent: 100,
+          tempHp: 0,
+          xpPercent: 10,
+          nextLevelThreshold: 900,
+          experiencePoints: 100,
+          ac: 12,
+          initiative: 1,
+          passivePerception: 13,
+        } as any}
+        restState="exploration"
+        usingHitDie={false}
+        onUseHitDie={() => undefined}
+        onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Efeitos ativos");
+    expect(markup).toContain("Owl&#x27;s Wisdom");
+    expect(markup).toContain("Concentração");
+    expect(markup).toContain("Shield of Faith");
+    expect(markup).toContain("Remover");
+  });
+
+  it("não renderiza painel de efeitos ativos quando a lista está vazia", () => {
+    const markup = renderToStaticMarkup(
+      <PlayerBoardStatusPanel
+        activeSpellEffects={[]}
+        combatActive={false}
+        pendingRoll={null}
+        playerStatus={{
+          level: 3,
+          currentHp: 20,
+          maxHp: 20,
+          hpPercent: 100,
+          tempHp: 0,
+          xpPercent: 10,
+          nextLevelThreshold: 900,
+          experiencePoints: 100,
+          ac: 12,
+          initiative: 1,
+          passivePerception: 13,
+        } as any}
+        restState="exploration"
+        usingHitDie={false}
+        onUseHitDie={() => undefined}
+        onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
+      />,
+    );
+
+    expect(markup).not.toContain("Efeitos ativos");
+  });
+
+  it("desabilita botão de remover quando removingEffectId corresponde", () => {
+    const markup = renderToStaticMarkup(
+      <PlayerBoardStatusPanel
+        activeSpellEffects={[
+          {
+            id: "eff-1",
+            kind: "spell_effect",
+            duration_type: "manual",
+            created_at: "2026-01-01T00:00:00Z",
+            display_label: "Bless",
+            metadata: {},
+          },
+        ] as any}
+        removingEffectId="eff-1"
+        combatActive={false}
+        pendingRoll={null}
+        playerStatus={{
+          level: 3,
+          currentHp: 20,
+          maxHp: 20,
+          hpPercent: 100,
+          tempHp: 0,
+          xpPercent: 10,
+          nextLevelThreshold: 900,
+          experiencePoints: 100,
+          ac: 12,
+          initiative: 1,
+          passivePerception: 13,
+        } as any}
+        restState="exploration"
+        usingHitDie={false}
+        onUseHitDie={() => undefined}
+        onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("disabled");
+    expect(markup).toContain("Removendo...");
   });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
@@ -1,9 +1,10 @@
 import type { ActiveConcentration } from "../../entities/character";
+import type { ActiveEffect } from "../../shared/api/combatRepo";
 import type { CharacterSheet } from "../../features/character-sheet/model/characterSheet.types";
 import { useLocale } from "../../shared/hooks/useLocale";
 import { SpellSlotSummary } from "../../shared/ui/SpellSlotSummary";
 import { formatPassiveBonusBreakdown } from "../../features/character-sheet/utils/passiveSkillBonusDisplay";
-import { formatActiveConcentrationLabel } from "./concentrationLabel";
+import { formatActiveConcentrationLabel, formatActiveEffectLabel } from "./concentrationLabel";
 import type { PendingRoll, PlayerBoardStatusSummary } from "./playerBoard.types";
 import {
   DeathSaveCard,
@@ -24,12 +25,15 @@ const encumbranceAccentMap: Record<PlayerBoardStatusSummary["encumbranceTier"], 
 
 type Props = {
   activeConcentration?: ActiveConcentration | null;
+  activeSpellEffects?: ActiveEffect[] | null;
   clearingConcentration?: boolean;
   combatActive: boolean;
   onClearConcentration: () => void;
+  onRemoveEffect: (effectId: string) => void;
   pendingRoll: PendingRoll | null;
   playerSheet?: CharacterSheet | null;
   playerStatus: PlayerBoardStatusSummary | null;
+  removingEffectId?: string | null;
   restState: "exploration" | "short_rest" | "long_rest";
   usingHitDie: boolean;
   onUseHitDie: () => void;
@@ -37,12 +41,15 @@ type Props = {
 
 export const PlayerBoardStatusPanel = ({
   activeConcentration,
+  activeSpellEffects,
   clearingConcentration,
   combatActive,
   onClearConcentration,
+  onRemoveEffect,
   pendingRoll,
   playerSheet,
   playerStatus,
+  removingEffectId,
   restState,
   usingHitDie,
   onUseHitDie,
@@ -208,6 +215,43 @@ export const PlayerBoardStatusPanel = ({
                   {clearingConcentration ? t("playerBoard.clearingConcentration") : t("playerBoard.clearConcentration")}
                 </button>
               </div>
+            </div>
+          ) : null}
+
+          {activeSpellEffects?.length ? (
+            <div className="mt-5 rounded-3xl border border-white/8 bg-white/4 px-4 py-4">
+              <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-slate-400">
+                {t("playerBoard.activeEffectsLabel")}
+              </p>
+              <ul className="mt-3 space-y-2">
+                {activeSpellEffects.map((effect) => {
+                  const label = formatActiveEffectLabel(effect) ?? t("playerBoard.activeEffectFallback");
+                  const isConcentration = Boolean(
+                    (effect.metadata as Record<string, unknown> | null)?.concentration,
+                  );
+                  const isRemoving = removingEffectId === effect.id;
+                  return (
+                    <li key={effect.id} className="flex items-center justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium text-white">{label}</p>
+                        {isConcentration ? (
+                          <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-violet-400">
+                            {t("playerBoard.activeConcentrationLabel")}
+                          </p>
+                        ) : null}
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => onRemoveEffect(effect.id)}
+                        disabled={isRemoving}
+                        className="shrink-0 rounded-full bg-white/8 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.22em] text-slate-300 transition hover:bg-red-500/20 hover:text-red-300 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {isRemoving ? t("playerBoard.removingEffect") : t("playerBoard.removeEffect")}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
             </div>
           ) : null}
 

--- a/apps/control-web/src/pages/PlayerBoardPage/concentrationLabel.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/concentrationLabel.ts
@@ -11,3 +11,20 @@ export const formatActiveConcentrationLabel = (
   if (spellKey) return spellKey;
   return null;
 };
+
+export const formatActiveEffectLabel = (
+  effect: Record<string, unknown>,
+): string | null => {
+  const metadata = ((effect.metadata ?? {}) as Record<string, unknown>) || {};
+  const variantLabel = metadata.selected_variant_label as string | undefined;
+  const spellName = metadata.source_spell_name as string | undefined;
+  const displayLabel = effect.display_label as string | undefined;
+  const spellKey = metadata.source_spell_key as string | undefined;
+
+  if (spellName && variantLabel) return `${spellName} \u2014 ${variantLabel}`;
+  if (variantLabel) return variantLabel;
+  if (displayLabel) return displayLabel;
+  if (spellName) return spellName;
+  if (spellKey) return spellKey;
+  return null;
+};

--- a/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardResources.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardResources.ts
@@ -6,6 +6,7 @@ import { sessionStatesRepo } from "../../shared/api/sessionStatesRepo";
 import type { InventoryItem } from "../../entities/inventory";
 import type { Item } from "../../entities/item";
 import type { ActiveConcentration } from "../../entities/character";
+import type { ActiveEffect } from "../../shared/api/combatRepo";
 import type { CurrencyWallet } from "../../shared/api/inventoryRepo";
 import { EMPTY_WALLET, normalizeWallet } from "../../features/shop/utils/shopCurrency";
 import { parseCharacterSheet } from "../../features/character-sheet/model/characterSheet.schema";
@@ -51,6 +52,7 @@ export const usePlayerBoardResources = ({
   const [playerWallet, setPlayerWallet] = useState<CurrencyWallet | null>(null);
   const [playerSheet, setPlayerSheet] = useState<CharacterSheet | null>(null);
   const [activeConcentration, setActiveConcentration] = useState<ActiveConcentration | null>(null);
+  const [activeSpellEffects, setActiveSpellEffects] = useState<ActiveEffect[] | null>(null);
 
   const applyRealtimeStateSnapshot = useCallback((rawState: unknown): boolean => {
     try {
@@ -105,6 +107,7 @@ export const usePlayerBoardResources = ({
       setPlayerWallet(null);
       setPlayerSheet(null);
       setActiveConcentration(null);
+      setActiveSpellEffects(null);
       return;
     }
     try {
@@ -115,10 +118,14 @@ export const usePlayerBoardResources = ({
       );
       setPlayerWallet(nextWallet);
       setActiveConcentration(record.activeConcentration ?? null);
+      setActiveSpellEffects(
+        (record.activeSpellEffects as ActiveEffect[] | null | undefined) ?? null,
+      );
     } catch {
       setPlayerWallet(EMPTY_WALLET);
       setPlayerSheet(null);
       setActiveConcentration(null);
+      setActiveSpellEffects(null);
     }
   }, [activeSession?.id]);
 
@@ -314,6 +321,7 @@ export const usePlayerBoardResources = ({
   return {
     activeConcentration,
     activeSession,
+    activeSpellEffects,
     catalogItems,
     clearCommand,
     clearSessionEnded,
@@ -333,6 +341,7 @@ export const usePlayerBoardResources = ({
     rollEvents,
     sessionEndedAt,
     setActiveConcentration,
+    setActiveSpellEffects,
     setMyInventory,
     setPlayerSheet,
     setPlayerWallet,

--- a/apps/control-web/src/shared/api/sessionStatesRepo.ts
+++ b/apps/control-web/src/shared/api/sessionStatesRepo.ts
@@ -17,4 +17,7 @@ export const sessionStatesRepo = {
     http.post<SessionStateRecord>(`/sessions/${sessionId}/state/me/concentration/clear`, {
       concentrationGroup: concentrationGroup ?? null,
     }),
+
+  removePersistedEffect: (sessionId: string, effectId: string) =>
+    http.del<SessionStateRecord>(`/sessions/${sessionId}/state/me/effects/${effectId}`),
 };

--- a/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
@@ -181,4 +181,10 @@ export const playerBoardEnUSDictionary = {
   "playerBoard.clearingConcentration": "Ending...",
   "playerBoard.clearConcentrationErrorTitle": "Failed to end concentration",
   "playerBoard.clearConcentrationErrorDescription": "Could not end concentration.",
+  "playerBoard.activeEffectsLabel": "Active effects",
+  "playerBoard.activeEffectFallback": "Effect",
+  "playerBoard.removeEffect": "Remove",
+  "playerBoard.removingEffect": "Removing...",
+  "playerBoard.removeEffectErrorTitle": "Failed to remove effect",
+  "playerBoard.removeEffectErrorDescription": "Could not remove the effect.",
 } as const;

--- a/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
@@ -181,4 +181,10 @@ export const playerBoardPtBRDictionary = {
   "playerBoard.clearingConcentration": "Encerrando...",
   "playerBoard.clearConcentrationErrorTitle": "Erro ao encerrar concentração",
   "playerBoard.clearConcentrationErrorDescription": "Não foi possível encerrar a concentração.",
+  "playerBoard.activeEffectsLabel": "Efeitos ativos",
+  "playerBoard.activeEffectFallback": "Efeito",
+  "playerBoard.removeEffect": "Remover",
+  "playerBoard.removingEffect": "Removendo...",
+  "playerBoard.removeEffectErrorTitle": "Erro ao remover efeito",
+  "playerBoard.removeEffectErrorDescription": "Não foi possível remover o efeito.",
 } as const;


### PR DESCRIPTION
## Summary

Adds an out-of-combat active effects panel to the Player Board and supports removing persisted active effects.

Players can now see active persisted effects from `state_json.active_spell_effects` and remove them directly from the board.

Removing a concentration-linked effect clears its whole concentration group, while removing a non-concentration effect removes only that effect.

## Context

Out-of-combat active effects now have backend lifecycle support:

- manual effects persist in `state_json.active_spell_effects`
- effects restore when combat starts
- long rest clears persisted effects
- concentration is tracked outside combat
- active concentration can be shown and cleared
- persisted concentration is normalized to a single group

Before this PR, players could see some effects indirectly through derived values such as Passive Perception, and they could clear concentration through the concentration card. But there was no compact list showing all persisted active effects.

The basement had monsters. Now at least we installed lighting.

## Backend changes

### Persisted effect removal helper

Updated:

```text
apps/control-server/app/services/combat_service/persistent_effects.py
````

Added:

```py
remove_persisted_effect(state_json, effect_id)
```

Behavior:

* pure function
* idempotent when `effect_id` is unknown
* removes only the target effect for non-concentration effects
* clears the whole `concentration_group` for concentration-linked effects
* treats concentration effects without a group as solo effects and removes only that effect
* removes the `active_spell_effects` key when the list becomes empty

This keeps removal safe for retries/double-clicks while avoiding half-alive concentration spell packages. Nobody wants a spell limping around missing one leg.

### Remove persisted effect endpoint

Added:

```http
DELETE /sessions/{session_id}/state/me/effects/{effect_id}
```

Behavior:

* follows the same pattern as `clear_my_concentration`
* updates `state_json`
* returns updated `SessionStateRead`
* includes derived `activeSpellEffects`
* includes derived `activeConcentration`
* publishes realtime state update via Centrifugo

### Backend tests

Updated:

```text
apps/control-server/tests/test_persistent_effects.py
apps/control-server/tests/test_session_concentration.py
```

Added:

* 8 pure helper tests for `remove_persisted_effect`
* 4 endpoint tests for the DELETE route

Validation:

```text
1844 passed, 1 skipped
```

## Frontend changes

### API

Updated:

```text
apps/control-web/src/shared/api/sessionStatesRepo.ts
```

Added:

```ts
removePersistedEffect(sessionId, effectId)
```

using:

```http
DELETE /sessions/{session_id}/state/me/effects/{effect_id}
```

### Effect label formatting

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/concentrationLabel.ts
```

Added:

```ts
formatActiveEffectLabel(effect)
```

Label priority:

```text
spellName + variantLabel
→ variantLabel
→ display_label
→ spellName
→ spellKey
```

### i18n

Updated PT-BR and EN-US player board dictionaries with:

```text
activeEffectsLabel
activeEffectFallback
removeEffect
removingEffect
removeEffectErrorTitle
removeEffectErrorDescription
```

### Player board resource state

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardResources.ts
```

Now exposes:

```ts
activeSpellEffects
setActiveSpellEffects
```

The value is populated from `sessionStatesRepo.getMine()` and typed as:

```ts
ActiveEffect[] | null
```

### Active effects panel

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
```

Adds a compact active effects panel:

* rendered between the concentration card and the rest card
* hidden when there are no active effects
* each row shows a readable label
* concentration-linked effects show a concentration badge
* each row has a remove button
* remove button disables while that effect is being removed

### Page wiring

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
```

Added:

* `handleRemoveEffect`
* `removingEffectId` state
* success handling from updated session state
* error toasts on failure

On successful removal, the page updates:

```text
playerSheet
activeConcentration
activeSpellEffects
```

The concentration clear handler also now updates `activeSpellEffects` for consistency.

### Frontend tests

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
```

Changes:

* updated existing renders with `onRemoveEffect`
* added 3 tests:

  * renders active effects panel
  * hides panel when empty
  * disables remove button while removing

Validation:

```text
20 frontend tests pass
```

## TypeScript

`tsc --noEmit` still reports only pre-existing errors in unrelated files.

No new TypeScript errors were introduced by this PR.

## Behavior

### Non-concentration effect removal

```text
activeSpellEffects:
- Sabedoria da Coruja
- Bônus X

remove Bônus X
→ only Bônus X is removed
→ Sabedoria da Coruja remains
```

### Concentration-linked effect removal

```text
activeSpellEffects:
- Melhorar Habilidade — Sabedoria da Coruja
- linked concentration effect from same group
- unrelated effect

remove one effect from that concentration group
→ whole concentration group is cleared
→ unrelated effect remains
→ activeConcentration updates/nulls
```

### Unknown effect removal

```text
DELETE unknown effect_id
→ no-op
→ returns current SessionStateRead
```

This keeps the endpoint idempotent and safe for retries.

## Out of scope

This PR intentionally does not implement:

* applying new effects from the UI
* editing effect duration
* duration countdowns
* short/long-rest labels
* full active effect history
* combat active effects panel
* automatic concentration checks
* casting workflow changes
* permanent item effects model
* advanced grouping UI

## Notes for reviewers

The active effects panel is intentionally compact.

The goal is visibility and basic control over persisted out-of-combat effects, not a full active effect management system.

Removing a concentration-linked effect clears the whole concentration group by design, because concentration spells can create multiple linked effects. Removing only one effect from the group could leave a partial spell package active, also known as software necromancy.