### PR TITLE
feat(effects): add lifecycle metadata and badges for active effects

### DIFF
--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
@@ -29,6 +29,13 @@ vi.mock("../../shared/hooks/useLocale", () => ({
         "playerBoard.activeEffectFallback": "Efeito",
         "playerBoard.removeEffect": "Remover",
         "playerBoard.removingEffect": "Removendo...",
+        "playerBoard.lifecycleConcentration": "Concentração",
+        "playerBoard.lifecycleManual": "Manual",
+        "playerBoard.lifecycleRounds": "{count} rodadas",
+        "playerBoard.lifecycleRoundsUnknown": "Por rodadas",
+        "playerBoard.lifecycleUntilTurnStart": "Até início do turno",
+        "playerBoard.lifecycleUntilTurnEnd": "Até fim do turno",
+        "playerBoard.lifecycleLongRest": "Limpa no descanso longo",
       }[key] ?? key),
   }),
 }));
@@ -476,6 +483,92 @@ describe("PlayerBoardStatusPanel", () => {
     expect(markup).toContain("Concentração");
     expect(markup).toContain("Shield of Faith");
     expect(markup).toContain("Remover");
+    // Lifecycle badges for concentration manual effect
+    expect(markup).toContain("Manual");
+    expect(markup).toContain("Limpa no descanso longo");
+  });
+
+  it("renderiza badges de ciclo de vida para efeito manual sem concentração", () => {
+    const markup = renderToStaticMarkup(
+      <PlayerBoardStatusPanel
+        activeSpellEffects={[
+          {
+            id: "eff-1",
+            kind: "spell_effect",
+            duration_type: "manual",
+            created_at: "2026-01-01T00:00:00Z",
+            display_label: "Cat's Grace",
+            metadata: { source_spell_name: "Cat's Grace" },
+          },
+        ] as any}
+        combatActive={false}
+        pendingRoll={null}
+        playerStatus={{
+          level: 3,
+          currentHp: 20,
+          maxHp: 20,
+          hpPercent: 100,
+          tempHp: 0,
+          xpPercent: 10,
+          nextLevelThreshold: 900,
+          experiencePoints: 100,
+          ac: 12,
+          initiative: 1,
+          passivePerception: 13,
+        } as any}
+        restState="exploration"
+        usingHitDie={false}
+        onUseHitDie={() => undefined}
+        onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Cat&#x27;s Grace");
+    expect(markup).toContain("Manual");
+    expect(markup).toContain("Limpa no descanso longo");
+    expect(markup).not.toContain("Concentração");
+  });
+
+  it("renderiza badge de rodadas para efeito com duration_type rounds", () => {
+    const markup = renderToStaticMarkup(
+      <PlayerBoardStatusPanel
+        activeSpellEffects={[
+          {
+            id: "eff-1",
+            kind: "spell_effect",
+            duration_type: "rounds",
+            remaining_rounds: 5,
+            created_at: "2026-01-01T00:00:00Z",
+            display_label: "Haste",
+            metadata: {},
+          },
+        ] as any}
+        combatActive={false}
+        pendingRoll={null}
+        playerStatus={{
+          level: 3,
+          currentHp: 20,
+          maxHp: 20,
+          hpPercent: 100,
+          tempHp: 0,
+          xpPercent: 10,
+          nextLevelThreshold: 900,
+          experiencePoints: 100,
+          ac: 12,
+          initiative: 1,
+          passivePerception: 13,
+        } as any}
+        restState="exploration"
+        usingHitDie={false}
+        onUseHitDie={() => undefined}
+        onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Haste");
+    expect(markup).toContain("5 rodadas");
   });
 
   it("não renderiza painel de efeitos ativos quando a lista está vazia", () => {

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
@@ -5,6 +5,7 @@ import { useLocale } from "../../shared/hooks/useLocale";
 import { SpellSlotSummary } from "../../shared/ui/SpellSlotSummary";
 import { formatPassiveBonusBreakdown } from "../../features/character-sheet/utils/passiveSkillBonusDisplay";
 import { formatActiveConcentrationLabel, formatActiveEffectLabel } from "./concentrationLabel";
+import { getActiveEffectLifecycleBadges } from "./activeEffectLifecycle";
 import type { PendingRoll, PlayerBoardStatusSummary } from "./playerBoard.types";
 import {
   DeathSaveCard,
@@ -226,17 +227,26 @@ export const PlayerBoardStatusPanel = ({
               <ul className="mt-3 space-y-2">
                 {activeSpellEffects.map((effect) => {
                   const label = formatActiveEffectLabel(effect) ?? t("playerBoard.activeEffectFallback");
-                  const isConcentration = Boolean(
-                    (effect.metadata as Record<string, unknown> | null)?.concentration,
-                  );
+                  const lifecycleBadges = getActiveEffectLifecycleBadges(effect);
                   const isRemoving = removingEffectId === effect.id;
                   return (
                     <li key={effect.id} className="flex items-center justify-between gap-3">
                       <div className="min-w-0">
                         <p className="truncate text-sm font-medium text-white">{label}</p>
-                        {isConcentration ? (
-                          <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-violet-400">
-                            {t("playerBoard.activeConcentrationLabel")}
+                        {lifecycleBadges.length > 0 ? (
+                          <p className="mt-0.5 flex flex-wrap gap-x-1.5 gap-y-0.5">
+                            {lifecycleBadges.map((badge, index) => (
+                              <span key={badge.key} className="inline-flex items-center gap-x-1.5">
+                                {index > 0 ? (
+                                  <span className="text-[10px] text-slate-600">{"\u00B7"}</span>
+                                ) : null}
+                                <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-violet-400">
+                                  {badge.params
+                                    ? t(badge.i18nKey).replace("{count}", String(badge.params.count))
+                                    : t(badge.i18nKey)}
+                                </span>
+                              </span>
+                            ))}
                           </p>
                         ) : null}
                       </div>

--- a/apps/control-web/src/pages/PlayerBoardPage/activeEffectLifecycle.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/activeEffectLifecycle.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { getActiveEffectLifecycleBadges } from "./activeEffectLifecycle";
+
+describe("getActiveEffectLifecycleBadges", () => {
+  it("returns concentration + manual + long-rest for concentration manual effect", () => {
+    const effect = {
+      id: "eff-1",
+      kind: "spell_effect",
+      duration_type: "manual",
+      metadata: { concentration: true, concentration_group: "grp-1" },
+    };
+    const badges = getActiveEffectLifecycleBadges(effect);
+    expect(badges.map((b) => b.key)).toEqual(["concentration", "manual", "long-rest"]);
+  });
+
+  it("returns manual + long-rest for non-concentration manual effect", () => {
+    const effect = {
+      id: "eff-1",
+      kind: "spell_effect",
+      duration_type: "manual",
+      metadata: { source_spell_name: "Cat's Grace" },
+    };
+    const badges = getActiveEffectLifecycleBadges(effect);
+    expect(badges.map((b) => b.key)).toEqual(["manual", "long-rest"]);
+  });
+
+  it("returns rounds badge with count when remaining_rounds is a number", () => {
+    const effect = {
+      id: "eff-1",
+      kind: "spell_effect",
+      duration_type: "rounds",
+      remaining_rounds: 3,
+    };
+    const badges = getActiveEffectLifecycleBadges(effect);
+    expect(badges).toHaveLength(1);
+    expect(badges[0].key).toBe("rounds");
+    expect(badges[0].params).toEqual({ count: 3 });
+  });
+
+  it("returns rounds-unknown badge when remaining_rounds is missing", () => {
+    const effect = {
+      id: "eff-1",
+      kind: "spell_effect",
+      duration_type: "rounds",
+    };
+    const badges = getActiveEffectLifecycleBadges(effect);
+    expect(badges).toHaveLength(1);
+    expect(badges[0].key).toBe("rounds-unknown");
+    expect(badges[0].params).toBeUndefined();
+  });
+
+  it("returns until-turn-start badge for until_turn_start duration", () => {
+    const effect = {
+      id: "eff-1",
+      kind: "spell_effect",
+      duration_type: "until_turn_start",
+    };
+    const badges = getActiveEffectLifecycleBadges(effect);
+    expect(badges).toHaveLength(1);
+    expect(badges[0].key).toBe("until-turn-start");
+  });
+
+  it("returns until-turn-end badge for until_turn_end duration", () => {
+    const effect = {
+      id: "eff-1",
+      kind: "spell_effect",
+      duration_type: "until_turn_end",
+    };
+    const badges = getActiveEffectLifecycleBadges(effect);
+    expect(badges).toHaveLength(1);
+    expect(badges[0].key).toBe("until-turn-end");
+  });
+
+  it("returns empty array for unknown duration type", () => {
+    const effect = {
+      id: "eff-1",
+      kind: "spell_effect",
+      duration_type: "unknown",
+    };
+    const badges = getActiveEffectLifecycleBadges(effect);
+    expect(badges).toHaveLength(0);
+  });
+
+  it("returns empty array when duration_type is missing", () => {
+    const effect = {
+      id: "eff-1",
+      kind: "spell_effect",
+    };
+    const badges = getActiveEffectLifecycleBadges(effect);
+    expect(badges).toHaveLength(0);
+  });
+
+  it("returns concentration only for concentration effect without manual duration", () => {
+    const effect = {
+      id: "eff-1",
+      kind: "spell_effect",
+      duration_type: "rounds",
+      remaining_rounds: 5,
+      metadata: { concentration: true },
+    };
+    const badges = getActiveEffectLifecycleBadges(effect);
+    expect(badges.map((b) => b.key)).toEqual(["concentration", "rounds"]);
+  });
+});

--- a/apps/control-web/src/pages/PlayerBoardPage/activeEffectLifecycle.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/activeEffectLifecycle.ts
@@ -1,0 +1,62 @@
+import type { LocaleKey } from "../../shared/i18n";
+
+export type ActiveEffectLifecycleBadge = {
+  key: string;
+  i18nKey: LocaleKey;
+  params?: Record<string, string | number>;
+};
+
+export const getActiveEffectLifecycleBadges = (
+  effect: Record<string, unknown>,
+): ActiveEffectLifecycleBadge[] => {
+  const badges: ActiveEffectLifecycleBadge[] = [];
+  const metadata = ((effect.metadata ?? {}) as Record<string, unknown>) || {};
+  const durationType = effect.duration_type as string | undefined;
+
+  if (metadata.concentration === true) {
+    badges.push({
+      key: "concentration",
+      i18nKey: "playerBoard.lifecycleConcentration",
+    });
+  }
+
+  if (durationType === "manual") {
+    badges.push({
+      key: "manual",
+      i18nKey: "playerBoard.lifecycleManual",
+    });
+  } else if (durationType === "rounds") {
+    const remaining = effect.remaining_rounds;
+    if (typeof remaining === "number") {
+      badges.push({
+        key: "rounds",
+        i18nKey: "playerBoard.lifecycleRounds",
+        params: { count: remaining },
+      });
+    } else {
+      badges.push({
+        key: "rounds-unknown",
+        i18nKey: "playerBoard.lifecycleRoundsUnknown",
+      });
+    }
+  } else if (durationType === "until_turn_start") {
+    badges.push({
+      key: "until-turn-start",
+      i18nKey: "playerBoard.lifecycleUntilTurnStart",
+    });
+  } else if (durationType === "until_turn_end") {
+    badges.push({
+      key: "until-turn-end",
+      i18nKey: "playerBoard.lifecycleUntilTurnEnd",
+    });
+  }
+
+  if (durationType === "manual") {
+    badges.push({
+      key: "long-rest",
+      i18nKey: "playerBoard.lifecycleLongRest",
+    });
+  }
+
+  return badges;
+};

--- a/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
@@ -187,4 +187,11 @@ export const playerBoardEnUSDictionary = {
   "playerBoard.removingEffect": "Removing...",
   "playerBoard.removeEffectErrorTitle": "Failed to remove effect",
   "playerBoard.removeEffectErrorDescription": "Could not remove the effect.",
+  "playerBoard.lifecycleConcentration": "Concentration",
+  "playerBoard.lifecycleManual": "Manual",
+  "playerBoard.lifecycleRounds": "{count} rounds",
+  "playerBoard.lifecycleRoundsUnknown": "By rounds",
+  "playerBoard.lifecycleUntilTurnStart": "Until turn start",
+  "playerBoard.lifecycleUntilTurnEnd": "Until turn end",
+  "playerBoard.lifecycleLongRest": "Clears on long rest",
 } as const;

--- a/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
@@ -187,4 +187,11 @@ export const playerBoardPtBRDictionary = {
   "playerBoard.removingEffect": "Removendo...",
   "playerBoard.removeEffectErrorTitle": "Erro ao remover efeito",
   "playerBoard.removeEffectErrorDescription": "Não foi possível remover o efeito.",
+  "playerBoard.lifecycleConcentration": "Concentração",
+  "playerBoard.lifecycleManual": "Manual",
+  "playerBoard.lifecycleRounds": "{count} rodadas",
+  "playerBoard.lifecycleRoundsUnknown": "Por rodadas",
+  "playerBoard.lifecycleUntilTurnStart": "Até início do turno",
+  "playerBoard.lifecycleUntilTurnEnd": "Até fim do turno",
+  "playerBoard.lifecycleLongRest": "Limpa no descanso longo",
 } as const;


### PR DESCRIPTION
## Summary

Adds lifecycle metadata badges to persisted out-of-combat active effects in the Player Board.

Active effects now display compact metadata such as concentration, manual duration, round duration, and long-rest cleanup behavior.

This is a display-only change. No backend behavior or effect lifecycle rules were changed.

## Context

The Player Board already has an out-of-combat active effects panel backed by `activeSpellEffects`.

Before this PR, the panel showed active effect names and removal actions, but did not explain lifecycle details such as:

- whether the effect requires concentration
- whether it is manually managed
- whether it clears on long rest
- whether it has a round-based duration

This PR adds compact lifecycle badges to make persisted effects easier to understand.

## What changed

### Lifecycle helper

Added:

```text
apps/control-web/src/pages/PlayerBoardPage/activeEffectLifecycle.ts
````

Introduces:

```ts
getActiveEffectLifecycleBadges(effect)
```

The helper returns typed lifecycle badge metadata:

```ts
ActiveEffectLifecycleBadge[]
```

Badge labels are represented by i18n keys typed as `LocaleKey`, keeping rendering TypeScript-safe.

Supported badges include:

* concentration
* manual
* long-rest cleanup
* rounds with count
* rounds with unknown count
* until turn start
* until turn end

Examples:

```text
Concentração · Manual · Limpa no descanso longo
Manual · Limpa no descanso longo
5 rodadas
Por rodadas
Até início do turno
Até fim do turno
```

### i18n

Updated:

```text
apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
apps/control-web/src/shared/i18n/enUS/playerBoard.ts
```

Added lifecycle keys:

```text
lifecycleConcentration
lifecycleManual
lifecycleRounds
lifecycleRoundsUnknown
lifecycleUntilTurnStart
lifecycleUntilTurnEnd
lifecycleLongRest
```

PT-BR examples:

```text
Concentração
Manual
{count} rodadas
Por rodadas
Até início do turno
Até fim do turno
Limpa no descanso longo
```

EN-US examples:

```text
Concentration
Manual
{count} rounds
By rounds
Until turn start
Until turn end
Clears on long rest
```

### Player Board active effects panel

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
```

Replaced the previous concentration-only badge with a lifecycle badge row.

Badges are rendered compactly using a middle-dot separator:

```text
Concentração · Manual · Limpa no descanso longo
```

The visual style keeps the existing compact uppercase treatment:

```text
text-[10px] font-semibold uppercase tracking-[0.2em] text-violet-400
```

Round-count interpolation is handled using the project’s existing string replacement pattern.

### Tests

Added:

```text
apps/control-web/src/pages/PlayerBoardPage/activeEffectLifecycle.test.ts
```

Coverage includes:

* concentration + manual effect
* non-concentration manual effect
* rounds with count
* rounds without count
* until turn start
* until turn end
* unknown duration
* missing `duration_type`
* concentration without manual duration

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
```

Changes:

* added lifecycle i18n keys to the `useLocale` mock
* updated active effects assertions for lifecycle badges
* added tests for non-concentration manual badges
* added test for round-count badge rendering

## Behavior

Example output:

```text
Efeitos ativos

Melhorar Habilidade — Sabedoria da Coruja
Concentração · Manual · Limpa no descanso longo
[Remover]

Graça do Gato
Manual · Limpa no descanso longo
[Remover]

Haste
5 rodadas
[Remover]
```

## Validation

Frontend targeted tests:

```bash
cd apps/control-web
npx vitest run activeEffectLifecycle PlayerBoardStatusPanel
```

Result:

```text
31 tests passed
```

TypeScript:

```text
No new TypeScript errors in modified files
```

Backend regression:

```text
1844 passed, 1 skipped
```

No backend files were changed.

## Out of scope

This PR intentionally does not implement:

* new duration rules
* real expiration/countdown behavior
* `until_long_rest` duration type
* short rest cleanup
* concentration replacement warnings
* casting workflow changes
* active effects grouping UI
* backend changes
* combat active effects panel changes

## Notes for reviewers

This PR only displays lifecycle metadata already present on active effects.

Manual effects receive the long-rest cleanup badge because this panel only shows persisted out-of-combat effects, and that bucket is cleared on long rest.

No effect persistence or duration behavior was changed.
