### PR TITLE
test(effects): harden movement speed modifiers

### DIFF
--- a/apps/control-server/tests/test_movement_speed_bonus.py
+++ b/apps/control-server/tests/test_movement_speed_bonus.py
@@ -191,10 +191,85 @@ class TestResolveSyncEntryMovementSpeedBonus(unittest.TestCase):
         speed = self._get_speed_cells(participant, speed_meters=9)
         self.assertEqual(speed, 10)
 
+    def test_float_bonus_converts_via_floor(self):
+        participant = _player(active_effects=[_movement_speed_effect(bonus_meters=1.5)])
+        speed = self._get_speed_cells(participant, speed_meters=8)
+        self.assertEqual(speed, 6)
+
 
 class TestEncumbranceOrder(unittest.TestCase):
 
     def test_penalty_first_then_bonus(self):
+        db = _make_db(9)
+        participant = _player(
+            encumbrance_tier="encumbered",
+            active_effects=[_movement_speed_effect(bonus_meters=3)],
+        )
+        _, spawn = resolve_sync_entry(db, "s1", participant, _map_state_empty())
+        self.assertIsNotNone(spawn)
+        self.assertEqual(spawn.movement_speed_cells, 6)
+
+
+class TestMovementSpeedEdgeCases(unittest.TestCase):
+
+    def test_effective_speed_clamps_to_zero(self):
+        db = _make_db(2)
+        participant = _player(
+            encumbrance_tier="heavily_encumbered",
+            active_effects=[_movement_speed_effect(bonus_meters=1)],
+        )
+        _, spawn = resolve_sync_entry(db, "s1", participant, _map_state_empty())
+        self.assertIsNotNone(spawn)
+        self.assertEqual(spawn.movement_speed_cells, 0)
+
+    def test_bonus_meters_float_value(self):
+        participant = _player(active_effects=[_movement_speed_effect(bonus_meters=1.5)])
+        total, sources = get_movement_speed_bonus_meters(participant)
+        self.assertEqual(total, 1.5)
+        self.assertEqual(len(sources), 1)
+
+    def test_negative_bonus_handled_defensively_not_in_catalog_v1(self):
+        participant = _player(active_effects=[_movement_speed_effect(bonus_meters=-3)])
+        total, sources = get_movement_speed_bonus_meters(participant)
+        self.assertEqual(total, -3.0)
+        self.assertEqual(len(sources), 1)
+        self.assertEqual(sources[0]["value"], -3.0)
+
+    def test_missing_params_ignored(self):
+        participant = _player(active_effects=[{
+            "id": "e1",
+            "kind": "spell_effect",
+            "metadata": {
+                "declarative_effect": {
+                    "type": "modify_movement_speed",
+                },
+                "source_spell_name": "NoParams",
+            },
+        }])
+        total, sources = get_movement_speed_bonus_meters(participant)
+        self.assertEqual(total, 0.0)
+        self.assertEqual(len(sources), 0)
+
+    def test_missing_declarative_effect_ignored(self):
+        participant = _player(active_effects=[{
+            "id": "e1",
+            "kind": "spell_effect",
+            "metadata": {
+                "source_spell_name": "Something",
+            },
+        }])
+        total, sources = get_movement_speed_bonus_meters(participant)
+        self.assertEqual(total, 0.0)
+        self.assertEqual(len(sources), 0)
+
+    def test_token_resolution_12m_base_plus_3m_bonus(self):
+        db = _make_db(12)
+        participant = _player(active_effects=[_movement_speed_effect(bonus_meters=3)])
+        _, spawn = resolve_sync_entry(db, "s1", participant, _map_state_empty())
+        self.assertIsNotNone(spawn)
+        self.assertEqual(spawn.movement_speed_cells, 10)
+
+    def test_encumbrance_order_9m_encumbered_plus_3m_bonus(self):
         db = _make_db(9)
         participant = _player(
             encumbrance_tier="encumbered",

--- a/apps/control-server/tests/test_persistent_effects.py
+++ b/apps/control-server/tests/test_persistent_effects.py
@@ -946,5 +946,80 @@ class TestRestorePersistedConcentrationNormalization(unittest.TestCase):
         self.assertEqual(persisted[0]["id"], "eff-new")
 
 
+class TestLongstriderLifecycle(unittest.TestCase):
+
+    @staticmethod
+    def _longstrider_effect(effect_id: str = "eff-ls") -> dict:
+        return {
+            "id": effect_id,
+            "kind": "spell_effect",
+            "source_participant_id": None,
+            "duration_type": "until_long_rest",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "display_label": "Passos Longos",
+            "metadata": {
+                "source_spell_name": "Passos Longos",
+                "source_spell_key": "longstrider",
+                "context_origin": "out_of_combat_cast",
+                "declarative_effect": {
+                    "type": "modify_movement_speed",
+                    "params": {"bonus_meters": 3},
+                },
+            },
+        }
+
+    def test_persist_longstrider_until_long_rest(self):
+        effect = self._longstrider_effect("eff-ls")
+        state = _make_state_with_participants([effect])
+        db = MagicMock()
+        session_state = _make_session_state({})
+        db.exec.return_value.first.return_value = session_state
+
+        persist_surviving_spell_effects(db, state)
+
+        persisted = session_state.state_json["active_spell_effects"]
+        self.assertEqual(len(persisted), 1)
+        self.assertEqual(persisted[0]["id"], "eff-ls")
+        self.assertEqual(persisted[0]["duration_type"], "until_long_rest")
+        self.assertEqual(
+            persisted[0]["metadata"]["declarative_effect"]["type"],
+            "modify_movement_speed",
+        )
+        self.assertEqual(
+            persisted[0]["metadata"]["declarative_effect"]["params"]["bonus_meters"],
+            3,
+        )
+
+    def test_restore_longstrider_from_state_json(self):
+        effect = self._longstrider_effect("eff-ls")
+        participant = {"kind": "player", "ref_id": "player-1", "active_effects": []}
+        db = MagicMock()
+        session_state = _make_session_state({"active_spell_effects": [effect]})
+        db.exec.return_value.first.return_value = session_state
+
+        restore_persisted_effects(db, "session-1", participant)
+
+        self.assertEqual(len(participant["active_effects"]), 1)
+        self.assertEqual(participant["active_effects"][0]["id"], "eff-ls")
+
+    def test_remove_longstrider_effect(self):
+        eff_ls = self._longstrider_effect("eff-ls")
+        eff_other = _manual_spell_effect("eff-other")
+        state_json = {"active_spell_effects": [eff_ls, eff_other]}
+
+        updated = remove_persisted_effect(state_json, "eff-ls")
+
+        self.assertEqual(len(updated["active_spell_effects"]), 1)
+        self.assertEqual(updated["active_spell_effects"][0]["id"], "eff-other")
+
+    def test_remove_last_longstrider_removes_key(self):
+        eff_ls = self._longstrider_effect("eff-ls")
+        state_json = {"active_spell_effects": [eff_ls]}
+
+        updated = remove_persisted_effect(state_json, "eff-ls")
+
+        self.assertNotIn("active_spell_effects", updated)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/apps/control-web/src/features/character-sheet/hooks/useCharacterSheetDerived.test.ts
+++ b/apps/control-web/src/features/character-sheet/hooks/useCharacterSheetDerived.test.ts
@@ -101,4 +101,46 @@ describe("useCharacterSheetDerived", () => {
     expect(derived.movementSpeedBonusSources).toHaveLength(1);
     expect(derived.movementSpeedBonusSources![0].label).toBe("Passos Longos");
   });
+
+  it("clamps effective speed to 0 with large negative bonus", () => {
+    const activeEffects = [
+      {
+        id: "eff-neg",
+        kind: "spell_effect" as const,
+        duration_type: "until_long_rest" as const,
+        created_at: "2026-05-01T00:00:00Z",
+        metadata: {
+          source_spell_name: "Slow",
+          declarative_effect: {
+            type: "modify_movement_speed",
+            params: { bonus_meters: -15 },
+          },
+        },
+      },
+    ];
+    const derived = useCharacterSheetDerived(
+      { ...INITIAL_SHEET, speedMeters: 3 },
+      activeEffects,
+    );
+    expect(derived.effectiveSpeedMeters).toBe(0);
+  });
+
+  it("does not crash with empty active effects array", () => {
+    const derived = useCharacterSheetDerived(
+      { ...INITIAL_SHEET, speedMeters: 9 },
+      [],
+    );
+    expect(derived.effectiveSpeedMeters).toBe(9);
+    expect(derived.movementSpeedBonus).toBeUndefined();
+    expect(derived.movementSpeedBonusSources).toBeUndefined();
+  });
+
+  it("shows base speed equal to sheet speedMeters when no bonus", () => {
+    const derived = useCharacterSheetDerived({
+      ...INITIAL_SHEET,
+      speedMeters: 11,
+    });
+    expect(derived.effectiveSpeedMeters).toBe(11);
+    expect(derived.effectiveSpeedMeters).toBe(11);
+  });
 });

