### PR TITLE
feat(spell-preparation): implement spell preparation logic after long…

### DIFF
--- a/apps/control-server/app/api/routes/sessions/commands_service.py
+++ b/apps/control-server/app/api/routes/sessions/commands_service.py
@@ -360,6 +360,8 @@ async def send_session_command_service(
         session.refresh(state)
 
     if ended_rest_type == "long_rest":
+        from app.services.spell_preparation import create_pending_spell_preparation
+
         ended_combat = session.exec(
             select(CombatState).where(
                 CombatState.session_id == entry_id,
@@ -369,6 +371,16 @@ async def send_session_command_service(
         if ended_combat is not None:
             session.delete(ended_combat)
             session.commit()
+
+        for state in states:
+            pending = create_pending_spell_preparation(state.state_json)
+            if pending:
+                state.state_json = {**state.state_json, "pending_spell_preparation": pending}
+                flag_modified(state, "state_json")
+                session.add(state)
+        session.commit()
+        for state in states:
+            session.refresh(state)
 
     event_type = "rest_ended"
     event_payload["restType"] = ended_rest_type

--- a/apps/control-server/app/api/routes/sessions/state.py
+++ b/apps/control-server/app/api/routes/sessions/state.py
@@ -9,6 +9,7 @@ from app.models.item import ItemType
 from app.models.session_state import SessionState
 from app.schemas.session_state import (
     ClearConcentrationRequest,
+    PrepareSpellsRequest,
     SessionStateLoadoutUpdate,
     SessionStateRead,
     SessionStateUpdate,
@@ -20,6 +21,7 @@ from app.services.combat_service.persistent_effects import (
 )
 from app.services.session_rest import ensure_rest_state
 from app.services.session_state_finalize import finalize_session_state_data
+from app.services.spell_preparation import apply_prepared_spells
 from ._shared import record_session_activity, require_identifier
 from .state_common import (
     ensure_session_state,
@@ -276,6 +278,68 @@ async def remove_my_persisted_effect(
 
     updated = remove_persisted_effect(state.state_json, effect_id)
     state.state_json = finalize_session_state_data(updated)
+    session.add(state)
+    session.commit()
+    session.refresh(state)
+
+    await publish_state_update(
+        entry,
+        user.id,
+        state.updated_at or state.created_at,
+        state.state_json if isinstance(state.state_json, dict) else None,
+    )
+    return to_state_read(state)
+
+
+@router.post("/sessions/{session_id}/state/me/spells/prepare", response_model=SessionStateRead)
+async def prepare_my_spells(
+    session_id: str,
+    payload: PrepareSpellsRequest,
+    user=Depends(get_current_user),
+    session: DbSession = Depends(get_session),
+):
+    entry = get_session_entry(session_id, session)
+    require_session_view_access(entry, user, session, user.id)
+
+    state = session.exec(
+        select(SessionState).where(
+            SessionState.session_id == session_id,
+            SessionState.player_user_id == user.id,
+        )
+    ).first()
+    state = ensure_session_state(state, session_id, user.id, entry.party_id, session)
+    if not state:
+        raise HTTPException(status_code=404, detail="Session state not found")
+
+    pending = (state.state_json or {}).get("pending_spell_preparation")
+    if not pending:
+        raise HTTPException(status_code=400, detail="No pending spell preparation.")
+
+    spellcasting = (state.state_json or {}).get("spellcasting")
+    spells = spellcasting.get("spells", []) if isinstance(spellcasting, dict) else []
+    spell_id_set = {s.get("id") for s in spells if isinstance(s, dict)}
+
+    for sid in payload.preparedSpellIds:
+        if sid not in spell_id_set:
+            raise HTTPException(status_code=400, detail=f"Unknown spell id: {sid}")
+
+    leveled_count = sum(
+        1
+        for s in spells
+        if isinstance(s, dict)
+        and s.get("id") in payload.preparedSpellIds
+        and s.get("level", 0) > 0
+    )
+    limit = pending.get("prepared_limit", 0)
+    if leveled_count > limit:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Prepared spell count ({leveled_count}) exceeds limit ({limit}).",
+        )
+
+    state.state_json = apply_prepared_spells(state.state_json, payload.preparedSpellIds)
+    state.state_json = finalize_session_state_data(state.state_json)
+    flag_modified(state, "state_json")
     session.add(state)
     session.commit()
     session.refresh(state)

--- a/apps/control-server/app/api/routes/sessions/state_common.py
+++ b/apps/control-server/app/api/routes/sessions/state_common.py
@@ -54,6 +54,7 @@ def to_state_read(entry: SessionState) -> SessionStateRead:
         updatedAt=entry.updated_at,
         activeSpellEffects=state_json.get("active_spell_effects"),
         activeConcentration=derive_active_concentration(state_json),
+        pendingSpellPreparation=state_json.get("pending_spell_preparation"),
     )
 
 

--- a/apps/control-server/app/schemas/session_state.py
+++ b/apps/control-server/app/schemas/session_state.py
@@ -12,10 +12,15 @@ class SessionStateRead(BaseModel):
     updatedAt: datetime | None
     activeSpellEffects: list[dict] | None = None
     activeConcentration: dict | None = None
+    pendingSpellPreparation: dict | None = None
 
 
 class ClearConcentrationRequest(BaseModel):
     concentrationGroup: str | None = None
+
+
+class PrepareSpellsRequest(BaseModel):
+    preparedSpellIds: list[str]
 
 
 class SessionStateUpdate(BaseModel):

--- a/apps/control-server/app/services/spell_preparation.py
+++ b/apps/control-server/app/services/spell_preparation.py
@@ -1,0 +1,123 @@
+"""Spell preparation logic for prepared and spellbook casters.
+
+Triggered after long rest to prompt players to review their prepared spells.
+v1 is additive: existing prepared flags are preserved as the initial state.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+# Classes that use prepared spellcasting (including spellbook, which is a variant of prepared).
+_PREPARED_CASTER_CLASSES: set[str] = {"cleric", "druid", "paladin", "wizard"}
+
+# Half-casters use half their character level for spell slot / preparation scaling.
+_HALF_CASTER_CLASSES: set[str] = {"paladin", "ranger"}
+
+
+def _normalize_class(class_id: str | None) -> str | None:
+    if not isinstance(class_id, str):
+        return None
+    normalized = class_id.strip().lower()
+    return normalized if normalized else None
+
+
+def _ability_modifier(score: int) -> int:
+    return (score - 10) // 2
+
+
+def compute_prepared_spell_limit(
+    class_id: str,
+    character_level: int,
+    ability_modifier: int,
+) -> int:
+    """Return the maximum number of leveled spells a prepared caster can prepare.
+
+    Formula: caster_level + ability_modifier, minimum 1.
+    Half-casters (e.g. Paladin) use floor(level / 2).
+    Full casters use full character level.
+    """
+    normalized = _normalize_class(class_id)
+    if normalized in _HALF_CASTER_CLASSES:
+        caster_level = max(1, character_level // 2)
+    else:
+        caster_level = character_level
+    return max(1, caster_level + ability_modifier)
+
+
+def create_pending_spell_preparation(data: dict) -> dict | None:
+    """Build a pending_spell_preparation dict if the character is eligible.
+
+    Returns None for non-casters, known-spell casters, or characters without
+    a valid spellcasting block.
+    """
+    class_id = data.get("class")
+    level = data.get("level")
+    spellcasting = data.get("spellcasting")
+
+    if not class_id or not level or not isinstance(spellcasting, dict):
+        return None
+
+    normalized = _normalize_class(class_id)
+    if normalized not in _PREPARED_CASTER_CLASSES:
+        return None
+
+    ability = spellcasting.get("ability")
+    spells = spellcasting.get("spells", [])
+    if not ability or not spells:
+        return None
+
+    abilities = data.get("abilities", {})
+    score = 10
+    if isinstance(abilities, dict):
+        raw_score = abilities.get(ability)
+        if isinstance(raw_score, int):
+            score = raw_score
+
+    modifier = _ability_modifier(score)
+    prepared_limit = compute_prepared_spell_limit(normalized, int(level), modifier)
+
+    # Current prepared spell IDs (leveled spells only; cantrips excluded from limit).
+    current_prepared = [
+        s.get("id")
+        for s in spells
+        if isinstance(s, dict)
+        and s.get("prepared") is True
+        and s.get("level", 0) > 0
+    ]
+
+    return {
+        "source": "long_rest",
+        "class_key": normalized,
+        "prepared_limit": prepared_limit,
+        "current_prepared_spell_ids": current_prepared,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def apply_prepared_spells(data: dict, prepared_spell_ids: list[str]) -> dict:
+    """Update spellcasting.spells[].prepared flags and clear pending state.
+
+    Cantrips are always set to prepared=True.
+    Leveled spells are prepared only if their id is in prepared_spell_ids.
+    """
+    next_data = dict(data)
+    spellcasting = next_data.get("spellcasting")
+    if not isinstance(spellcasting, dict):
+        next_data.pop("pending_spell_preparation", None)
+        return next_data
+
+    spells = list(spellcasting.get("spells", []))
+    prepared_set = set(prepared_spell_ids)
+
+    for spell in spells:
+        if not isinstance(spell, dict):
+            continue
+        if spell.get("level", 0) == 0:
+            spell["prepared"] = True
+        else:
+            spell["prepared"] = spell.get("id") in prepared_set
+
+    next_data["spellcasting"] = {**spellcasting, "spells": spells}
+    next_data.pop("pending_spell_preparation", None)
+    return next_data

--- a/apps/control-server/tests/test_spell_preparation.py
+++ b/apps/control-server/tests/test_spell_preparation.py
@@ -1,0 +1,200 @@
+"""Tests for spell preparation logic.
+
+Covers:
+- compute_prepared_spell_limit
+- create_pending_spell_preparation
+- apply_prepared_spells
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from app.services.spell_preparation import (
+    apply_prepared_spells,
+    compute_prepared_spell_limit,
+    create_pending_spell_preparation,
+)
+
+
+class TestComputePreparedSpellLimit(unittest.TestCase):
+    def test_full_caster(self):
+        self.assertEqual(compute_prepared_spell_limit("cleric", 5, 3), 8)
+
+    def test_half_caster(self):
+        self.assertEqual(compute_prepared_spell_limit("paladin", 5, 2), 4)
+
+    def test_half_caster_low_level(self):
+        self.assertEqual(compute_prepared_spell_limit("paladin", 2, 1), 2)
+
+    def test_minimum_one(self):
+        self.assertEqual(compute_prepared_spell_limit("cleric", 1, -2), 1)
+
+    def test_zero_modifier(self):
+        self.assertEqual(compute_prepared_spell_limit("druid", 3, 0), 3)
+
+
+class TestCreatePendingSpellPreparation(unittest.TestCase):
+    def _base_state(self, **overrides):
+        defaults = {
+            "class": "cleric",
+            "level": 5,
+            "abilities": {"wisdom": 16},
+            "spellcasting": {
+                "ability": "wisdom",
+                "spells": [
+                    {
+                        "id": "s1",
+                        "name": "Bless",
+                        "level": 1,
+                        "prepared": True,
+                    },
+                    {
+                        "id": "s2",
+                        "name": "Cure Wounds",
+                        "level": 1,
+                        "prepared": False,
+                    },
+                    {
+                        "id": "s3",
+                        "name": "Guidance",
+                        "level": 0,
+                        "prepared": True,
+                    },
+                ],
+            },
+        }
+        # Handle class_ kwarg → "class" dict key (class is a reserved word)
+        if "class_" in overrides:
+            overrides["class"] = overrides.pop("class_")
+        defaults.update(overrides)
+        return defaults
+
+    def test_creates_pending_for_prepared_caster(self):
+        pending = create_pending_spell_preparation(self._base_state())
+        self.assertIsNotNone(pending)
+        self.assertEqual(pending["class_key"], "cleric")
+        self.assertEqual(pending["prepared_limit"], 8)  # 5 + 3
+        self.assertEqual(pending["current_prepared_spell_ids"], ["s1"])
+        self.assertEqual(pending["source"], "long_rest")
+
+    def test_creates_pending_for_spellbook_caster(self):
+        pending = create_pending_spell_preparation(
+            self._base_state(
+                class_="wizard",
+                abilities={"intelligence": 18},
+                spellcasting={
+                    "ability": "intelligence",
+                    "spells": [
+                        {"id": "w1", "name": "Magic Missile", "level": 1, "prepared": True},
+                    ],
+                },
+            )
+        )
+        self.assertIsNotNone(pending)
+        self.assertEqual(pending["class_key"], "wizard")
+        self.assertEqual(pending["prepared_limit"], 9)  # 5 + 4
+
+    def test_creates_pending_for_half_caster(self):
+        pending = create_pending_spell_preparation(
+            self._base_state(
+                class_="paladin",
+                level=5,
+                abilities={"charisma": 14},
+                spellcasting={
+                    "ability": "charisma",
+                    "spells": [
+                        {"id": "p1", "name": "Bless", "level": 1, "prepared": True},
+                    ],
+                },
+            )
+        )
+        self.assertIsNotNone(pending)
+        self.assertEqual(pending["class_key"], "paladin")
+        self.assertEqual(pending["prepared_limit"], 4)  # floor(5/2) + 2
+
+    def test_no_pending_for_known_caster(self):
+        pending = create_pending_spell_preparation(
+            self._base_state(class_="sorcerer")
+        )
+        self.assertIsNone(pending)
+
+    def test_no_pending_for_non_caster(self):
+        pending = create_pending_spell_preparation(
+            self._base_state(class_="fighter", spellcasting=None)
+        )
+        self.assertIsNone(pending)
+
+    def test_no_pending_without_spellcasting(self):
+        pending = create_pending_spell_preparation(
+            self._base_state(spellcasting=None)
+        )
+        self.assertIsNone(pending)
+
+    def test_no_pending_without_spells(self):
+        pending = create_pending_spell_preparation(
+            self._base_state(spellcasting={"ability": "wisdom", "spells": []})
+        )
+        self.assertIsNone(pending)
+
+    def test_no_pending_without_ability(self):
+        pending = create_pending_spell_preparation(
+            self._base_state(spellcasting={"spells": [{"id": "s1", "level": 1}]})
+        )
+        self.assertIsNone(pending)
+
+    def test_cantrips_excluded_from_current_prepared(self):
+        pending = create_pending_spell_preparation(self._base_state())
+        self.assertEqual(pending["current_prepared_spell_ids"], ["s1"])
+
+
+class TestApplyPreparedSpells(unittest.TestCase):
+    def _base_state(self):
+        return {
+            "pending_spell_preparation": {"prepared_limit": 2},
+            "spellcasting": {
+                "ability": "wisdom",
+                "spells": [
+                    {"id": "s1", "name": "Bless", "level": 1, "prepared": True},
+                    {"id": "s2", "name": "Cure Wounds", "level": 1, "prepared": False},
+                    {"id": "s3", "name": "Guidance", "level": 0, "prepared": False},
+                ],
+            },
+        }
+
+    def test_updates_prepared_flags(self):
+        result = apply_prepared_spells(self._base_state(), ["s2"])
+        spells = result["spellcasting"]["spells"]
+        self.assertFalse(spells[0]["prepared"])  # s1 not in list
+        self.assertTrue(spells[1]["prepared"])   # s2 in list
+        self.assertTrue(spells[2]["prepared"])   # s3 cantrip
+
+    def test_clears_pending_state(self):
+        result = apply_prepared_spells(self._base_state(), ["s1"])
+        self.assertNotIn("pending_spell_preparation", result)
+
+    def test_preserves_cantrips_always_prepared(self):
+        result = apply_prepared_spells(self._base_state(), [])
+        spells = result["spellcasting"]["spells"]
+        self.assertTrue(spells[2]["prepared"])  # cantrip
+
+    def test_handles_missing_spellcasting(self):
+        result = apply_prepared_spells(
+            {"pending_spell_preparation": {}}, ["s1"]
+        )
+        self.assertNotIn("pending_spell_preparation", result)
+
+    def test_idempotent_on_empty_spells(self):
+        result = apply_prepared_spells(
+            {
+                "pending_spell_preparation": {},
+                "spellcasting": {"ability": "wisdom", "spells": []},
+            },
+            [],
+        )
+        self.assertEqual(result["spellcasting"]["spells"], [])
+        self.assertNotIn("pending_spell_preparation", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/control-web/src/entities/character/character.types.ts
+++ b/apps/control-web/src/entities/character/character.types.ts
@@ -42,4 +42,5 @@ export type SessionStateRecord = {
   updatedAt?: string | null;
   activeSpellEffects?: Record<string, unknown>[] | null;
   activeConcentration?: ActiveConcentration | null;
+  pendingSpellPreparation?: Record<string, unknown> | null;
 };

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
@@ -19,6 +19,7 @@ import { PlayerBoardRollDialog } from "./PlayerBoardRollDialog";
 import { usePlayerBoardCallbacks } from "./usePlayerBoardCallbacks";
 import { usePlayerBoardRestActions } from "./usePlayerBoardRestActions";
 import { PlayerBoardStatusPanel } from "./PlayerBoardStatusPanel";
+import { SpellPreparationDialog } from "./SpellPreparationDialog";
 import { parseCharacterSheet } from "../../features/character-sheet/model/characterSheet.schema";
 import { usePlayerBoardLoadout } from "./usePlayerBoardLoadout";
 import { usePlayerBoardRestFeedback } from "./usePlayerBoardRestFeedback";
@@ -58,6 +59,7 @@ export const PlayerBoardPage = () => {
     lastCommand,
     lastEvent,
     myInventory,
+    pendingSpellPreparation,
     playerSheet,
     playerWallet,
     refresh,
@@ -70,6 +72,7 @@ export const PlayerBoardPage = () => {
     setActiveConcentration,
     setActiveSpellEffects,
     setMyInventory,
+    setPendingSpellPreparation,
     setPlayerSheet,
     setPlayerWallet,
     setSelectedSessionId,
@@ -169,6 +172,8 @@ export const PlayerBoardPage = () => {
   });
   const [clearingConcentration, setClearingConcentration] = useState(false);
   const [removingEffectId, setRemovingEffectId] = useState<string | null>(null);
+  const [showPrepDialog, setShowPrepDialog] = useState(false);
+  const [preparingSpells, setPreparingSpells] = useState(false);
   const previousConcentrationRef = useRef<import("../../entities/character").ActiveConcentration | null>(null);
 
   const handleClearConcentration = async () => {
@@ -210,6 +215,27 @@ export const PlayerBoardPage = () => {
       });
     } finally {
       setRemovingEffectId(null);
+    }
+  };
+
+  const handlePrepareSpells = async (preparedSpellIds: string[]) => {
+    if (!activeSession?.id || preparingSpells) return;
+    setPreparingSpells(true);
+    try {
+      const record = await sessionStatesRepo.prepareSpells(activeSession.id, preparedSpellIds);
+      setPlayerSheet(parseCharacterSheet(record.state));
+      setPendingSpellPreparation(
+        (record.pendingSpellPreparation as import("../../shared/api/combatRepo").PendingSpellPreparation | null | undefined) ?? null,
+      );
+      setShowPrepDialog(false);
+    } catch {
+      showToast({
+        variant: "error",
+        title: t("playerBoard.prepareSpellsErrorTitle"),
+        description: t("playerBoard.prepareSpellsErrorDescription"),
+      });
+    } finally {
+      setPreparingSpells(false);
     }
   };
 
@@ -340,6 +366,30 @@ export const PlayerBoardPage = () => {
       ) : null}
 
       <PlayerBoardRestBanner restState={restState} />
+
+      {pendingSpellPreparation && !combatActive && (
+        <div className="mx-auto max-w-7xl px-4 sm:px-6">
+          <div className="rounded-2xl border border-amber-700/30 bg-amber-900/20 px-4 py-3">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-semibold text-amber-200">
+                  {t("playerBoard.prepareSpellsPrompt")}
+                </p>
+                <p className="text-xs text-amber-300/70">
+                  {t("playerBoard.prepareSpellsDescription")}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setShowPrepDialog(true)}
+                className="shrink-0 rounded-full bg-amber-600/30 px-4 py-1.5 text-xs font-bold uppercase tracking-[0.2em] text-amber-200 transition hover:bg-amber-600/50"
+              >
+                {t("playerBoard.prepareSpellsButton")}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.08fr)_minmax(320px,0.92fr)]">
         <div className="space-y-6">
@@ -498,6 +548,15 @@ export const PlayerBoardPage = () => {
           onVirtualRoll={handleRoll}
         />
       ) : null}
+      <SpellPreparationDialog
+        open={showPrepDialog}
+        onClose={() => setShowPrepDialog(false)}
+        spells={playerSheet?.spellcasting?.spells ?? []}
+        preparedLimit={pendingSpellPreparation?.preparedLimit ?? 0}
+        currentPreparedIds={pendingSpellPreparation?.currentPreparedSpellIds ?? []}
+        onSubmit={handlePrepareSpells}
+        isSubmitting={preparingSpells}
+      />
       <DiceVisualizer events={rollEvents} />
         </>
       )}

