### PR TITLE
feat(effects): support movement speed modifiers

### DIFF
--- a/Base/base_spells.seed.json
+++ b/Base/base_spells.seed.json
@@ -859,7 +859,21 @@
       "targetAnchor": "selected_target",
       "attackType": "none",
       "rangeKind": "touch",
-      "effectTiming": "persistent"
+      "effectTiming": "persistent",
+      "outOfCombatCastable": true,
+      "outOfCombatTarget": "self_or_ally",
+      "effects": [
+        {
+          "type": "modify_movement_speed",
+          "target": "selected_target",
+          "duration": {
+            "type": "manual"
+          },
+          "params": {
+            "bonus_meters": 3
+          }
+        }
+      ]
     },
     {
       "system": "DND5E",

--- a/apps/control-server/app/schemas/base_spell_effects.py
+++ b/apps/control-server/app/schemas/base_spell_effects.py
@@ -16,6 +16,7 @@ SpellDeclarativeEffectType = Literal[
     "grant_temp_hp",
     "passive_skill_bonus",
     "carrying_capacity_multiplier",
+    "modify_movement_speed",
     "fall_damage_immunity_threshold",
 ]
 
@@ -114,6 +115,10 @@ class FallDamageImmunityThresholdParams(BaseModel):
     max_distance_meters: float
 
 
+class ModifyMovementSpeedParams(BaseModel):
+    bonus_meters: float
+
+
 class SpellDeclarativeEffect(BaseModel):
     type: SpellDeclarativeEffectType
     target: SpellDeclarativeEffectTarget
@@ -126,6 +131,7 @@ class SpellDeclarativeEffect(BaseModel):
         | GrantTempHpParams
         | PassiveSkillBonusParams
         | CarryingCapacityMultiplierParams
+        | ModifyMovementSpeedParams
         | FallDamageImmunityThresholdParams
     )
     stacking: SpellDeclarativeEffectStacking | None = None
@@ -150,4 +156,6 @@ class SpellDeclarativeEffect(BaseModel):
             raise ValueError("carrying_capacity_multiplier effects require CarryingCapacityMultiplierParams")
         if self.type == "fall_damage_immunity_threshold" and not isinstance(self.params, FallDamageImmunityThresholdParams):
             raise ValueError("fall_damage_immunity_threshold effects require FallDamageImmunityThresholdParams")
+        if self.type == "modify_movement_speed" and not isinstance(self.params, ModifyMovementSpeedParams):
+            raise ValueError("modify_movement_speed effects require ModifyMovementSpeedParams")
         return self

--- a/apps/control-server/app/services/combat_service/condition_effects_predicates.py
+++ b/apps/control-server/app/services/combat_service/condition_effects_predicates.py
@@ -419,6 +419,15 @@ def _carrying_capacity_group_key(metadata: dict, effect: dict, params: dict) -> 
     )
 
 
+def _movement_speed_group_key(metadata: dict, effect: dict, params: dict) -> str:
+    return _declarative_effect_group_key(
+        metadata,
+        effect,
+        "modify_movement_speed",
+        str(params.get("bonus_meters", "")),
+    )
+
+
 def get_passive_skill_bonus(participant: dict, skill: str) -> int:
     groups: dict[str, int] = {}
     for effect in participant.get("active_effects") or []:
@@ -471,3 +480,46 @@ def get_carrying_capacity_multiplier(participant: dict) -> float:
     if not groups:
         return 1.0
     return max(groups.values())
+
+
+def get_movement_speed_bonus_meters(participant: dict) -> tuple[float, list[dict]]:
+    total_bonus = 0.0
+    sources: list[dict] = []
+    groups: dict[str, float] = {}
+    group_sources: dict[str, dict] = {}
+    for effect in participant.get("active_effects") or []:
+        if effect.get("kind") != "spell_effect":
+            continue
+        metadata = effect.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        declarative = metadata.get("declarative_effect")
+        if not isinstance(declarative, dict):
+            continue
+        if declarative.get("type") != "modify_movement_speed":
+            continue
+        params = declarative.get("params")
+        if not isinstance(params, dict):
+            continue
+        bonus = params.get("bonus_meters")
+        if not isinstance(bonus, (int, float)):
+            continue
+        key = _movement_speed_group_key(metadata, effect, params)
+        current = groups.get(key)
+        if current is None or bonus > current:
+            groups[key] = float(bonus)
+            label = (
+                metadata.get("selected_variant_label")
+                or effect.get("display_label")
+                or metadata.get("source_spell_name")
+                or "Movement speed bonus"
+            )
+            group_sources[key] = {
+                "label": label,
+                "value": float(bonus),
+                "type": "modify_movement_speed",
+            }
+    for source in group_sources.values():
+        total_bonus += source["value"]
+        sources.append(source)
+    return total_bonus, sources

--- a/apps/control-server/app/services/combat_service/token_resolution.py
+++ b/apps/control-server/app/services/combat_service/token_resolution.py
@@ -10,7 +10,7 @@ from app.models.campaign_entity import CampaignEntity
 from app.models.session_entity import SessionEntity
 from app.models.session_state import SessionState
 
