### PR TITLE
feat(effects): add GM active effect admin controls

### DIFF
--- a/apps/control-server/app/api/routes/sessions/activity.py
+++ b/apps/control-server/app/api/routes/sessions/activity.py
@@ -442,14 +442,26 @@ def get_session_activity(
                 userId=command.user_id,
                 username=command_user.username if command_user else None,
                 displayName=actor_name,
-                actorPlayerUserId=payload.get("actor_player_user_id") if isinstance(payload.get("actor_player_user_id"), str) else None,
+                actorUserId=payload.get("actor_user_id") if isinstance(payload.get("actor_user_id"), str) else None,
+                actorPlayerUserId=(
+                    payload.get("actor_player_user_id")
+                    if isinstance(payload.get("actor_player_user_id"), str)
+                    else (
+                        payload.get("actor_user_id")
+                        if isinstance(payload.get("actor_user_id"), str)
+                        else None
+                    )
+                ),
                 actorDisplayName=payload.get("actor_display_name") if isinstance(payload.get("actor_display_name"), str) else actor_name,
+                targetPlayerUserId=payload.get("target_player_user_id") if isinstance(payload.get("target_player_user_id"), str) else None,
+                targetDisplayName=payload.get("target_display_name") if isinstance(payload.get("target_display_name"), str) else None,
                 removedEffectId=str(payload.get("removed_effect_id") or ""),
                 effectLabel=str(payload.get("effect_label") or "Effect"),
                 sourceSpellName=payload.get("source_spell_name") if isinstance(payload.get("source_spell_name"), str) else None,
                 variantLabel=payload.get("variant_label") if isinstance(payload.get("variant_label"), str) else None,
                 concentrationGroup=payload.get("concentration_group") if isinstance(payload.get("concentration_group"), str) else None,
                 brokeConcentrationGroup=bool(payload.get("broke_concentration_group", False)),
+                removedByGm=bool(payload.get("removed_by_gm", False)),
                 timestamp=command.created_at,
                 sessionOffsetSeconds=offset(command.created_at),
             ))

