### PR TITLE
fix(effects): clear caster concentration when target removes linked e…

### DIFF
--- a/apps/control-server/app/api/routes/sessions/state.py
+++ b/apps/control-server/app/api/routes/sessions/state.py
@@ -286,18 +286,47 @@ async def remove_my_persisted_effect(
     if not state:
         raise HTTPException(status_code=404, detail="Session state not found")
 
+    # Extract effect metadata BEFORE removal
+    effect_metadata = None
+    state_json = state.state_json if isinstance(state.state_json, dict) else {}
+    for eff in state_json.get("active_spell_effects", []) or []:
+        if isinstance(eff, dict) and eff.get("id") == effect_id:
+            effect_metadata = eff.get("metadata") if isinstance(eff.get("metadata"), dict) else None
+            break
+
     updated = remove_persisted_effect(state.state_json, effect_id)
     state.state_json = finalize_session_state_data(updated)
     session.add(state)
+
+    # Cross-clear concentration group for ally-target effects
+    affected_allies: list[SessionState] = []
+    if effect_metadata:
+        was_concentration = effect_metadata.get("concentration") is True
+        caster_id = effect_metadata.get("caster_player_user_id")
+        target_id = effect_metadata.get("target_player_user_id")
+        is_ally_target = caster_id is not None and target_id is not None and caster_id != target_id
+        concentration_group = effect_metadata.get("concentration_group")
+        if was_concentration and is_ally_target and concentration_group:
+            affected_allies = clear_concentration_group_across_session(
+                session, session_id, concentration_group, exclude_user_id=user.id
+            )
+
     session.commit()
     session.refresh(state)
 
-    await publish_state_update(
-        entry,
-        user.id,
-        state.updated_at or state.created_at,
-        state.state_json if isinstance(state.state_json, dict) else None,
-    )
+    # Publish updates for all modified players (deduped by player_user_id)
+    states_to_publish: dict[str, SessionState] = {user.id: state}
+    for ally in affected_allies:
+        if ally.player_user_id not in states_to_publish:
+            states_to_publish[ally.player_user_id] = ally
+
+    for player_id, st in states_to_publish.items():
+        await publish_state_update(
+            entry,
+            player_id,
+            st.updated_at or st.created_at,
+            st.state_json if isinstance(st.state_json, dict) else None,
+        )
     return to_state_read(state)
 
 

--- a/apps/control-server/app/services/combat_service/persistent_effects.py
+++ b/apps/control-server/app/services/combat_service/persistent_effects.py
@@ -245,7 +245,7 @@ def clear_persisted_concentration_effects(
     data = dict(state_json or {})
     persisted = data.get("active_spell_effects")
     if not isinstance(persisted, list):
-        return data
+        return state_json if state_json is not None else data
 
     if concentration_group is not None:
         filtered = [
@@ -259,7 +259,7 @@ def clear_persisted_concentration_effects(
         ]
 
     if len(filtered) == len(persisted):
-        return data
+        return state_json if state_json is not None else data
     if filtered:
         data["active_spell_effects"] = filtered
     else:

--- a/apps/control-server/tests/test_persistent_effects.py
+++ b/apps/control-server/tests/test_persistent_effects.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 from app.models.combat import CombatPhase, CombatState
 from app.models.session_state import SessionState
 from app.services.combat_service.persistent_effects import (
+    clear_concentration_group_across_session,
     clear_persisted_concentration_effects,
     derive_active_concentration,
     enforce_single_persisted_concentration_group,
@@ -533,6 +534,41 @@ class TestClearPersistedConcentrationEffects(unittest.TestCase):
         result = clear_persisted_concentration_effects(state_json)
 
         self.assertEqual(len(result["active_spell_effects"]), 1)
+
+
+class TestClearConcentrationGroupAcrossSession(unittest.TestCase):
+    def test_only_matching_group_states_are_modified(self):
+        matching_group = _manual_spell_effect("eff-match", concentration=True)
+        matching_group["metadata"]["concentration_group"] = "grp-a"
+        other_group = _manual_spell_effect("eff-other-group", concentration=True)
+        other_group["metadata"]["concentration_group"] = "grp-b"
+        unrelated = _manual_spell_effect("eff-unrelated")
+
+        matching_state = _make_session_state(
+            {"active_spell_effects": [matching_group, unrelated]}
+        )
+        matching_state.player_user_id = "player-a"
+
+        untouched_state = _make_session_state(
+            {"active_spell_effects": [other_group, unrelated]}
+        )
+        untouched_state.player_user_id = "player-b"
+
+        db = MagicMock()
+        db.exec.return_value.all.return_value = [matching_state, untouched_state]
+
+        modified = clear_concentration_group_across_session(db, "session-1", "grp-a")
+
+        self.assertEqual(modified, [matching_state])
+        self.assertEqual(
+            [effect["id"] for effect in matching_state.state_json["active_spell_effects"]],
+            ["eff-unrelated"],
+        )
+        self.assertEqual(
+            [effect["id"] for effect in untouched_state.state_json["active_spell_effects"]],
+            ["eff-other-group", "eff-unrelated"],
+        )
+        self.assertEqual(db.add.call_count, 1)
 
 
 class TestToStateReadActiveConcentration(unittest.TestCase):

--- a/apps/control-server/tests/test_session_concentration.py
+++ b/apps/control-server/tests/test_session_concentration.py
@@ -496,5 +496,395 @@ class TestRemoveMyPersistedEffect(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class TestAllyTargetConcentrationRemoval(unittest.IsolatedAsyncioTestCase):
+    @patch("app.api.routes.sessions.state.clear_concentration_group_across_session")
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data")
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    async def test_removing_ally_target_concentration_effect_breaks_entire_group(
+        self,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_view,
+        mock_get_entry,
+        mock_clear_cross_session,
+    ):
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        group_effect = {
+            "id": "eff-ally",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-1",
+                "source_spell_name": "Bless",
+                "caster_player_user_id": "caster-1",
+                "target_player_user_id": "target-1",
+            },
+        }
+        target_unrelated = _non_concentration_effect("target-unrelated")
+        db, state = _make_db_session(
+            {"active_spell_effects": [group_effect, target_unrelated]}
+        )
+        state.player_user_id = "target-1"
+        mock_ensure.return_value = state
+        mock_finalize.side_effect = lambda x: x
+
+        caster_unrelated = _non_concentration_effect("caster-unrelated")
+        ally_unrelated = _non_concentration_effect("ally-unrelated")
+        caster_state = MagicMock()
+        caster_state.player_user_id = "caster-1"
+        caster_state.updated_at = None
+        caster_state.created_at = "2026-01-01T00:00:00+00:00"
+        caster_state.state_json = {"active_spell_effects": [caster_unrelated]}
+
+        ally_state = MagicMock()
+        ally_state.player_user_id = "ally-b"
+        ally_state.updated_at = None
+        ally_state.created_at = "2026-01-01T00:00:00+00:00"
+        ally_state.state_json = {"active_spell_effects": [ally_unrelated]}
+
+        duplicate_target_state = MagicMock()
+        duplicate_target_state.player_user_id = "target-1"
+        duplicate_target_state.updated_at = None
+        duplicate_target_state.created_at = "2026-01-01T00:00:00+00:00"
+        duplicate_target_state.state_json = {"active_spell_effects": [target_unrelated]}
+
+        mock_clear_cross_session.return_value = [
+            caster_state,
+            ally_state,
+            duplicate_target_state,
+        ]
+
+        result = await remove_my_persisted_effect(
+            session_id="session-1",
+            effect_id="eff-ally",
+            user=_make_user("target-1"),
+            session=db,
+        )
+
+        mock_clear_cross_session.assert_called_once_with(
+            db, "session-1", "grp-1", exclude_user_id="target-1"
+        )
+        self.assertIsNone(result.activeConcentration)
+        self.assertEqual(result.activeSpellEffects, [target_unrelated])
+        self.assertEqual(state.state_json["active_spell_effects"], [target_unrelated])
+        self.assertEqual(mock_publish.await_count, 3)
+
+        published_payloads = {
+            call.args[1]: call.args[3]["active_spell_effects"]
+            for call in mock_publish.await_args_list
+        }
+        self.assertEqual(set(published_payloads), {"target-1", "caster-1", "ally-b"})
+        self.assertEqual(
+            [effect["id"] for effect in published_payloads["target-1"]],
+            ["target-unrelated"],
+        )
+        self.assertEqual(
+            [effect["id"] for effect in published_payloads["caster-1"]],
+            ["caster-unrelated"],
+        )
+        self.assertEqual(
+            [effect["id"] for effect in published_payloads["ally-b"]],
+            ["ally-unrelated"],
+        )
+        for effects in published_payloads.values():
+            self.assertTrue(
+                all((effect.get("metadata") or {}).get("concentration_group") != "grp-1" for effect in effects)
+            )
+
+    @patch("app.api.routes.sessions.state.clear_concentration_group_across_session")
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data")
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_ally_target_removal_clears_other_ally_effects(
+        self,
+        mock_to_state_read,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_view,
+        mock_get_entry,
+        mock_clear_cross_session,
+    ):
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        eff = {
+            "id": "eff-ally-a",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-1",
+                "source_spell_name": "Bless",
+                "caster_player_user_id": "caster-1",
+                "target_player_user_id": "ally-a",
+            },
+        }
+        db, state = _make_db_session({"active_spell_effects": [eff]})
+        state.player_user_id = "ally-a"
+        mock_ensure.return_value = state
+        mock_finalize.side_effect = lambda x: x
+
+        caster_state = MagicMock()
+        caster_state.player_user_id = "caster-1"
+        caster_state.updated_at = None
+        caster_state.created_at = "2026-01-01T00:00:00+00:00"
+        caster_state.state_json = {}
+
+        ally_b_state = MagicMock()
+        ally_b_state.player_user_id = "ally-b"
+        ally_b_state.updated_at = None
+        ally_b_state.created_at = "2026-01-01T00:00:00+00:00"
+        ally_b_state.state_json = {}
+
+        mock_clear_cross_session.return_value = [caster_state, ally_b_state]
+        mock_to_state_read.return_value = SessionStateRead(
+            id="ss-1",
+            sessionId="session-1",
+            playerUserId="ally-a",
+            state={},
+            createdAt="2026-01-01T00:00:00+00:00",
+            updatedAt=None,
+            activeSpellEffects=[],
+            activeConcentration=None,
+        )
+
+        result = await remove_my_persisted_effect(
+            session_id="session-1",
+            effect_id="eff-ally-a",
+            user=_make_user("ally-a"),
+            session=db,
+        )
+
+        mock_clear_cross_session.assert_called_once_with(
+            db, "session-1", "grp-1", exclude_user_id="ally-a"
+        )
+        self.assertEqual(mock_publish.await_count, 3)
+
+    @patch("app.api.routes.sessions.state.clear_concentration_group_across_session")
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data")
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_self_target_removal_skips_cross_clear(
+        self,
+        mock_to_state_read,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_view,
+        mock_get_entry,
+        mock_clear_cross_session,
+    ):
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        eff = {
+            "id": "eff-self",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-1",
+                "source_spell_name": "Bless",
+                "caster_player_user_id": "user-1",
+                "target_player_user_id": "user-1",
+            },
+        }
+        db, state = _make_db_session({"active_spell_effects": [eff]})
+        mock_ensure.return_value = state
+        mock_finalize.side_effect = lambda x: x
+        mock_clear_cross_session.return_value = []
+        mock_to_state_read.return_value = SessionStateRead(
+            id="ss-1",
+            sessionId="session-1",
+            playerUserId="user-1",
+            state={},
+            createdAt="2026-01-01T00:00:00+00:00",
+            updatedAt=None,
+            activeSpellEffects=[],
+            activeConcentration=None,
+        )
+
+        result = await remove_my_persisted_effect(
+            session_id="session-1",
+            effect_id="eff-self",
+            user=_make_user("user-1"),
+            session=db,
+        )
+
+        mock_clear_cross_session.assert_not_called()
+        self.assertEqual(mock_publish.await_count, 1)
+
+    @patch("app.api.routes.sessions.state.clear_concentration_group_across_session")
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data")
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_non_concentration_removal_skips_cross_clear(
+        self,
+        mock_to_state_read,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_view,
+        mock_get_entry,
+        mock_clear_cross_session,
+    ):
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        db, state = _make_db_session(
+            {"active_spell_effects": [_non_concentration_effect("eff-other")]}
+        )
+        mock_ensure.return_value = state
+        mock_finalize.side_effect = lambda x: x
+        mock_clear_cross_session.return_value = []
+        mock_to_state_read.return_value = SessionStateRead(
+            id="ss-1",
+            sessionId="session-1",
+            playerUserId="user-1",
+            state={},
+            createdAt="2026-01-01T00:00:00+00:00",
+            updatedAt=None,
+            activeSpellEffects=[],
+            activeConcentration=None,
+        )
+
+        result = await remove_my_persisted_effect(
+            session_id="session-1",
+            effect_id="eff-other",
+            user=_make_user(),
+            session=db,
+        )
+
+        mock_clear_cross_session.assert_not_called()
+        self.assertEqual(mock_publish.await_count, 1)
+
+    @patch("app.api.routes.sessions.state.clear_concentration_group_across_session")
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data")
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_unknown_effect_removal_is_idempotent_no_cross_clear(
+        self,
+        mock_to_state_read,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_view,
+        mock_get_entry,
+        mock_clear_cross_session,
+    ):
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        db, state = _make_db_session(
+            {"active_spell_effects": [_non_concentration_effect("eff-a")]}
+        )
+        mock_ensure.return_value = state
+        mock_finalize.side_effect = lambda x: x
+        mock_clear_cross_session.return_value = []
+        mock_to_state_read.return_value = SessionStateRead(
+            id="ss-1",
+            sessionId="session-1",
+            playerUserId="user-1",
+            state={},
+            createdAt="2026-01-01T00:00:00+00:00",
+            updatedAt=None,
+            activeSpellEffects=[_non_concentration_effect("eff-a")],
+            activeConcentration=None,
+        )
+
+        result = await remove_my_persisted_effect(
+            session_id="session-1",
+            effect_id="eff-unknown",
+            user=_make_user(),
+            session=db,
+        )
+
+        mock_clear_cross_session.assert_not_called()
+        self.assertEqual(mock_publish.await_count, 1)
+
+    @patch("app.api.routes.sessions.state.clear_concentration_group_across_session")
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data")
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_ally_target_removal_publishes_all_modified_states(
+        self,
+        mock_to_state_read,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_view,
+        mock_get_entry,
+        mock_clear_cross_session,
+    ):
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        eff = {
+            "id": "eff-ally",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-1",
+                "source_spell_name": "Bless",
+                "caster_player_user_id": "caster-1",
+                "target_player_user_id": "target-1",
+            },
+        }
+        db, state = _make_db_session({"active_spell_effects": [eff]})
+        state.player_user_id = "target-1"
+        mock_ensure.return_value = state
+        mock_finalize.side_effect = lambda x: x
+
+        caster_state = MagicMock()
+        caster_state.player_user_id = "caster-1"
+        caster_state.updated_at = None
+        caster_state.created_at = "2026-01-01T00:00:00+00:00"
+        caster_state.state_json = {}
+
+        caller_dup = MagicMock()
+        caller_dup.player_user_id = "target-1"
+        caller_dup.updated_at = None
+        caller_dup.created_at = "2026-01-01T00:00:00+00:00"
+        caller_dup.state_json = {}
+
+        mock_clear_cross_session.return_value = [caster_state, caller_dup]
+        mock_to_state_read.return_value = SessionStateRead(
+            id="ss-1",
+            sessionId="session-1",
+            playerUserId="target-1",
+            state={},
+            createdAt="2026-01-01T00:00:00+00:00",
+            updatedAt=None,
+            activeSpellEffects=[],
+            activeConcentration=None,
+        )
+
+        result = await remove_my_persisted_effect(
+            session_id="session-1",
+            effect_id="eff-ally",
+            user=_make_user("target-1"),
+            session=db,
+        )
+
+        self.assertEqual(mock_publish.await_count, 2)
+        published_ids = [
+            mock_publish.await_args_list[i].args[1] for i in range(mock_publish.await_count)
+        ]
+        self.assertIn("target-1", published_ids)
+        self.assertIn("caster-1", published_ids)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# fix(effects): break linked concentration when target removes persisted effect

## Summary

Fixes persisted effect removal for ally-target concentration spells.

When a target removes a persisted active effect that belongs to another player’s concentration group, the full concentration group is now cleared across the session. This removes the caster’s lightweight concentration marker and any linked target effects, while preserving unrelated effects.

## Context

Out-of-combat ally targeting uses split ownership:

```text
target state
→ receives the real active effect

caster state
→ receives lightweight concentration marker
````

Both are linked by:

```text
metadata.concentration_group
```

Before this fix, if the target removed the linked effect through:

```http
DELETE /sessions/{session_id}/state/me/effects/{effect_id}
```

the target effect disappeared, but the caster concentration marker could remain active.

That created ghost concentration: mechanically dead, emotionally still haunting the UI.

## What changed

### Persisted effect removal endpoint

Updated:

```text
apps/control-server/app/api/routes/sessions/state.py
```

The endpoint now:

* captures removed effect metadata before calling `remove_persisted_effect`
* detects ally-target concentration effects
* clears the full concentration group across the session with `clear_concentration_group_across_session`
* avoids double-modifying the target state by passing `exclude_user_id=user.id`
* performs one commit after all mutations
* publishes one deduplicated update per modified `SessionState`

Cross-session cleanup is triggered when the removed effect has:

```text
metadata.concentration == true
metadata.concentration_group
metadata.caster_player_user_id != metadata.target_player_user_id
```

### Persistent effects helper

Updated:

```text
apps/control-server/app/services/combat_service/persistent_effects.py
```

Adjusted `clear_persisted_concentration_effects` so it returns the original `state_json` when nothing changed.

This prevents unchanged states from being treated as modified and published unnecessarily.

A rare case of the code learning not to yell “update!” into an empty room.

## Behavior

When an ally removes a linked concentration effect:

```text
Ally A removes effect from group X
→ Ally A loses the selected effect
→ caster concentration marker for group X is removed
→ all effects in group X across the session are cleared
→ unrelated effects remain
→ caster activeConcentration becomes null
```

Self-target behavior remains unchanged.

Non-concentration effect removal remains unchanged.

Unknown effect removal remains idempotent.

## Tests

Updated:

```text
apps/control-server/tests/test_session_concentration.py
apps/control-server/tests/test_persistent_effects.py
```

### Main regression

Renamed and strengthened:

```text
test_removing_ally_target_concentration_effect_breaks_entire_group
```

Now validates:

* full group break
* target linked effect is removed
* caster concentration marker is removed
* unrelated target effects are preserved
* unrelated caster effects are preserved
* caster `activeConcentration` becomes null
* publish deduplication by `player_user_id`

### Helper regression

Added direct helper coverage ensuring only states containing the target concentration group are modified.

## Validation

```bash
cd apps/control-server
.venv/bin/pytest tests/test_session_concentration.py tests/test_persistent_effects.py tests/test_out_of_combat_cast.py -q
```

Result:

```text
130 passed, 12 subtests passed
```

## Out of scope

This PR intentionally does not change:

* frontend behavior
* schemas or migrations
* combat effect removal path
* `clear_my_concentration`
* cast history/log
* GM casting
* duration countdowns