### PR TITLE
feat(effects): add warning for replacing out-of-combat concentration …

### DIFF
--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useLocale } from "../../shared/hooks/useLocale";
 import { useCampaigns } from "../../features/campaign-select";
@@ -26,6 +26,7 @@ import { usePlayerBoardRealtime } from "./usePlayerBoardRealtime";
 import { sessionStatesRepo } from "../../shared/api/sessionStatesRepo";
 import { usePlayerBoardResources } from "./usePlayerBoardResources";
 import { usePlayerBoardSummary } from "./usePlayerBoardSummary";
+import { getConcentrationReplacementNotice } from "./concentrationLabel";
 import { useSession } from "../../features/sessions";
 import { CombatModeBar } from "../../features/combat-ui/components/CombatModeBar";
 import { PlayerCombatModeShell } from "../../features/combat-ui/player/PlayerCombatModeShell";
@@ -168,6 +169,7 @@ export const PlayerBoardPage = () => {
   });
   const [clearingConcentration, setClearingConcentration] = useState(false);
   const [removingEffectId, setRemovingEffectId] = useState<string | null>(null);
+  const previousConcentrationRef = useRef<import("../../entities/character").ActiveConcentration | null>(null);
 
   const handleClearConcentration = async () => {
     if (!activeSession?.id || clearingConcentration) return;
@@ -242,6 +244,25 @@ export const PlayerBoardPage = () => {
       collapseCombatUi();
     }
   }, [collapseCombatUi, combatActive, combatUiExpanded, pendingRoll?.rollType]);