--- a/apps/control-web/src/features/character-sheet/utils/calculations.test.ts
+++ b/apps/control-web/src/features/character-sheet/utils/calculations.test.ts
@@ -1014,4 +1014,63 @@ describe("computeMovementSpeedBonusSources", () => {
   it("returns empty array with no effects", () => {
     expect(computeMovementSpeedBonusSources([])).toEqual([]);
   });
+
+  it("ignores effect with null metadata", () => {
+    const effects: ActiveEffect[] = [
+      {
+        id: "null-meta",
+        kind: "spell_effect",
+        duration_type: "manual",
+        created_at: "2026-05-01T00:00:00Z",
+        metadata: null,
+      },
+    ];
+    expect(computeMovementSpeedBonus(effects)).toBe(0);
+  });
+
+  it("ignores effect without declarative_effect", () => {
+    const effects: ActiveEffect[] = [
+      {
+        id: "no-decl",
+        kind: "spell_effect",
+        duration_type: "manual",
+        created_at: "2026-05-01T00:00:00Z",
+        metadata: { source_spell_name: "Something" },
+      },
+    ];
+    expect(computeMovementSpeedBonus(effects)).toBe(0);
+  });
+
+  it("handles float bonus_meters", () => {
+    const effects = [makeMovementSpeedEffect(1.5, {
+      metadata: {
+        source_spell_name: "Passos Longos",
+        declarative_effect_group_id: "g-float",
+        declarative_effect: { type: "modify_movement_speed", params: { bonus_meters: 1.5 } },
+      },
+    })];
+    expect(computeMovementSpeedBonus(effects)).toBe(1.5);
+  });
+
+  it("dedup keeps highest per group", () => {
+    const effects = [
+      makeMovementSpeedEffect(3, {
+        id: "eff-a",
+        metadata: {
+          source_spell_name: "Passos Longos",
+          declarative_effect_group_id: "same-group",
+          declarative_effect: { type: "modify_movement_speed", params: { bonus_meters: 3 } },
+        },
+      }),
+      makeMovementSpeedEffect(5, {
+        id: "eff-b",
+        metadata: {
+          source_spell_name: "Passos Longos Upcast",
+          declarative_effect_group_id: "same-group",
+          declarative_effect: { type: "modify_movement_speed", params: { bonus_meters: 5 } },
+        },
+      }),
+    ];
+    expect(computeMovementSpeedBonus(effects)).toBe(5);
+  });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
@@ -39,6 +39,11 @@ vi.mock("../../shared/hooks/useLocale", () => ({
         "playerBoard.lifecycleUntilShortRest": "Até descanso curto",
         "playerBoard.lifecycleUntilRemoved": "Até remover",
         "playerBoard.lifecycleLongRest": "Limpa no descanso longo",
+        "playerBoard.speedLabel": "Deslocamento",
+        "playerBoard.speedPenaltyHint": "Penalidade de carga",
+        "playerBoard.carryingCapacityLabel": "Capacidade",
+        "playerBoard.pushDragLiftLabel": "Empurrar",
+        "playerBoard.encumbranceTierLabel": "Peso",
       }[key] ?? key),
   }),
 }));