-from .condition_effects_predicates import apply_encumbrance_movement_penalty
+from .condition_effects_predicates import apply_encumbrance_movement_penalty, get_movement_speed_bonus_meters
 from .participant_attributes import (
     resolve_entity_movement_speed,
     resolve_entity_size,
@@ -280,6 +280,8 @@ def resolve_sync_entry(
     if movement_speed_base is not None:
         encumbrance_tier = participant.get("encumbrance_tier", "normal")
         effective_speed = apply_encumbrance_movement_penalty(movement_speed_base, encumbrance_tier)
+        movement_bonus, _ = get_movement_speed_bonus_meters(participant)
+        effective_speed = max(0.0, effective_speed + movement_bonus)
         movement_speed_cells = meters_to_movement_cells(effective_speed)
     else:
         movement_speed_cells = None

--- a/apps/control-server/tests/test_movement_speed_bonus.py
+++ b/apps/control-server/tests/test_movement_speed_bonus.py
@@ -1,0 +1,205 @@
+"""Tests for modify_movement_speed declarative effect.
+
+Covers:
+- get_movement_speed_bonus_meters predicate
+- Integration into resolve_sync_entry (token_resolution)
+- Encumbrance + bonus ordering
+- Dedup by group key
+"""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from app.integrations.limiar_map_client_types import LimiarMapStateResponse
+from app.services.combat_service.condition_effects_predicates import (
+    get_movement_speed_bonus_meters,
+)
+from app.services.combat_service.token_resolution import resolve_sync_entry
+
+
+def _map_state_empty() -> LimiarMapStateResponse:
+    return LimiarMapStateResponse(session_id="s1", version=1, tokens=())
+
+
+def _make_db(speed_meters: int) -> MagicMock:
+    db = MagicMock()
+    entry = MagicMock()
+    entry.state_json = {"speedMeters": speed_meters}
+    db.exec.return_value.first.return_value = entry
+    return db
+
+
+def _player(
+    *,
+    encumbrance_tier: str | None = None,
+    active_effects: list[dict] | None = None,
+) -> dict:
+    p: dict = {
+        "id": "p1",
+        "kind": "player",
+        "ref_id": "user-1",
+        "display_name": "Hero",
+        "active_effects": active_effects or [],
+    }
+    if encumbrance_tier is not None:
+        p["encumbrance_tier"] = encumbrance_tier
+    return p
+
+
+def _movement_speed_effect(
+    *,
+    bonus_meters: float = 3,
+    group_id: str = "g1",
+    spell_name: str = "Passos Longos",
+    effect_id: str = "eff-1",
+) -> dict:
+    return {
+        "id": effect_id,
+        "kind": "spell_effect",
+        "condition_type": None,
+        "numeric_value": None,
+        "duration_type": "until_long_rest",
+        "display_label": spell_name,
+        "metadata": {
+            "declarative_effect_group_id": group_id,
+            "declarative_effect": {
+                "type": "modify_movement_speed",
+                "params": {"bonus_meters": bonus_meters},
+            },
+            "source_spell_name": spell_name,
+        },
+    }
+
+
+class TestGetMovementSpeedBonusMeters(unittest.TestCase):
+
+    def test_single_effect_adds_bonus(self):
+        participant = _player(active_effects=[_movement_speed_effect(bonus_meters=3)])
+        total, sources = get_movement_speed_bonus_meters(participant)
+        self.assertEqual(total, 3.0)
+        self.assertEqual(len(sources), 1)
+        self.assertEqual(sources[0]["label"], "Passos Longos")
+        self.assertEqual(sources[0]["value"], 3.0)
+
+    def test_ignores_non_spell_effects(self):
+        participant = _player(active_effects=[
+            {"kind": "condition", "condition_type": "blinded"},
+        ])
+        total, sources = get_movement_speed_bonus_meters(participant)
+        self.assertEqual(total, 0.0)
+        self.assertEqual(len(sources), 0)
+
+    def test_ignores_wrong_type(self):
+        participant = _player(active_effects=[{
+            "id": "e1",
+            "kind": "spell_effect",
+            "metadata": {
+                "declarative_effect": {
+                    "type": "passive_skill_bonus",
+                    "params": {"skill": "perception", "bonus": 5},
+                },
+                "source_spell_name": "Other",
+            },
+        }])
+        total, sources = get_movement_speed_bonus_meters(participant)
+        self.assertEqual(total, 0.0)
+
+    def test_ignores_invalid_bonus_meters(self):
+        participant = _player(active_effects=[{
+            "id": "e1",
+            "kind": "spell_effect",
+            "metadata": {
+                "declarative_effect": {
+                    "type": "modify_movement_speed",
+                    "params": {"bonus_meters": "not_a_number"},
+                },
+                "source_spell_name": "Bad",
+            },
+        }])
+        total, sources = get_movement_speed_bonus_meters(participant)
+        self.assertEqual(total, 0.0)
+
+    def test_multiple_effects_stack(self):
+        participant = _player(active_effects=[
+            _movement_speed_effect(bonus_meters=3, group_id="g1", spell_name="Passos Longos"),
+            _movement_speed_effect(bonus_meters=2, group_id="g2", spell_name="Outro Buff", effect_id="eff-2"),
+        ])
+        total, sources = get_movement_speed_bonus_meters(participant)
+        self.assertEqual(total, 5.0)
+        self.assertEqual(len(sources), 2)
+
+    def test_dedup_same_group_id(self):
+        participant = _player(active_effects=[
+            _movement_speed_effect(bonus_meters=3, group_id="g1", effect_id="eff-1"),
+            _movement_speed_effect(bonus_meters=3, group_id="g1", effect_id="eff-1-dup"),
+        ])
+        total, sources = get_movement_speed_bonus_meters(participant)
+        self.assertEqual(total, 3.0)
+        self.assertEqual(len(sources), 1)
+
+    def test_no_active_effects(self):
+        participant = _player()
+        total, sources = get_movement_speed_bonus_meters(participant)
+        self.assertEqual(total, 0.0)
+        self.assertEqual(len(sources), 0)
+
+
+class TestResolveSyncEntryMovementSpeedBonus(unittest.TestCase):
+
+    def _get_speed_cells(self, participant: dict, speed_meters: int = 9) -> int | None:
+        db = _make_db(speed_meters)
+        _, spawn = resolve_sync_entry(db, "s1", participant, _map_state_empty())
+        self.assertIsNotNone(spawn)
+        return spawn.movement_speed_cells
+
+    def test_normal_no_bonus(self):
+        speed = self._get_speed_cells(_player())
+        self.assertEqual(speed, 6)
+
+    def test_bonus_adds_to_speed(self):
+        participant = _player(active_effects=[_movement_speed_effect(bonus_meters=3)])
+        speed = self._get_speed_cells(participant, speed_meters=9)
+        self.assertEqual(speed, 8)
+
+    def test_encumbrance_before_bonus(self):
+        participant = _player(
+            encumbrance_tier="encumbered",
+            active_effects=[_movement_speed_effect(bonus_meters=3)],
+        )
+        speed = self._get_speed_cells(participant, speed_meters=9)
+        self.assertEqual(speed, 6)
+
+    def test_heavily_encumbered_with_bonus(self):
+        participant = _player(
+            encumbrance_tier="heavily_encumbered",
+            active_effects=[_movement_speed_effect(bonus_meters=3)],
+        )
+        speed = self._get_speed_cells(participant, speed_meters=9)
+        self.assertEqual(speed, 4)
+
+    def test_overloaded_with_bonus_clamped(self):
+        participant = _player(
+            encumbrance_tier="overloaded",
+            active_effects=[_movement_speed_effect(bonus_meters=3)],
+        )
+        speed = self._get_speed_cells(participant, speed_meters=9)
+        self.assertEqual(speed, 2)
+
+    def test_large_bonus_converts_correctly(self):
+        participant = _player(active_effects=[_movement_speed_effect(bonus_meters=6)])
+        speed = self._get_speed_cells(participant, speed_meters=9)
+        self.assertEqual(speed, 10)
+
+
+class TestEncumbranceOrder(unittest.TestCase):
+
+    def test_penalty_first_then_bonus(self):
+        db = _make_db(9)
+        participant = _player(
+            encumbrance_tier="encumbered",
+            active_effects=[_movement_speed_effect(bonus_meters=3)],
+        )
+        _, spawn = resolve_sync_entry(db, "s1", participant, _map_state_empty())
+        self.assertIsNotNone(spawn)
+        self.assertEqual(spawn.movement_speed_cells, 6)

--- a/apps/control-server/tests/test_out_of_combat_cast.py
+++ b/apps/control-server/tests/test_out_of_combat_cast.py
@@ -3196,3 +3196,67 @@ class TestOutOfCombatActivityPrune(unittest.TestCase):
         self.assertIn("DELETE FROM session_command_event", delete_sql)
         self.assertIn("'evt-1'", delete_sql)
         self.assertIn("'evt-2'", delete_sql)
+
+
+class TestLongstriderOutOfCombatCast(unittest.TestCase):
+
+    def _make_longstrider_spell(self) -> MagicMock:
+        return _make_campaign_spell(
+            canonical_key="longstrider",
+            level=1,
+            concentration=False,
+            name_pt="Passada Larga",
+            name_en="Longstrider",
+            effects_json=[
+                {
+                    "type": "modify_movement_speed",
+                    "target": "selected_target",
+                    "duration": {"type": "manual"},
+                    "params": {"bonus_meters": 3},
+                }
+            ],
+        )
+
+    def test_eligibility_ok(self):
+        spell = self._make_longstrider_spell()
+        state_json = _slots_state(level=1)
+        ok, reason = check_out_of_combat_cast_eligibility(
+            spell=spell,
+            state_json=state_json,
+            slot_level=1,
+            variant_key=None,
+            out_of_combat_target="self_or_ally",
+            target_user_id="user-1",
+            caster_user_id="user-1",
+        )
+        self.assertTrue(ok)
+        self.assertIsNone(reason)
+
+    def test_build_persisted_effects_contains_movement_speed(self):
+        spell = self._make_longstrider_spell()
+        effects = build_persisted_effects(
+            spell=spell,
+            caster_user_id="user-1",
+            target_user_id="user-1",
+            variant_key=None,
+        )
+        self.assertEqual(len(effects), 1)
+        effect = effects[0]
+        self.assertEqual(effect["kind"], "spell_effect")
+        self.assertEqual(effect["duration_type"], "until_long_rest")
+        metadata = effect["metadata"]
+        declarative = metadata["declarative_effect"]
+        self.assertEqual(declarative["type"], "modify_movement_speed")
+        self.assertEqual(declarative["params"]["bonus_meters"], 3)
+
+    def test_build_persisted_effects_metadata_has_source(self):
+        spell = self._make_longstrider_spell()
+        effects = build_persisted_effects(
+            spell=spell,
+            caster_user_id="user-1",
+            target_user_id="user-1",
+            variant_key=None,
+        )
+        metadata = effects[0]["metadata"]
+        self.assertEqual(metadata["source_spell_key"], "longstrider")
+        self.assertEqual(metadata["source_spell_name"], "Passada Larga")

--- a/apps/control-web/src/features/character-sheet/components/CharacterSheet.tsx
+++ b/apps/control-web/src/features/character-sheet/components/CharacterSheet.tsx
@@ -225,10 +225,13 @@ export const CharacterSheet = ({
   const {
     ac,
     acBreakdown,
+    effectiveSpeedMeters,
     hpColor,
     hpPercent,
     hpTextColor,
     initiative,
+    movementSpeedBonus,
+    movementSpeedBonusSources,
     passivePerception,
     passivePerceptionBonus,
     passivePerceptionBonusSources,
@@ -369,6 +372,9 @@ export const CharacterSheet = ({
                 ac={ac}
                 initiative={initiative}
                 acBreakdown={acBreakdown}
+                effectiveSpeedMeters={effectiveSpeedMeters}
+                movementSpeedBonus={movementSpeedBonus}
+                movementSpeedBonusSources={movementSpeedBonusSources}
                 set={actions.set}
                 selectArmor={actions.selectArmor}
                 toggleShield={actions.toggleShield}

--- a/apps/control-web/src/features/character-sheet/components/CombatStats.tsx
+++ b/apps/control-web/src/features/character-sheet/components/CombatStats.tsx
@@ -15,6 +15,9 @@ type Props = {
   ac: number;
   initiative: number;
   acBreakdown: { label: string; value: number }[];
+  effectiveSpeedMeters?: number;
+  movementSpeedBonus?: number;
+  movementSpeedBonusSources?: Array<{ label: string; value: number }>;
   set: SheetActions["set"];
   selectArmor: SheetActions["selectArmor"];
   toggleShield: SheetActions["toggleShield"];
@@ -27,6 +30,9 @@ export const CombatStats = ({
   ac,
   initiative,
   acBreakdown,
+  effectiveSpeedMeters,
+  movementSpeedBonus,
+  movementSpeedBonusSources,
   set,
   selectArmor,
   toggleShield,
@@ -66,8 +72,12 @@ export const CombatStats = ({
             />
             <CombatPreviewCard
               label="Speed"
-              value={sheet.speedMeters > 0 ? `${sheet.speedMeters}m` : "-"}
-              note={sheet.speedMeters > 0 ? t("sheet.combat.baseSpeed") : t("sheet.combat.selectRace")}
+              value={effectiveSpeedMeters != null && effectiveSpeedMeters > 0 ? `${effectiveSpeedMeters}m` : (sheet.speedMeters > 0 ? `${sheet.speedMeters}m` : "-")}
+              note={
+                movementSpeedBonus && movementSpeedBonusSources?.length
+                  ? `${sheet.speedMeters}m + ${movementSpeedBonusSources.map((s) => `${s.label} +${s.value}m`).join(", ")}`
+                  : (sheet.speedMeters > 0 ? t("sheet.combat.baseSpeed") : t("sheet.combat.selectRace"))
+              }
             />
           </div>
 

--- a/apps/control-web/src/features/character-sheet/hooks/useCharacterSheetDerived.test.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/useCharacterSheetDerived.test.ts
@@ -64,4 +64,41 @@ describe("useCharacterSheetDerived", () => {
     expect(derived.hasElementalAffinity).toBe(false);
     expect(derived.resistances).toEqual([]);
   });
+
+  it("exposes effectiveSpeedMeters as base speed with no active effects", () => {
+    const derived = useCharacterSheetDerived({
+      ...INITIAL_SHEET,
+      speedMeters: 9,
+    });
+    expect(derived.effectiveSpeedMeters).toBe(9);
+    expect(derived.movementSpeedBonus).toBeUndefined();
+  });
+
+  it("exposes effectiveSpeedMeters with movement speed bonus from active effects", () => {
+    const activeEffects = [
+      {
+        id: "eff-1",
+        kind: "spell_effect" as const,
+        duration_type: "until_long_rest" as const,
+        created_at: "2026-05-01T00:00:00Z",
+        display_label: "Passos Longos",
+        metadata: {
+          source_spell_name: "Passos Longos",
+          declarative_effect_group_id: "g1",
+          declarative_effect: {
+            type: "modify_movement_speed",
+            params: { bonus_meters: 3 },
+          },
+        },
+      },
+    ];
+    const derived = useCharacterSheetDerived(
+      { ...INITIAL_SHEET, speedMeters: 9 },
+      activeEffects,
+    );
+    expect(derived.effectiveSpeedMeters).toBe(12);
+    expect(derived.movementSpeedBonus).toBe(3);
+    expect(derived.movementSpeedBonusSources).toHaveLength(1);
+    expect(derived.movementSpeedBonusSources![0].label).toBe("Passos Longos");
+  });
 });

--- a/apps/control-web/src/features/character-sheet/hooks/useCharacterSheetDerived.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/useCharacterSheetDerived.ts
@@ -1,5 +1,7 @@
 import {
   computeInitiative,
+  computeMovementSpeedBonus,
+  computeMovementSpeedBonusSources,
   computePassivePerception,
   computePassiveSkillBonus,
   computePassiveSkillBonusSources,
@@ -39,6 +41,13 @@ export const useCharacterSheetDerived = (
   const passivePerceptionBonusSources = activeEffects?.length
     ? computePassiveSkillBonusSources(activeEffects, "perception")
     : undefined;
+  const movementSpeedBonus = activeEffects?.length
+    ? computeMovementSpeedBonus(activeEffects)
+    : 0;
+  const movementSpeedBonusSources = activeEffects?.length
+    ? computeMovementSpeedBonusSources(activeEffects)
+    : undefined;
+  const effectiveSpeedMeters = Math.max(0, sheet.speedMeters + movementSpeedBonus);
 
   const spellAbilityScore = sheet.spellcasting
     ? sheet.abilities[sheet.spellcasting.ability]
@@ -102,5 +111,8 @@ export const useCharacterSheetDerived = (
     resistances,
     spellAttack,
     spellSaveDC,
+    effectiveSpeedMeters,
+    movementSpeedBonus: movementSpeedBonus || undefined,
+    movementSpeedBonusSources,
   };
 };

--- a/apps/control-web/src/features/character-sheet/utils/calculations.test.ts
+++ b/apps/control-web/src/features/character-sheet/utils/calculations.test.ts
@@ -6,6 +6,8 @@ import {
   computeCarryingCapacityMultiplier,
   computeCarryingCapacityMultiplierSources,
   computeEncumbranceTier,
+  computeMovementSpeedBonus,
+  computeMovementSpeedBonusSources,
   computePassiveSkillBonus,
   computePassiveSkillBonusSources,
   computeProjectedEncumbranceTier,
@@ -887,5 +889,129 @@ describe("computeProjectedEncumbranceTier — hardening", () => {
     const r = computeProjectedEncumbranceTier({ strengthScore: 10, currentWeightKg: NaN, addedWeightLb: 0 });
     expect(r.tier).toBe("normal");
     expect(Number.isNaN(r.remainingKg)).toBe(false);
+  });
+});
+
+const makeMovementSpeedEffect = (
+  bonusMeters: number,
+  overrides: Partial<ActiveEffect> = {},
+): ActiveEffect => ({
+  id: `effect-ms-${bonusMeters}`,
+  kind: "spell_effect",
+  duration_type: "until_long_rest",
+  created_at: "2026-05-01T00:00:00Z",
+  display_label: "Passos Longos",
+  metadata: {
+    source_spell_name: "Passos Longos",
+    declarative_effect: {
+      type: "modify_movement_speed",
+      params: { bonus_meters: bonusMeters },
+    },
+  },
+  ...overrides,
+});
+
+describe("computeMovementSpeedBonus", () => {
+  it("returns 0 with no effects", () => {
+    expect(computeMovementSpeedBonus([])).toBe(0);
+  });
+
+  it("returns bonus from single effect", () => {
+    const effects = [makeMovementSpeedEffect(3)];
+    expect(computeMovementSpeedBonus(effects)).toBe(3);
+  });
+
+  it("sums multiple different sources", () => {
+    const effects = [
+      makeMovementSpeedEffect(3, {
+        id: "eff-a",
+        metadata: {
+          source_spell_name: "Passos Longos",
+          declarative_effect_group_id: "group-a",
+          declarative_effect: { type: "modify_movement_speed", params: { bonus_meters: 3 } },
+        },
+      }),
+      makeMovementSpeedEffect(2, {
+        id: "eff-b",
+        metadata: {
+          source_spell_name: "Outro Buff",
+          declarative_effect_group_id: "group-b",
+          declarative_effect: { type: "modify_movement_speed", params: { bonus_meters: 2 } },
+        },
+      }),
+    ];
+    expect(computeMovementSpeedBonus(effects)).toBe(5);
+  });
+
+  it("deduplicates same group_id", () => {
+    const effects = [
+      makeMovementSpeedEffect(3, {
+        id: "eff-1",
+        metadata: {
+          source_spell_name: "Passos Longos",
+          declarative_effect_group_id: "same-group",
+          declarative_effect: { type: "modify_movement_speed", params: { bonus_meters: 3 } },
+        },
+      }),
+      makeMovementSpeedEffect(3, {
+        id: "eff-1-dup",
+        metadata: {
+          source_spell_name: "Passos Longos",
+          declarative_effect_group_id: "same-group",
+          declarative_effect: { type: "modify_movement_speed", params: { bonus_meters: 3 } },
+        },
+      }),
+    ];
+    expect(computeMovementSpeedBonus(effects)).toBe(3);
+  });
+
+  it("ignores non-numeric bonus_meters", () => {
+    const effects: ActiveEffect[] = [
+      {
+        id: "bad",
+        kind: "spell_effect",
+        duration_type: "manual",
+        created_at: "2026-05-01T00:00:00Z",
+        metadata: {
+          declarative_effect: {
+            type: "modify_movement_speed",
+            params: { bonus_meters: "not a number" },
+          },
+        },
+      },
+    ];
+    expect(computeMovementSpeedBonus(effects)).toBe(0);
+  });
+
+  it("ignores wrong effect type", () => {
+    const effects: ActiveEffect[] = [
+      {
+        id: "wrong",
+        kind: "spell_effect",
+        duration_type: "manual",
+        created_at: "2026-05-01T00:00:00Z",
+        metadata: {
+          declarative_effect: {
+            type: "passive_skill_bonus",
+            params: { skill: "perception", bonus: 5 },
+          },
+        },
+      },
+    ];
+    expect(computeMovementSpeedBonus(effects)).toBe(0);
+  });
+});
+
+describe("computeMovementSpeedBonusSources", () => {
+  it("returns label and value", () => {
+    const effects = [makeMovementSpeedEffect(3)];
+    const sources = computeMovementSpeedBonusSources(effects);
+    expect(sources).toHaveLength(1);
+    expect(sources[0].label).toBe("Passos Longos");
+    expect(sources[0].value).toBe(3);
+  });
+
+  it("returns empty array with no effects", () => {
+    expect(computeMovementSpeedBonusSources([])).toEqual([]);
   });
 });

--- a/apps/control-web/src/features/character-sheet/utils/calculations.ts
+++ b/apps/control-web/src/features/character-sheet/utils/calculations.ts
@@ -305,7 +305,53 @@ export const applyEncumbranceMovementPenalty = (
   return baseSpeedMeters;
 };
 
+function movementSpeedGroupKey(
+  metadata: Record<string, unknown>,
+  effect: ActiveEffect,
+  params: Record<string, unknown>,
+  index: number,
+): string {
+  const bonus = params.bonus_meters ?? "";
+  return declarativeEffectGroupKey(metadata, effect, "modify_movement_speed", `${bonus}`, index);
+}
+
+export const computeMovementSpeedBonusSources = (
+  activeEffects: ActiveEffect[],
+): MovementSpeedBonusSource[] => {
+  const groupBest = new Map<string, MovementSpeedBonusSource>();
+  for (let i = 0; i < activeEffects.length; i++) {
+    const effect = activeEffects[i];
+    const metadata = effect.metadata;
+    if (!metadata || typeof metadata !== "object") continue;
+    const declarative = metadata.declarative_effect;
+    if (!declarative || typeof declarative !== "object") continue;
+    if ((declarative as Record<string, unknown>).type !== "modify_movement_speed") continue;
+    const params = (declarative as Record<string, unknown>).params;
+    if (!params || typeof params !== "object") continue;
+    const p = params as Record<string, unknown>;
+    if (typeof p.bonus_meters !== "number") continue;
+    const label =
+      (typeof effect.display_label === "string" && effect.display_label) ||
+      (typeof metadata.source_spell_name === "string" && metadata.source_spell_name) ||
+      "Movement speed bonus";
+    const key = movementSpeedGroupKey(metadata as Record<string, unknown>, effect, p, i);
+    const existing = groupBest.get(key);
+    if (!existing || p.bonus_meters > existing.value) {
+      groupBest.set(key, { label, value: p.bonus_meters, groupKey: key });
+    }
+  }
+  return Array.from(groupBest.values());
+};
+
+export const computeMovementSpeedBonus = (activeEffects: ActiveEffect[]): number =>
+  computeMovementSpeedBonusSources(activeEffects).reduce(
+    (sum, s) => sum + s.value,
+    0,
+  );
+
 export type CarryingCapacitySource = { label: string; multiplier: number; groupKey: string };
+
+export type MovementSpeedBonusSource = { label: string; value: number; groupKey: string };
 
 function carryingCapacityGroupKey(
   metadata: Record<string, unknown>,

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
@@ -142,13 +142,21 @@ export const PlayerBoardStatusPanel = ({
             <StatCard
               label={t("playerBoard.speedLabel")}
               value={playerStatus.baseSpeedMeters > 0 ? `${playerStatus.effectiveSpeedMeters} m` : "-"}
-              accent={playerStatus.effectiveSpeedMeters < playerStatus.baseSpeedMeters
-                ? encumbranceAccentMap[playerStatus.encumbranceTier]
-                : undefined}
-              helper={
+              accent={
                 playerStatus.effectiveSpeedMeters < playerStatus.baseSpeedMeters
-                  ? `${t("playerBoard.speedPenaltyHint")} (base ${playerStatus.baseSpeedMeters} m)`
-                  : null
+                  ? encumbranceAccentMap[playerStatus.encumbranceTier]
+                  : playerStatus.effectiveSpeedMeters > playerStatus.baseSpeedMeters
+                    ? "text-emerald-400"
+                    : undefined
+              }
+              helper={
+                playerStatus.movementSpeedBonus && playerStatus.movementSpeedBonusSources?.length
+                  ? playerStatus.effectiveSpeedMeters < playerStatus.baseSpeedMeters
+                    ? `${t("playerBoard.speedPenaltyHint")} (base ${playerStatus.baseSpeedMeters} m) + ${playerStatus.movementSpeedBonusSources.map((s) => `${s.label} +${s.value}m`).join(", ")}`
+                    : `base ${playerStatus.baseSpeedMeters} m + ${playerStatus.movementSpeedBonusSources.map((s) => `${s.label} +${s.value}m`).join(", ")}`
+                  : playerStatus.effectiveSpeedMeters < playerStatus.baseSpeedMeters
+                    ? `${t("playerBoard.speedPenaltyHint")} (base ${playerStatus.baseSpeedMeters} m)`
+                    : null
               }
             />
             <StatCard

--- a/apps/control-web/src/pages/PlayerBoardPage/playerBoard.types.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/playerBoard.types.ts
@@ -44,6 +44,8 @@ export type PlayerBoardStatusSummary = {
   encumbranceHeavilyEncumberedMaxKg: number;
   baseSpeedMeters: number;
   effectiveSpeedMeters: number;
+  movementSpeedBonus?: number | null;
+  movementSpeedBonusSources?: Array<{ label: string; value: number }> | null;
   experiencePoints: number;
   hitDiceRemaining: number;
   hitDiceTotal: number;

--- a/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardSummary.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardSummary.ts
@@ -6,7 +6,7 @@ import { useCharacterSheetDerived } from "../../features/character-sheet/hooks/u
 import { useCarryingCapacity } from "../../features/character-sheet/hooks/useCarryingCapacity";
 import { INITIAL_SHEET } from "../../features/character-sheet/model/initialSheet";
 import { getCharacterProgressState } from "../../features/character-sheet/utils/progression";
-import { computeTotalWeight, computeEncumbranceTier, applyEncumbranceMovementPenalty, LB_TO_KG } from "../../features/character-sheet/utils/calculations";
+import { computeTotalWeight, computeEncumbranceTier, applyEncumbranceMovementPenalty, computeMovementSpeedBonus, computeMovementSpeedBonusSources, LB_TO_KG } from "../../features/character-sheet/utils/calculations";
 import type { CharacterSheet } from "../../features/character-sheet/model/characterSheet.types";
 import type { ActiveEffect } from "../../shared/api/combatRepo";
 import type { LocaleKey } from "../../shared/i18n";
@@ -106,9 +106,15 @@ export const usePlayerBoardSummary = ({
   );
 
   const baseSpeedMeters = playerSheet?.speedMeters ?? 0;
+  const movementSpeedBonus = activeEffects?.length
+    ? computeMovementSpeedBonus(activeEffects)
+    : 0;
+  const movementSpeedBonusSources = activeEffects?.length
+    ? computeMovementSpeedBonusSources(activeEffects)
+    : undefined;
   const effectiveSpeedMeters = encumbrance
-    ? applyEncumbranceMovementPenalty(baseSpeedMeters, encumbrance.tier)
-    : baseSpeedMeters;
+    ? Math.max(0, applyEncumbranceMovementPenalty(baseSpeedMeters, encumbrance.tier) + movementSpeedBonus)
+    : Math.max(0, baseSpeedMeters + movementSpeedBonus);
 
   const playerStatus = useMemo<PlayerBoardStatusSummary | null>(() => {
     if (!playerSheet) return null;
@@ -127,6 +133,8 @@ export const usePlayerBoardSummary = ({
       encumbranceHeavilyEncumberedMaxKg: encumbrance?.heavilyEncumberedMaxKg ?? 0,
       baseSpeedMeters,
       effectiveSpeedMeters,
+      movementSpeedBonus: movementSpeedBonus || undefined,
+      movementSpeedBonusSources,
       experiencePoints: playerSheet.experiencePoints,
       hitDiceRemaining: playerSheet.hitDiceRemaining,
       hitDiceTotal: playerSheet.hitDiceTotal,


### PR DESCRIPTION
## Summary

Adds support for declarative movement speed modifiers.

Active effects can now modify a character’s effective movement speed across backend token resolution, Character Sheet derived stats, and PlayerBoard display.

This enables spells such as Longstrider / Passos Longos to actually affect movement instead of only appearing as a decorative active effect.

## Backend changes

### Declarative effect type

Updated:

```text
apps/control-server/app/schemas/base_spell_effects.py
````

Added:

```text
modify_movement_speed
```

with params:

```py
bonus_meters: float
```

The effect is now part of the declarative effect union and validated through `SpellDeclarativeEffect.validate_params_shape`.

### Movement speed predicate

Updated:

```text
apps/control-server/app/services/combat_service/condition_effects_predicates.py
```

Added:

```py
get_movement_speed_bonus_meters(participant)
```

Behavior:

* reads active effects from participant data
* filters `kind == "spell_effect"`
* reads `metadata.declarative_effect.type == "modify_movement_speed"`
* validates numeric `params.bonus_meters`
* deduplicates by group key using the same pattern as carrying capacity
* returns total bonus and source breakdown

### Token/map movement integration

Updated:

```text
apps/control-server/app/services/combat_service/token_resolution.py
```

Movement speed resolution now applies active effect movement bonuses after encumbrance adjustment:

```text
effective speed = max(0, encumbrance-adjusted speed + movement bonus)
```

This means the map receives the correct `movement_speed_cells` value when active effects modify speed.

### Longstrider seed

Updated:

```text
Base/base_spells.seed.json
```

The existing Longstrider entry now supports out-of-combat casting with:

* `outOfCombatCastable`
* `outOfCombatTarget`
* `modify_movement_speed`
* `bonus_meters: 3`

## Frontend changes

### Movement speed calculations

Updated:

```text
apps/control-web/src/features/character-sheet/utils/calculations.ts
```

Added:

```ts
computeMovementSpeedBonus
computeMovementSpeedBonusSources
movementSpeedGroupKey
```

The frontend follows the same grouping/dedup pattern used for carrying capacity.

### Character Sheet derived stats

Updated:

```text
apps/control-web/src/features/character-sheet/hooks/useCharacterSheetDerived.ts
apps/control-web/src/features/character-sheet/components/CharacterSheet.tsx
apps/control-web/src/features/character-sheet/components/CombatStats.tsx
```

The sheet now derives and displays:

* `effectiveSpeedMeters`
* `movementSpeedBonus`
* `movementSpeedBonusSources`

When movement speed is boosted, CombatStats shows the effective value and source breakdown.

### PlayerBoard movement display

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/usePlayerBoardSummary.ts
apps/control-web/src/pages/PlayerBoardPage/playerBoard.types.ts
apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
```

PlayerBoard now computes effective movement speed as:

```text
max(0, encumbrance-adjusted base speed + movement speed bonus)
```

It also shows helper text for movement bonuses and highlights speed changes in both directions:

* increased speed
* reduced speed from encumbrance/other modifiers

## Tests

### Backend

Added:

```text
apps/control-server/tests/test_movement_speed_bonus.py
```

Coverage includes:

* movement speed bonus extraction
* invalid params ignored
* multiple sources stacking
* deduplication by group key
* source labels
* token resolution integration
* encumbrance ordering

Extended:

```text
apps/control-server/tests/test_out_of_combat_cast.py
```

Added coverage for:

* Longstrider appears as eligible OOC spell
* Longstrider cast creates `modify_movement_speed` effect
* Longstrider persisted metadata includes expected `bonus_meters`

### Frontend

Extended:

```text
apps/control-web/src/features/character-sheet/utils/calculations.test.ts
apps/control-web/src/features/character-sheet/hooks/useCharacterSheetDerived.test.ts
```

Coverage includes:

* movement speed bonus computation
* stacking
* deduplication
* invalid data ignored
* source extraction
* effective speed with active effects
* effective speed without active effects

## Validation

Backend:

```text
17 new backend tests pass
```

Frontend:

```text
90 frontend tests pass
```

TypeScript:

```text
No new TypeScript errors introduced
```

## Design notes

The movement formula is intentionally:

```text
encumbrance first, active effect bonus after
```

So the effective value is:

```text
max(0, encumbrance_adjusted_speed + movement_bonus)
```

This is now covered by tests.

`modify_movement_speed` is persisted as a normal `spell_effect` with `metadata.declarative_effect`, so existing active effect display, lifecycle, removal, and OOC cast infrastructure continue to work without a special persistence path.

## Out of scope

This PR intentionally does not implement:

* real-time duration countdowns
* fly/swim/climb speeds
* difficult terrain changes
* dash/action economy changes
* pathfinding changes
* movement penalties from conditions
* Longstrider duration as exactly 1 hour