--- a/apps/control-web/src/pages/PlayerBoardPage/SpellPreparationDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/SpellPreparationDialog.tsx
@@ -1,0 +1,167 @@
+import { useMemo, useState } from "react";
+import { useLocale } from "../../shared/hooks/useLocale";
+import type { Spell } from "../../features/character-sheet/model/characterSheet.types";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  spells: Spell[];
+  preparedLimit: number;
+  currentPreparedIds: string[];
+  onSubmit: (preparedIds: string[]) => void;
+  isSubmitting?: boolean;
+};
+
+export const SpellPreparationDialog = ({
+  open,
+  onClose,
+  spells,
+  preparedLimit,
+  currentPreparedIds,
+  onSubmit,
+  isSubmitting,
+}: Props) => {
+  const { t } = useLocale();
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(
+    () => new Set(currentPreparedIds),
+  );
+
+  const grouped = useMemo(() => {
+    const byLevel: Record<number, Spell[]> = {};
+    for (const spell of spells) {
+      const level = spell.level ?? 0;
+      if (!byLevel[level]) byLevel[level] = [];
+      byLevel[level].push(spell);
+    }
+    return Object.entries(byLevel)
+      .map(([level, list]) => ({
+        level: Number(level),
+        spells: list.sort((a, b) => a.name.localeCompare(b.name)),
+      }))
+      .sort((a, b) => a.level - b.level);
+  }, [spells]);
+
+  const leveledCount = useMemo(() => {
+    return spells.filter(
+      (s) => (s.level ?? 0) > 0 && selectedIds.has(s.id),
+    ).length;
+  }, [spells, selectedIds]);
+
+  const overLimit = leveledCount > preparedLimit;
+
+  const toggle = (id: string, level: number) => {
+    if (level === 0) return; // cantrips are always prepared
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+      <div className="max-h-[80vh] w-full max-w-md overflow-y-auto rounded-3xl border border-white/10 bg-[#0f172a] p-6 shadow-2xl">
+        <h2 className="text-lg font-bold text-white">
+          {t("playerBoard.prepareSpellsPrompt")}
+        </h2>
+        <p className="mt-1 text-sm text-slate-400">
+          {t("playerBoard.prepareSpellsDescription")}
+        </p>
+
+        <div className="mt-4 flex items-center justify-between">
+          <p
+            className={`text-sm font-semibold ${
+              overLimit ? "text-red-400" : "text-slate-300"
+            }`}
+          >
+            {t("playerBoard.prepareSpellsSelected")
+              .replace("{count}", String(leveledCount))
+              .replace("{limit}", String(preparedLimit))}
+          </p>
+          {overLimit ? (
+            <span className="text-xs font-bold uppercase tracking-wider text-red-400">
+              {t("playerBoard.prepareSpellsOverLimit")}
+            </span>
+          ) : null}
+        </div>
+
+        <div className="mt-4 space-y-4">
+          {grouped.map(({ level, spells: levelSpells }) => (
+            <div key={level}>
+              <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">
+                {level === 0
+                  ? t("playerBoard.prepareSpellsCantrips")
+                  : t("playerBoard.prepareSpellsLevel").replace(
+                      "{level}",
+                      String(level),
+                    )}
+              </p>
+              <ul className="mt-2 space-y-1.5">
+                {levelSpells.map((spell) => {
+                  const isCantrip = (spell.level ?? 0) === 0;
+                  const isSelected = selectedIds.has(spell.id);
+                  return (
+                    <li key={spell.id}>
+                      <label
+                        className={`flex cursor-pointer items-center gap-3 rounded-xl border px-3 py-2 transition ${
+                          isCantrip
+                            ? "border-white/5 bg-white/3 opacity-60"
+                            : isSelected
+                              ? "border-violet-500/30 bg-violet-500/10"
+                              : "border-white/5 bg-white/3 hover:bg-white/6"
+                        }`}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          disabled={isCantrip || isSubmitting}
+                          onChange={() => toggle(spell.id, spell.level ?? 0)}
+                          className="h-4 w-4 accent-violet-500"
+                        />
+                        <span className="text-sm text-slate-200">
+                          {spell.name}
+                        </span>
+                        {isCantrip ? (
+                          <span className="ml-auto text-[10px] uppercase tracking-wider text-slate-500">
+                            {t("playerBoard.prepareSpellsCantrips")}
+                          </span>
+                        ) : null}
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-6 flex gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="flex-1 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-slate-300 transition hover:bg-white/10 disabled:opacity-50"
+          >
+            {t("common.cancel")}
+          </button>
+          <button
+            type="button"
+            onClick={() => onSubmit(Array.from(selectedIds))}
+            disabled={overLimit || isSubmitting}
+            className="flex-1 rounded-full bg-violet-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-violet-500 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isSubmitting
+              ? t("common.saving")
+              : t("playerBoard.prepareSpellsButton")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardResources.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardResources.ts
@@ -6,7 +6,7 @@ import { sessionStatesRepo } from "../../shared/api/sessionStatesRepo";
 import type { InventoryItem } from "../../entities/inventory";
 import type { Item } from "../../entities/item";
 import type { ActiveConcentration } from "../../entities/character";
-import type { ActiveEffect } from "../../shared/api/combatRepo";
+import type { ActiveEffect, PendingSpellPreparation } from "../../shared/api/combatRepo";
 import type { CurrencyWallet } from "../../shared/api/inventoryRepo";
 import { EMPTY_WALLET, normalizeWallet } from "../../features/shop/utils/shopCurrency";
 import { parseCharacterSheet } from "../../features/character-sheet/model/characterSheet.schema";
@@ -53,6 +53,7 @@ export const usePlayerBoardResources = ({
   const [playerSheet, setPlayerSheet] = useState<CharacterSheet | null>(null);
   const [activeConcentration, setActiveConcentration] = useState<ActiveConcentration | null>(null);
   const [activeSpellEffects, setActiveSpellEffects] = useState<ActiveEffect[] | null>(null);
+  const [pendingSpellPreparation, setPendingSpellPreparation] = useState<PendingSpellPreparation | null>(null);
 
   const applyRealtimeStateSnapshot = useCallback((rawState: unknown): boolean => {
     try {
@@ -108,6 +109,7 @@ export const usePlayerBoardResources = ({
       setPlayerSheet(null);
       setActiveConcentration(null);
       setActiveSpellEffects(null);
+      setPendingSpellPreparation(null);
       return;
     }
     try {
@@ -121,11 +123,15 @@ export const usePlayerBoardResources = ({
       setActiveSpellEffects(
         (record.activeSpellEffects as ActiveEffect[] | null | undefined) ?? null,
       );
+      setPendingSpellPreparation(
+        (record.pendingSpellPreparation as PendingSpellPreparation | null | undefined) ?? null,
+      );
     } catch {
       setPlayerWallet(EMPTY_WALLET);
       setPlayerSheet(null);
       setActiveConcentration(null);
       setActiveSpellEffects(null);
+      setPendingSpellPreparation(null);
     }
   }, [activeSession?.id]);
 
@@ -318,7 +324,7 @@ export const usePlayerBoardResources = ({
     return () => window.clearInterval(handle);
   }, [effectiveCampaignId, activeSession, refresh]);
 
-  return {
+    return {
     activeConcentration,
     activeSession,
     activeSpellEffects,
@@ -330,6 +336,7 @@ export const usePlayerBoardResources = ({
     lastCommand,
     lastEvent,
     myInventory,
+    pendingSpellPreparation,
     playerSheet,
     playerWallet,
     refresh,
@@ -343,6 +350,7 @@ export const usePlayerBoardResources = ({
     setActiveConcentration,
     setActiveSpellEffects,
     setMyInventory,
+    setPendingSpellPreparation,
     setPlayerSheet,
     setPlayerWallet,
     setSelectedSessionId,

--- a/apps/control-web/src/shared/api/combatRepo.ts
+++ b/apps/control-web/src/shared/api/combatRepo.ts
@@ -61,6 +61,14 @@ export type ActiveEffect = {
   display_label?: string | null;
 };
 
+export type PendingSpellPreparation = {
+  source: string;
+  classKey: string;
+  preparedLimit: number;
+  currentPreparedSpellIds: string[];
+  createdAt: string;
+};
+
 export type CombatSpellContextOrigin =
   | "initial_cast"
   | "pending_save"

--- a/apps/control-web/src/shared/api/sessionStatesRepo.ts
+++ b/apps/control-web/src/shared/api/sessionStatesRepo.ts
@@ -20,4 +20,8 @@ export const sessionStatesRepo = {
 
   removePersistedEffect: (sessionId: string, effectId: string) =>
     http.del<SessionStateRecord>(`/sessions/${sessionId}/state/me/effects/${effectId}`),
+  prepareSpells: (sessionId: string, preparedSpellIds: string[]) =>
+    http.post<SessionStateRecord>(`/sessions/${sessionId}/state/me/spells/prepare`, {
+      preparedSpellIds,
+    }),
 };

--- a/apps/control-web/src/shared/i18n/enUS/common.ts
+++ b/apps/control-web/src/shared/i18n/enUS/common.ts
@@ -1,4 +1,6 @@
 export const commonEnUSDictionary = {
   "common.close": "Close",
   "common.selectTarget": "Select Target...",
+  "common.cancel": "Cancel",
+  "common.saving": "Saving...",
 } as const;

--- a/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
@@ -199,4 +199,13 @@ export const playerBoardEnUSDictionary = {
   "playerBoard.lifecycleLongRest": "Clears on long rest",
   "playerBoard.concentrationReplacedTitle": "Concentration replaced",
   "playerBoard.concentrationReplacedDescription": "Previous concentration ended: {previous}. New concentration: {next}.",
+  "playerBoard.prepareSpellsPrompt": "Prepare spells",
+  "playerBoard.prepareSpellsDescription": "You completed a long rest. Review your prepared spells.",
+  "playerBoard.prepareSpellsButton": "Prepare spells",
+  "playerBoard.prepareSpellsSelected": "Selected: {count} / {limit}",
+  "playerBoard.prepareSpellsOverLimit": "Limit exceeded",
+  "playerBoard.prepareSpellsCantrips": "Cantrips",
+  "playerBoard.prepareSpellsLevel": "Level {level}",
+  "playerBoard.prepareSpellsErrorTitle": "Failed to prepare spells",
+  "playerBoard.prepareSpellsErrorDescription": "Could not save prepared spells.",
 } as const;

--- a/apps/control-web/src/shared/i18n/ptBR/common.ts
+++ b/apps/control-web/src/shared/i18n/ptBR/common.ts
@@ -1,4 +1,6 @@
 export const commonPtBRDictionary = {
   "common.close": "Fechar",
   "common.selectTarget": "Selecionar alvo...",
+  "common.cancel": "Cancelar",
+  "common.saving": "Salvando...",
 } as const;

--- a/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
@@ -199,4 +199,13 @@ export const playerBoardPtBRDictionary = {
   "playerBoard.lifecycleLongRest": "Limpa no descanso longo",
   "playerBoard.concentrationReplacedTitle": "Concentração substituída",
   "playerBoard.concentrationReplacedDescription": "Concentração anterior encerrada: {previous}. Nova concentração: {next}.",
+  "playerBoard.prepareSpellsPrompt": "Preparar magias",
+  "playerBoard.prepareSpellsDescription": "Você concluiu um descanso longo. Revise suas magias preparadas.",
+  "playerBoard.prepareSpellsButton": "Preparar magias",
+  "playerBoard.prepareSpellsSelected": "Selecionadas: {count} / {limit}",
+  "playerBoard.prepareSpellsOverLimit": "Limite excedido",
+  "playerBoard.prepareSpellsCantrips": "Truques",
+  "playerBoard.prepareSpellsLevel": "Nível {level}",
+  "playerBoard.prepareSpellsErrorTitle": "Erro ao preparar magias",
+  "playerBoard.prepareSpellsErrorDescription": "Não foi possível salvar as magias preparadas.",
 } as const;


### PR DESCRIPTION
# feat(spells): add prepared spell lists after long rest

## Summary

Adds a post-long-rest spell preparation workflow for prepared/spellbook casters.

When a GM ends a long rest, eligible characters receive a pending spell preparation prompt. Players can review and update their prepared leveled spells from the Player Board, then submit the prepared list.

This is additive and non-disruptive: existing prepared flags are preserved as the dialog’s initial state.

## Context

The system already supports:

- out-of-combat active effects
- rest-based duration metadata
- long/short rest cleanup
- active effects panels on Player Board and Character Sheet
- concentration lifecycle outside combat

The next roadmap step is spell preparation.

Prepared casters need a way to review and update their prepared spell list after long rest, before future work such as out-of-combat spell casting.

This PR adds that workflow without implementing out-of-combat casting yet.

Choosing the menu is now supported. Eating the menu is a future crime.

## Backend changes

### Spell preparation service

Added:

```text
apps/control-server/app/services/spell_preparation.py
````

Includes:

```py
compute_prepared_spell_limit
create_pending_spell_preparation
apply_prepared_spells
```

Behavior:

* detects eligible prepared/spellbook casters
* computes preparation limit
* creates `pending_spell_preparation`
* applies submitted prepared spell IDs
* preserves cantrips as always prepared
* clears pending preparation after successful submit

### Long rest integration

Updated:

```text
apps/control-server/app/api/routes/sessions/commands_service.py
```

When the GM ends a long rest, the backend scans each player state.

Eligible classes receive:

```text
pending_spell_preparation
```

Prepared/spellbook caster classes in v1:

```text
cleric
druid
paladin
wizard
```

Known casters and non-casters do not receive a prompt.

### Prepare spells endpoint

Updated:

```text
apps/control-server/app/api/routes/sessions/state.py
```

Added:

```http
POST /sessions/{id}/state/me/spells/prepare
```

The endpoint:

* requires pending preparation
* validates submitted spell IDs
* validates prepared spell count against the limit
* applies prepared flags to `spellcasting.spells`
* keeps cantrips prepared
* clears `pending_spell_preparation`
* returns updated `SessionStateRead`

### Session state schema

Updated:

```text
apps/control-server/app/schemas/session_state.py
apps/control-server/app/api/routes/sessions/state_common.py
```

Added:

```text
PrepareSpellsRequest
pendingSpellPreparation
```

`to_state_read()` now exposes pending spell preparation data from `state_json`.

## Preparation limit

| Caster type                        | Formula                       |
| ---------------------------------- | ----------------------------- |
| Full caster: cleric, druid, wizard | `level + modifier`            |
| Half caster: paladin               | `floor(level / 2) + modifier` |
| All                                | minimum `1`                   |

## Frontend changes

### Types and API

Updated:

```text
apps/control-web/src/shared/api/combatRepo.ts
apps/control-web/src/entities/character/character.types.ts
apps/control-web/src/shared/api/sessionStatesRepo.ts
```

Added:

* `PendingSpellPreparation`
* `SessionStateRecord.pendingSpellPreparation`
* `sessionStatesRepo.prepareSpells`

### Player Board resources

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardResources.ts
```

Now extracts `pendingSpellPreparation` from session state.

### Player Board prompt

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
```

Adds an amber post-long-rest prompt when pending preparation exists.

The prompt lets the player open the preparation dialog.

### Spell preparation dialog

Added:

```text
apps/control-web/src/pages/PlayerBoardPage/SpellPreparationDialog.tsx
```

Features:

* grouped spell list: cantrips + leveled spells
* cantrips shown as always prepared
* leveled spell toggle checkboxes
* selected count / prepared limit
* over-limit guard
* submit handler

### i18n

Updated:

```text
apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
apps/control-web/src/shared/i18n/enUS/playerBoard.ts
```

Added 7 preparation keys and 2 common keys.

## V1 behavior

This PR intentionally preserves existing prepared flags.

Long rest creates a review/adjustment prompt, but does not automatically reset all leveled spells to unprepared.

That avoids the delightful UX disaster where a player forgets to re-prepare spells and walks into combat with the magical confidence of a wet cardboard box.

## Backward compatibility

* known casters keep current behavior
* non-casters keep current behavior
* existing prepared flags are preserved
* combat spell availability continues using existing `prepared` gating
* Character Sheet prepared checkboxes remain unchanged
* no out-of-combat casting behavior added

## Tests

Added:

```text
apps/control-server/tests/test_spell_preparation.py
```

Coverage includes:

* preparation limit computation
* full caster limit
* half caster limit
* minimum limit
* pending creation for cleric
* pending creation for druid
* pending creation for paladin
* pending creation for wizard/spellbook caster
* no pending for known casters
* no pending for non-casters
* apply prepared spell flags
* cantrip preservation
* pending state cleanup

## Validation

Backend:

```text
1874 passed, 1 skipped
```

Frontend:

```text
40 passed, 0 failed
```

TypeScript:

```text
No new errors in modified files
```

## Out of scope

This PR intentionally does not implement:

* out-of-combat spell casting
* applying buffs or utility spells outside combat
* spell slot spending outside combat
* wizard spellbook acquisition/copying
* multiclass preparation
* GM override for prepared spells
* search/filter in preparation dialog
* prepared spell history/log
* auto-preparing domain/oath spells
* resetting all prepared spells on long rest

## Notes for reviewers

This PR adds the post-long-rest preparation workflow only.

It does not change the spellcasting/casting pipeline directly. It relies on the existing `prepared` flag behavior already used by combat spell availability.
