### PR TITLE
feat(character-sheet): allow removing persisted active effects from character sheet

### DIFF
--- a/apps/control-web/src/features/character-sheet/components/CharacterActiveEffectsPanel.test.tsx
+++ b/apps/control-web/src/features/character-sheet/components/CharacterActiveEffectsPanel.test.tsx
@@ -1,0 +1,152 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { CharacterActiveEffectsPanel } from "./CharacterActiveEffectsPanel";
+
+vi.mock("../../../shared/hooks/useLocale", () => ({
+  useLocale: () => ({
+    t: (key: string) =>
+      ({
+        "playerBoard.activeEffectsLabel": "Efeitos ativos",
+        "playerBoard.activeEffectFallback": "Efeito",
+        "playerBoard.removeEffect": "Remover",
+        "playerBoard.removingEffect": "Removendo...",
+        "playerBoard.lifecycleConcentration": "Concentração",
+        "playerBoard.lifecycleManual": "Manual",
+        "playerBoard.lifecycleRounds": "{count} rodadas",
+        "playerBoard.lifecycleRoundsUnknown": "Por rodadas",
+        "playerBoard.lifecycleUntilTurnStart": "Até início do turno",
+        "playerBoard.lifecycleUntilTurnEnd": "Até fim do turno",
+        "playerBoard.lifecycleLongRest": "Limpa no descanso longo",
+      }[key] ?? key),
+  }),
+}));
+
+describe("CharacterActiveEffectsPanel", () => {
+  it("renderiza painel quando há efeitos ativos", () => {
+    const markup = renderToStaticMarkup(
+      <CharacterActiveEffectsPanel
+        activeEffects={[
+          {
+            id: "eff-1",
+            kind: "spell_effect",
+            duration_type: "manual",
+            created_at: "2026-01-01T00:00:00Z",
+            display_label: "Owl's Wisdom",
+            metadata: {
+              source_spell_name: "Owl's Wisdom",
+              concentration: true,
+              concentration_group: "grp-1",
+            },
+          },
+        ] as any}
+        onRemoveEffect={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Efeitos ativos");
+    expect(markup).toContain("Owl&#x27;s Wisdom");
+    expect(markup).toContain("Concentração");
+    expect(markup).toContain("Manual");
+    expect(markup).toContain("Limpa no descanso longo");
+    expect(markup).toContain("Remover");
+  });
+
+  it("não renderiza quando a lista está vazia", () => {
+    const markup = renderToStaticMarkup(
+      <CharacterActiveEffectsPanel
+        activeEffects={[]}
+        onRemoveEffect={() => undefined}
+      />,
+    );
+
+    expect(markup).not.toContain("Efeitos ativos");
+    expect(markup).toBe("");
+  });
+
+  it("não renderiza botão Remover quando onRemoveEffect não é passado", () => {
+    const markup = renderToStaticMarkup(
+      <CharacterActiveEffectsPanel
+        activeEffects={[
+          {
+            id: "eff-1",
+            kind: "spell_effect",
+            duration_type: "manual",
+            created_at: "2026-01-01T00:00:00Z",
+            display_label: "Bless",
+            metadata: {},
+          },
+        ] as any}
+      />,
+    );
+
+    expect(markup).toContain("Efeitos ativos");
+    expect(markup).toContain("Bless");
+    expect(markup).not.toContain("Remover");
+  });
+
+  it("desabilita botão e mostra 'Removendo...' quando removingEffectId corresponde", () => {
+    const markup = renderToStaticMarkup(
+      <CharacterActiveEffectsPanel
+        activeEffects={[
+          {
+            id: "eff-1",
+            kind: "spell_effect",
+            duration_type: "manual",
+            created_at: "2026-01-01T00:00:00Z",
+            display_label: "Bless",
+            metadata: {},
+          },
+        ] as any}
+        removingEffectId="eff-1"
+        onRemoveEffect={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("disabled");
+    expect(markup).toContain("Removendo...");
+    expect(markup).not.toContain(">Remover<");
+  });
+
+  it("renderiza badge de rodadas com contagem", () => {
+    const markup = renderToStaticMarkup(
+      <CharacterActiveEffectsPanel
+        activeEffects={[
+          {
+            id: "eff-1",
+            kind: "spell_effect",
+            duration_type: "rounds",
+            remaining_rounds: 5,
+            created_at: "2026-01-01T00:00:00Z",
+            display_label: "Haste",
+            metadata: {},
+          },
+        ] as any}
+        onRemoveEffect={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Haste");
+    expect(markup).toContain("5 rodadas");
+  });
+
+  it("renderiza badge de until-turn-start", () => {
+    const markup = renderToStaticMarkup(
+      <CharacterActiveEffectsPanel
+        activeEffects={[
+          {
+            id: "eff-1",
+            kind: "condition",
+            condition_type: "restrained",
+            duration_type: "until_turn_start",
+            expires_on: "turn_start",
+            created_at: "2026-01-01T00:00:00Z",
+            metadata: {},
+          },
+        ] as any}
+        onRemoveEffect={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Até início do turno");
+  });
+});

--- a/apps/control-web/src/features/character-sheet/components/CharacterActiveEffectsPanel.tsx
+++ b/apps/control-web/src/features/character-sheet/components/CharacterActiveEffectsPanel.tsx
@@ -1,0 +1,89 @@
+import type { ActiveEffect } from "../../../shared/api/combatRepo";
+import { useLocale } from "../../../shared/hooks/useLocale";
+import {
+  formatActiveEffectLabel,
+  getActiveEffectLifecycleBadges,
+} from "../../../features/active-effects";
+
+type Props = {
+  activeEffects: ActiveEffect[];
+  removingEffectId?: string | null;
+  onRemoveEffect?: (effectId: string) => void;
+};
+
+export const CharacterActiveEffectsPanel = ({
+  activeEffects,
+  removingEffectId,
+  onRemoveEffect,
+}: Props) => {
+  const { t } = useLocale();
+
+  if (activeEffects.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="rounded-3xl border border-white/8 bg-white/4 px-4 py-4">
+      <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-slate-400">
+        {t("playerBoard.activeEffectsLabel")}
+      </p>
+      <ul className="mt-3 space-y-2">
+        {activeEffects.map((effect) => {
+          const label =
+            formatActiveEffectLabel(effect) ??
+            t("playerBoard.activeEffectFallback");
+          const badges = getActiveEffectLifecycleBadges(effect);
+          const isRemoving = removingEffectId === effect.id;
+          return (
+            <li
+              key={effect.id}
+              className="flex items-center justify-between gap-3"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-white">
+                  {label}
+                </p>
+                {badges.length > 0 ? (
+                  <p className="mt-0.5 flex flex-wrap gap-x-1.5 gap-y-0.5">
+                    {badges.map((badge, index) => (
+                      <span
+                        key={badge.key}
+                        className="inline-flex items-center gap-x-1.5"
+                      >
+                        {index > 0 ? (
+                          <span className="text-[10px] text-slate-600">
+                            {"\u00B7"}
+                          </span>
+                        ) : null}
+                        <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-violet-400">
+                          {badge.params
+                            ? t(badge.i18nKey).replace(
+                                "{count}",
+                                String(badge.params.count),
+                              )
+                            : t(badge.i18nKey)}
+                        </span>
+                      </span>
+                    ))}
+                  </p>
+                ) : null}
+              </div>
+              {onRemoveEffect ? (
+                <button
+                  type="button"
+                  onClick={() => onRemoveEffect(effect.id)}
+                  disabled={isRemoving}
+                  className="shrink-0 rounded-full bg-white/8 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.22em] text-slate-300 transition hover:bg-red-500/20 hover:text-red-300 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {isRemoving
+                    ? t("playerBoard.removingEffect")
+                    : t("playerBoard.removeEffect")}
+                </button>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+};

--- a/apps/control-web/src/features/character-sheet/components/CharacterSheet.tsx
+++ b/apps/control-web/src/features/character-sheet/components/CharacterSheet.tsx
@@ -17,6 +17,7 @@ import { Spellcasting } from "./Spellcasting";
 import { Proficiencies } from "./Proficiencies";
 import { Conditions } from "./Conditions";
 import { FeaturesTraits } from "./FeaturesTraits";
+import { CharacterActiveEffectsPanel } from "./CharacterActiveEffectsPanel";
 import { CharacterSheetCreationConfirmDialog } from "./CharacterSheetCreationConfirmDialog";
 import { CharacterSheetInventoryResetConfirmDialog } from "./CharacterSheetInventoryResetConfirmDialog";
 import { CharacterSheetStateScreen } from "./CharacterSheetStateScreen";
@@ -29,8 +30,9 @@ import {
   getDraftWeaponProficiencyOptions,
 } from "../utils/proficiencyCatalog";
 import { useLocale } from "../../../shared/hooks/useLocale";
+import { useToast } from "../../../shared/hooks/useToast";
+import { Toast } from "../../../shared/ui/Toast";
 import { useCharacterSheetDerived } from "../hooks/useCharacterSheetDerived";
-import { formatActiveEffectLabel, getActiveEffectLifecycleBadges } from "../../../features/active-effects";
 
 type Props = {
   partyId?: string | null;
@@ -70,6 +72,7 @@ export const CharacterSheet = ({
   });
   const { sheet, activeSpellEffects } = actions;
   const { t } = useLocale();
+  const { toast, showToast, clearToast } = useToast();
   const sheetActiveEffects = activeSpellEffects ?? [];
   const isCreation = mode === "creation";
   const isCreationDraft = isCreation && creationDraftMode;
@@ -205,6 +208,18 @@ export const CharacterSheet = ({
       return;
     }
     void actions.save(isDraftEditor ? normalizedDraftName : undefined);
+  };
+
+  const handleRemoveEffect = async (effectId: string) => {
+    try {
+      await actions.removeActiveEffect(effectId);
+    } catch {
+      showToast({
+        variant: "error",
+        title: t("playerBoard.removeEffectErrorTitle"),
+        description: t("playerBoard.removeEffectErrorDescription"),
+      });
+    }
   };
 
   const {
@@ -513,39 +528,12 @@ export const CharacterSheet = ({
           />
         )}
 
-        {!isCreation && sheetActiveEffects.length > 0 && (
-          <section className="rounded-3xl border border-white/8 bg-white/4 px-4 py-4">
-            <p className="text-[10px] font-bold uppercase tracking-[0.24em] text-slate-400">
-              {t("playerBoard.activeEffectsLabel")}
-            </p>
-            <ul className="mt-3 space-y-2">
-              {sheetActiveEffects.map((effect) => {
-                const label = formatActiveEffectLabel(effect) ?? t("playerBoard.activeEffectFallback");
-                const badges = getActiveEffectLifecycleBadges(effect);
-                return (
-                  <li key={effect.id} className="min-w-0">
-                    <p className="truncate text-sm font-medium text-white">{label}</p>
-                    {badges.length > 0 ? (
-                      <p className="mt-0.5 flex flex-wrap gap-x-1.5 gap-y-0.5">
-                        {badges.map((badge, index) => (
-                          <span key={badge.key} className="inline-flex items-center gap-x-1.5">
-                            {index > 0 ? (
-                              <span className="text-[10px] text-slate-600">{"\u00B7"}</span>
-                            ) : null}
-                            <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-violet-400">
-                              {badge.params
-                                ? t(badge.i18nKey).replace("{count}", String(badge.params.count))
-                                : t(badge.i18nKey)}
-                            </span>
-                          </span>
-                        ))}
-                      </p>
-                    ) : null}
-                  </li>
-                );
-              })}
-            </ul>
-          </section>
+        {!isCreation && (
+          <CharacterActiveEffectsPanel
+            activeEffects={sheetActiveEffects}
+            removingEffectId={actions.removingEffectId}
+            onRemoveEffect={handleRemoveEffect}
+          />
         )}
 
         <FeaturesTraits
@@ -556,6 +544,8 @@ export const CharacterSheet = ({
           readOnly={isPlayReadOnly || isSheetLocked}
         />
       </div>
+
+      <Toast toast={toast} onClose={clearToast} />
     </div>
   );
 };

--- a/apps/control-web/src/features/character-sheet/hooks/useCharacterSheet.state.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/useCharacterSheet.state.ts
@@ -49,6 +49,11 @@ export type CharacterSheetHookAction =
   | { type: "saving_fail"; error: string }
   | { type: "import_success"; sheet: CharacterSheet }
   | { type: "import_fail"; error: string }
+  | {
+      type: "active_effects_updated";
+      sheet: CharacterSheet;
+      activeSpellEffects: ActiveEffect[];
+    }
   | { type: "reset" };
 
 export const initialCharacterSheetHookState: CharacterSheetHookState = {
@@ -112,6 +117,12 @@ export function characterSheetHookReducer(
       return { ...state, sheet: action.sheet, isDirty: true, importError: null };
     case "import_fail":
       return { ...state, importError: action.error };
+    case "active_effects_updated":
+      return {
+        ...state,
+        sheet: action.sheet,
+        activeSpellEffects: action.activeSpellEffects,
+      };
     case "reset":
       return {
         ...state,

--- a/apps/control-web/src/features/character-sheet/hooks/useCharacterSheet.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/useCharacterSheet.ts
@@ -23,6 +23,8 @@ import {
   useCharacterSheetLevelUp,
   useCharacterSheetSave,
 } from "./useCharacterSheetSave";
+import { sessionStatesRepo } from "../../../shared/api/sessionStatesRepo";
+import { parseCharacterSheet } from "../model/characterSheet.schema";
 
 type UseCharacterSheetOptions = {
   playPlayerUserId?: string | null;
@@ -54,6 +56,7 @@ export const useCharacterSheet = (
   const [requestLevelUpError, setRequestLevelUpError] = useState<string | null>(null);
   const [acceptingSheet, setAcceptingSheet] = useState(false);
   const [acceptSheetError, setAcceptSheetError] = useState<string | null>(null);
+  const [removingEffectId, setRemovingEffectId] = useState<string | null>(null);
   const playPlayerUserId = options.playPlayerUserId ?? null;
   const creationPlayerUserId = options.creationPlayerUserId ?? null;
   const creationDraftId = options.creationDraftId ?? null;
@@ -166,6 +169,28 @@ export const useCharacterSheet = (
       })(sheet, ability, value),
     );
 
+  const removeActiveEffect = async (effectId: string) => {
+    if (!state.playSessionId || removingEffectId) return;
+    setRemovingEffectId(effectId);
+    try {
+      const record = await sessionStatesRepo.removePersistedEffect(
+        state.playSessionId,
+        effectId,
+      );
+      dispatch({
+        type: "active_effects_updated",
+        sheet: parseCharacterSheet(record.state),
+        activeSpellEffects:
+          (record.activeSpellEffects as
+            | import("../../../shared/api/combatRepo").ActiveEffect[]
+            | null
+            | undefined) ?? [],
+      });
+    } finally {
+      setRemovingEffectId(null);
+    }
+  };
+
   const baseActions = createBaseSheetActions(guardedUpdate, set, mode, {
     allowCreationEditing: creationDraftMode,
     campaignId,
@@ -199,8 +224,10 @@ export const useCharacterSheet = (
     requestLevelUpError,
     acceptingSheet,
     acceptSheetError,
+    removingEffectId,
     requestLevelUp,
     acceptPendingSheet,
+    removeActiveEffect,
     save,
     creationDraftMode,
     set,


### PR DESCRIPTION
# feat(character-sheet): allow removing persisted active effects from character sheet

## Summary

Allows persisted active effects to be removed directly from the Character Sheet.

The Character Sheet already displayed persisted active effects. This PR adds removal support using the existing persisted effect removal endpoint, while extracting the active effects UI into a reusable, focused component.

No backend changes were required.

## Context

Persisted out-of-combat active effects are now visible in both the Player Board and Character Sheet.

Before this PR:

- Player Board showed active effects and allowed removal
- Character Sheet showed active effects but was display-only

This created a small UX gap: a player could see an effect on the sheet, but had to go elsewhere to remove it.

Now the Character Sheet can remove persisted active effects directly.

## What changed

### New Character Active Effects panel

Added:

```text
apps/control-web/src/features/character-sheet/components/CharacterActiveEffectsPanel.tsx
````

The new component is props-driven and reusable:

```ts
activeEffects
removingEffectId
onRemoveEffect
```

It renders:

* active effect labels
* lifecycle badges
* optional remove button
* loading/disabled state while removing

The panel reuses the shared active effect helpers, so labels and lifecycle badges stay consistent with Player Board.

### Character Sheet hook removal action

Updated:

```text
apps/control-web/src/features/character-sheet/hooks/useCharacterSheet.ts
apps/control-web/src/features/character-sheet/hooks/useCharacterSheet.state.ts
```

Added:

```ts
removeActiveEffect(effectId)
removingEffectId
```

`removeActiveEffect`:

* uses the existing `playSessionId` from hook state
* calls the existing persisted effect removal API
* parses the returned sheet state
* dispatches an `active_effects_updated` action
* updates both:

  * `sheet`
  * `activeSpellEffects`

This keeps session/API details inside the hook instead of leaking them into the component.

### CharacterSheet integration

Updated:

```text
apps/control-web/src/features/character-sheet/components/CharacterSheet.tsx
```

Changes:

* replaced inline active effects markup with `<CharacterActiveEffectsPanel />`
* added `handleRemoveEffect`
* added `useToast`
* renders `<Toast />` for removal errors

If removal fails, the user now gets feedback instead of clicking into the void like a doomed NPC.

### Backend/API

No backend changes.

This PR reuses the existing endpoint:

```http
DELETE /sessions/{session_id}/state/me/effects/{effect_id}
```

### i18n

No new keys.

The Character Sheet reuses existing `playerBoard.*` effect removal labels.

## Tests

Added:

```text
apps/control-web/src/features/character-sheet/components/CharacterActiveEffectsPanel.test.tsx
```

Coverage includes:

* renders active effects
* shows lifecycle badges
* renders remove action
* calls `onRemoveEffect`
* disables the active remove button while pending
* hides/removes controls as expected through props

Regression suites:

```text
activeEffectDisplay.test.ts
PlayerBoardStatusPanel.test.tsx
```

## Validation

```text
CharacterActiveEffectsPanel.test.tsx — 6 passed
activeEffectDisplay.test.ts — 15 passed
PlayerBoardStatusPanel.test.tsx — 15 passed
Total — 36 passed
```

TypeScript:

```text
No new errors in modified files
```

Existing unrelated TypeScript errors remain unchanged.

## Out of scope

This PR intentionally does not implement:

* backend changes
* new effect application UI
* editing effect duration
* active effect history
* combat active effects panel
* GM sheet controls
* duration countdowns
* out-of-combat casting lifecycle

## Notes for reviewers

The key design choice is extracting `CharacterActiveEffectsPanel` instead of growing `CharacterSheet.tsx`.

This keeps the sheet component smaller, makes the panel easy to test, and keeps active effect display/removal logic reusable.