@@ -774,5 +779,120 @@ describe("PlayerBoardStatusPanel – out-of-combat spell casting", () => {
       />,
     );
     expect(lastCastCardProps?.onCast).toBe(handleCast);
+  });
+});
+
+describe("PlayerBoardStatusPanel – movement speed", () => {
+  const baseStatus = {
+    level: 3,
+    currentHp: 20,
+    maxHp: 20,
+    hpPercent: 100,
+    tempHp: 0,
+    xpPercent: 10,
+    nextLevelThreshold: 900,
+    experiencePoints: 100,
+    ac: 12,
+    initiative: 1,
+    passivePerception: 13,
+    baseSpeedMeters: 9,
+    effectiveSpeedMeters: 9,
+    encumbranceTier: "normal" as const,
+    encumbranceNormalMaxKg: 22,
+    encumbranceEncumberedMaxKg: 45,
+    encumbranceHeavilyEncumberedMaxKg: 68,
+    totalWeightKg: 10,
+    baseCarryingCapacityKg: 68,
+    carryingCapacityKg: 68,
+    pushDragLiftKg: 136,
+    hitDiceRemaining: 3,
+    hitDiceTotal: 3,
+    hitDieType: "d8",
+  };
+
+  it("shows base speed when no bonus", () => {
+    const markup = renderToStaticMarkup(
+      <PlayerBoardStatusPanel
+        combatActive={false}
+        pendingRoll={null}
+        playerStatus={{ ...baseStatus } as any}
+        restState="exploration"
+        usingHitDie={false}
+        onUseHitDie={() => undefined}
+        onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
+      />,
+    );
+    expect(markup).toContain("9 m");
+    expect(markup).not.toContain("Passos Longos");
+    expect(markup).not.toContain("Penalidade de carga");
+  });
+
+  it("shows boosted speed with bonus helper", () => {
+    const markup = renderToStaticMarkup(
+      <PlayerBoardStatusPanel
+        combatActive={false}
+        pendingRoll={null}
+        playerStatus={{
+          ...baseStatus,
+          effectiveSpeedMeters: 12,
+          movementSpeedBonus: 3,
+          movementSpeedBonusSources: [{ label: "Passos Longos", value: 3 }],
+        } as any}
+        restState="exploration"
+        usingHitDie={false}
+        onUseHitDie={() => undefined}
+        onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
+      />,
+    );
+    expect(markup).toContain("12 m");
+    expect(markup).toContain("Passos Longos");
+    expect(markup).toContain("base 9 m");
+  });
+
+  it("shows encumbrance penalty and bonus together", () => {
+    const markup = renderToStaticMarkup(
+      <PlayerBoardStatusPanel
+        combatActive={false}
+        pendingRoll={null}
+        playerStatus={{
+          ...baseStatus,
+          effectiveSpeedMeters: 7,
+          baseSpeedMeters: 9,
+          encumbranceTier: "encumbered",
+          movementSpeedBonus: 1,
+          movementSpeedBonusSources: [{ label: "Passos Longos", value: 1 }],
+        } as any}
+        restState="exploration"
+        usingHitDie={false}
+        onUseHitDie={() => undefined}
+        onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
+      />,
+    );
+    expect(markup).toContain("9 m");
+    expect(markup).toContain("Penalidade de carga");
+    expect(markup).toContain("Passos Longos");
+  });
+
+  it("does not crash with malformed movementSpeedBonusSources", () => {
+    const markup = renderToStaticMarkup(
+      <PlayerBoardStatusPanel
+        combatActive={false}
+        pendingRoll={null}
+        playerStatus={{
+          ...baseStatus,
+          movementSpeedBonus: null,
+          movementSpeedBonusSources: null,
+        } as any}
+        restState="exploration"
+        usingHitDie={false}
+        onUseHitDie={() => undefined}
+        onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
+      />,
+    );
+    expect(markup).toContain("9 m");
   });
 });


