### PR TITLE
feat(character-sheet): show persisted active effects on character sheet

### DIFF
--- a/apps/control-web/src/features/active-effects/activeEffectDisplay.test.ts
+++ b/apps/control-web/src/features/active-effects/activeEffectDisplay.test.ts
@@ -1,5 +1,47 @@
 import { describe, expect, it } from "vitest";
-import { getActiveEffectLifecycleBadges } from "./activeEffectLifecycle";
+import { formatActiveEffectLabel, getActiveEffectLifecycleBadges } from "./activeEffectDisplay";
+
+describe("formatActiveEffectLabel", () => {
+  it("returns spellName + variantLabel when both exist", () => {
+    const result = formatActiveEffectLabel({
+      metadata: { source_spell_name: "Bless", selected_variant_label: "Ally" },
+    });
+    expect(result).toBe("Bless — Ally");
+  });
+
+  it("falls back to variantLabel alone when spellName is missing", () => {
+    const result = formatActiveEffectLabel({
+      metadata: { selected_variant_label: "Ally" },
+    });
+    expect(result).toBe("Ally");
+  });
+
+  it("falls back to display_label when variantLabel is missing", () => {
+    const result = formatActiveEffectLabel({
+      display_label: "Owl's Wisdom",
+    });
+    expect(result).toBe("Owl's Wisdom");
+  });
+
+  it("falls back to spellName when display_label is missing", () => {
+    const result = formatActiveEffectLabel({
+      metadata: { source_spell_name: "Bless" },
+    });
+    expect(result).toBe("Bless");
+  });
+
+  it("falls back to spellKey when all names are missing", () => {
+    const result = formatActiveEffectLabel({
+      metadata: { source_spell_key: "bless" },
+    });
+    expect(result).toBe("bless");
+  });
+
+  it("returns null when nothing is available", () => {
+    const result = formatActiveEffectLabel({});
+    expect(result).toBeNull();
+  });
+});
 
 describe("getActiveEffectLifecycleBadges", () => {
   it("returns concentration + manual + long-rest for concentration manual effect", () => {

--- a/apps/control-web/src/features/active-effects/activeEffectDisplay.ts
+++ b/apps/control-web/src/features/active-effects/activeEffectDisplay.ts
@@ -6,6 +6,23 @@ export type ActiveEffectLifecycleBadge = {
   params?: Record<string, string | number>;
 };
 
+export const formatActiveEffectLabel = (
+  effect: Record<string, unknown>,
+): string | null => {
+  const metadata = ((effect.metadata ?? {}) as Record<string, unknown>) || {};
+  const variantLabel = metadata.selected_variant_label as string | undefined;
+  const spellName = metadata.source_spell_name as string | undefined;
+  const displayLabel = effect.display_label as string | undefined;
+  const spellKey = metadata.source_spell_key as string | undefined;
+
+  if (spellName && variantLabel) return `${spellName} \u2014 ${variantLabel}`;
+  if (variantLabel) return variantLabel;
+  if (displayLabel) return displayLabel;
+  if (spellName) return spellName;
+  if (spellKey) return spellKey;
+  return null;
+};
+
 export const getActiveEffectLifecycleBadges = (
   effect: Record<string, unknown>,
 ): ActiveEffectLifecycleBadge[] => {

--- a/apps/control-web/src/features/active-effects/index.ts
+++ b/apps/control-web/src/features/active-effects/index.ts
@@ -1,0 +1,2 @@
+export { formatActiveEffectLabel, getActiveEffectLifecycleBadges } from "./activeEffectDisplay";
+export type { ActiveEffectLifecycleBadge } from "./activeEffectDisplay";

--- a/apps/control-web/src/features/character-sheet/components/CharacterSheet.tsx
+++ b/apps/control-web/src/features/character-sheet/components/CharacterSheet.tsx
@@ -30,6 +30,7 @@ import {
 } from "../utils/proficiencyCatalog";
 import { useLocale } from "../../../shared/hooks/useLocale";
 import { useCharacterSheetDerived } from "../hooks/useCharacterSheetDerived";
+import { formatActiveEffectLabel, getActiveEffectLifecycleBadges } from "../../../features/active-effects";
 
 type Props = {
   partyId?: string | null;
@@ -69,6 +70,7 @@ export const CharacterSheet = ({
   });
   const { sheet, activeSpellEffects } = actions;
   const { t } = useLocale();
+  const sheetActiveEffects = activeSpellEffects ?? [];
   const isCreation = mode === "creation";
   const isCreationDraft = isCreation && creationDraftMode;
   const isPlay = mode === "play";
@@ -509,6 +511,41 @@ export const CharacterSheet = ({
             onToggle={actions.toggleCondition}
             readOnly={isRuntimeReadOnly || isSheetLocked}
           />
+        )}
+
+        {!isCreation && sheetActiveEffects.length > 0 && (
+          <section className="rounded-3xl border border-white/8 bg-white/4 px-4 py-4">
+            <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-slate-400">
+              {t("playerBoard.activeEffectsLabel")}
+            </p>
+            <ul className="mt-3 space-y-2">
+              {sheetActiveEffects.map((effect) => {
+                const label = formatActiveEffectLabel(effect) ?? t("playerBoard.activeEffectFallback");
+                const badges = getActiveEffectLifecycleBadges(effect);
+                return (
+                  <li key={effect.id} className="min-w-0">
+                    <p className="truncate text-sm font-medium text-white">{label}</p>
+                    {badges.length > 0 ? (
+                      <p className="mt-0.5 flex flex-wrap gap-x-1.5 gap-y-0.5">
+                        {badges.map((badge, index) => (
+                          <span key={badge.key} className="inline-flex items-center gap-x-1.5">
+                            {index > 0 ? (
+                              <span className="text-[10px] text-slate-600">{"\u00B7"}</span>
+                            ) : null}
+                            <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-violet-400">
+                              {badge.params
+                                ? t(badge.i18nKey).replace("{count}", String(badge.params.count))
+                                : t(badge.i18nKey)}
+                            </span>
+                          </span>
+                        ))}
+                      </p>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
         )}
 
         <FeaturesTraits

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
@@ -4,8 +4,8 @@ import type { CharacterSheet } from "../../features/character-sheet/model/charac
 import { useLocale } from "../../shared/hooks/useLocale";
 import { SpellSlotSummary } from "../../shared/ui/SpellSlotSummary";
 import { formatPassiveBonusBreakdown } from "../../features/character-sheet/utils/passiveSkillBonusDisplay";
-import { formatActiveConcentrationLabel, formatActiveEffectLabel } from "./concentrationLabel";
-import { getActiveEffectLifecycleBadges } from "./activeEffectLifecycle";
+import { formatActiveConcentrationLabel } from "./concentrationLabel";
+import { formatActiveEffectLabel, getActiveEffectLifecycleBadges } from "../../features/active-effects";
 import type { PendingRoll, PlayerBoardStatusSummary } from "./playerBoard.types";
 import {
   DeathSaveCard,

--- a/apps/control-web/src/pages/PlayerBoardPage/concentrationLabel.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/concentrationLabel.ts
@@ -36,19 +36,4 @@ export const getConcentrationReplacementNotice = (
   };
 };
 
-export const formatActiveEffectLabel = (
-  effect: Record<string, unknown>,
-): string | null => {
-  const metadata = ((effect.metadata ?? {}) as Record<string, unknown>) || {};
-  const variantLabel = metadata.selected_variant_label as string | undefined;
-  const spellName = metadata.source_spell_name as string | undefined;
-  const displayLabel = effect.display_label as string | undefined;
-  const spellKey = metadata.source_spell_key as string | undefined;
 
-  if (spellName && variantLabel) return `${spellName} \u2014 ${variantLabel}`;
-  if (variantLabel) return variantLabel;
-  if (displayLabel) return displayLabel;
-  if (spellName) return spellName;
-  if (spellKey) return spellKey;
-  return null;
-};


### PR DESCRIPTION
# feat(character-sheet): show persisted active effects on character sheet

## Summary

Adds a display-only persisted active effects panel to the Character Sheet.

The Character Sheet now shows active effects from `activeSpellEffects`, using the same label and lifecycle formatting as the Player Board.

This PR also moves active effect display helpers into a shared `features/active-effects` module so Player Board and Character Sheet can reuse the same formatting without cross-page imports or duplicated logic.

## Context

Out-of-combat active effects are now visible and manageable from the Player Board:

- persisted effects are stored in `state_json.active_spell_effects`
- active effects can be shown on the Player Board
- lifecycle badges explain duration/concentration/long-rest cleanup
- effects can be removed from the Player Board
- active concentration is shown and can be cleared

The Character Sheet already consumed `activeSpellEffects` for derived values such as Passive Perception, but it did not show which active effects were responsible.

This PR fixes that visibility gap.

## What changed

### Shared active effects module

Added:

```text
apps/control-web/src/features/active-effects/activeEffectDisplay.ts
apps/control-web/src/features/active-effects/index.ts
apps/control-web/src/features/active-effects/activeEffectDisplay.test.ts
````

The new shared module exposes:

```ts
formatActiveEffectLabel(effect)
getActiveEffectLifecycleBadges(effect)
ActiveEffectLifecycleBadge
```

These helpers are now shared by:

* `PlayerBoardStatusPanel`
* `CharacterSheet`

No cross-page helper imports. No duplicated effect formatting. No spaghetti wearing a little wizard hat.

### Helper cleanup

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/concentrationLabel.ts
```

Removed `formatActiveEffectLabel`.

Kept:

```ts
formatActiveConcentrationLabel
getConcentrationReplacementNotice
```

Deleted old page-local lifecycle helper files:

```text
apps/control-web/src/pages/PlayerBoardPage/activeEffectLifecycle.ts
apps/control-web/src/pages/PlayerBoardPage/activeEffectLifecycle.test.ts
```

### PlayerBoard import update

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
```

Now imports active effect display helpers from:

```ts
features/active-effects
```

PlayerBoard behavior remains unchanged.

### Character Sheet active effects panel

Updated:

```text
apps/control-web/src/features/character-sheet/components/CharacterSheet.tsx
```

Added a display-only active effects panel.

Behavior:

* renders after `<Conditions />`
* renders before `<FeaturesTraits />`
* only appears outside creation mode
* only appears when `activeSpellEffects` exist
* uses shared label formatting
* uses shared lifecycle badges
* uses the same compact visual language as PlayerBoard
* does not include remove controls in v1

Added safe normalization:

```ts
const sheetActiveEffects = activeSpellEffects ?? [];
```

So the sheet does not perform the ancient JavaScript ritual of exploding on `undefined.length`.

## Example

```text
Efeitos ativos

Melhorar Habilidade — Sabedoria da Coruja
Concentração · Manual · Limpa no descanso longo

Graça do Gato
Manual · Limpa no descanso longo
```

## Tests

Added/moved/expanded:

```text
apps/control-web/src/features/active-effects/activeEffectDisplay.test.ts
```

Coverage includes:

* 6 tests for `formatActiveEffectLabel`
* 9 tests for `getActiveEffectLifecycleBadges`

Existing tests remain green:

```text
concentrationLabel.test.ts
PlayerBoardStatusPanel.test.tsx
```

## Validation

Frontend:

```bash
cd apps/control-web
npx vitest run activeEffectDisplay concentrationLabel PlayerBoardStatusPanel
```

Result:

```text
46 tests passed
```

TypeScript:

```text
No new TypeScript errors in modified files
```

Backend:

```text
1844 passed, 1 skipped
```

No backend changes.

## Out of scope

This PR intentionally does not implement:

* removing effects from the Character Sheet
* applying effects from the Character Sheet
* backend changes
* active effect duration countdowns
* active effect editing
* combat active effects panel
* GM sheet view support
* active effect history/log

## Notes for reviewers

This PR is display-only for the Character Sheet.

The Player Board remains the control surface for removing persisted effects. The Character Sheet now provides visibility so derived stat changes, such as Passive Perception bonuses, are easier to understand from the sheet itself.
