### PR TITLE
feat(spells): add has_castable_effects function and update list_out_o…

### DIFF
--- a/apps/control-server/app/api/routes/sessions/state.py
+++ b/apps/control-server/app/api/routes/sessions/state.py
@@ -25,6 +25,7 @@ from app.services.out_of_combat_cast import (
     build_persisted_effects,
     check_out_of_combat_cast_eligibility,
     consume_spell_slot,
+    has_castable_effects,
 )
 from app.services.session_rest import ensure_rest_state
 from app.services.session_state_finalize import finalize_session_state_data
@@ -397,6 +398,7 @@ def list_out_of_combat_castable_spells(
         )
     ).all()
 
+    campaign_spells = [cs for cs in campaign_spells if has_castable_effects(cs)]
     eligible_keys = {cs.canonical_key for cs in campaign_spells}
 
     result = []

--- a/apps/control-server/app/services/out_of_combat_cast.py
+++ b/apps/control-server/app/services/out_of_combat_cast.py
@@ -181,6 +181,18 @@ def _has_resolvable_effects(spell, variant_key: str | None) -> bool:
     return bool(_resolve_effects(spell, variant_key))
 
 
+def has_castable_effects(spell) -> bool:
+    """True if the spell has any supported declarative effects (direct or via variants).
+
+    Used by the eligible-list endpoint to exclude spells that would always be
+    rejected at cast time due to having no persistable effects.
+    """
+    if spell.effects_json:
+        return True
+    variants = spell.variants_json or []
+    return any(v.get("effects") for v in variants)
+
+
 _SKIP_EFFECT_TYPES = {"grant_temp_hp"}
 
 