### PR DESCRIPTION
## Summary

Hardens movement speed modifier behavior with regression coverage across backend predicates, persistence lifecycle, frontend calculations, derived character sheet data, and PlayerBoard display.

No production code was changed.

## Context

Movement speed modifiers were added through the declarative effect type:

```text
modify_movement_speed
````

This effect now powers Longstrider / Passos Longos and affects:

* backend movement bonus predicates
* token movement resolution
* persisted active effects
* Character Sheet derived speed
* PlayerBoard effective speed display

Because this touches movement and active effects, this PR adds targeted regression coverage before expanding the utility spell catalog.

## Backend tests

### Movement speed bonus

Updated:

```text
apps/control-server/tests/test_movement_speed_bonus.py
```

Added coverage for:

* fractional `bonus_meters`
* floor behavior when converting meters to cells
* clamp-to-zero behavior
* negative bonus values handled defensively
* missing `params` ignored
* missing `metadata.declarative_effect` ignored
* encumbrance penalty applied before movement bonus

The important ordering remains covered:

```text
effective = max(0, encumbrance_adjusted_speed + movement_bonus)
```

### Longstrider persistence lifecycle

Updated:

```text
apps/control-server/tests/test_persistent_effects.py
```

Added Longstrider lifecycle coverage:

* persists as `until_long_rest`
* restores from `state_json.active_spell_effects`
* removes by effect id
* removes the `active_spell_effects` key when it was the last effect

## Frontend tests

### Character calculations

Updated:

```text
apps/control-web/src/features/character-sheet/utils/calculations.test.ts
```

Added coverage for:

* empty active effects
* null/missing metadata
* fractional movement bonus
* dedup behavior
* malformed effect data

### Character Sheet derived state

Updated:

```text
apps/control-web/src/features/character-sheet/hooks/useCharacterSheetDerived.test.ts
```

Added coverage for:

* base speed with no active effects
* effective speed with active effect bonus
* clamp-to-zero with large negative bonus
* empty active effects safety

### PlayerBoard status panel

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
```

Added coverage for:

* speed label rendering
* encumbrance penalty hint
* movement bonus helper text
* malformed movement bonus sources

Note: the combined UI scenario uses `+1m` instead of `+3m` because with the current formula, `+3m` cancels the encumbrance penalty and returns to base speed, so the penalty helper is not displayed.

## Validation

Backend:

```bash
./.venv/bin/pytest apps/control-server/tests/test_movement_speed_bonus.py apps/control-server/tests/test_persistent_effects.py
```

Result:

```text
80 passed
```

Frontend:

```bash
npm run test -w apps/control-web -- --run src/features/character-sheet/utils/calculations.test.ts src/features/character-sheet/hooks/useCharacterSheetDerived.test.ts src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
```

Result:

```text
123 passed
```

## Scope

This PR intentionally does not add or change production behavior.

Out of scope:

* new movement mechanics
* new spells
* fly/swim/climb speeds
* difficult terrain changes
* duration countdowns
* movement penalties from conditions
* pathfinding changes