+
+  useEffect(() => {
+    const notice = getConcentrationReplacementNotice(
+      previousConcentrationRef.current,
+      activeConcentration,
+    );
+    previousConcentrationRef.current = activeConcentration ?? null;
+    if (notice) {
+      const prevLabel = notice.previousLabel ?? t("playerBoard.activeEffectFallback");
+      const nextLabel = notice.nextLabel ?? t("playerBoard.activeEffectFallback");
+      showToast({
+        variant: "info",
+        title: t("playerBoard.concentrationReplacedTitle"),
+        description: t("playerBoard.concentrationReplacedDescription")
+          .replace("{previous}", prevLabel)
+          .replace("{next}", nextLabel),
+      });
+    }
+  }, [activeConcentration, showToast, t]);
 
   return (
     <section className="space-y-6">

--- a/apps/control-web/src/pages/PlayerBoardPage/concentrationLabel.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/concentrationLabel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatActiveConcentrationLabel } from "./concentrationLabel";
+import { formatActiveConcentrationLabel, getConcentrationReplacementNotice } from "./concentrationLabel";
 
 describe("formatActiveConcentrationLabel", () => {
   it("returns null when concentration is null", () => {
@@ -48,5 +48,134 @@ describe("formatActiveConcentrationLabel", () => {
       effectIds: ["eff-1"],
     });
     expect(result).toBeNull();
+  });
+});
+
+describe("getConcentrationReplacementNotice", () => {
+  it("returns null when previous is null (initial load)", () => {
+    const result = getConcentrationReplacementNotice(null, {
+      spellName: "Haste",
+      effectIds: ["eff-1"],
+      concentrationGroup: "grp-b",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when next is null (manual clear)", () => {
+    const result = getConcentrationReplacementNotice(
+      {
+        spellName: "Bless",
+        effectIds: ["eff-1"],
+        concentrationGroup: "grp-a",
+      },
+      null,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when group is the same", () => {
+    const result = getConcentrationReplacementNotice(
+      {
+        spellName: "Bless",
+        variantLabel: "Ally",
+        effectIds: ["eff-1"],
+        concentrationGroup: "grp-a",
+      },
+      {
+        spellName: "Bless",
+        variantLabel: "Ally",
+        effectIds: ["eff-2"],
+        concentrationGroup: "grp-a",
+      },
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns notice when group changes", () => {
+    const result = getConcentrationReplacementNotice(
+      {
+        spellName: "Bless",
+        variantLabel: "Ally",
+        effectIds: ["eff-1"],
+        concentrationGroup: "grp-a",
+      },
+      {
+        spellName: "Haste",
+        effectIds: ["eff-2"],
+        concentrationGroup: "grp-b",
+      },
+    );
+    expect(result).not.toBeNull();
+    expect(result?.previousLabel).toBe("Bless — Ally");
+    expect(result?.nextLabel).toBe("Haste");
+  });
+
+  it("returns null when both are null", () => {
+    const result = getConcentrationReplacementNotice(null, null);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when both lack group key and same label", () => {
+    const result = getConcentrationReplacementNotice(
+      {
+        spellName: "Bless",
+        effectIds: ["eff-1"],
+      },
+      {
+        spellName: "Bless",
+        effectIds: ["eff-2"],
+      },
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns notice when both lack group key but labels differ", () => {
+    const result = getConcentrationReplacementNotice(
+      {
+        spellName: "Bless",
+        effectIds: ["eff-1"],
+      },
+      {
+        spellName: "Haste",
+        effectIds: ["eff-2"],
+      },
+    );
+    expect(result).not.toBeNull();
+    expect(result?.previousLabel).toBe("Bless");
+    expect(result?.nextLabel).toBe("Haste");
+  });
+
+  it("returns notice when previous has no label (only effectIds)", () => {
+    const result = getConcentrationReplacementNotice(
+      {
+        effectIds: ["eff-1"],
+        concentrationGroup: "grp-a",
+      },
+      {
+        spellName: "Haste",
+        effectIds: ["eff-2"],
+        concentrationGroup: "grp-b",
+      },
+    );
+    expect(result).not.toBeNull();
+    expect(result?.previousLabel).toBeNull();
+    expect(result?.nextLabel).toBe("Haste");
+  });
+
+  it("returns notice when next has no label (only effectIds)", () => {
+    const result = getConcentrationReplacementNotice(
+      {
+        spellName: "Bless",
+        effectIds: ["eff-1"],
+        concentrationGroup: "grp-a",
+      },
+      {
+        effectIds: ["eff-2"],
+        concentrationGroup: "grp-b",
+      },
+    );
+    expect(result).not.toBeNull();
+    expect(result?.previousLabel).toBe("Bless");
+    expect(result?.nextLabel).toBeNull();
   });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/concentrationLabel.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/concentrationLabel.ts
@@ -12,6 +12,30 @@ export const formatActiveConcentrationLabel = (
   return null;
 };
 
+export const getConcentrationReplacementNotice = (
+  previous: ActiveConcentration | null | undefined,
+  next: ActiveConcentration | null | undefined,
+): { previousLabel: string | null; nextLabel: string | null } | null => {
+  if (!next) return null;
+  if (!previous) return null;
+
+  const prevGroup = previous.concentrationGroup ?? null;
+  const nextGroup = next.concentrationGroup ?? null;
+
+  if (prevGroup && nextGroup && prevGroup === nextGroup) return null;
+
+  if (!prevGroup && !nextGroup) {
+    const prevLabel = formatActiveConcentrationLabel(previous);
+    const nextLabel = formatActiveConcentrationLabel(next);
+    if (prevLabel === nextLabel) return null;
+  }
+
+  return {
+    previousLabel: formatActiveConcentrationLabel(previous),
+    nextLabel: formatActiveConcentrationLabel(next),
+  };
+};
+
 export const formatActiveEffectLabel = (
   effect: Record<string, unknown>,
 ): string | null => {

--- a/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
@@ -194,4 +194,6 @@ export const playerBoardEnUSDictionary = {
   "playerBoard.lifecycleUntilTurnStart": "Until turn start",
   "playerBoard.lifecycleUntilTurnEnd": "Until turn end",
   "playerBoard.lifecycleLongRest": "Clears on long rest",
+  "playerBoard.concentrationReplacedTitle": "Concentration replaced",
+  "playerBoard.concentrationReplacedDescription": "Previous concentration ended: {previous}. New concentration: {next}.",
 } as const;

--- a/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
@@ -194,4 +194,6 @@ export const playerBoardPtBRDictionary = {
   "playerBoard.lifecycleUntilTurnStart": "Até início do turno",
   "playerBoard.lifecycleUntilTurnEnd": "Até fim do turno",
   "playerBoard.lifecycleLongRest": "Limpa no descanso longo",
+  "playerBoard.concentrationReplacedTitle": "Concentração substituída",
+  "playerBoard.concentrationReplacedDescription": "Concentração anterior encerrada: {previous}. Nova concentração: {next}.",
 } as const;


### PR DESCRIPTION
## Summary

Adds an informational toast when out-of-combat concentration is replaced.

When `activeConcentration` changes from one concentration to another, the Player Board now informs the user that the previous concentration ended and shows the new one.

This is a frontend-only UX change. No backend behavior was changed.

## Context

Out-of-combat concentration is now supported end-to-end:

- manual concentration effects persist outside combat
- `activeConcentration` is derived from persisted effects
- PlayerBoard shows active concentration
- users can clear concentration
- the backend enforces a single persisted concentration group

Mechanically, when a new concentration replaces an old one, the previous concentration disappears correctly.

Before this PR, that replacement could look like an effect vanished without explanation.

Now the UI says what happened instead of doing sleight of hand in a dark alley.

## What changed

### Concentration replacement helper

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/concentrationLabel.ts
````

Added:

```ts
getConcentrationReplacementNotice(previous, next)
```

Behavior:

* returns `null` on initial load
* returns `null` on manual clear
* returns `null` when the concentration group is unchanged
* returns `null` when both concentrations lack group keys but have the same label
* returns a notice when concentration groups differ
* returns a notice when labels differ and no group keys exist
* returns nullable labels so the UI can apply localized fallbacks

### i18n

Updated PT-BR and EN-US player board dictionaries.

Added:

```text
playerBoard.concentrationReplacedTitle
playerBoard.concentrationReplacedDescription
```

PT-BR:

```text
Concentração substituída
Concentração anterior encerrada: {previous}. Nova concentração: {next}.
```

EN-US:

```text
Concentration replaced
Previous concentration ended: {previous}. New concentration: {next}.
```

### PlayerBoardPage wiring

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
```

Added:

* `useRef` to track the previous concentration
* `useEffect` that watches `activeConcentration`
* informational toast when replacement is detected
* fallback label through `playerBoard.activeEffectFallback`

The implementation catches all update paths because they all eventually update `activeConcentration`:

* polling / `refreshPlayerState`
* campaign events
* clear concentration
* remove effect
* direct session state refresh

No toast is shown for:

* initial load
* manual clear to `null`
* same concentration group
* same label without group key

Toast variant:

```ts
variant: "info"
```

## Example

```text
Concentração substituída
Concentração anterior encerrada: Melhorar Habilidade — Sabedoria da Coruja. Nova concentração: Haste.
```

## Tests

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/concentrationLabel.test.ts
```

Added 9 tests for `getConcentrationReplacementNotice`:

* no previous + new returns null
* previous + null next returns null
* same group returns null
* different groups returns notice
* both null returns null
* no group + same label returns null
* no group + different labels returns notice
* previous label missing returns notice with `null`
* next label missing returns notice with `null`

## Validation

Frontend:

```bash
cd apps/control-web
npx vitest run concentrationLabel
```

Result:

```text
16 tests passed
```

TypeScript:

```text
No new TypeScript errors in modified files
```

Backend regression:

```text
1844 passed, 1 skipped
```

No backend files were changed.

## Out of scope

This PR intentionally does not implement:

* confirmation before replacing concentration
* undo replacement
* out-of-combat casting workflow changes
* spell slot handling
* damage-triggered concentration checks
* active effects history/log
* backend event logs
* combat concentration behavior changes