--- a/apps/control-server/app/api/routes/sessions/state.py
+++ b/apps/control-server/app/api/routes/sessions/state.py
@@ -95,6 +95,19 @@ def _resolve_ooc_activity_actor(entry, user, session: DbSession) -> tuple[str | 
     return resolved_member_id, resolved_actor
 
 
+def _resolve_ooc_activity_target_display_name(entry, player_user_id: str, session: DbSession) -> str:
+    member = session.exec(
+        select(CampaignMember).where(
+            CampaignMember.campaign_id == entry.campaign_id,
+            CampaignMember.user_id == player_user_id,
+        )
+    ).first()
+    display_name = getattr(member, "display_name", None) if member else None
+    if isinstance(display_name, str) and display_name.strip():
+        return display_name.strip()
+    return player_user_id
+
+
 def _require_session_participant(entry, session: DbSession, player_user_id: str, *, label: str) -> None:
     if entry.party_id:
         party_member = session.exec(
@@ -705,13 +718,34 @@ async def remove_my_persisted_effect(
 ):
     entry = get_session_entry(session_id, session)
     require_session_view_access(entry, user, session, user.id)
+    return await _remove_persisted_effect_for_player(
+        session=session,
+        entry=entry,
+        session_id=session_id,
+        actor_user=user,
+        owner_player_user_id=user.id,
+        effect_id=effect_id,
+        removed_by_gm=False,
+    )
+
+
+async def _remove_persisted_effect_for_player(
+    *,
+    session: DbSession,
+    entry,
+    session_id: str,
+    actor_user,
+    owner_player_user_id: str,
+    effect_id: str,
+    removed_by_gm: bool,
+) -> SessionStateRead:
     state = session.exec(
         select(SessionState).where(
             SessionState.session_id == session_id,
-            SessionState.player_user_id == user.id,
+            SessionState.player_user_id == owner_player_user_id,
         )
     ).first()
-    state = ensure_session_state(state, session_id, user.id, entry.party_id, session)
+    state = ensure_session_state(state, session_id, owner_player_user_id, entry.party_id, session)
     if not state:
         raise HTTPException(status_code=404, detail="Session state not found")
 
@@ -754,27 +788,36 @@ async def remove_my_persisted_effect(
         is_ally_target = caster_id is not None and target_id is not None and caster_id != target_id
         if was_concentration and is_ally_target and concentration_group:
             affected_allies = clear_concentration_group_across_session(
-                session, session_id, concentration_group, exclude_user_id=user.id
+                session, session_id, concentration_group, exclude_user_id=owner_player_user_id
             )
 
-    actor_member_id, actor_display_name = _resolve_ooc_activity_actor(entry, user, session)
+    actor_member_id, actor_display_name = _resolve_ooc_activity_actor(entry, actor_user, session)
     if removed_effect and actor_member_id:
+        target_display_name = _resolve_ooc_activity_target_display_name(
+            entry,
+            owner_player_user_id,
+            session,
+        )
         record_session_activity(
             entry,
             "out_of_combat_effect_removed",
             session,
             member_id=actor_member_id,
-            user_id=user.id,
+            user_id=actor_user.id,
             actor_name=actor_display_name,
             payload={
-                "actor_player_user_id": user.id,
+                "actor_user_id": actor_user.id,
+                "actor_player_user_id": actor_user.id,  # legacy compatibility
                 "actor_display_name": actor_display_name,
+                "target_player_user_id": owner_player_user_id,
+                "target_display_name": target_display_name,
                 "removed_effect_id": effect_id,
                 "effect_label": effect_label,
                 "source_spell_name": source_spell_name,
                 "variant_label": variant_label,
                 "concentration_group": concentration_group,
                 "broke_concentration_group": broke_concentration_group,
+                "removed_by_gm": removed_by_gm,
             },
         )
         _prune_out_of_combat_session_activity(session, session_id)
@@ -783,7 +826,7 @@ async def remove_my_persisted_effect(
     session.refresh(state)
 
     # Publish updates for all modified players (deduped by player_user_id)
-    states_to_publish: dict[str, SessionState] = {user.id: state}
+    states_to_publish: dict[str, SessionState] = {owner_player_user_id: state}
     for ally in affected_allies:
         if ally.player_user_id not in states_to_publish:
             states_to_publish[ally.player_user_id] = ally
@@ -796,6 +839,28 @@ async def remove_my_persisted_effect(
             st.state_json if isinstance(st.state_json, dict) else None,
         )
     return to_state_read(state)
+
+
+@router.delete("/sessions/{session_id}/state/{player_user_id}/effects/{effect_id}", response_model=SessionStateRead)
+async def remove_player_persisted_effect(
+    session_id: str,
+    player_user_id: str,
+    effect_id: str,
+    user=Depends(get_current_user),
+    session: DbSession = Depends(get_session),
+):
+    entry = get_session_entry(session_id, session)
+    require_session_gm(entry, user, session)
+    _require_session_participant(entry, session, player_user_id, label="Target")
+    return await _remove_persisted_effect_for_player(
+        session=session,
+        entry=entry,
+        session_id=session_id,
+        actor_user=user,
+        owner_player_user_id=player_user_id,
+        effect_id=effect_id,
+        removed_by_gm=True,
+    )
 
 
 @router.post("/sessions/{session_id}/state/me/spells/prepare", response_model=SessionStateRead)

--- a/apps/control-server/app/schemas/session.py
+++ b/apps/control-server/app/schemas/session.py
@@ -317,14 +317,18 @@ class OutOfCombatEffectRemovedActivityEvent(BaseModel):
     userId: Optional[str] = None
     username: Optional[str] = None
     displayName: Optional[str] = None
+    actorUserId: Optional[str] = None
     actorPlayerUserId: Optional[str] = None
     actorDisplayName: Optional[str] = None
+    targetPlayerUserId: Optional[str] = None
+    targetDisplayName: Optional[str] = None
     removedEffectId: str
     effectLabel: str
     sourceSpellName: Optional[str] = None
     variantLabel: Optional[str] = None
     concentrationGroup: Optional[str] = None
     brokeConcentrationGroup: bool = False
+    removedByGm: bool = False
     timestamp: datetime
     sessionOffsetSeconds: int
 

--- a/apps/control-server/tests/test_session_concentration.py
+++ b/apps/control-server/tests/test_session_concentration.py
@@ -6,7 +6,11 @@ Covers route-level behavior of POST /sessions/{id}/state/me/concentration/clear.
 import unittest
 from unittest.mock import MagicMock, patch
 
-from app.api.routes.sessions.state import clear_my_concentration, remove_my_persisted_effect
+from app.api.routes.sessions.state import (
+    clear_my_concentration,
+    remove_my_persisted_effect,
+    remove_player_persisted_effect,
+)
 from app.schemas.session_state import ClearConcentrationRequest, SessionStateRead
 
 
@@ -1004,6 +1008,426 @@ class TestOutOfCombatRemovalActivityLogging(unittest.IsolatedAsyncioTestCase):
 
         mock_record_activity.assert_not_called()
         mock_prune_activity.assert_not_called()
+
+
+class TestGmRemovePersistedEffect(unittest.IsolatedAsyncioTestCase):
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_gm")
+    @patch("app.api.routes.sessions.state._require_session_participant")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data")
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_gm_can_remove_player_persisted_effect(
+        self,
+        mock_to_state_read,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_participant,
+        mock_require_gm,
+        mock_get_entry,
+    ):
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        effect = _non_concentration_effect("eff-a")
+        db, state = _make_db_session({"active_spell_effects": [effect]})
+        state.player_user_id = "ally-a"
+        mock_ensure.return_value = state
+        mock_finalize.side_effect = lambda x: x
+        mock_to_state_read.return_value = SessionStateRead(
+            id="ss-1",
+            sessionId="session-1",
+            playerUserId="ally-a",
+            state={},
+            createdAt="2026-01-01T00:00:00+00:00",
+            updatedAt=None,
+            activeSpellEffects=[],
+            activeConcentration=None,
+        )
+
+        await remove_player_persisted_effect(
+            session_id="session-1",
+            player_user_id="ally-a",
+            effect_id="eff-a",
+            user=_make_user("gm-1"),
+            session=db,
+        )
+
+        mock_require_gm.assert_called_once()
+        mock_require_participant.assert_called_once_with(
+            mock_get_entry.return_value,
+            db,
+            "ally-a",
+            label="Target",
+        )
+        self.assertEqual(mock_publish.await_count, 1)
+        published_player = mock_publish.await_args_list[0].args[1]
+        self.assertEqual(published_player, "ally-a")
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_gm")
+    async def test_non_gm_cannot_remove_other_player_effect(
+        self,
+        mock_require_gm,
+        mock_get_entry,
+    ):
+        from fastapi import HTTPException
+
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        mock_require_gm.side_effect = HTTPException(status_code=403, detail="GM required")
+
+        with self.assertRaises(HTTPException):
+            await remove_player_persisted_effect(
+                session_id="session-1",
+                player_user_id="ally-a",
+                effect_id="eff-a",
+                user=_make_user("player-1"),
+                session=MagicMock(),
+            )
+
+    @patch("app.api.routes.sessions.state._prune_out_of_combat_session_activity")
+    @patch("app.api.routes.sessions.state.record_session_activity")
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_gm")
+    @patch("app.api.routes.sessions.state._require_session_participant")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data")
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_gm_remove_unknown_effect_is_idempotent(
+        self,
+        mock_to_state_read,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_participant,
+        mock_require_gm,
+        mock_get_entry,
+        mock_record_activity,
+        mock_prune_activity,
+    ):
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        db, state = _make_db_session({"active_spell_effects": [_non_concentration_effect("eff-a")]})
+        state.player_user_id = "ally-a"
+        mock_ensure.return_value = state
+        mock_finalize.side_effect = lambda x: x
+        mock_to_state_read.return_value = SessionStateRead(
+            id="ss-1",
+            sessionId="session-1",
+            playerUserId="ally-a",
+            state={},
+            createdAt="2026-01-01T00:00:00+00:00",
+            updatedAt=None,
+            activeSpellEffects=[_non_concentration_effect("eff-a")],
+            activeConcentration=None,
+        )
+
+        await remove_player_persisted_effect(
+            session_id="session-1",
+            player_user_id="ally-a",
+            effect_id="eff-unknown",
+            user=_make_user("gm-1"),
+            session=db,
+        )
+
+        mock_record_activity.assert_not_called()
+        mock_prune_activity.assert_not_called()
+        self.assertEqual(mock_publish.await_count, 1)
+
+    @patch("app.api.routes.sessions.state._prune_out_of_combat_session_activity")
+    @patch("app.api.routes.sessions.state.record_session_activity")
+    @patch("app.api.routes.sessions.state._resolve_ooc_activity_actor", return_value=("member-gm", "GM"))
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_gm")
+    @patch("app.api.routes.sessions.state._require_session_participant")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data")
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_gm_remove_activity_logs_actor_and_target(
+        self,
+        mock_to_state_read,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_participant,
+        mock_require_gm,
+        mock_get_entry,
+        mock_resolve_actor,
+        mock_record_activity,
+        mock_prune_activity,
+    ):
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        effect = _non_concentration_effect("eff-a")
+        db, state = _make_db_session({"active_spell_effects": [effect]})
+        state.player_user_id = "ally-a"
+        mock_ensure.return_value = state
+        mock_finalize.side_effect = lambda x: x
+        mock_to_state_read.return_value = SessionStateRead(
+            id="ss-1",
+            sessionId="session-1",
+            playerUserId="ally-a",
+            state={},
+            createdAt="2026-01-01T00:00:00+00:00",
+            updatedAt=None,
+            activeSpellEffects=[],
+            activeConcentration=None,
+        )
+
+        await remove_player_persisted_effect(
+            session_id="session-1",
+            player_user_id="ally-a",
+            effect_id="eff-a",
+            user=_make_user("gm-1"),
+            session=db,
+        )
+
+        mock_record_activity.assert_called_once()
+        payload = mock_record_activity.call_args.kwargs["payload"]
+        self.assertEqual(payload["actor_user_id"], "gm-1")
+        self.assertEqual(payload["actor_player_user_id"], "gm-1")
+        self.assertEqual(payload["target_player_user_id"], "ally-a")
+        self.assertEqual(payload["target_display_name"], "ally-a")
+        self.assertTrue(payload["removed_by_gm"])
+        self.assertEqual(payload["removed_effect_id"], "eff-a")
+        mock_prune_activity.assert_called_once_with(db, "session-1")
+
+    @patch("app.api.routes.sessions.state.clear_concentration_group_across_session")
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_gm")
+    @patch("app.api.routes.sessions.state._require_session_participant")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data")
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_gm_remove_concentration_effect_breaks_linked_group(
+        self,
+        mock_to_state_read,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_participant,
+        mock_require_gm,
+        mock_get_entry,
+        mock_clear_cross_session,
+    ):
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        effect = {
+            "id": "eff-ally",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-1",
+                "source_spell_name": "Bless",
+                "caster_player_user_id": "caster-1",
+                "target_player_user_id": "ally-a",
+            },
+        }
+        db, state = _make_db_session({"active_spell_effects": [effect]})
+        state.player_user_id = "ally-a"
+        mock_ensure.return_value = state
+        mock_finalize.side_effect = lambda x: x
+
+        caster_state = MagicMock()
+        caster_state.player_user_id = "caster-1"
+        caster_state.updated_at = None
+        caster_state.created_at = "2026-01-01T00:00:00+00:00"
+        caster_state.state_json = {}
+        mock_clear_cross_session.return_value = [caster_state]
+        mock_to_state_read.return_value = SessionStateRead(
+            id="ss-1",
+            sessionId="session-1",
+            playerUserId="ally-a",
+            state={},
+            createdAt="2026-01-01T00:00:00+00:00",
+            updatedAt=None,
+            activeSpellEffects=[],
+            activeConcentration=None,
+        )
+
+        await remove_player_persisted_effect(
+            session_id="session-1",
+            player_user_id="ally-a",
+            effect_id="eff-ally",
+            user=_make_user("gm-1"),
+            session=db,
+        )
+
+        mock_clear_cross_session.assert_called_once_with(
+            db,
+            "session-1",
+            "grp-1",
+            exclude_user_id="ally-a",
+        )
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_gm")
+    @patch("app.api.routes.sessions.state._require_session_participant")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data", side_effect=lambda x: x)
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_gm_remove_preserves_unrelated_effects(
+        self,
+        mock_to_state_read,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_participant,
+        mock_require_gm,
+        mock_get_entry,
+    ):
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        removable = {
+            "id": "eff-remove",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-1",
+                "source_spell_name": "Bless",
+                "caster_player_user_id": "caster-1",
+                "target_player_user_id": "ally-a",
+            },
+        }
+        unrelated = _non_concentration_effect("eff-keep")
+        db, state = _make_db_session({"active_spell_effects": [removable, unrelated]})
+        state.player_user_id = "ally-a"
+        mock_ensure.return_value = state
+        mock_to_state_read.return_value = SessionStateRead(
+            id="ss-1",
+            sessionId="session-1",
+            playerUserId="ally-a",
+            state={},
+            createdAt="2026-01-01T00:00:00+00:00",
+            updatedAt=None,
+            activeSpellEffects=[unrelated],
+            activeConcentration=None,
+        )
+
+        await remove_player_persisted_effect(
+            session_id="session-1",
+            player_user_id="ally-a",
+            effect_id="eff-remove",
+            user=_make_user("gm-1"),
+            session=db,
+        )
+
+        remaining = state.state_json.get("active_spell_effects", [])
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0].get("id"), "eff-keep")
+
+    @patch("app.api.routes.sessions.state.clear_concentration_group_across_session")
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_gm")
+    @patch("app.api.routes.sessions.state._require_session_participant")
+    @patch("app.api.routes.sessions.state.ensure_session_state")
+    @patch("app.api.routes.sessions.state.finalize_session_state_data")
+    @patch("app.api.routes.sessions.state.publish_state_update")
+    @patch("app.api.routes.sessions.state.to_state_read")
+    async def test_gm_remove_publishes_affected_states_deduped(
+        self,
+        mock_to_state_read,
+        mock_publish,
+        mock_finalize,
+        mock_ensure,
+        mock_require_participant,
+        mock_require_gm,
+        mock_get_entry,
+        mock_clear_cross_session,
+    ):
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        effect = {
+            "id": "eff-ally",
+            "kind": "spell_effect",
+            "duration_type": "manual",
+            "metadata": {
+                "concentration": True,
+                "concentration_group": "grp-1",
+                "source_spell_name": "Bless",
+                "caster_player_user_id": "caster-1",
+                "target_player_user_id": "ally-a",
+            },
+        }
+        db, state = _make_db_session({"active_spell_effects": [effect]})
+        state.player_user_id = "ally-a"
+        mock_ensure.return_value = state
+        mock_finalize.side_effect = lambda x: x
+
+        caster_state = MagicMock()
+        caster_state.player_user_id = "caster-1"
+        caster_state.updated_at = None
+        caster_state.created_at = "2026-01-01T00:00:00+00:00"
+        caster_state.state_json = {}
+
+        target_dup = MagicMock()
+        target_dup.player_user_id = "ally-a"
+        target_dup.updated_at = None
+        target_dup.created_at = "2026-01-01T00:00:00+00:00"
+        target_dup.state_json = {}
+
+        mock_clear_cross_session.return_value = [caster_state, target_dup]
+        mock_to_state_read.return_value = SessionStateRead(
+            id="ss-1",
+            sessionId="session-1",
+            playerUserId="ally-a",
+            state={},
+            createdAt="2026-01-01T00:00:00+00:00",
+            updatedAt=None,
+            activeSpellEffects=[],
+            activeConcentration=None,
+        )
+
+        await remove_player_persisted_effect(
+            session_id="session-1",
+            player_user_id="ally-a",
+            effect_id="eff-ally",
+            user=_make_user("gm-1"),
+            session=db,
+        )
+
+        self.assertEqual(mock_publish.await_count, 2)
+        published_players = [
+            mock_publish.await_args_list[i].args[1] for i in range(mock_publish.await_count)
+        ]
+        self.assertIn("ally-a", published_players)
+        self.assertIn("caster-1", published_players)
+
+    @patch("app.api.routes.sessions.state.get_session_entry")
+    @patch("app.api.routes.sessions.state.require_session_view_access")
+    @patch("app.api.routes.sessions.state._remove_persisted_effect_for_player")
+    async def test_existing_me_remove_endpoint_still_works(
+        self,
+        mock_remove_helper,
+        mock_require_view,
+        mock_get_entry,
+    ):
+        expected = SessionStateRead(
+            id="ss-1",
+            sessionId="session-1",
+            playerUserId="user-1",
+            state={},
+            createdAt="2026-01-01T00:00:00+00:00",
+            updatedAt=None,
+            activeSpellEffects=[],
+            activeConcentration=None,
+        )
+        mock_get_entry.return_value = MagicMock(party_id="party-1")
+        mock_remove_helper.return_value = expected
+
+        result = await remove_my_persisted_effect(
+            session_id="session-1",
+            effect_id="eff-a",
+            user=_make_user("user-1"),
+            session=MagicMock(),
+        )
+
+        self.assertEqual(result, expected)
+        mock_remove_helper.assert_awaited_once()
+        helper_call = mock_remove_helper.await_args
+        self.assertEqual(helper_call.kwargs["owner_player_user_id"], "user-1")
+        self.assertEqual(helper_call.kwargs["removed_by_gm"], False)
 
 
 if __name__ == "__main__":