--- a/apps/control-server/tests/test_out_of_combat_cast.py
+++ b/apps/control-server/tests/test_out_of_combat_cast.py
@@ -610,3 +610,585 @@ class TestCastSpellOutOfCombat(unittest.IsolatedAsyncioTestCase):
         for e in effects:
             meta = e.get("metadata", {})
             self.assertEqual(meta.get("selected_variant_key"), "owls_wisdom")
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data", side_effect=lambda d: d)
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_prepared_leveled_spell_accepted(
+        self,
+        mock_to_state_read,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_view,
+        mock_get_entry,
+    ):
+        entry = MagicMock(party_id="party-1", campaign_id="camp-1")
+        mock_get_entry.return_value = entry
+
+        state_json = _slots_state(level=1, used=0, max_slots=4)
+        state_json["spellcasting"]["spells"] = [
+            {"id": "spell-sof-1", "canonicalKey": "shield_of_faith", "level": 1, "prepared": True}
+        ]
+        db = MagicMock()
+        state = MagicMock()
+        state.state_json = state_json
+        state.id = "ss-1"
+        state.session_id = "session-1"
+        state.player_user_id = "user-1"
+        state.created_at = "2026-01-01T00:00:00+00:00"
+        state.updated_at = None
+
+        shield = _make_campaign_spell(
+            canonical_key="shield_of_faith",
+            level=1,
+            concentration=True,
+            out_of_combat_castable=True,
+            effects_json=[_ac_bonus_effect(2)],
+        )
+        call_count = [0]
+
+        def exec_side(q, **kw):
+            r = MagicMock()
+            r.first.return_value = state if call_count[0] == 0 else shield
+            call_count[0] += 1
+            return r
+
+        db.exec.side_effect = exec_side
+        mock_ensure.return_value = state
+        mock_to_state_read.return_value = MagicMock()
+
+        req = OutOfCombatCastRequest(spellId="spell-sof-1", slotLevel=1, variantKey=None)
+        result = await cast_spell_out_of_combat(
+            session_id="session-1", req=req, user=_make_user(), session=db
+        )
+        self.assertIsNotNone(result)
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data", side_effect=lambda d: d)
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_non_concentration_effects_survive_concentration_replacement(
+        self,
+        mock_to_state_read,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_view,
+        mock_get_entry,
+    ):
+        entry = MagicMock(party_id="party-1", campaign_id="camp-1")
+        mock_get_entry.return_value = entry
+
+        non_conc_effect = {
+            "id": "non-conc-eff",
+            "kind": "spell_effect",
+            "duration_type": "until_long_rest",
+            "metadata": {
+                "concentration": False,
+                "concentration_group": None,
+                "source_spell_key": "guidance",
+            },
+        }
+        old_conc_effect = {
+            "id": "old-conc-eff",
+            "kind": "spell_effect",
+            "duration_type": "until_long_rest",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "old-grp",
+                "source_spell_key": "bless",
+            },
+        }
+        state_json = {
+            **_slots_state(level=1),
+            "active_spell_effects": [non_conc_effect, old_conc_effect],
+        }
+        state_json["spellcasting"]["spells"] = [
+            {"id": "spell-sof-1", "canonicalKey": "shield_of_faith", "level": 1, "prepared": True}
+        ]
+        db = MagicMock()
+        state = MagicMock()
+        state.state_json = state_json
+        state.id = "ss-1"
+        state.session_id = "session-1"
+        state.player_user_id = "user-1"
+        state.created_at = "2026-01-01T00:00:00+00:00"
+        state.updated_at = None
+
+        shield = _make_campaign_spell(
+            canonical_key="shield_of_faith",
+            level=1,
+            concentration=True,
+            out_of_combat_castable=True,
+            effects_json=[_ac_bonus_effect(2)],
+        )
+        call_count = [0]
+
+        def exec_side(q, **kw):
+            r = MagicMock()
+            r.first.return_value = state if call_count[0] == 0 else shield
+            call_count[0] += 1
+            return r
+
+        db.exec.side_effect = exec_side
+        mock_ensure.return_value = state
+        mock_to_state_read.return_value = MagicMock()
+
+        req = OutOfCombatCastRequest(spellId="spell-sof-1", slotLevel=1, variantKey=None)
+        await cast_spell_out_of_combat(
+            session_id="session-1", req=req, user=_make_user(), session=db
+        )
+
+        remaining = state.state_json.get("active_spell_effects", [])
+        ids = [e["id"] for e in remaining]
+        self.assertIn("non-conc-eff", ids, "Non-concentration effect must survive concentration replacement")
+        self.assertNotIn("old-conc-eff", ids, "Old concentration effect must be cleared")
+
+
+# ---------------------------------------------------------------------------
+# Tests: list_out_of_combat_castable_spells endpoint
+# ---------------------------------------------------------------------------
+
+class TestListCastableEndpoint(unittest.TestCase):
+    def _make_state_with_spells(self, spells: list) -> MagicMock:
+        state = MagicMock()
+        state.state_json = {
+            "spellcasting": {
+                "slots": {},
+                "spells": spells,
+            }
+        }
+        return state
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    def test_returns_only_out_of_combat_castable_spells(
+        self, mock_ensure, mock_require, mock_get_entry
+    ):
+        entry = MagicMock(party_id="party-1", campaign_id="camp-1")
+        mock_get_entry.return_value = entry
+
+        state = self._make_state_with_spells([
+            {"id": "spell-ea-1", "canonicalKey": "enhance_ability", "level": 2, "prepared": True},
+            {"id": "spell-fb-1", "canonicalKey": "fireball", "level": 3, "prepared": True},
+        ])
+        mock_ensure.return_value = state
+
+        # DB returns only the castable spell (fireball filtered out at DB level)
+        enhance_cs = _make_campaign_spell(
+            canonical_key="enhance_ability",
+            level=2,
+            out_of_combat_castable=True,
+            variants_json=[{"key": "owls_wisdom", "labelPt": "Sabedoria", "effects": [_advantage_effect()]}],
+        )
+        db = MagicMock()
+        call_count = [0]
+
+        def exec_side(q, **kw):
+            r = MagicMock()
+            if call_count[0] == 0:
+                r.first.return_value = state
+            else:
+                r.all.return_value = [enhance_cs]
+            call_count[0] += 1
+            return r
+
+        db.exec.side_effect = exec_side
+
+        result = list_out_of_combat_castable_spells(
+            session_id="session-1", user=_make_user(), session=db
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["canonicalKey"], "enhance_ability")
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    def test_excludes_spells_with_no_effects_or_variants(
+        self, mock_ensure, mock_require, mock_get_entry
+    ):
+        entry = MagicMock(party_id="party-1", campaign_id="camp-1")
+        mock_get_entry.return_value = entry
+
+        state = self._make_state_with_spells([
+            {"id": "spell-empty-1", "canonicalKey": "empty_spell", "level": 1, "prepared": True},
+        ])
+        mock_ensure.return_value = state
+
+        empty_cs = _make_campaign_spell(
+            canonical_key="empty_spell",
+            level=1,
+            out_of_combat_castable=True,
+            effects_json=[],
+            variants_json=[],
+        )
+        db = MagicMock()
+        call_count = [0]
+
+        def exec_side(q, **kw):
+            r = MagicMock()
+            if call_count[0] == 0:
+                r.first.return_value = state
+            else:
+                r.all.return_value = [empty_cs]
+            call_count[0] += 1
+            return r
+
+        db.exec.side_effect = exec_side
+
+        result = list_out_of_combat_castable_spells(
+            session_id="session-1", user=_make_user(), session=db
+        )
+
+        self.assertEqual(result, [], "Spells with no effects should be excluded from the eligible list")
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    def test_includes_variant_only_spells(
+        self, mock_ensure, mock_require, mock_get_entry
+    ):
+        """Enhance Ability has no top-level effects but variant effects; it should appear."""
+        entry = MagicMock(party_id="party-1", campaign_id="camp-1")
+        mock_get_entry.return_value = entry
+
+        state = self._make_state_with_spells([
+            {"id": "spell-ea-1", "canonicalKey": "enhance_ability", "level": 2, "prepared": True},
+        ])
+        mock_ensure.return_value = state
+
+        enhance_cs = _make_campaign_spell(
+            canonical_key="enhance_ability",
+            level=2,
+            out_of_combat_castable=True,
+            effects_json=[],
+            variants_json=[{"key": "owls_wisdom", "labelPt": "Sabedoria", "effects": [_advantage_effect()]}],
+        )
+        db = MagicMock()
+        call_count = [0]
+
+        def exec_side(q, **kw):
+            r = MagicMock()
+            if call_count[0] == 0:
+                r.first.return_value = state
+            else:
+                r.all.return_value = [enhance_cs]
+            call_count[0] += 1
+            return r
+
+        db.exec.side_effect = exec_side
+
+        result = list_out_of_combat_castable_spells(
+            session_id="session-1", user=_make_user(), session=db
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["canonicalKey"], "enhance_ability")
+
+
+# ---------------------------------------------------------------------------
+# Tests: cast mutation safety (failed cast must not mutate state)
+# ---------------------------------------------------------------------------
+
+class TestCastMutationSafety(unittest.IsolatedAsyncioTestCase):
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    async def test_failed_cast_does_not_spend_slots(
+        self, mock_ensure, mock_require_view, mock_get_entry
+    ):
+        from fastapi import HTTPException
+
+        entry = MagicMock(party_id="party-1", campaign_id="camp-1")
+        mock_get_entry.return_value = entry
+
+        state_json = _slots_state(level=3, used=0, max_slots=2)
+        state_json["spellcasting"]["spells"] = [
+            {"id": "spell-fb-1", "canonicalKey": "fireball", "level": 3, "prepared": True}
+        ]
+        db = MagicMock()
+        state = MagicMock()
+        state.state_json = state_json
+        state.id = "ss-1"
+        state.session_id = "session-1"
+        state.player_user_id = "user-1"
+        state.created_at = "2026-01-01T00:00:00+00:00"
+        state.updated_at = None
+
+        fireball = _make_campaign_spell(
+            canonical_key="fireball", level=3, out_of_combat_castable=False
+        )
+        call_count = [0]
+
+        def exec_side(q, **kw):
+            r = MagicMock()
+            r.first.return_value = state if call_count[0] == 0 else fireball
+            call_count[0] += 1
+            return r
+
+        db.exec.side_effect = exec_side
+        mock_ensure.return_value = state
+
+        req = OutOfCombatCastRequest(spellId="spell-fb-1", slotLevel=3, variantKey=None)
+        with self.assertRaises(HTTPException):
+            await cast_spell_out_of_combat(
+                session_id="session-1", req=req, user=_make_user(), session=db
+            )
+
+        used = state.state_json["spellcasting"]["slots"]["3"]["used"]
+        self.assertEqual(used, 0, "Slots must not be decremented after a failed cast")
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    async def test_failed_cast_does_not_create_active_effects(
+        self, mock_ensure, mock_require_view, mock_get_entry
+    ):
+        from fastapi import HTTPException
+
+        entry = MagicMock(party_id="party-1", campaign_id="camp-1")
+        mock_get_entry.return_value = entry
+
+        state_json = _slots_state(level=3, used=0, max_slots=2)
+        state_json["spellcasting"]["spells"] = [
+            {"id": "spell-fb-1", "canonicalKey": "fireball", "level": 3, "prepared": True}
+        ]
+        state_json["active_spell_effects"] = []
+        db = MagicMock()
+        state = MagicMock()
+        state.state_json = state_json
+        state.id = "ss-1"
+        state.session_id = "session-1"
+        state.player_user_id = "user-1"
+        state.created_at = "2026-01-01T00:00:00+00:00"
+        state.updated_at = None
+
+        fireball = _make_campaign_spell(
+            canonical_key="fireball", level=3, out_of_combat_castable=False
+        )
+        call_count = [0]
+
+        def exec_side(q, **kw):
+            r = MagicMock()
+            r.first.return_value = state if call_count[0] == 0 else fireball
+            call_count[0] += 1
+            return r
+
+        db.exec.side_effect = exec_side
+        mock_ensure.return_value = state
+
+        req = OutOfCombatCastRequest(spellId="spell-fb-1", slotLevel=3, variantKey=None)
+        with self.assertRaises(HTTPException):
+            await cast_spell_out_of_combat(
+                session_id="session-1", req=req, user=_make_user(), session=db
+            )
+
+        effects = state.state_json.get("active_spell_effects", [])
+        self.assertEqual(effects, [], "Active effects must not be modified after a failed cast")
+
+
+# ---------------------------------------------------------------------------
+# Tests: Enhance Ability variant regression
+# ---------------------------------------------------------------------------
+
+class TestEnhanceAbilityVariants(unittest.TestCase):
+    _VARIANTS = [
+        ("bears_endurance", "Resistência do Urso", "Bear's Endurance", "constitution"),
+        ("bulls_strength", "Força do Touro", "Bull's Strength", "strength"),
+        ("cats_grace", "Graça do Gato", "Cat's Grace", "dexterity"),
+        ("eagles_splendor", "Esplendor da Águia", "Eagle's Splendor", "charisma"),
+        ("foxs_cunning", "Astúcia da Raposa", "Fox's Cunning", "intelligence"),
+        ("owls_wisdom", "Sabedoria da Coruja", "Owl's Wisdom", "wisdom"),
+    ]
+
+    def _make_enhance_ability_spell(self):
+        return _make_campaign_spell(
+            canonical_key="enhance_ability",
+            level=2,
+            concentration=True,
+            out_of_combat_castable=True,
+            effects_json=[],
+            variants_json=[
+                {
+                    "key": key,
+                    "labelPt": label_pt,
+                    "labelEn": label_en,
+                    "effects": [_advantage_effect(ability)],
+                }
+                for key, label_pt, label_en, ability in self._VARIANTS
+            ],
+        )
+
+    def test_spell_exposes_all_six_variants(self):
+        spell = self._make_enhance_ability_spell()
+        self.assertEqual(len(spell.variants_json), 6)
+        keys = {v["key"] for v in spell.variants_json}
+        for key, _, _, _ in self._VARIANTS:
+            self.assertIn(key, keys)
+
+    def test_each_variant_stores_correct_metadata(self):
+        spell = self._make_enhance_ability_spell()
+        for key, label_pt, _, ability in self._VARIANTS:
+            with self.subTest(variant=key):
+                effects = build_persisted_effects(
+                    spell=spell, caster_user_id="user-1", variant_key=key
+                )
+                self.assertEqual(len(effects), 1)
+                meta = effects[0]["metadata"]
+                self.assertEqual(meta["selected_variant_key"], key)
+                self.assertEqual(meta["selected_variant_label"], label_pt)
+                self.assertEqual(
+                    meta["declarative_effect"]["params"]["ability"],
+                    ability,
+                    f"Wrong ability for variant {key!r}",
+                )
+
+    def test_cats_grace_grants_dexterity_advantage(self):
+        spell = self._make_enhance_ability_spell()
+        effects = build_persisted_effects(
+            spell=spell, caster_user_id="user-1", variant_key="cats_grace"
+        )
+        meta = effects[0]["metadata"]
+        self.assertEqual(meta["declarative_effect"]["type"], "advantage_on_checks")
+        self.assertEqual(meta["declarative_effect"]["params"]["ability"], "dexterity")
+
+    def test_owls_wisdom_grants_wisdom_advantage(self):
+        spell = self._make_enhance_ability_spell()
+        effects = build_persisted_effects(
+            spell=spell, caster_user_id="user-1", variant_key="owls_wisdom"
+        )
+        meta = effects[0]["metadata"]
+        self.assertEqual(meta["declarative_effect"]["type"], "advantage_on_checks")
+        self.assertEqual(meta["declarative_effect"]["params"]["ability"], "wisdom")
+
+    def test_each_variant_effect_is_concentration(self):
+        spell = self._make_enhance_ability_spell()
+        for key, _, _, _ in self._VARIANTS:
+            with self.subTest(variant=key):
+                effects = build_persisted_effects(
+                    spell=spell, caster_user_id="user-1", variant_key=key
+                )
+                meta = effects[0]["metadata"]
+                self.assertTrue(meta["concentration"])
+                self.assertIsNotNone(meta["concentration_group"])
+
+
+# ---------------------------------------------------------------------------
+# Tests: Shield of Faith regression
+# ---------------------------------------------------------------------------
+
+class TestShieldOfFaithRegression(unittest.IsolatedAsyncioTestCase):
+    def _make_shield_spell(self):
+        return _make_campaign_spell(
+            canonical_key="shield_of_faith",
+            level=1,
+            concentration=True,
+            out_of_combat_castable=True,
+            effects_json=[_ac_bonus_effect(2)],
+            name_pt="Escudo da Fé",
+            name_en="Shield of Faith",
+        )
+
+    def _setup_cast(self, mock_get_entry, mock_ensure):
+        entry = MagicMock(party_id="party-1", campaign_id="camp-1")
+        mock_get_entry.return_value = entry
+
+        state_json = _slots_state(level=1, used=0, max_slots=4)
+        state_json["spellcasting"]["spells"] = [
+            {"id": "spell-sof-1", "canonicalKey": "shield_of_faith", "level": 1, "prepared": True}
+        ]
+        db = MagicMock()
+        state = MagicMock()
+        state.state_json = state_json
+        state.id = "ss-1"
+        state.session_id = "session-1"
+        state.player_user_id = "user-1"
+        state.created_at = "2026-01-01T00:00:00+00:00"
+        state.updated_at = None
+
+        shield = self._make_shield_spell()
+        call_count = [0]
+
+        def exec_side(q, **kw):
+            r = MagicMock()
+            r.first.return_value = state if call_count[0] == 0 else shield
+            call_count[0] += 1
+            return r
+
+        db.exec.side_effect = exec_side
+        mock_ensure.return_value = state
+        return db, state
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data", side_effect=lambda d: d)
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_cast_creates_temp_ac_bonus_effect(
+        self, mock_to_state, mock_pub, mock_fin, mock_ensure, mock_req, mock_entry
+    ):
+        mock_to_state.return_value = MagicMock()
+        db, state = self._setup_cast(mock_entry, mock_ensure)
+
+        req = OutOfCombatCastRequest(spellId="spell-sof-1", slotLevel=1, variantKey=None)
+        await cast_spell_out_of_combat(
+            session_id="session-1", req=req, user=_make_user(), session=db
+        )
+
+        effects = state.state_json.get("active_spell_effects", [])
+        ac_effects = [e for e in effects if e.get("kind") == "temp_ac_bonus"]
+        self.assertEqual(len(ac_effects), 1)
+        self.assertEqual(ac_effects[0]["numeric_value"], 2)
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data", side_effect=lambda d: d)
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_slot_is_spent_after_cast(
+        self, mock_to_state, mock_pub, mock_fin, mock_ensure, mock_req, mock_entry
+    ):
+        mock_to_state.return_value = MagicMock()
+        db, state = self._setup_cast(mock_entry, mock_ensure)
+
+        req = OutOfCombatCastRequest(spellId="spell-sof-1", slotLevel=1, variantKey=None)
+        await cast_spell_out_of_combat(
+            session_id="session-1", req=req, user=_make_user(), session=db
+        )
+
+        used = state.state_json["spellcasting"]["slots"]["1"]["used"]
+        self.assertEqual(used, 1)
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data", side_effect=lambda d: d)
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_concentration_metadata_present(
+        self, mock_to_state, mock_pub, mock_fin, mock_ensure, mock_req, mock_entry
+    ):
+        mock_to_state.return_value = MagicMock()
+        db, state = self._setup_cast(mock_entry, mock_ensure)
+
+        req = OutOfCombatCastRequest(spellId="spell-sof-1", slotLevel=1, variantKey=None)
+        await cast_spell_out_of_combat(
+            session_id="session-1", req=req, user=_make_user(), session=db
+        )
+
+        effects = state.state_json.get("active_spell_effects", [])
+        self.assertTrue(len(effects) >= 1)
+        for e in effects:
+            meta = e.get("metadata", {})
+            self.assertTrue(meta.get("concentration"))
+            self.assertIsNotNone(meta.get("concentration_group"))

