### PR TITLE
feat(spells): allow GM out-of-combat casts as players

### DIFF
--- a/apps/control-server/app/api/routes/sessions/activity.py
+++ b/apps/control-server/app/api/routes/sessions/activity.py
@@ -393,8 +393,19 @@ def get_session_activity(
                 userId=command.user_id,
                 username=command_user.username if command_user else None,
                 displayName=actor_name,
-                actorPlayerUserId=payload.get("actor_player_user_id") if isinstance(payload.get("actor_player_user_id"), str) else None,
+                actorUserId=payload.get("actor_user_id") if isinstance(payload.get("actor_user_id"), str) else None,
+                actorPlayerUserId=(
+                    payload.get("actor_player_user_id")
+                    if isinstance(payload.get("actor_player_user_id"), str)
+                    else (
+                        payload.get("actor_user_id")
+                        if isinstance(payload.get("actor_user_id"), str)
+                        else None
+                    )
+                ),
                 actorDisplayName=payload.get("actor_display_name") if isinstance(payload.get("actor_display_name"), str) else actor_name,
+                casterPlayerUserId=payload.get("caster_player_user_id") if isinstance(payload.get("caster_player_user_id"), str) else None,
+                casterDisplayName=payload.get("caster_display_name") if isinstance(payload.get("caster_display_name"), str) else None,
                 targetPlayerUserId=payload.get("target_player_user_id") if isinstance(payload.get("target_player_user_id"), str) else None,
                 targetDisplayName=payload.get("target_display_name") if isinstance(payload.get("target_display_name"), str) else None,
                 spellKey=payload.get("spell_key") if isinstance(payload.get("spell_key"), str) else None,
@@ -421,6 +432,7 @@ def get_session_activity(
                 ),
                 previousSpellName=payload.get("previous_spell_name") if isinstance(payload.get("previous_spell_name"), str) else None,
                 previousVariantLabel=payload.get("previous_variant_label") if isinstance(payload.get("previous_variant_label"), str) else None,
+                castByGm=bool(payload.get("cast_by_gm", False)),
                 timestamp=command.created_at,
                 sessionOffsetSeconds=offset(command.created_at),
             ))

--- a/apps/control-server/app/api/routes/sessions/state.py
+++ b/apps/control-server/app/api/routes/sessions/state.py
@@ -8,6 +8,7 @@ from app.db.session import get_session
 from app.models.campaign_member import CampaignMember
 from app.models.campaign_spell import CampaignSpell
 from app.models.item import ItemType