--- a/apps/control-web/src/features/sessions/components/SessionActivityRow.ooc.test.tsx
+++ b/apps/control-web/src/features/sessions/components/SessionActivityRow.ooc.test.tsx
@@ -16,6 +16,7 @@ vi.mock("../../../shared/hooks/useLocale", () => ({
         "sessionActivity.usingSlotLevel": "usando espaço de",
         "sessionActivity.slotLevelSuffix": "º nível.",
         "sessionActivity.removedEffectVerb": "removeu",
+        "sessionActivity.fromTarget": "de",
         "sessionActivity.concentrationEndedSentence": "A concentração foi encerrada.",
         "sessionActivity.previousConcentrationEndedPrefix": "A concentração anterior em",
       }[key] ?? key),
@@ -121,11 +122,14 @@ describe("SessionActivityRow out-of-combat events", () => {
       type: "out_of_combat_effect_removed",
       actorDisplayName: "Caue",
       actorPlayerUserId: "caster-1",
+      removedByGm: true,
       brokeConcentrationGroup: true,
       concentrationGroup: "grp-1",
       displayName: "Caue",
       effectLabel: "Escudo da Fé",
       removedEffectId: "eff-1",
+      targetPlayerUserId: "ally-a",
+      targetDisplayName: "Aelar",
       sessionOffsetSeconds: 5,
       sourceSpellName: "Escudo da Fé",
       timestamp: "2026-05-05T10:01:00Z",
@@ -136,6 +140,8 @@ describe("SessionActivityRow out-of-combat events", () => {
     expect(markup).toContain("Caue");
     expect(markup).toContain("removeu");
     expect(markup).toContain("Escudo da Fé");
+    expect(markup).toContain("de");
+    expect(markup).toContain("Aelar");
     expect(markup).toContain("A concentração foi encerrada.");
   });
 
@@ -159,6 +165,7 @@ describe("SessionActivityRow out-of-combat events", () => {
     expect(markup).toContain("Caue");
     expect(markup).toContain("removeu");
     expect(markup).toContain("Armadura Arcana");
+    expect(markup).not.toContain("Aelar");
     expect(markup).not.toContain("A concentração foi encerrada.");
   });
 });

--- a/apps/control-web/src/features/sessions/components/SessionActivityRowEventsB.tsx
+++ b/apps/control-web/src/features/sessions/components/SessionActivityRowEventsB.tsx
@@ -339,18 +339,37 @@ export const SessionActivityOutOfCombatEffectRemovedRow = ({ event, actor }: Pro
   if (event.type !== "out_of_combat_effect_removed") return null;
 
   const actorLabel = event.actorDisplayName ?? actor;
+  const removedByGm = event.removedByGm === true;
+  const targetLabel = event.targetDisplayName ?? event.targetPlayerUserId ?? t("sessionActivity.unknownTarget");
 
   return (
     <div className="flex items-start gap-3 rounded-xl bg-slate-950/60 px-4 py-3">
       <span className="mt-0.5 text-base">🧹</span>
       <div className="min-w-0 flex-1">
         <p className="text-sm text-white">
-          <span className="font-semibold">{actorLabel}</span>
-          {" "}
-          {t("sessionActivity.removedEffectVerb")}
-          {" "}
-          <span className="font-semibold text-slate-100">{event.effectLabel}</span>
-          .
+          {removedByGm ? (
+            <>
+              <span className="font-semibold">{actorLabel}</span>
+              {" "}
+              {t("sessionActivity.removedEffectVerb")}
+              {" "}
+              <span className="font-semibold text-slate-100">{event.effectLabel}</span>
+              {" "}
+              {t("sessionActivity.fromTarget")}
+              {" "}
+              <span className="font-semibold text-slate-200">{targetLabel}</span>
+              .
+            </>
+          ) : (
+            <>
+              <span className="font-semibold">{actorLabel}</span>
+              {" "}
+              {t("sessionActivity.removedEffectVerb")}
+              {" "}
+              <span className="font-semibold text-slate-100">{event.effectLabel}</span>
+              .
+            </>
+          )}
           {event.brokeConcentrationGroup
             ? (
               <>

--- a/apps/control-web/src/pages/GmDashboardPage/GmDashboardPlayerInventoryCard.ooc.test.tsx
+++ b/apps/control-web/src/pages/GmDashboardPage/GmDashboardPlayerInventoryCard.ooc.test.tsx
@@ -4,6 +4,15 @@ import { GmDashboardPlayerInventoryCard } from "./GmDashboardPlayerInventoryCard
 
 const testState = vi.hoisted(() => ({
   sessionStatesRepoMock: {
+    getByPlayer: vi.fn(async () => ({
+      id: "ss-1",
+      sessionId: "session-1",
+      playerUserId: "ally-a",
+      state: {},
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: null,
+      activeSpellEffects: [],
+    })),
     listCastableOutOfCombatForPlayer: vi.fn(async () => []),
     castSpellOutOfCombatForPlayer: vi.fn(async () => ({
       id: "ss-1",
@@ -12,9 +21,20 @@ const testState = vi.hoisted(() => ({
       state: {},
       createdAt: "2026-01-01T00:00:00Z",
       updatedAt: null,
+      activeSpellEffects: [],
+    })),
+    removePersistedEffectForPlayer: vi.fn(async () => ({
+      id: "ss-1",
+      sessionId: "session-1",
+      playerUserId: "ally-a",
+      state: {},
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: null,
+      activeSpellEffects: [],
     })),
   },
   lastCastCardProps: null as Record<string, unknown> | null,
+  lastEffectsPanelProps: null as Record<string, unknown> | null,
 }));
 
 vi.mock("../../shared/hooks/useLocale", () => ({
@@ -41,6 +61,13 @@ vi.mock("./GmDashboardInventoryItemList", () => ({
 
 vi.mock("./GmDashboardGrantPanels", () => ({
   GmDashboardGrantPanels: () => null,
+}));
+
+vi.mock("../../features/character-sheet/components/CharacterActiveEffectsPanel", () => ({
+  CharacterActiveEffectsPanel: (props: Record<string, unknown>) => {
+    testState.lastEffectsPanelProps = props;
+    return null;
+  },
 }));
 
 vi.mock("../PlayerBoardPage/OutOfCombatSpellCastCard", () => ({
@@ -129,6 +156,82 @@ describe("GmDashboardPlayerInventoryCard OOC cast", () => {
         variantKey: "owls_wisdom",
         targetPlayerUserId: "ally-b",
       },
+    );
+  });
+
+  it("dispatches GM remove endpoint with player_user_id and effect_id", async () => {
+    testState.lastEffectsPanelProps = null;
+    testState.sessionStatesRepoMock.removePersistedEffectForPlayer.mockClear();
+
+    renderToStaticMarkup(
+      <GmDashboardPlayerInventoryCard
+        activeSessionId="session-1"
+        activeSessionPartyId="party-1"
+        catalogItems={{}}
+        currencyDraft={undefined}
+        effectiveCampaignId={null}
+        equippedOnly={false}
+        grantFeedback={undefined}
+        grantingCurrencyForUserId={null}
+        grantingItemForUserId={null}
+        grantingXpForUserId={null}
+        hpActionState={null}
+        hpDraft=""
+        inventoryGroup="all"
+        inventorySearch=""
+        isOnline
+        isOpen
+        itemDraft={undefined}
+        levelUpActionState={null}
+        locale="pt-BR"
+        navigate={() => undefined}
+        player={{
+          userId: "ally-a",
+          role: "PLAYER",
+          status: "joined",
+          createdAt: "2026-01-01T00:00:00Z",
+          displayName: "Aelar",
+          username: "aelar",
+        }}
+        playerItems={[]}
+        sheet={undefined}
+        sortedCatalogItems={[]}
+        wallet={undefined}
+        xpDraft=""
+        targetOptions={[
+          { playerUserId: "ally-a", label: "Aelar" },
+          { playerUserId: "ally-b", label: "Luna" },
+        ]}
+        onApproveLevelUp={() => undefined}
+        onDamagePlayer={() => undefined}
+        onDenyLevelUp={() => undefined}
+        onGrantCurrency={() => undefined}
+        onGrantItem={() => undefined}
+        onGrantXp={() => undefined}
+        onHealPlayer={() => undefined}
+        onOpenInventory={() => undefined}
+        onGroupChange={() => undefined}
+        onSearchChange={() => undefined}
+        onToggleEquippedOnly={() => undefined}
+        setCurrencyDraft={() => ({ amount: "", coin: "gp" })}
+        setHpDraftByUserId={() => ({})}
+        setItemDraft={() => ({ itemId: "", quantity: "" })}
+        setXpDraftByUserId={() => ({})}
+      />,
+    );
+
+    expect(testState.lastEffectsPanelProps).not.toBeNull();
+    const onRemoveEffect = testState.lastEffectsPanelProps?.onRemoveEffect as
+      | ((effectId: string) => Promise<void> | void)
+      | undefined;
+    expect(onRemoveEffect).toBeTypeOf("function");
+
+    await onRemoveEffect?.("eff-1");
+
+    expect(testState.sessionStatesRepoMock.removePersistedEffectForPlayer).toHaveBeenCalledWith(
+      "session-1",
+      "ally-a",
+      "eff-1",
     );
   });
 });

--- a/apps/control-web/src/pages/GmDashboardPage/GmDashboardPlayerInventoryCard.tsx
+++ b/apps/control-web/src/pages/GmDashboardPage/GmDashboardPlayerInventoryCard.tsx
@@ -15,6 +15,8 @@ import { GmDashboardGrantPanels } from "./GmDashboardGrantPanels";
 import { useLocale } from "../../shared/hooks/useLocale";
 import { sessionStatesRepo } from "../../shared/api/sessionStatesRepo";
 import { OutOfCombatSpellCastCard } from "../PlayerBoardPage/OutOfCombatSpellCastCard";
+import { CharacterActiveEffectsPanel } from "../../features/character-sheet/components/CharacterActiveEffectsPanel";
+import type { ActiveEffect } from "../../shared/api/combatRepo";
 import { computeTotalWeight, computeEncumbranceTier, LB_TO_KG } from "../../features/character-sheet/utils/calculations";
 
 type Props = {
@@ -119,6 +121,16 @@ export const GmDashboardPlayerInventoryCard = ({
   const [loadingCastableSpells, setLoadingCastableSpells] = useState(false);
   const [castingSpell, setCastingSpell] = useState(false);
   const [castFeedback, setCastFeedback] = useState<string | null>(null);
+  const [activeEffects, setActiveEffects] = useState<ActiveEffect[]>([]);
+  const [loadingActiveEffects, setLoadingActiveEffects] = useState(false);
+  const [removingEffectId, setRemovingEffectId] = useState<string | null>(null);
+  const [effectFeedback, setEffectFeedback] = useState<string | null>(null);
+
+  const coerceActiveEffects = useCallback(
+    (effects: Record<string, unknown>[] | null | undefined): ActiveEffect[] =>
+      (Array.isArray(effects) ? effects : []) as ActiveEffect[],
+    [],
+  );
 
   const encumbranceData = useMemo(() => {
     if (!sheet) return null;
@@ -145,10 +157,29 @@ export const GmDashboardPlayerInventoryCard = ({
     }
   }, [activeSessionId, player.userId]);
 
+  const loadActiveEffects = useCallback(async () => {
+    if (!activeSessionId) {
+      setActiveEffects([]);
+      return;
+    }
+    setLoadingActiveEffects(true);
+    setEffectFeedback(null);
+    try {
+      const state = await sessionStatesRepo.getByPlayer(activeSessionId, player.userId);
+      setActiveEffects(coerceActiveEffects(state.activeSpellEffects));
+    } catch {
+      setActiveEffects([]);
+      setEffectFeedback("Falha ao carregar efeitos ativos.");
+    } finally {
+      setLoadingActiveEffects(false);
+    }
+  }, [activeSessionId, coerceActiveEffects, player.userId]);
+
   useEffect(() => {
     if (!isOpen) return;
     void loadCastableSpells();
-  }, [isOpen, loadCastableSpells]);
+    void loadActiveEffects();
+  }, [isOpen, loadCastableSpells, loadActiveEffects]);
 
   const handleCastSpellOutOfCombat = useCallback(async (
     spellId: string,
@@ -160,12 +191,13 @@ export const GmDashboardPlayerInventoryCard = ({
     setCastingSpell(true);
     setCastFeedback(null);
     try {
-      await sessionStatesRepo.castSpellOutOfCombatForPlayer(activeSessionId, player.userId, {
+      const record = await sessionStatesRepo.castSpellOutOfCombatForPlayer(activeSessionId, player.userId, {
         spellId,
         slotLevel,
         variantKey,
         targetPlayerUserId,
       });
+      setActiveEffects(coerceActiveEffects(record.activeSpellEffects));
       setCastFeedback("Magia OOC lançada com sucesso.");
       void loadCastableSpells();
     } catch {
@@ -173,7 +205,26 @@ export const GmDashboardPlayerInventoryCard = ({
     } finally {
       setCastingSpell(false);
     }
-  }, [activeSessionId, castingSpell, loadCastableSpells, player.userId]);
+  }, [activeSessionId, castingSpell, coerceActiveEffects, loadCastableSpells, player.userId]);
+
+  const handleRemoveActiveEffect = useCallback(async (effectId: string) => {
+    if (!activeSessionId || removingEffectId) return;
+    setRemovingEffectId(effectId);
+    setEffectFeedback(null);
+    try {
+      const record = await sessionStatesRepo.removePersistedEffectForPlayer(
+        activeSessionId,
+        player.userId,
+        effectId,
+      );
+      setActiveEffects(coerceActiveEffects(record.activeSpellEffects));
+      setEffectFeedback("Efeito removido com sucesso.");
+    } catch {
+      setEffectFeedback("Nao foi possivel remover o efeito.");
+    } finally {
+      setRemovingEffectId(null);
+    }
+  }, [activeSessionId, coerceActiveEffects, player.userId, removingEffectId]);
 
   const playSheetRoute = activeSessionPartyId
     ? `${routes.characterSheetParty.replace(":partyId", activeSessionPartyId)}?${new URLSearchParams({
@@ -273,6 +324,18 @@ export const GmDashboardPlayerInventoryCard = ({
             )}
             {castFeedback ? (
               <p className="text-xs text-slate-400">{castFeedback}</p>
+            ) : null}
+            {loadingActiveEffects ? (
+              <p className="text-xs text-slate-400">Carregando efeitos ativos...</p>
+            ) : (
+              <CharacterActiveEffectsPanel
+                activeEffects={activeEffects}
+                removingEffectId={removingEffectId}
+                onRemoveEffect={handleRemoveActiveEffect}
+              />
+            )}
+            {effectFeedback ? (
+              <p className="text-xs text-slate-400">{effectFeedback}</p>
             ) : null}
 
             <GmDashboardInventoryFilters

--- a/apps/control-web/src/shared/api/sessionStatesRepo.ts
+++ b/apps/control-web/src/shared/api/sessionStatesRepo.ts
@@ -20,6 +20,8 @@ export const sessionStatesRepo = {
 
   removePersistedEffect: (sessionId: string, effectId: string) =>
     http.del<SessionStateRecord>(`/sessions/${sessionId}/state/me/effects/${effectId}`),
+  removePersistedEffectForPlayer: (sessionId: string, playerUserId: string, effectId: string) =>
+    http.del<SessionStateRecord>(`/sessions/${sessionId}/state/${playerUserId}/effects/${effectId}`),
   prepareSpells: (sessionId: string, preparedSpellIds: string[]) =>
     http.post<SessionStateRecord>(`/sessions/${sessionId}/state/me/spells/prepare`, {
       preparedSpellIds,

--- a/apps/control-web/src/shared/api/sessionsRepo.ts
+++ b/apps/control-web/src/shared/api/sessionsRepo.ts
@@ -363,14 +363,18 @@ export type OutOfCombatEffectRemovedActivityEvent = {
   userId?: string | null;
   username?: string | null;
   displayName?: string | null;
+  actorUserId?: string | null;
   actorPlayerUserId?: string | null;
   actorDisplayName?: string | null;
+  targetPlayerUserId?: string | null;
+  targetDisplayName?: string | null;
   removedEffectId: string;
   effectLabel: string;
   sourceSpellName?: string | null;
   variantLabel?: string | null;
   concentrationGroup?: string | null;
   brokeConcentrationGroup: boolean;
+  removedByGm?: boolean;
   timestamp: string;
   sessionOffsetSeconds: number;
 };

--- a/apps/control-web/src/shared/i18n/enUS/sessionActivity.ts
+++ b/apps/control-web/src/shared/i18n/enUS/sessionActivity.ts
@@ -36,6 +36,7 @@ export const sessionActivityEnUSDictionary = {
   "sessionActivity.usingSlotLevel": "using a level",
   "sessionActivity.slotLevelSuffix": " slot.",
   "sessionActivity.removedEffectVerb": "removed",
+  "sessionActivity.fromTarget": "from",
   "sessionActivity.concentrationEndedSentence": "Concentration ended.",
   "sessionActivity.previousConcentrationEndedPrefix": "Previous concentration on",
   "sessionActivity.rollModeNormal": "Normal",

--- a/apps/control-web/src/shared/i18n/ptBR/sessionActivity.ts
+++ b/apps/control-web/src/shared/i18n/ptBR/sessionActivity.ts
@@ -36,6 +36,7 @@ export const sessionActivityPtBRDictionary = {
   "sessionActivity.usingSlotLevel": "usando espaco de",
   "sessionActivity.slotLevelSuffix": "º nivel.",
   "sessionActivity.removedEffectVerb": "removeu",
+  "sessionActivity.fromTarget": "de",
   "sessionActivity.concentrationEndedSentence": "A concentracao foi encerrada.",
   "sessionActivity.previousConcentrationEndedPrefix": "A concentracao anterior em",
   "sessionActivity.rollModeNormal": "Normal",


### PR DESCRIPTION
# feat(effects): add GM active effect admin controls

## Summary

Adds GM controls for removing persisted active effects from any player in the session.

The GM can now inspect/remove a player’s persisted active effects from the GM Dashboard. Removal reuses the same backend engine used by the player `/me` endpoint, including concentration cleanup, idempotency, realtime publish deduplication, and activity logging.

No arbitrary effect creation or editing was added.

## Context

Out-of-combat spell/effect support already includes:

- persisted active effects
- player-side effect removal
- Character Sheet effect removal
- out-of-combat casting by players
- out-of-combat casting by GM on behalf of players
- concentration cleanup across caster/target states
- OOC cast/remove activity logs

The missing operational tool was GM-side effect removal.

This PR adds that v1 admin control: a broom, not a wand.

## Backend changes

### Shared persisted effect removal engine

Updated:

```text
apps/control-server/app/api/routes/sessions/state.py
````

Extracted shared removal flow into:

```py
_remove_persisted_effect_for_player(...)
```

The helper separates:

```text
actor = who performs the action
owner = whose SessionState/effect is being modified
```

This supports both:

```http
DELETE /sessions/{session_id}/state/me/effects/{effect_id}
```

and the new GM endpoint:

```http
DELETE /sessions/{session_id}/state/{player_user_id}/effects/{effect_id}
```

Shared behavior includes:

* captures effect metadata before mutation
* removes effect with `remove_persisted_effect`
* finalizes state data
* breaks linked ally-target concentration groups when applicable
* uses `exclude_user_id=owner_player_user_id` for cross-session concentration cleanup
* commits once
* publishes realtime updates deduplicated by `player_user_id`
* returns the owner’s updated `SessionStateRead`

### GM remove endpoint

Added GM-only route:

```http
DELETE /sessions/{session_id}/state/{player_user_id}/effects/{effect_id}
```

Security order:

```text
require_session_gm
→ _require_session_participant
→ ensure_session_state
```

So arbitrary users are not silently seeded into the session. Lovely. The chaos door remains locked.

### Activity log

Updated OOC effect removal activity payload.

Event type remains:

```text
out_of_combat_effect_removed
```

New/enriched fields:

```text
actor_user_id
actor_player_user_id
target_player_user_id
target_display_name
removed_by_gm
```

Compatibility is preserved for existing/legacy events.

Idempotent unknown-effect removal does not create activity log entries.

### Activity schema/parser

Updated:

```text
apps/control-server/app/api/routes/sessions/activity.py
apps/control-server/app/schemas/session.py
```

Activity parsing now supports the new fields with legacy fallbacks.

## Frontend changes

### API

Updated:

```text
apps/control-web/src/shared/api/sessionStatesRepo.ts
```

Added:

```ts
removePersistedEffectForPlayer(sessionId, playerUserId, effectId)
```

### Activity event types

Updated:

```text
apps/control-web/src/shared/api/sessionsRepo.ts
```

Expanded the OOC effect removal activity type with the new GM fields.

### Activity row rendering

Updated:

```text
apps/control-web/src/features/sessions/components/SessionActivityRowEventsB.tsx
```

When:

```ts
removedByGm === true
```

the activity row renders GM-specific wording including the target player.

Legacy/player-side removal keeps the existing wording.

### GM Dashboard controls

Updated:

```text
apps/control-web/src/pages/GmDashboardPage/GmDashboardPlayerInventoryCard.tsx
```

Added GM active effect controls:

* loads player persisted active effects
* displays active effect labels and lifecycle badges
* supports removing effects via GM endpoint
* uses row-level `removingEffectId`
* shows inline feedback on failure
* updates local effect list from returned `SessionStateRead`

### i18n

Updated:

```text
apps/control-web/src/shared/i18n/ptBR/sessionActivity.ts
apps/control-web/src/shared/i18n/enUS/sessionActivity.ts
```

Added:

```text
sessionActivity.fromTarget
```

## Tests

### Backend

Updated:

```text
apps/control-server/tests/test_session_concentration.py
apps/control-server/tests/test_session_activity_ooc.py
```

Coverage includes:

* GM can remove player persisted effect
* GM removal preserves idempotency
* GM removal uses concentration cleanup behavior
* unrelated effects are preserved
* realtime publishes are deduplicated
* non-GM cannot remove another player’s effect
* activity logs GM as actor and selected player as target
* legacy `/me` removal still works

### Frontend

Updated:

```text
apps/control-web/src/pages/GmDashboardPage/GmDashboardPlayerInventoryCard.ooc.test.tsx
apps/control-web/src/features/sessions/components/SessionActivityRow.ooc.test.tsx
```

Coverage includes:

* GM dashboard renders/removes player effects
* remove action calls GM endpoint
* loading/error states work
* activity row renders GM removal wording
* legacy/player removal wording remains compatible

## Validation

Backend:

```bash
cd apps/control-server
.venv/bin/pytest tests/test_session_concentration.py tests/test_out_of_combat_cast.py -v
```

Result:

```text
97 passed
```

Backend activity:

```bash
cd apps/control-server
.venv/bin/pytest tests/test_session_activity_ooc.py -v
```

Result:

```text
1 passed
```

Frontend tests:

```bash
cd apps/control-web
npm test -- src/pages/GmDashboardPage/GmDashboardPlayerInventoryCard.ooc.test.tsx src/features/sessions/components/SessionActivityRow.ooc.test.tsx
```

Result:

```text
8 passed
```

Build:

```bash
cd apps/control-web
npm run build
```

Result:

```text
ok
```

## Out of scope

This PR intentionally does not implement:

* arbitrary effect creation by GM
* editing effect duration
* editing effect params
* manual spell slot adjustment
* prepared validation override
* combat active effect admin
* NPC effects
* Longstrider / movement speed effects
* duration countdowns
* new spells

## Notes for reviewers

This PR adds GM removal/admin controls only.

The backend removal logic is shared between player and GM paths so concentration cleanup, activity logging, idempotency, and realtime behavior remain consistent.