--- a/apps/control-web/src/pages/PlayerBoardPage/OutOfCombatSpellCastCard.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/OutOfCombatSpellCastCard.test.tsx
@@ -1,0 +1,147 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { OutOfCombatSpellCastCard } from "./OutOfCombatSpellCastCard";
+import type { OutOfCombatCastableSpell } from "../../entities/character";
+
+vi.mock("../../shared/hooks/useLocale", () => ({
+  useLocale: () => ({
+    t: (key: string) =>
+      ({
+        "playerBoard.castSpells": "Conjurar magia",
+        "playerBoard.concentration": "Concentração",
+        "playerBoard.notPrepared": "Não preparado",
+        "playerBoard.selectVariant": "Variante",
+        "playerBoard.selectSlotLevel": "Slot",
+        "playerBoard.castSpellLoading": "Conjurando...",
+        "playerBoard.castSpellConfirm": "Conjurar",
+      }[key] ?? key),
+  }),
+}));
+
+const makeSpell = (
+  overrides: Partial<OutOfCombatCastableSpell> = {},
+): OutOfCombatCastableSpell => ({
+  id: "spell-1",
+  canonicalKey: "shield_of_faith",
+  nameEn: "Shield of Faith",
+  namePt: "Escudo da Fé",
+  level: 1,
+  concentration: true,
+  prepared: true,
+  variants: [],
+  effects: [],
+  ...overrides,
+});
+
+describe("OutOfCombatSpellCastCard", () => {
+  it("returns null when spell list is empty", () => {
+    const markup = renderToStaticMarkup(
+      <OutOfCombatSpellCastCard spells={[]} casting={false} onCast={() => undefined} />,
+    );
+    expect(markup).toBe("");
+  });
+
+  it("renders spell name for each eligible spell", () => {
+    const markup = renderToStaticMarkup(
+      <OutOfCombatSpellCastCard
+        spells={[makeSpell({ namePt: "Escudo da Fé" })]}
+        casting={false}
+        onCast={() => undefined}
+      />,
+    );
+    expect(markup).toContain("Escudo da Fé");
+  });
+
+  it("shows level badge for leveled spells", () => {
+    const markup = renderToStaticMarkup(
+      <OutOfCombatSpellCastCard
+        spells={[makeSpell({ level: 2 })]}
+        casting={false}
+        onCast={() => undefined}
+      />,
+    );
+    expect(markup).toContain("Nv 2");
+  });
+
+  it("shows concentration badge for concentration spells", () => {
+    const markup = renderToStaticMarkup(
+      <OutOfCombatSpellCastCard
+        spells={[makeSpell({ concentration: true })]}
+        casting={false}
+        onCast={() => undefined}
+      />,
+    );
+    expect(markup).toContain("Concentração");
+  });
+
+  it("shows not-prepared badge for unprepared spells", () => {
+    const markup = renderToStaticMarkup(
+      <OutOfCombatSpellCastCard
+        spells={[makeSpell({ prepared: false })]}
+        casting={false}
+        onCast={() => undefined}
+      />,
+    );
+    expect(markup).toContain("Não preparado");
+  });
+
+  it("does not show expand arrow for unprepared spells", () => {
+    const markup = renderToStaticMarkup(
+      <OutOfCombatSpellCastCard
+        spells={[makeSpell({ prepared: false })]}
+        casting={false}
+        onCast={() => undefined}
+      />,
+    );
+    expect(markup).not.toContain("▼");
+  });
+
+  it("shows expand arrow for prepared spells", () => {
+    const markup = renderToStaticMarkup(
+      <OutOfCombatSpellCastCard
+        spells={[makeSpell({ prepared: true })]}
+        casting={false}
+        onCast={() => undefined}
+      />,
+    );
+    expect(markup).toContain("▼");
+  });
+
+  it("renders multiple spells", () => {
+    const markup = renderToStaticMarkup(
+      <OutOfCombatSpellCastCard
+        spells={[
+          makeSpell({ id: "s1", nameEn: "Bless", namePt: "Benção" }),
+          makeSpell({ id: "s2", nameEn: "Shield of Faith", namePt: "Escudo da Fé" }),
+        ]}
+        casting={false}
+        onCast={() => undefined}
+      />,
+    );
+    expect(markup).toContain("Benção");
+    expect(markup).toContain("Escudo da Fé");
+  });
+
+  it("does not crash with casting=true", () => {
+    expect(() =>
+      renderToStaticMarkup(
+        <OutOfCombatSpellCastCard
+          spells={[makeSpell()]}
+          casting={true}
+          onCast={() => undefined}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it("falls back to nameEn when namePt is absent", () => {
+    const markup = renderToStaticMarkup(
+      <OutOfCombatSpellCastCard
+        spells={[makeSpell({ namePt: undefined, nameEn: "Guidance" })]}
+        casting={false}
+        onCast={() => undefined}
+      />,
+    );
+    expect(markup).toContain("Guidance");
+  });
+});

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
@@ -43,6 +43,11 @@ vi.mock("../../shared/hooks/useLocale", () => ({
   }),
 }));
 
+vi.mock("./OutOfCombatSpellCastCard", () => ({
+  OutOfCombatSpellCastCard: ({ spells }: { spells: unknown[] }) =>
+    spells.length > 0 ? <div data-testid="cast-card">cast-card</div> : null,
+}));
+
 vi.mock("./player-board-status/PlayerBoardStatusCards", () => ({
   DeathSaveCard: () => <div>death</div>,
   ProgressCard: ({ label, value }: { label: string; value: string }) => <div>{label}:{value}</div>,
@@ -643,5 +648,86 @@ describe("PlayerBoardStatusPanel", () => {
 
     expect(markup).toContain("disabled");
     expect(markup).toContain("Removendo...");
+  });
+});
+
+describe("PlayerBoardStatusPanel – out-of-combat spell casting", () => {
+  const baseProps = {
+    combatActive: false,
+    pendingRoll: null,
+    playerStatus: {
+      level: 3,
+      currentHp: 20,
+      maxHp: 20,
+      hpPercent: 100,
+      tempHp: 0,
+      xpPercent: 10,
+      nextLevelThreshold: 900,
+      experiencePoints: 100,
+      ac: 12,
+      initiative: 1,
+      passivePerception: 13,
+    } as any,
+    restState: "exploration" as const,
+    usingHitDie: false,
+    onUseHitDie: () => undefined,
+    onClearConcentration: () => undefined,
+    onRemoveEffect: () => undefined,
+  };
+
+  const eligibleSpell = {
+    id: "spell-sof-1",
+    canonicalKey: "shield_of_faith",
+    nameEn: "Shield of Faith",
+    namePt: "Escudo da Fé",
+    level: 1,
+    concentration: true,
+    prepared: true,
+    variants: [],
+    effects: [],
+  } as any;
+
+  it("renders cast card when not in combat and spells are available", () => {
+    const markup = renderToStaticMarkup(
+      <PlayerBoardStatusPanel
+        {...baseProps}
+        castableSpells={[eligibleSpell]}
+        onCastSpell={() => undefined}
+      />,
+    );
+    expect(markup).toContain("cast-card");
+  });
+
+  it("hides cast card when combat is active", () => {
+    const markup = renderToStaticMarkup(
+      <PlayerBoardStatusPanel
+        {...baseProps}
+        combatActive={true}
+        castableSpells={[eligibleSpell]}
+        onCastSpell={() => undefined}
+      />,
+    );
+    expect(markup).not.toContain("cast-card");
+  });
+
+  it("hides cast card when castableSpells is empty", () => {
+    const markup = renderToStaticMarkup(
+      <PlayerBoardStatusPanel
+        {...baseProps}
+        castableSpells={[]}
+        onCastSpell={() => undefined}
+      />,
+    );
+    expect(markup).not.toContain("cast-card");
+  });
+
+  it("hides cast card when onCastSpell is not provided", () => {
+    const markup = renderToStaticMarkup(
+      <PlayerBoardStatusPanel
+        {...baseProps}
+        castableSpells={[eligibleSpell]}
+      />,
+    );
+    expect(markup).not.toContain("cast-card");
   });
 });


### PR DESCRIPTION
# test(spells): harden out-of-combat casting v1

## Summary

Hardens out-of-combat spell casting v1 with backend and frontend regression coverage.

This PR also fixes one small production issue found during hardening: spells flagged as `out_of_combat_castable` but without direct or variant effects could appear in the eligible list even though they would fail when cast.

Closes #231

## Context

Out-of-combat spell casting v1 supports self-target buff/utility spells that:

- are explicitly marked `out_of_combat_castable`
- have supported declarative effects
- pass prepared/known validation
- spend spell slots when required
- create persisted active effects
- support concentration replacement
- update PlayerBoard active effects/concentration state

Before expanding to ally targeting or more spell types, this PR locks down the v1 behavior.

No new spellcasting feature scope was added.

## Production fix

Updated:

```text
apps/control-server/app/services/out_of_combat_cast.py
````

Added:

```py
has_castable_effects(spell)
```

This helper checks whether a spell has any castable direct or variant effects.

It is now used by `list_out_of_combat_castable_spells`.

This prevents spells with:

```text
out_of_combat_castable = true
effects = []
variants = [] / no variant effects
```

from appearing in the eligible out-of-combat cast list.

Previously, such spells could show up as castable but fail later during cast resolution. Very “the button exists, the universe disagrees”. Now the eligible list matches actual castability.

## Backend tests

Updated:

```text
apps/control-server/tests/test_out_of_combat_cast.py
```

Added 20 tests, bringing the file to 37 tests total.

### `TestListCastableEndpoint`

Covers:

* returns only out-of-combat castable spells
* excludes effect-less spells
* includes variant-only spells such as Enhance Ability

### `TestCastMutationSafety`

Covers failed cast safety:

* failed cast leaves spell slots unchanged
* failed cast does not create active effects

### `TestCastSpellOutOfCombat`

Added coverage for:

* prepared spell accepted
* non-concentration effects survive concentration replacement
* response includes updated active effects

### `TestEnhanceAbilityVariants`

Covers all six variants with subtests:

* correct `selected_variant_key`
* correct `selected_variant_label`
* correct `metadata.declarative_effect`
* Cat’s Grace maps to Dexterity
* Owl’s Wisdom maps to Wisdom

### `TestShieldOfFaithRegression`

Covers:

* creates `temp_ac_bonus`
* AC bonus value is `2`
* spends a spell slot
* concentration metadata is present

## Frontend tests

Added 13 tests across:

```text
OutOfCombatSpellCastCard.test.tsx
PlayerBoardStatusPanel.test.tsx
```

### `OutOfCombatSpellCastCard.test.tsx`

Added 9 tests covering:

* renders nothing when spell list is empty
* renders spell names
* renders spell level badge
* renders concentration badge
* renders not-prepared badge
* renders expand arrow
* supports multiple spells
* handles `casting=true` safely
* falls back to `nameEn`

### `PlayerBoardStatusPanel.test.tsx`

Added 4 tests covering:

* out-of-combat casting card is shown when not in combat and spells exist
* card is hidden during active combat
* card is hidden when no spells exist
* card is hidden when no cast handler exists

## Validation

Backend:

```text
109/109 backend tests pass
```

Frontend targeted tests:

```text
13 new frontend tests pass
```

## Out of scope

This PR intentionally does not implement:

* ally targeting
* Longstrider / movement speed effects
* real-time duration countdowns
* out-of-combat cast history/log
* GM casting on behalf of player
* hostile spells
* AoE
* spell attacks
* saving throws
* Ready Action
* Feather Fall

## Notes for reviewers

The main behavior fix is that the eligible out-of-combat cast list now checks both the explicit `out_of_combat_castable` flag and the presence of direct or variant effects.

This keeps the frontend list backend-authoritative and prevents effect-less spells from being advertised as castable.