+from app.models.party_member import PartyMember, PartyMemberStatus
 from app.models.session_command_event import SessionCommandEvent
 from app.models.session_state import SessionState
 from app.schemas.session_state import (
@@ -92,6 +93,365 @@ def _resolve_ooc_activity_actor(entry, user, session: DbSession) -> tuple[str | 
     resolved_member_id = member_id if isinstance(member_id, str) and member_id else None
     resolved_actor = actor_display_name if isinstance(actor_display_name, str) and actor_display_name else user.id
     return resolved_member_id, resolved_actor
+
+
+def _require_session_participant(entry, session: DbSession, player_user_id: str, *, label: str) -> None:
+    if entry.party_id:
+        party_member = session.exec(
+            select(PartyMember).where(
+                PartyMember.party_id == entry.party_id,
+                PartyMember.user_id == player_user_id,
+                PartyMember.status == PartyMemberStatus.JOINED,
+            )
+        ).first()
+        if not party_member:
+            raise HTTPException(status_code=400, detail=f"{label} is not a participant in this session")
+        return
+
+    campaign_member = session.exec(
+        select(CampaignMember).where(
+            CampaignMember.campaign_id == entry.campaign_id,
+            CampaignMember.user_id == player_user_id,
+        )
+    ).first()
+    if not campaign_member:
+        raise HTTPException(status_code=400, detail=f"{label} is not a participant in this session")
+
+
+def _list_out_of_combat_castable_spells_for_player(
+    *,
+    entry,
+    session_id: str,
+    caster_user_id: str,
+    session: DbSession,
+) -> list[dict]:
+    state = session.exec(
+        select(SessionState).where(
+            SessionState.session_id == session_id,
+            SessionState.player_user_id == caster_user_id,
+        )
+    ).first()
+    state = ensure_session_state(state, session_id, caster_user_id, entry.party_id, session)
+    if not state:
+        return []
+
+    spellcasting = (state.state_json or {}).get("spellcasting") or {}
+    player_spells = spellcasting.get("spells") or []
+
+    canonical_keys = [
+        s.get("canonicalKey") for s in player_spells
+        if isinstance(s, dict) and s.get("canonicalKey")
+    ]
+    if not canonical_keys:
+        return []
+
+    campaign_spells = session.exec(
+        select(CampaignSpell).where(
+            CampaignSpell.campaign_id == entry.campaign_id,
+            CampaignSpell.canonical_key.in_(canonical_keys),
+            CampaignSpell.out_of_combat_castable == True,  # noqa: E712
+            CampaignSpell.is_enabled == True,  # noqa: E712
+        )
+    ).all()
+
+    campaign_spells = [cs for cs in campaign_spells if has_castable_effects(cs)]
+    eligible_keys = {cs.canonical_key for cs in campaign_spells}
+
+    result: list[dict] = []
+    for player_spell in player_spells:
+        if not isinstance(player_spell, dict):
+            continue
+        spell_key = player_spell.get("canonicalKey")
+        if spell_key not in eligible_keys:
+            continue
+        campaign_spell = next((c for c in campaign_spells if c.canonical_key == spell_key), None)
+        if not campaign_spell:
+            continue
+        result.append({
+            "id": player_spell.get("id"),
+            "canonicalKey": campaign_spell.canonical_key,
+            "nameEn": campaign_spell.name_en,
+            "namePt": campaign_spell.name_pt,
+            "level": campaign_spell.level,
+            "concentration": campaign_spell.concentration,
+            "prepared": player_spell.get("prepared", False),
+            "variants": campaign_spell.variants_json or [],
+            "effects": campaign_spell.effects_json or [],
+            "outOfCombatTarget": campaign_spell.out_of_combat_target,
+        })
+    return result
+
+
+async def _cast_spell_out_of_combat_for_player(
+    *,
+    entry,
+    session_id: str,
+    req: OutOfCombatCastRequest,
+    actor_user,
+    caster_user_id: str,
+    session: DbSession,
+    cast_by_gm: bool,
+    enforce_target_membership: bool = False,
+) -> SessionStateRead:
+    # --- Load caster state ---
+    caster_state = session.exec(
+        select(SessionState).where(
+            SessionState.session_id == session_id,
+            SessionState.player_user_id == caster_user_id,
+        )
+    ).first()
+    caster_state = ensure_session_state(caster_state, session_id, caster_user_id, entry.party_id, session)
+    if not caster_state:
+        raise HTTPException(status_code=404, detail="Session state not found")
+
+    # --- Resolve target ---
+    target_user_id = req.targetPlayerUserId or caster_user_id
+    is_ally_target = target_user_id != caster_user_id
+
+    target_state: SessionState | None = None
+    if is_ally_target:
+        if enforce_target_membership:
+            _require_session_participant(entry, session, target_user_id, label="Target")
+        target_state = session.exec(
+            select(SessionState).where(
+                SessionState.session_id == session_id,
+                SessionState.player_user_id == target_user_id,
+            )
+        ).first()
+        if not target_state:
+            raise HTTPException(status_code=400, detail="Target is not a participant in this session")
+
+    # --- Validate spell ---
+    state_json = caster_state.state_json or {}
+    spellcasting = state_json.get("spellcasting") or {}
+    player_spells = spellcasting.get("spells") or []
+    player_spell = next(
+        (s for s in player_spells if isinstance(s, dict) and s.get("id") == req.spellId),
+        None,
+    )
+    if player_spell is None:
+        raise HTTPException(status_code=400, detail=f"Spell not found in character spell list: {req.spellId!r}")
+
+    canonical_key = player_spell.get("canonicalKey")
+    if not canonical_key:
+        raise HTTPException(status_code=400, detail="Spell entry is missing canonicalKey")
+
+    spell_level = player_spell.get("level", 0)
+    if spell_level > 0 and player_spell.get("prepared") is False:
+        raise HTTPException(status_code=400, detail="Spell is not prepared")
+
+    campaign_spell = session.exec(
+        select(CampaignSpell).where(
+            CampaignSpell.campaign_id == entry.campaign_id,
+            CampaignSpell.canonical_key == canonical_key,
+            CampaignSpell.is_enabled == True,  # noqa: E712
+        )
+    ).first()
+    if not campaign_spell:
+        raise HTTPException(status_code=400, detail=f"Spell not found in campaign catalog: {canonical_key!r}")
+
+    if campaign_spell.out_of_combat_target == "ally" and not req.targetPlayerUserId:
+        raise HTTPException(status_code=400, detail="Spell requires an ally target")
+
+    if is_ally_target and campaign_spell.out_of_combat_target not in ("ally", "self_or_ally"):
+        raise HTTPException(status_code=400, detail="Spell cannot target allies out of combat")
+
+    ok, rejection = check_out_of_combat_cast_eligibility(
+        spell=campaign_spell,
+        state_json=state_json,
+        slot_level=req.slotLevel,
+        variant_key=req.variantKey,
+        out_of_combat_target=campaign_spell.out_of_combat_target,
+        target_user_id=target_user_id,
+        caster_user_id=caster_user_id,
+    )
+    if not ok:
+        raise HTTPException(status_code=400, detail=rejection)
+
+    # --- Capture previous concentration metadata BEFORE any mutation ---
+    previous_concentration_metadata = next(
+        (
+            metadata
+            for effect in (state_json.get("active_spell_effects") or [])
+            if isinstance(effect, dict)
+            for metadata in [effect.get("metadata")]
+            if isinstance(metadata, dict) and metadata.get("concentration")
+        ),
+        None,
+    )
+    old_group = (
+        previous_concentration_metadata.get("concentration_group")
+        if isinstance(previous_concentration_metadata, dict)
+        and isinstance(previous_concentration_metadata.get("concentration_group"), str)
+        else None
+    )
+    previous_spell_name = (
+        previous_concentration_metadata.get("source_spell_name")
+        if isinstance(previous_concentration_metadata, dict)
+        and isinstance(previous_concentration_metadata.get("source_spell_name"), str)
+        else None
+    )
+    previous_variant_label = (
+        previous_concentration_metadata.get("selected_variant_label")
+        if isinstance(previous_concentration_metadata, dict)
+        and isinstance(previous_concentration_metadata.get("selected_variant_label"), str)
+        else None
+    )
+
+    # --- Spend slot and clear caster concentration ---
+    updated_caster_json = dict(state_json)
+
+    if spell_level > 0 and req.slotLevel is not None:
+        try:
+            updated_caster_json = consume_spell_slot(updated_caster_json, req.slotLevel)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    affected_allies: list[SessionState] = []
+    if campaign_spell.concentration:
+        updated_caster_json = clear_persisted_concentration_effects(updated_caster_json)
+        if old_group:
+            affected_allies = clear_concentration_group_across_session(
+                session, session_id, old_group, exclude_user_id=caster_user_id
+            )
+
+    # --- Build target effects ---
+    new_target_effects = build_persisted_effects(
+        spell=campaign_spell,
+        caster_user_id=caster_user_id,
+        target_user_id=target_user_id,
+        variant_key=req.variantKey,
+    )
+    if not new_target_effects:
+        raise HTTPException(status_code=400, detail="No persistable effects could be created for this spell")
+
+    group_id: str | None = (
+        (new_target_effects[0].get("metadata") or {}).get("concentration_group")
+        if new_target_effects else None
+    )
+
+    # --- Apply effects ---
+    if is_ally_target:
+        # Concentration marker on the caster (no gameplay bonus)
+        if campaign_spell.concentration and group_id:
+            marker = build_concentration_marker(
+                spell=campaign_spell,
+                caster_user_id=caster_user_id,
+                target_user_id=target_user_id,
+                concentration_group=group_id,
+                variant_key=req.variantKey,
+            )
+            caster_effects = list(updated_caster_json.get("active_spell_effects") or [])
+            caster_effects.append(marker)
+            updated_caster_json["active_spell_effects"] = caster_effects
+            marker_effect_id = marker.get("id") if isinstance(marker.get("id"), str) else None
+        else:
+            marker_effect_id = None
+
+        # Buff effects land on the target
+        target_json = dict(target_state.state_json or {})  # type: ignore[union-attr]
+        target_effects = list(target_json.get("active_spell_effects") or [])
+        target_effects.extend(new_target_effects)
+        target_json["active_spell_effects"] = target_effects
+        target_state.state_json = finalize_session_state_data(target_json)  # type: ignore[union-attr]
+        flag_modified(target_state, "state_json")
+        session.add(target_state)
+    else:
+        # Self-target: original behaviour unchanged
+        existing_effects = list(updated_caster_json.get("active_spell_effects") or [])
+        existing_effects.extend(new_target_effects)
+        updated_caster_json["active_spell_effects"] = existing_effects
+        marker_effect_id = None
+
+    # --- Persist caster state ---
+    caster_state.state_json = finalize_session_state_data(updated_caster_json)
+    flag_modified(caster_state, "state_json")
+    session.add(caster_state)
+
+    actor_member_id, actor_display_name = _resolve_ooc_activity_actor(entry, actor_user, session)
+    if actor_member_id:
+        spell_name = (
+            campaign_spell.name_pt
+            or campaign_spell.name_en
+            or campaign_spell.canonical_key
+        )
+        variant_label = (
+            (new_target_effects[0].get("metadata") or {}).get("selected_variant_label")
+            if new_target_effects
+            and isinstance(new_target_effects[0], dict)
+            and isinstance(new_target_effects[0].get("metadata"), dict)
+            else None
+        )
+        created_effect_ids = [
+            effect_id
+            for effect_id in (
+                [effect.get("id") for effect in new_target_effects]
+                + ([marker_effect_id] if marker_effect_id else [])
+            )
+            if isinstance(effect_id, str) and effect_id
+        ]
+        replaced_concentration = bool(campaign_spell.concentration and previous_concentration_metadata)
+        activity_payload: dict = {
+            "actor_user_id": actor_user.id,
+            "actor_player_user_id": actor_user.id,  # legacy compatibility
+            "actor_display_name": actor_display_name,
+            "caster_player_user_id": caster_user_id,
+            "caster_display_name": (
+                actor_display_name if caster_user_id == actor_user.id else caster_user_id
+            ),
+            "target_player_user_id": target_user_id,
+            "target_display_name": (
+                actor_display_name if target_user_id == actor_user.id else target_user_id
+            ),
+            "spell_key": campaign_spell.canonical_key,
+            "spell_name": spell_name,
+            "variant_key": req.variantKey,
+            "variant_label": variant_label,
+            "created_effect_ids": created_effect_ids,
+            "concentration_group": group_id,
+            "replaced_concentration": replaced_concentration,
+            "previous_concentration_group": old_group,
+            "new_concentration_group": group_id if campaign_spell.concentration else None,
+            "previous_spell_name": previous_spell_name,
+            "previous_variant_label": previous_variant_label,
+            "cast_by_gm": cast_by_gm,
+        }
+        if req.slotLevel is not None:
+            activity_payload["slot_level"] = req.slotLevel
+        record_session_activity(
+            entry,
+            "out_of_combat_spell_cast",
+            session,
+            member_id=actor_member_id,
+            user_id=actor_user.id,
+            actor_name=actor_display_name,
+            payload=activity_payload,
+        )
+        _prune_out_of_combat_session_activity(session, session_id)
+
+    # --- Single commit ---
+    session.commit()
+    session.refresh(caster_state)
+    if is_ally_target and target_state is not None:
+        session.refresh(target_state)
+
+    # --- Publish updates (deduped by player_user_id) ---
+    states_to_publish: dict[str, SessionState] = {caster_user_id: caster_state}
+    if is_ally_target and target_state is not None:
+        states_to_publish[target_user_id] = target_state
+    for ally in affected_allies:
+        if ally.player_user_id not in states_to_publish:
+            states_to_publish[ally.player_user_id] = ally
+
+    for player_id, state in states_to_publish.items():
+        await publish_state_update(
+            entry,
+            player_id,
+            state.updated_at or state.created_at,
+            state.state_json if isinstance(state.state_json, dict) else None,
+        )
+
+    return to_state_read(caster_state)
 
 
 def _prune_out_of_combat_session_activity(session: DbSession, session_id: str) -> None:
@@ -508,60 +868,30 @@ def list_out_of_combat_castable_spells(
 ):
     entry = get_session_entry(session_id, session)
     require_session_view_access(entry, user, session, user.id)
-    state = session.exec(
-        select(SessionState).where(
-            SessionState.session_id == session_id,
-            SessionState.player_user_id == user.id,
-        )
-    ).first()
-    state = ensure_session_state(state, session_id, user.id, entry.party_id, session)
-    if not state:
-        return []
+    return _list_out_of_combat_castable_spells_for_player(
+        entry=entry,
+        session_id=session_id,
+        caster_user_id=user.id,
+        session=session,
+    )
 
-    spellcasting = (state.state_json or {}).get("spellcasting") or {}
-    player_spells = spellcasting.get("spells") or []
 
-    canonical_keys = [
-        s.get("canonicalKey") for s in player_spells
-        if isinstance(s, dict) and s.get("canonicalKey")
-    ]
-    if not canonical_keys:
-        return []
-
-    campaign_spells = session.exec(
-        select(CampaignSpell).where(
-            CampaignSpell.campaign_id == entry.campaign_id,
-            CampaignSpell.canonical_key.in_(canonical_keys),
-            CampaignSpell.out_of_combat_castable == True,  # noqa: E712
-            CampaignSpell.is_enabled == True,  # noqa: E712
-        )
-    ).all()
-
-    campaign_spells = [cs for cs in campaign_spells if has_castable_effects(cs)]
-    eligible_keys = {cs.canonical_key for cs in campaign_spells}
-
-    result = []
-    for s in player_spells:
-        if not isinstance(s, dict):
-            continue
-        if s.get("canonicalKey") not in eligible_keys:
-            continue
-        cs = next((c for c in campaign_spells if c.canonical_key == s.get("canonicalKey")), None)
-        if not cs:
-            continue
-        result.append({
-            "id": s.get("id"),
-            "canonicalKey": cs.canonical_key,
-            "nameEn": cs.name_en,
-            "namePt": cs.name_pt,
-            "level": cs.level,
-            "concentration": cs.concentration,
-            "prepared": s.get("prepared", False),
-            "variants": cs.variants_json or [],
-            "effects": cs.effects_json or [],
-            "outOfCombatTarget": cs.out_of_combat_target,
-        })
-    return result
+@router.get("/sessions/{session_id}/state/{player_user_id}/spells/castable-out-of-combat")
+def list_out_of_combat_castable_spells_for_player(
+    session_id: str,
+    player_user_id: str,
+    user=Depends(get_current_user),
+    session: DbSession = Depends(get_session),
+):
+    entry = get_session_entry(session_id, session)
+    require_session_gm(entry, user, session)
+    _require_session_participant(entry, session, player_user_id, label="Caster")
+    return _list_out_of_combat_castable_spells_for_player(
+        entry=entry,
+        session_id=session_id,
+        caster_user_id=player_user_id,
+        session=session,
+    )
 
 
 @router.post("/sessions/{session_id}/state/me/spells/cast", response_model=SessionStateRead)
@@ -573,254 +903,35 @@ async def cast_spell_out_of_combat(
 ):
     entry = get_session_entry(session_id, session)
     require_session_view_access(entry, user, session, user.id)
-
-    # --- Load caster state ---
-    state = session.exec(
-        select(SessionState).where(
-            SessionState.session_id == session_id,
-            SessionState.player_user_id == user.id,
-        )
-    ).first()
-    state = ensure_session_state(state, session_id, user.id, entry.party_id, session)
-    if not state:
-        raise HTTPException(status_code=404, detail="Session state not found")
-
-    # --- Resolve target ---
-    target_user_id = req.targetPlayerUserId or user.id
-    is_ally_target = target_user_id != user.id
-
-    target_state: SessionState | None = None
-    if is_ally_target:
-        target_state = session.exec(
-            select(SessionState).where(
-                SessionState.session_id == session_id,
-                SessionState.player_user_id == target_user_id,
-            )
-        ).first()
-        if not target_state:
-            raise HTTPException(status_code=400, detail="Target is not a participant in this session")
-
-    # --- Validate spell ---
-    state_json = state.state_json or {}
-    spellcasting = state_json.get("spellcasting") or {}
-    player_spells = spellcasting.get("spells") or []
-    player_spell = next(
-        (s for s in player_spells if isinstance(s, dict) and s.get("id") == req.spellId),
-        None,
-    )
-    if player_spell is None:
-        raise HTTPException(status_code=400, detail=f"Spell not found in character spell list: {req.spellId!r}")
-
-    canonical_key = player_spell.get("canonicalKey")
-    if not canonical_key:
-        raise HTTPException(status_code=400, detail="Spell entry is missing canonicalKey")
-
-    spell_level = player_spell.get("level", 0)
-    if spell_level > 0 and player_spell.get("prepared") is False:
-        raise HTTPException(status_code=400, detail="Spell is not prepared")
-
-    campaign_spell = session.exec(
-        select(CampaignSpell).where(
-            CampaignSpell.campaign_id == entry.campaign_id,
-            CampaignSpell.canonical_key == canonical_key,
-            CampaignSpell.is_enabled == True,  # noqa: E712
-        )
-    ).first()
-    if not campaign_spell:
-        raise HTTPException(status_code=400, detail=f"Spell not found in campaign catalog: {canonical_key!r}")
-
-    if campaign_spell.out_of_combat_target == "ally" and not req.targetPlayerUserId:
-        raise HTTPException(status_code=400, detail="Spell requires an ally target")
-
-    if is_ally_target and campaign_spell.out_of_combat_target not in ("ally", "self_or_ally"):
-        raise HTTPException(status_code=400, detail="Spell cannot target allies out of combat")
-
-    ok, rejection = check_out_of_combat_cast_eligibility(
-        spell=campaign_spell,
-        state_json=state_json,
-        slot_level=req.slotLevel,
-        variant_key=req.variantKey,
-        out_of_combat_target=campaign_spell.out_of_combat_target,
-        target_user_id=target_user_id,
+    return await _cast_spell_out_of_combat_for_player(
+        entry=entry,
+        session_id=session_id,
+        req=req,
+        actor_user=user,
         caster_user_id=user.id,
-    )
-    if not ok:
-        raise HTTPException(status_code=400, detail=rejection)
-
-    # --- Capture previous concentration metadata BEFORE any mutation ---
-    previous_concentration_metadata = next(
-        (
-            metadata
-            for e in (state_json.get("active_spell_effects") or [])
-            if isinstance(e, dict)
-            for metadata in [e.get("metadata")]
-            if isinstance(metadata, dict) and metadata.get("concentration")
-        ),
-        None,
-    )
-    old_group = (
-        previous_concentration_metadata.get("concentration_group")
-        if isinstance(previous_concentration_metadata, dict)
-        and isinstance(previous_concentration_metadata.get("concentration_group"), str)
-        else None
-    )
-    previous_spell_name = (
-        previous_concentration_metadata.get("source_spell_name")
-        if isinstance(previous_concentration_metadata, dict)
-        and isinstance(previous_concentration_metadata.get("source_spell_name"), str)
-        else None
-    )
-    previous_variant_label = (
-        previous_concentration_metadata.get("selected_variant_label")
-        if isinstance(previous_concentration_metadata, dict)
-        and isinstance(previous_concentration_metadata.get("selected_variant_label"), str)
-        else None
+        session=session,
+        cast_by_gm=False,
     )
 
-    # --- Spend slot and clear caster concentration ---
-    updated = dict(state_json)
 
-    if spell_level > 0 and req.slotLevel is not None:
-        try:
-            updated = consume_spell_slot(updated, req.slotLevel)
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-    affected_allies: list[SessionState] = []
-    if campaign_spell.concentration:
-        updated = clear_persisted_concentration_effects(updated)
-        if old_group:
-            affected_allies = clear_concentration_group_across_session(
-                session, session_id, old_group, exclude_user_id=user.id
-            )
-
-    # --- Build target effects ---
-    new_target_effects = build_persisted_effects(
-        spell=campaign_spell,
-        caster_user_id=user.id,
-        target_user_id=target_user_id,
-        variant_key=req.variantKey,
+@router.post("/sessions/{session_id}/state/{player_user_id}/spells/cast", response_model=SessionStateRead)
+async def cast_spell_out_of_combat_for_player(
+    session_id: str,
+    player_user_id: str,
+    req: OutOfCombatCastRequest,
+    user=Depends(get_current_user),
+    session: DbSession = Depends(get_session),
+):
+    entry = get_session_entry(session_id, session)
+    require_session_gm(entry, user, session)
+    _require_session_participant(entry, session, player_user_id, label="Caster")
+    return await _cast_spell_out_of_combat_for_player(
+        entry=entry,
+        session_id=session_id,
+        req=req,
+        actor_user=user,
+        caster_user_id=player_user_id,
+        session=session,
+        cast_by_gm=True,
+        enforce_target_membership=True,
     )
-    if not new_target_effects:
-        raise HTTPException(status_code=400, detail="No persistable effects could be created for this spell")
-
-    group_id: str | None = (
-        (new_target_effects[0].get("metadata") or {}).get("concentration_group")
-        if new_target_effects else None
-    )
-
-    # --- Apply effects ---
-    if is_ally_target:
-        # Concentration marker on the caster (no gameplay bonus)
-        if campaign_spell.concentration and group_id:
-            marker = build_concentration_marker(
-                spell=campaign_spell,
-                caster_user_id=user.id,
-                target_user_id=target_user_id,
-                concentration_group=group_id,
-                variant_key=req.variantKey,
-            )
-            caster_effs = list(updated.get("active_spell_effects") or [])
-            caster_effs.append(marker)
-            updated["active_spell_effects"] = caster_effs
-            marker_effect_id = marker.get("id") if isinstance(marker.get("id"), str) else None
-        else:
-            marker_effect_id = None
-
-        # Buff effects land on the target
-        target_json = dict(target_state.state_json or {})  # type: ignore[union-attr]
-        target_effs = list(target_json.get("active_spell_effects") or [])
-        target_effs.extend(new_target_effects)
-        target_json["active_spell_effects"] = target_effs
-        target_state.state_json = finalize_session_state_data(target_json)  # type: ignore[union-attr]
-        flag_modified(target_state, "state_json")
-        session.add(target_state)
-    else:
-        # Self-target: original v1 behaviour unchanged
-        existing_effects = list(updated.get("active_spell_effects") or [])
-        existing_effects.extend(new_target_effects)
-        updated["active_spell_effects"] = existing_effects
-        marker_effect_id = None
-
-    # --- Persist caster state ---
-    state.state_json = finalize_session_state_data(updated)
-    flag_modified(state, "state_json")
-    session.add(state)
-
-    actor_member_id, actor_display_name = _resolve_ooc_activity_actor(entry, user, session)
-    if actor_member_id:
-        spell_name = (
-            campaign_spell.name_pt
-            or campaign_spell.name_en
-            or campaign_spell.canonical_key
-        )
-        variant_label = (
-            (new_target_effects[0].get("metadata") or {}).get("selected_variant_label")
-            if new_target_effects
-            and isinstance(new_target_effects[0], dict)
-            and isinstance(new_target_effects[0].get("metadata"), dict)
-            else None
-        )
-        created_effect_ids = [
-            effect_id
-            for effect_id in (
-                [e.get("id") for e in new_target_effects]
-                + ([marker_effect_id] if marker_effect_id else [])
-            )
-            if isinstance(effect_id, str) and effect_id
-        ]
-        replaced_concentration = bool(campaign_spell.concentration and previous_concentration_metadata)
-        target_display_name = actor_display_name if not is_ally_target else target_user_id
-        activity_payload: dict = {
-            "actor_player_user_id": user.id,
-            "actor_display_name": actor_display_name,
-            "target_player_user_id": target_user_id,
-            "target_display_name": target_display_name,
-            "spell_key": campaign_spell.canonical_key,
-            "spell_name": spell_name,
-            "variant_key": req.variantKey,
-            "variant_label": variant_label,
-            "created_effect_ids": created_effect_ids,
-            "concentration_group": group_id,
-            "replaced_concentration": replaced_concentration,
-            "previous_concentration_group": old_group,
-            "new_concentration_group": group_id if campaign_spell.concentration else None,
-            "previous_spell_name": previous_spell_name,
-            "previous_variant_label": previous_variant_label,
-        }
-        if req.slotLevel is not None:
-            activity_payload["slot_level"] = req.slotLevel
-        record_session_activity(
-            entry,
-            "out_of_combat_spell_cast",
-            session,
-            member_id=actor_member_id,
-            user_id=user.id,
-            actor_name=actor_display_name,
-            payload=activity_payload,
-        )
-        _prune_out_of_combat_session_activity(session, session_id)
-
-    # --- Single commit ---
-    session.commit()
-    session.refresh(state)
-    if is_ally_target and target_state is not None:
-        session.refresh(target_state)
-
-    # --- Publish updates (deduped by player_user_id) ---
-    states_to_publish: dict[str, SessionState] = {user.id: state}
-    if is_ally_target and target_state is not None:
-        states_to_publish[target_user_id] = target_state
-    for ally in affected_allies:
-        if ally.player_user_id not in states_to_publish:
-            states_to_publish[ally.player_user_id] = ally
-
-    for player_id, s in states_to_publish.items():
-        await publish_state_update(
-            entry,
-            player_id,
-            s.updated_at or s.created_at,
-            s.state_json if isinstance(s.state_json, dict) else None,
-        )
-
-    return to_state_read(state)

--- a/apps/control-server/app/schemas/session.py
+++ b/apps/control-server/app/schemas/session.py
@@ -288,8 +288,11 @@ class OutOfCombatSpellCastActivityEvent(BaseModel):
     userId: Optional[str] = None
     username: Optional[str] = None
     displayName: Optional[str] = None
+    actorUserId: Optional[str] = None
     actorPlayerUserId: Optional[str] = None
     actorDisplayName: Optional[str] = None
+    casterPlayerUserId: Optional[str] = None
+    casterDisplayName: Optional[str] = None
     targetPlayerUserId: Optional[str] = None
     targetDisplayName: Optional[str] = None
     spellKey: Optional[str] = None
@@ -304,6 +307,7 @@ class OutOfCombatSpellCastActivityEvent(BaseModel):
     newConcentrationGroup: Optional[str] = None
     previousSpellName: Optional[str] = None
     previousVariantLabel: Optional[str] = None
+    castByGm: bool = False
     timestamp: datetime
     sessionOffsetSeconds: int
 

--- a/apps/control-server/tests/test_out_of_combat_cast.py
+++ b/apps/control-server/tests/test_out_of_combat_cast.py
@@ -15,7 +15,9 @@ from unittest.mock import MagicMock, patch
 
 from app.api.routes.sessions.state import (
     _prune_out_of_combat_session_activity,
+    cast_spell_out_of_combat_for_player,
     cast_spell_out_of_combat,
+    list_out_of_combat_castable_spells_for_player,
     list_out_of_combat_castable_spells,
 )
 from app.api.serializers.base_spell import (
@@ -980,6 +982,73 @@ class TestListCastableEndpoint(unittest.TestCase):
             }
         }
         return state
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_gm")
+    @patch("app.api.routes.sessions.state._require_session_participant")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    def test_gm_can_list_castable_ooc_spells_for_player(
+        self, mock_ensure, mock_require_participant, mock_require_gm, mock_get_entry
+    ):
+        entry = MagicMock(party_id="party-1", campaign_id="camp-1")
+        mock_get_entry.return_value = entry
+
+        state = self._make_state_with_spells([
+            {"id": "spell-ea-1", "canonicalKey": "enhance_ability", "level": 2, "prepared": True},
+        ])
+        mock_ensure.return_value = state
+
+        enhance_cs = _make_campaign_spell(
+            canonical_key="enhance_ability",
+            level=2,
+            out_of_combat_castable=True,
+            variants_json=[{"key": "owls_wisdom", "labelPt": "Sabedoria", "effects": [_advantage_effect()]}],
+        )
+
+        db = MagicMock()
+        call_count = [0]
+
+        def exec_side(q, **kw):
+            r = MagicMock()
+            if call_count[0] == 0:
+                r.first.return_value = state
+            else:
+                r.all.return_value = [enhance_cs]
+            call_count[0] += 1
+            return r
+
+        db.exec.side_effect = exec_side
+
+        result = list_out_of_combat_castable_spells_for_player(
+            session_id="session-1",
+            player_user_id="ally-a",
+            user=_make_user("gm-1"),
+            session=db,
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["canonicalKey"], "enhance_ability")
+        mock_require_gm.assert_called_once()
+        mock_require_participant.assert_called_once_with(entry, db, "ally-a", label="Caster")
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_gm")
+    def test_player_cannot_list_castable_ooc_spells_for_other_player(
+        self, mock_require_gm, mock_get_entry
+    ):
+        from fastapi import HTTPException
+
+        entry = MagicMock(party_id="party-1", campaign_id="camp-1")
+        mock_get_entry.return_value = entry
+        mock_require_gm.side_effect = HTTPException(status_code=403, detail="GM required")
+
+        with self.assertRaises(HTTPException):
+            list_out_of_combat_castable_spells_for_player(
+                session_id="session-1",
+                player_user_id="ally-a",
+                user=_make_user("player-1"),
+                session=MagicMock(),
+            )
 
     @patch("app.api.routes.sessions.state.get_session_entry")
     @patch("app.api.routes.sessions.state.require_session_view_access")
@@ -2816,6 +2885,293 @@ class TestOutOfCombatActivityLogging(unittest.IsolatedAsyncioTestCase):
 
         mock_record_activity.assert_not_called()
         mock_prune_activity.assert_not_called()
+
+
+class TestGmOutOfCombatCastingEndpoints(unittest.IsolatedAsyncioTestCase):
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_gm")
+    @patch("app.api.routes.sessions.state._require_session_participant")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data", side_effect=lambda d: d)
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_gm_can_cast_ooc_spell_as_player_self_target(
+        self,
+        mock_to_state,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_participant,
+        mock_require_gm,
+        mock_get_entry,
+    ):
+        spell = _make_campaign_spell(
+            canonical_key="shield_of_faith",
+            level=1,
+            concentration=True,
+            out_of_combat_castable=True,
+            effects_json=[_ac_bonus_effect(2)],
+        )
+        spell.out_of_combat_target = "self_or_ally"
+
+        state_json = _slots_state(level=1, used=0, max_slots=3)
+        state_json["spellcasting"]["spells"] = [
+            {"id": "spell-1", "canonicalKey": "shield_of_faith", "level": 1, "prepared": True},
+        ]
+        db, state = _make_db_session(state_json=state_json, campaign_spell=spell)
+        state.player_user_id = "ally-a"
+        mock_ensure.return_value = state
+        mock_get_entry.return_value = MagicMock(party_id="party-1", campaign_id="camp-1")
+        mock_to_state.return_value = MagicMock()
+
+        await cast_spell_out_of_combat_for_player(
+            session_id="session-1",
+            player_user_id="ally-a",
+            req=OutOfCombatCastRequest(spellId="spell-1", slotLevel=1, variantKey=None),
+            user=_make_user("gm-1"),
+            session=db,
+        )
+
+        used_slots = state.state_json["spellcasting"]["slots"]["1"]["used"]
+        self.assertEqual(used_slots, 1, "GM cast must spend slot on selected caster")
+        self.assertEqual(mock_publish.call_count, 1)
+        published_player = mock_publish.call_args.args[1]
+        self.assertEqual(published_player, "ally-a")
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_gm")
+    @patch("app.api.routes.sessions.state._require_session_participant")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data", side_effect=lambda d: d)
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    @patch("app.api.routes.sessions.state.clear_concentration_group_across_session", return_value=[])
+    async def test_gm_can_cast_ooc_spell_as_player_onto_ally(
+        self,
+        mock_clear_across,
+        mock_to_state,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_participant,
+        mock_require_gm,
+        mock_get_entry,
+    ):
+        mock_to_state.return_value = MagicMock()
+        shield = _make_campaign_spell(
+            canonical_key="shield_of_faith",
+            level=1,
+            concentration=True,
+            out_of_combat_castable=True,
+            effects_json=[_ac_bonus_effect(2)],
+            name_pt="Escudo da Fé",
+        )
+        shield.out_of_combat_target = "self_or_ally"
+        db, caster_state, target_state, _ = _make_multiplayer_cast_setup(
+            mock_get_entry,
+            mock_ensure,
+            shield,
+            caster_user_id="ally-a",
+            target_user_id="ally-b",
+            slot_level=1,
+        )
+
+        await cast_spell_out_of_combat_for_player(
+            session_id="session-1",
+            player_user_id="ally-a",
+            req=OutOfCombatCastRequest(
+                spellId="spell-1",
+                slotLevel=1,
+                variantKey=None,
+                targetPlayerUserId="ally-b",
+            ),
+            user=_make_user("gm-1"),
+            session=db,
+        )
+
+        caster_effects = caster_state.state_json.get("active_spell_effects", [])
+        target_effects = target_state.state_json.get("active_spell_effects", [])
+        markers = [e for e in caster_effects if e.get("metadata", {}).get("concentration_marker")]
+        self.assertEqual(len(markers), 1, "Selected caster must receive concentration marker")
+        self.assertGreaterEqual(len(target_effects), 1, "Target must receive persisted buff effect")
+        published_players = {call.args[1] for call in mock_publish.call_args_list}
+        self.assertEqual(published_players, {"ally-a", "ally-b"})
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_gm")
+    async def test_non_gm_cannot_cast_as_other_player(
+        self, mock_require_gm, mock_get_entry
+    ):
+        from fastapi import HTTPException
+
+        mock_get_entry.return_value = MagicMock(party_id="party-1", campaign_id="camp-1")
+        mock_require_gm.side_effect = HTTPException(status_code=403, detail="GM required")
+
+        with self.assertRaises(HTTPException):
+            await cast_spell_out_of_combat_for_player(
+                session_id="session-1",
+                player_user_id="ally-a",
+                req=OutOfCombatCastRequest(spellId="spell-1", slotLevel=1, variantKey=None),
+                user=_make_user("player-1"),
+                session=MagicMock(),
+            )
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_gm")
+    @patch("app.api.routes.sessions.state._require_session_participant")
+    async def test_gm_cast_rejects_caster_not_in_party(
+        self, mock_require_participant, mock_require_gm, mock_get_entry
+    ):
+        from fastapi import HTTPException
+
+        mock_get_entry.return_value = MagicMock(party_id="party-1", campaign_id="camp-1")
+        mock_require_participant.side_effect = HTTPException(
+            status_code=400,
+            detail="Caster is not a participant in this session",
+        )
+
+        with self.assertRaises(HTTPException):
+            await cast_spell_out_of_combat_for_player(
+                session_id="session-1",
+                player_user_id="stranger-9",
+                req=OutOfCombatCastRequest(spellId="spell-1", slotLevel=1, variantKey=None),
+                user=_make_user("gm-1"),
+                session=MagicMock(),
+            )
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_gm")
+    @patch("app.api.routes.sessions.state._require_session_participant")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    async def test_gm_cast_rejects_target_outside_session(
+        self,
+        mock_ensure,
+        mock_require_participant,
+        mock_require_gm,
+        mock_get_entry,
+    ):
+        from fastapi import HTTPException
+
+        entry = MagicMock(party_id="party-1", campaign_id="camp-1")
+        mock_get_entry.return_value = entry
+
+        spell = _make_campaign_spell(
+            canonical_key="shield_of_faith",
+            level=1,
+            concentration=True,
+            out_of_combat_castable=True,
+            effects_json=[_ac_bonus_effect(2)],
+        )
+        spell.out_of_combat_target = "self_or_ally"
+        state_json = _slots_state(level=1, used=0, max_slots=3)
+        state_json["spellcasting"]["spells"] = [
+            {"id": "spell-1", "canonicalKey": "shield_of_faith", "level": 1, "prepared": True},
+        ]
+        caster_state = MagicMock()
+        caster_state.state_json = state_json
+        caster_state.player_user_id = "ally-a"
+        caster_state.session_id = "session-1"
+        caster_state.created_at = "2026-01-01T00:00:00+00:00"
+        caster_state.updated_at = None
+        mock_ensure.return_value = caster_state
+
+        db = MagicMock()
+        call_count = [0]
+
+        def exec_side(q, **kw):
+            r = MagicMock()
+            idx = call_count[0]
+            call_count[0] += 1
+            if idx == 0:
+                r.first.return_value = caster_state
+            elif idx == 1:
+                r.first.return_value = None  # missing target state
+            elif idx == 2:
+                r.first.return_value = spell
+            return r
+
+        db.exec.side_effect = exec_side
+
+        with self.assertRaises(HTTPException) as ctx:
+            await cast_spell_out_of_combat_for_player(
+                session_id="session-1",
+                player_user_id="ally-a",
+                req=OutOfCombatCastRequest(
+                    spellId="spell-1",
+                    slotLevel=1,
+                    variantKey=None,
+                    targetPlayerUserId="outsider-1",
+                ),
+                user=_make_user("gm-1"),
+                session=db,
+            )
+
+        self.assertIn("Target is not a participant", str(ctx.exception.detail))
+
+    @patch("app.api.routes.sessions.state._prune_out_of_combat_session_activity")
+    @patch("app.api.routes.sessions.state.record_session_activity")
+    @patch("app.api.routes.sessions.state._resolve_ooc_activity_actor", return_value=("member-gm", "GM"))
+    @patch("app.api.routes.sessions.state.clear_concentration_group_across_session", return_value=[])
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_gm")
+    @patch("app.api.routes.sessions.state._require_session_participant")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data", side_effect=lambda d: d)
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_gm_cast_activity_log_records_actor_caster_target_and_cast_by_gm(
+        self,
+        mock_to_state,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_participant,
+        mock_require_gm,
+        mock_get_entry,
+        mock_clear_across,
+        mock_resolve_actor,
+        mock_record_activity,
+        mock_prune_activity,
+    ):
+        mock_to_state.return_value = MagicMock()
+        shield = _make_campaign_spell(
+            canonical_key="shield_of_faith",
+            level=1,
+            concentration=True,
+            out_of_combat_castable=True,
+            effects_json=[_ac_bonus_effect(2)],
+            name_pt="Escudo da Fé",
+        )
+        shield.out_of_combat_target = "self_or_ally"
+        db, _, _, _ = _make_multiplayer_cast_setup(
+            mock_get_entry,
+            mock_ensure,
+            shield,
+            caster_user_id="ally-a",
+            target_user_id="ally-b",
+            slot_level=1,
+        )
+
+        await cast_spell_out_of_combat_for_player(
+            session_id="session-1",
+            player_user_id="ally-a",
+            req=OutOfCombatCastRequest(
+                spellId="spell-1",
+                slotLevel=1,
+                variantKey=None,
+                targetPlayerUserId="ally-b",
+            ),
+            user=_make_user("gm-1"),
+            session=db,
+        )
+
+        mock_record_activity.assert_called_once()
+        payload = mock_record_activity.call_args.kwargs["payload"]
+        self.assertEqual(payload["actor_user_id"], "gm-1")
+        self.assertEqual(payload["caster_player_user_id"], "ally-a")
+        self.assertEqual(payload["target_player_user_id"], "ally-b")
+        self.assertTrue(payload["cast_by_gm"])
+        self.assertEqual(mock_record_activity.call_args.args[1], "out_of_combat_spell_cast")
 
 
 class TestOutOfCombatActivityPrune(unittest.TestCase):

--- a/apps/control-server/tests/test_session_activity_ooc.py
+++ b/apps/control-server/tests/test_session_activity_ooc.py
@@ -28,8 +28,11 @@ class TestSessionActivityOutOfCombatEvents(unittest.TestCase):
         cast_cmd.command_type = "out_of_combat_spell_cast"
         cast_cmd.created_at = datetime(2026, 5, 5, 10, 0, 0, tzinfo=timezone.utc)
         cast_cmd.payload_json = {
+            "actor_user_id": "gm-1",
             "actor_player_user_id": "caster-1",
             "actor_display_name": "Caster One",
+            "caster_player_user_id": "ally-a",
+            "caster_display_name": "Aelar",
             "target_player_user_id": "ally-b",
             "target_display_name": "Ally B",
             "spell_key": "enhance_ability",
@@ -44,6 +47,7 @@ class TestSessionActivityOutOfCombatEvents(unittest.TestCase):
             "new_concentration_group": "grp-2",
             "previous_spell_name": "Benção",
             "previous_variant_label": None,
+            "cast_by_gm": True,
         }
 
         remove_cmd = MagicMock()
@@ -89,7 +93,10 @@ class TestSessionActivityOutOfCombatEvents(unittest.TestCase):
         self.assertEqual(len(events), 2)
         self.assertEqual(events[0].type, "out_of_combat_spell_cast")
         self.assertEqual(events[0].spellName, "Melhorar Habilidade")
+        self.assertEqual(events[0].actorUserId, "gm-1")
+        self.assertEqual(events[0].casterDisplayName, "Aelar")
         self.assertEqual(events[0].targetDisplayName, "Ally B")
+        self.assertTrue(events[0].castByGm)
         self.assertEqual(events[0].slotLevel, 2)
         self.assertEqual(events[1].type, "out_of_combat_effect_removed")
         self.assertEqual(events[1].effectLabel, "Escudo da Fé")

--- a/apps/control-web/src/features/sessions/components/SessionActivityRow.ooc.test.tsx
+++ b/apps/control-web/src/features/sessions/components/SessionActivityRow.ooc.test.tsx
@@ -11,6 +11,8 @@ vi.mock("../../../shared/hooks/useLocale", () => ({
         "sessionActivity.unknownTarget": "alvo desconhecido",
         "sessionActivity.onTarget": "em",
         "sessionActivity.castVerb": "lançou",
+        "sessionActivity.castByGmDid": "fez",
+        "sessionActivity.castByGmCastVerb": "lançar",
         "sessionActivity.usingSlotLevel": "usando espaço de",
         "sessionActivity.slotLevelSuffix": "º nível.",
         "sessionActivity.removedEffectVerb": "removeu",
@@ -75,6 +77,28 @@ describe("SessionActivityRow out-of-combat events", () => {
     expect(markup).toContain("em");
     expect(markup).toContain("Ally B");
     expect(markup).toContain("Escudo da Fé</span> em");
+  });
+
+  it("renders GM cast line with actor and caster when cast_by_gm is true", () => {
+    const markup = renderToStaticMarkup(
+      <SessionActivityRow
+        event={{
+          ...castBase,
+          castByGm: true,
+          actorDisplayName: "GM",
+          casterDisplayName: "Aelar",
+          targetDisplayName: "Luna",
+          spellName: "Melhorar Habilidade",
+          variantLabel: "Sabedoria da Coruja",
+        }}
+      />,
+    );
+    expect(markup).toContain("GM");
+    expect(markup).toContain("fez");
+    expect(markup).toContain("Aelar");
+    expect(markup).toContain("lançar");
+    expect(markup).toContain("Melhorar Habilidade — Sabedoria da Coruja");
+    expect(markup).toContain("Luna");
   });
 
   it("renders previous concentration context when replacement metadata exists", () => {

--- a/apps/control-web/src/features/sessions/components/SessionActivityRowEventsB.tsx
+++ b/apps/control-web/src/features/sessions/components/SessionActivityRowEventsB.tsx
@@ -265,19 +265,37 @@ export const SessionActivityOutOfCombatSpellCastRow = ({ event, actor }: Props) 
   if (event.type !== "out_of_combat_spell_cast") return null;
 
   const actorLabel = event.actorDisplayName ?? actor;
+  const casterLabel = event.casterDisplayName ?? event.casterPlayerUserId ?? actorLabel;
   const targetLabel = event.targetDisplayName ?? t("sessionActivity.unknownTarget");
   const spellLabel = event.variantLabel
     ? `${event.spellName} — ${event.variantLabel}`
     : event.spellName;
+  const renderedCastPrefix = event.castByGm
+    ? (
+      <>
+        <span className="font-semibold">{actorLabel}</span>
+        {" "}
+        {t("sessionActivity.castByGmDid")}
+        {" "}
+        <span className="font-semibold text-slate-200">{casterLabel}</span>
+        {" "}
+        {t("sessionActivity.castByGmCastVerb")}
+      </>
+    )
+    : (
+      <>
+        <span className="font-semibold">{actorLabel}</span>
+        {" "}
+        {t("sessionActivity.castVerb")}
+      </>
+    );
 
   return (
     <div className="flex items-start gap-3 rounded-xl bg-slate-950/60 px-4 py-3">
       <span className="mt-0.5 text-base">✨</span>
       <div className="min-w-0 flex-1">
         <p className="text-sm text-white">
-          <span className="font-semibold">{actorLabel}</span>
-          {" "}
-          {t("sessionActivity.castVerb")}
+          {renderedCastPrefix}
           {" "}
           <span className="font-semibold text-slate-100">{spellLabel}</span>
           {" "}

--- a/apps/control-web/src/pages/GmDashboardPage/GmDashboardPage.tsx
+++ b/apps/control-web/src/pages/GmDashboardPage/GmDashboardPage.tsx
@@ -312,6 +312,7 @@ export const GmDashboardPage = () => {
 
             {activeSession?.status === "ACTIVE" && (
                 <GmDashboardPartyInventories
+                    activeSessionId={activeSession.id}
                     activeSessionPartyId={activeSession.partyId ?? null}
                     catalogItems={catalogItems}
                     currencyDraftByUserId={currencyDraftByUserId}

--- a/apps/control-web/src/pages/GmDashboardPage/GmDashboardPartyInventories.tsx
+++ b/apps/control-web/src/pages/GmDashboardPage/GmDashboardPartyInventories.tsx
@@ -10,6 +10,7 @@ import { GmDashboardPlayerInventoryCard } from "./GmDashboardPlayerInventoryCard
 import { useState } from "react";
 
 type Props = {
+  activeSessionId: string | null;
   activeSessionPartyId: string | null;
   catalogItems: Record<string, Item>;
   currencyDraftByUserId: Record<string, CurrencyDraft>;
@@ -47,6 +48,7 @@ type Props = {
 };
 
 export const GmDashboardPartyInventories = ({
+  activeSessionId,
   activeSessionPartyId,
   catalogItems,
   currencyDraftByUserId,
@@ -100,6 +102,7 @@ export const GmDashboardPartyInventories = ({
           return (
             <GmDashboardPlayerInventoryCard
               key={player.userId}
+              activeSessionId={activeSessionId}
               activeSessionPartyId={activeSessionPartyId}
               catalogItems={catalogItems}
               currencyDraft={currencyDraftByUserId[player.userId]}
@@ -125,6 +128,10 @@ export const GmDashboardPartyInventories = ({
               sortedCatalogItems={sortedCatalogItems}
               wallet={walletByUserId[player.userId]}
               xpDraft={xpDraftByUserId[player.userId] ?? ""}
+              targetOptions={partyPlayers.map((member) => ({
+                playerUserId: member.userId,
+                label: member.displayName || member.username || member.userId,
+              }))}
               onApproveLevelUp={() => onApproveLevelUp(player.userId)}
               onDamagePlayer={() => onDamagePlayer(player.userId)}
               onDenyLevelUp={() => onDenyLevelUp(player.userId)}

--- a/apps/control-web/src/pages/GmDashboardPage/GmDashboardPlayerInventoryCard.ooc.test.tsx
+++ b/apps/control-web/src/pages/GmDashboardPage/GmDashboardPlayerInventoryCard.ooc.test.tsx
@@ -1,0 +1,134 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { GmDashboardPlayerInventoryCard } from "./GmDashboardPlayerInventoryCard";
+
+const testState = vi.hoisted(() => ({
+  sessionStatesRepoMock: {
+    listCastableOutOfCombatForPlayer: vi.fn(async () => []),
+    castSpellOutOfCombatForPlayer: vi.fn(async () => ({
+      id: "ss-1",
+      sessionId: "session-1",
+      playerUserId: "ally-a",
+      state: {},
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: null,
+    })),
+  },
+  lastCastCardProps: null as Record<string, unknown> | null,
+}));
+
+vi.mock("../../shared/hooks/useLocale", () => ({
+  useLocale: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("../../shared/api/sessionStatesRepo", () => ({
+  sessionStatesRepo: testState.sessionStatesRepoMock,
+}));
+
+vi.mock("./GmDashboardPlayerProgressBlock", () => ({
+  GmDashboardPlayerProgressBlock: () => null,
+}));
+
+vi.mock("./GmDashboardInventoryFilters", () => ({
+  GmDashboardInventoryFilters: () => null,
+}));
+
+vi.mock("./GmDashboardInventoryItemList", () => ({
+  GmDashboardInventoryItemList: () => null,
+}));
+
+vi.mock("./GmDashboardGrantPanels", () => ({
+  GmDashboardGrantPanels: () => null,
+}));
+
+vi.mock("../PlayerBoardPage/OutOfCombatSpellCastCard", () => ({
+  OutOfCombatSpellCastCard: (props: Record<string, unknown>) => {
+    testState.lastCastCardProps = props;
+    return null;
+  },
+}));
+
+describe("GmDashboardPlayerInventoryCard OOC cast", () => {
+  it("dispatches GM cast endpoint with player_user_id and payload", async () => {
+    testState.lastCastCardProps = null;
+    testState.sessionStatesRepoMock.castSpellOutOfCombatForPlayer.mockClear();
+
+    renderToStaticMarkup(
+      <GmDashboardPlayerInventoryCard
+        activeSessionId="session-1"
+        activeSessionPartyId="party-1"
+        catalogItems={{}}
+        currencyDraft={undefined}
+        effectiveCampaignId={null}
+        equippedOnly={false}
+        grantFeedback={undefined}
+        grantingCurrencyForUserId={null}
+        grantingItemForUserId={null}
+        grantingXpForUserId={null}
+        hpActionState={null}
+        hpDraft=""
+        inventoryGroup="all"
+        inventorySearch=""
+        isOnline
+        isOpen
+        itemDraft={undefined}
+        levelUpActionState={null}
+        locale="pt-BR"
+        navigate={() => undefined}
+        player={{
+          userId: "ally-a",
+          role: "PLAYER",
+          status: "joined",
+          createdAt: "2026-01-01T00:00:00Z",
+          displayName: "Aelar",
+          username: "aelar",
+        }}
+        playerItems={[]}
+        sheet={undefined}
+        sortedCatalogItems={[]}
+        wallet={undefined}
+        xpDraft=""
+        targetOptions={[
+          { playerUserId: "ally-a", label: "Aelar" },
+          { playerUserId: "ally-b", label: "Luna" },
+        ]}
+        onApproveLevelUp={() => undefined}
+        onDamagePlayer={() => undefined}
+        onDenyLevelUp={() => undefined}
+        onGrantCurrency={() => undefined}
+        onGrantItem={() => undefined}
+        onGrantXp={() => undefined}
+        onHealPlayer={() => undefined}
+        onOpenInventory={() => undefined}
+        onGroupChange={() => undefined}
+        onSearchChange={() => undefined}
+        onToggleEquippedOnly={() => undefined}
+        setCurrencyDraft={() => ({ amount: "", coin: "gp" })}
+        setHpDraftByUserId={() => ({})}
+        setItemDraft={() => ({ itemId: "", quantity: "" })}
+        setXpDraftByUserId={() => ({})}
+      />,
+    );
+
+    expect(testState.lastCastCardProps).not.toBeNull();
+    const onCast = testState.lastCastCardProps?.onCast as
+      | ((spellId: string, slotLevel: number | null, variantKey: string | null, targetPlayerUserId: string | null) => Promise<void> | void)
+      | undefined;
+    expect(onCast).toBeTypeOf("function");
+
+    await onCast?.("spell-1", 2, "owls_wisdom", "ally-b");
+
+    expect(testState.sessionStatesRepoMock.castSpellOutOfCombatForPlayer).toHaveBeenCalledWith(
+      "session-1",
+      "ally-a",
+      {
+        spellId: "spell-1",
+        slotLevel: 2,
+        variantKey: "owls_wisdom",
+        targetPlayerUserId: "ally-b",
+      },
+    );
+  });
+});

--- a/apps/control-web/src/pages/GmDashboardPage/GmDashboardPlayerInventoryCard.tsx
+++ b/apps/control-web/src/pages/GmDashboardPage/GmDashboardPlayerInventoryCard.tsx
@@ -1,9 +1,10 @@
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { routes } from "../../app/routes/routes";
 import type { PartyMemberSummary } from "../../shared/api/partiesRepo";
 import type { CurrencyWallet } from "../../shared/api/inventoryRepo";
 import type { InventoryItem } from "../../entities/inventory";
 import type { Item } from "../../entities/item";
+import type { OutOfCombatCastableSpell } from "../../entities/character";
 import type { CharacterSheet } from "../../features/character-sheet/model/characterSheet.types";
 import type { SessionInventoryFilterGroup } from "../../features/inventory/components/sessionInventoryPanel.utils";
 import type { CurrencyDraft, GrantFeedback, HpActionState, ItemDraft } from "./gmDashboard.types";
@@ -12,9 +13,12 @@ import { GmDashboardInventoryFilters } from "./GmDashboardInventoryFilters";
 import { GmDashboardInventoryItemList } from "./GmDashboardInventoryItemList";
 import { GmDashboardGrantPanels } from "./GmDashboardGrantPanels";
 import { useLocale } from "../../shared/hooks/useLocale";
+import { sessionStatesRepo } from "../../shared/api/sessionStatesRepo";
+import { OutOfCombatSpellCastCard } from "../PlayerBoardPage/OutOfCombatSpellCastCard";
 import { computeTotalWeight, computeEncumbranceTier, LB_TO_KG } from "../../features/character-sheet/utils/calculations";
 
 type Props = {
+  activeSessionId: string | null;
   activeSessionPartyId: string | null;
   catalogItems: Record<string, Item>;
   currencyDraft: CurrencyDraft | undefined;
@@ -40,6 +44,7 @@ type Props = {
   sortedCatalogItems: Item[];
   wallet: CurrencyWallet | undefined;
   xpDraft: string;
+  targetOptions: Array<{ playerUserId: string; label: string }>;
   onApproveLevelUp: () => void;
   onDamagePlayer: () => void;
   onDenyLevelUp: () => void;
@@ -58,6 +63,7 @@ type Props = {
 };
 
 export const GmDashboardPlayerInventoryCard = ({
+  activeSessionId,
   activeSessionPartyId,
   catalogItems,
   currencyDraft,
@@ -83,6 +89,7 @@ export const GmDashboardPlayerInventoryCard = ({
   sortedCatalogItems,
   wallet,
   xpDraft,
+  targetOptions,
   onApproveLevelUp,
   onDamagePlayer,
   onDenyLevelUp,
@@ -108,6 +115,10 @@ export const GmDashboardPlayerInventoryCard = ({
     hpActionState?.userId === player.userId && hpActionState.action === "damage";
   const isHealing =
     hpActionState?.userId === player.userId && hpActionState.action === "heal";
+  const [castableSpells, setCastableSpells] = useState<OutOfCombatCastableSpell[]>([]);
+  const [loadingCastableSpells, setLoadingCastableSpells] = useState(false);
+  const [castingSpell, setCastingSpell] = useState(false);
+  const [castFeedback, setCastFeedback] = useState<string | null>(null);
 
   const encumbranceData = useMemo(() => {
     if (!sheet) return null;
@@ -115,6 +126,54 @@ export const GmDashboardPlayerInventoryCard = ({
     const result = computeEncumbranceTier({ strengthScore: sheet.abilities.strength, totalWeightKg });
     return { strengthScore: sheet.abilities.strength, totalWeightKg, tier: result.tier };
   }, [sheet]);
+
+  const loadCastableSpells = useCallback(async () => {
+    if (!activeSessionId) {
+      setCastableSpells([]);
+      return;
+    }
+    setLoadingCastableSpells(true);
+    setCastFeedback(null);
+    try {
+      const spells = await sessionStatesRepo.listCastableOutOfCombatForPlayer(activeSessionId, player.userId);
+      setCastableSpells(spells);
+    } catch {
+      setCastableSpells([]);
+      setCastFeedback("Falha ao carregar magias OOC.");
+    } finally {
+      setLoadingCastableSpells(false);
+    }
+  }, [activeSessionId, player.userId]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    void loadCastableSpells();
+  }, [isOpen, loadCastableSpells]);
+
+  const handleCastSpellOutOfCombat = useCallback(async (
+    spellId: string,
+    slotLevel: number | null,
+    variantKey: string | null,
+    targetPlayerUserId: string | null,
+  ) => {
+    if (!activeSessionId || castingSpell) return;
+    setCastingSpell(true);
+    setCastFeedback(null);
+    try {
+      await sessionStatesRepo.castSpellOutOfCombatForPlayer(activeSessionId, player.userId, {
+        spellId,
+        slotLevel,
+        variantKey,
+        targetPlayerUserId,
+      });
+      setCastFeedback("Magia OOC lançada com sucesso.");
+      void loadCastableSpells();
+    } catch {
+      setCastFeedback("Nao foi possivel lançar a magia OOC.");
+    } finally {
+      setCastingSpell(false);
+    }
+  }, [activeSessionId, castingSpell, loadCastableSpells, player.userId]);
 
   const playSheetRoute = activeSessionPartyId
     ? `${routes.characterSheetParty.replace(":partyId", activeSessionPartyId)}?${new URLSearchParams({
@@ -202,6 +261,20 @@ export const GmDashboardPlayerInventoryCard = ({
           />
 
           <div className="mt-3 space-y-3">
+            {loadingCastableSpells ? (
+              <p className="text-xs text-slate-400">Carregando magias OOC...</p>
+            ) : (
+              <OutOfCombatSpellCastCard
+                spells={castableSpells}
+                casting={castingSpell}
+                onCast={handleCastSpellOutOfCombat}
+                targetOptions={targetOptions}
+              />
+            )}
+            {castFeedback ? (
+              <p className="text-xs text-slate-400">{castFeedback}</p>
+            ) : null}
+
             <GmDashboardInventoryFilters
               userId={player.userId}
               searchValue={inventorySearch}

--- a/apps/control-web/src/shared/api/sessionStatesRepo.ts
+++ b/apps/control-web/src/shared/api/sessionStatesRepo.ts
@@ -28,6 +28,16 @@ export const sessionStatesRepo = {
     http.get<OutOfCombatCastableSpell[]>(
       `/sessions/${sessionId}/state/me/spells/castable-out-of-combat`,
     ),
+  listCastableOutOfCombatForPlayer: (sessionId: string, playerUserId: string) =>
+    http.get<OutOfCombatCastableSpell[]>(
+      `/sessions/${sessionId}/state/${playerUserId}/spells/castable-out-of-combat`,
+    ),
   castSpellOutOfCombat: (sessionId: string, req: OutOfCombatCastRequest) =>
     http.post<SessionStateRecord>(`/sessions/${sessionId}/state/me/spells/cast`, req),
+  castSpellOutOfCombatForPlayer: (
+    sessionId: string,
+    playerUserId: string,
+    req: OutOfCombatCastRequest,
+  ) =>
+    http.post<SessionStateRecord>(`/sessions/${sessionId}/state/${playerUserId}/spells/cast`, req),
 };

--- a/apps/control-web/src/shared/api/sessionsRepo.ts
+++ b/apps/control-web/src/shared/api/sessionsRepo.ts
@@ -334,8 +334,11 @@ export type OutOfCombatSpellCastActivityEvent = {
   userId?: string | null;
   username?: string | null;
   displayName?: string | null;
+  actorUserId?: string | null;
   actorPlayerUserId?: string | null;
   actorDisplayName?: string | null;
+  casterPlayerUserId?: string | null;
+  casterDisplayName?: string | null;
   targetPlayerUserId?: string | null;
   targetDisplayName?: string | null;
   spellKey?: string | null;
@@ -350,6 +353,7 @@ export type OutOfCombatSpellCastActivityEvent = {
   newConcentrationGroup?: string | null;
   previousSpellName?: string | null;
   previousVariantLabel?: string | null;
+  castByGm?: boolean;
   timestamp: string;
   sessionOffsetSeconds: number;
 };

--- a/apps/control-web/src/shared/i18n/enUS/sessionActivity.ts
+++ b/apps/control-web/src/shared/i18n/enUS/sessionActivity.ts
@@ -31,6 +31,8 @@ export const sessionActivityEnUSDictionary = {
   "sessionActivity.usedConsumable": "used",
   "sessionActivity.onTarget": "on",
   "sessionActivity.castVerb": "cast",
+  "sessionActivity.castByGmDid": "made",
+  "sessionActivity.castByGmCastVerb": "cast",
   "sessionActivity.usingSlotLevel": "using a level",
   "sessionActivity.slotLevelSuffix": " slot.",
   "sessionActivity.removedEffectVerb": "removed",

--- a/apps/control-web/src/shared/i18n/ptBR/sessionActivity.ts
+++ b/apps/control-web/src/shared/i18n/ptBR/sessionActivity.ts
@@ -31,6 +31,8 @@ export const sessionActivityPtBRDictionary = {
   "sessionActivity.usedConsumable": "usou",
   "sessionActivity.onTarget": "em",
   "sessionActivity.castVerb": "lancou",
+  "sessionActivity.castByGmDid": "fez",
+  "sessionActivity.castByGmCastVerb": "lancar",
   "sessionActivity.usingSlotLevel": "usando espaco de",
   "sessionActivity.slotLevelSuffix": "º nivel.",
   "sessionActivity.removedEffectVerb": "removeu",


### PR DESCRIPTION
# feat(spells): allow GM to cast out-of-combat spells for players

## Summary

Adds GM support for out-of-combat spell casting on behalf of players.

The GM can now list eligible OOC spells for a selected player and cast those spells as that player, while preserving the same validation and mutation rules used by the player `/me` flow.

The selected player remains the caster: they spend the slot, own concentration, and appear as caster in activity logs. The GM is recorded separately as the actor.

## Context

Out-of-combat casting already supported player-driven self/ally buff casting:

- prepared validation
- slot spending
- target validation
- persisted active effects
- caster-owned concentration
- target-owned effects
- realtime updates
- OOC cast/remove activity logs

This PR adds a GM-authorized path for the same behavior.

The GM can help resolve table flow without bypassing spell rules.

## Backend changes

### Shared OOC cast/list engine

Updated:

```text
apps/control-server/app/api/routes/sessions/state.py
````

The OOC casting/listing logic is now shared by:

```http
GET /sessions/{session_id}/state/me/spells/castable-out-of-combat
POST /sessions/{session_id}/state/me/spells/cast
```

and the new GM routes:

```http
GET /sessions/{session_id}/state/{player_user_id}/spells/castable-out-of-combat
POST /sessions/{session_id}/state/{player_user_id}/spells/cast
```

The `/me` behavior remains compatible.

### GM permission and membership validation

The GM endpoints enforce:

```text
require_session_gm
→ validate selected player is a real participant
→ only then ensure/load SessionState
```

This prevents accidentally seeding arbitrary users into a session.

A rare and beautiful case of the permission check standing in front of the chaos door.

### Cast behavior

GM cast uses the same OOC engine rules:

* selected player is the caster
* caster spends spell slot
* target receives persisted active effect
* concentration belongs to caster
* ally targeting works
* cross-session concentration cleanup works
* realtime publishes are deduplicated by `player_user_id`
* operation uses one commit

### Activity log

Updated:

```text
apps/control-server/app/schemas/session.py
apps/control-server/app/api/routes/sessions/activity.py
```

OOC cast activity now includes:

```text
actor_user_id
caster_player_user_id
caster_display_name
cast_by_gm
```

Compatibility is preserved with the legacy/current `actor_player_user_id` payload shape.

The parser accepts both old and new fields.

## Frontend changes

### API client

Updated:

```text
apps/control-web/src/shared/api/sessionStatesRepo.ts
```

Added GM methods for:

* listing eligible OOC spells for a player
* casting OOC spells as a player

### Activity types/rendering

Updated:

```text
apps/control-web/src/shared/api/sessionsRepo.ts
apps/control-web/src/features/sessions/components/SessionActivityRowEventsB.tsx
```

When `cast_by_gm=true`, the activity feed renders the GM-specific wording.

Example:

```text
GM fez Aelar lançar Melhorar Habilidade — Sabedoria da Coruja em Luna.
```

When `cast_by_gm=false`, the existing player-cast text is preserved.

### GM Dashboard UI

Updated:

```text
apps/control-web/src/pages/GmDashboardPage/GmDashboardPlayerInventoryCard.tsx
apps/control-web/src/pages/GmDashboardPage/GmDashboardPartyInventories.tsx
apps/control-web/src/pages/GmDashboardPage/GmDashboardPage.tsx
```

Adds an OOC spell casting card per player in the GM Dashboard.

Behavior:

* loads eligible OOC spells on demand when the player card expands
* reuses `OutOfCombatSpellCastCard`
* sends casts through the GM endpoint
* keeps player-board casting UI unchanged

### i18n

Updated:

```text
apps/control-web/src/shared/i18n/ptBR/sessionActivity.ts
apps/control-web/src/shared/i18n/enUS/sessionActivity.ts
```

Added GM-specific OOC cast activity strings.

## Tests

### Backend

Updated:

```text
apps/control-server/tests/test_out_of_combat_cast.py
apps/control-server/tests/test_session_activity_ooc.py
```

Coverage includes:

* GM can list eligible OOC spells for selected player
* GM can cast as selected player
* selected caster spends slot
* concentration belongs to selected caster
* ally targeting works through GM route
* non-GM cannot cast as another player
* invalid caster/target is rejected
* existing `/me` endpoint still works
* OOC activity maps actor/caster fields correctly

### Frontend

Updated:

```text
apps/control-web/src/features/sessions/components/SessionActivityRow.ooc.test.tsx
apps/control-web/src/pages/GmDashboardPage/GmDashboardPlayerInventoryCard.ooc.test.tsx
```

Coverage includes:

* GM activity row renders actor + caster + target wording
* GM dashboard card calls the GM OOC cast endpoint flow correctly
* existing player activity rendering remains compatible

## Validation

Backend:

```bash
cd apps/control-server
.venv/bin/pytest tests/test_out_of_combat_cast.py tests/test_session_activity_ooc.py -v
```

Result:

```text
72 passed
```

Frontend:

```bash
cd apps/control-web
npm test -- src/features/sessions/components/SessionActivityRow.ooc.test.tsx src/pages/GmDashboardPage/GmDashboardPlayerInventoryCard.ooc.test.tsx
```

Result:

```text
2 test files passed / 7 tests passed
```

Build:

```bash
cd apps/control-web
npm run build
```

Result:

```text
build OK
```

## Out of scope

This PR intentionally does not implement:

* GM hostile spell casting
* NPC casting
* combat casting as GM
* casting without spending slots
* prepared validation override
* arbitrary effect application
* manual spell slot adjustment
* GM active effect admin panel

## Notes for reviewers

The core model is:

```text
actor = who clicked
caster = who casts, spends slot, owns concentration
target = who receives the effect
```

The GM route changes only the actor. It does not bypass the casting engine or spell rules.