### PR TITLE
feat(spell-preparation): enhance long rest spell preparation flow

### DIFF
--- a/apps/control-server/app/api/routes/sessions/commands_service.py
+++ b/apps/control-server/app/api/routes/sessions/commands_service.py
@@ -14,6 +14,10 @@ from app.services.session_rest import (
     end_rest as end_rest_state,
     start_rest as start_rest_state,
 )
+from app.services.spell_preparation import (
+    seed_long_rest_spell_preparation,
+    settle_long_rest_spell_preparation,
+)
 from app.services.session_state_finalize import finalize_session_state_data
 from ._shared import (
     get_or_create_session_runtime,
@@ -320,6 +324,8 @@ async def send_session_command_service(
                 state.state_json = finalize_session_state_data(
                     start_rest_state(state.state_json, target_rest_type)
                 )
+                if target_rest_type == "long_rest":
+                    state.state_json = seed_long_rest_spell_preparation(state.state_json)
             except SessionRestError as error:
                 raise HTTPException(status_code=400, detail=str(error)) from error
             session.add(state)
@@ -360,8 +366,6 @@ async def send_session_command_service(
         session.refresh(state)
 
     if ended_rest_type == "long_rest":
-        from app.services.spell_preparation import create_pending_spell_preparation
-
         ended_combat = session.exec(
             select(CombatState).where(
                 CombatState.session_id == entry_id,
@@ -373,11 +377,9 @@ async def send_session_command_service(
             session.commit()
 
         for state in states:
-            pending = create_pending_spell_preparation(state.state_json)
-            if pending:
-                state.state_json = {**state.state_json, "pending_spell_preparation": pending}
-                flag_modified(state, "state_json")
-                session.add(state)
+            state.state_json = settle_long_rest_spell_preparation(state.state_json)
+            flag_modified(state, "state_json")
+            session.add(state)
         session.commit()
         for state in states:
             session.refresh(state)

--- a/apps/control-server/app/api/routes/sessions/state.py
+++ b/apps/control-server/app/api/routes/sessions/state.py
@@ -34,7 +34,7 @@ from app.services.out_of_combat_cast import (
 )
 from app.services.session_rest import ensure_rest_state
 from app.services.session_state_finalize import finalize_session_state_data
-from app.services.spell_preparation import apply_prepared_spells
+from app.services.spell_preparation import apply_prepared_spells_with_long_rest_tracking
 from ._shared import record_session_activity, require_identifier
 from .state_common import (
     ensure_session_state,
@@ -909,7 +909,7 @@ async def prepare_my_spells(
             detail=f"Prepared spell count ({leveled_count}) exceeds limit ({limit}).",
         )
 
-    state.state_json = apply_prepared_spells(state.state_json, payload.preparedSpellIds)
+    state.state_json = apply_prepared_spells_with_long_rest_tracking(state.state_json, payload.preparedSpellIds)
     state.state_json = finalize_session_state_data(state.state_json)
     flag_modified(state, "state_json")
     session.add(state)

--- a/apps/control-server/app/api/routes/sessions/state_common.py
+++ b/apps/control-server/app/api/routes/sessions/state_common.py
@@ -15,7 +15,7 @@ from app.models.party import Party
 from app.models.party_member import PartyMember, PartyMemberStatus
 from app.models.session import Session, SessionStatus
 from app.models.session_state import SessionState
-from app.schemas.session_state import SessionStateRead
+from app.schemas.session_state import PendingSpellPreparationRead, SessionStateRead
 from app.services.centrifugo import centrifugo
 from app.services.realtime import build_event, campaign_channel, event_version
 from app.services.combat_service.persistent_effects import derive_active_concentration
@@ -43,6 +43,44 @@ REQUIRED_SHEET_KEYS = {
 }
 
 
+def _serialize_pending_spell_preparation(pending: object) -> PendingSpellPreparationRead | None:
+    if not isinstance(pending, dict):
+        return None
+
+    source = pending.get("source")
+    class_key = pending.get("class_key")
+    prepared_limit = pending.get("prepared_limit")
+    current_prepared_spell_ids = pending.get("current_prepared_spell_ids")
+    created_at = pending.get("created_at")
+    available_during_rest = pending.get("available_during_rest")
+
+    if not isinstance(source, str):
+        source = "long_rest"
+    if not isinstance(class_key, str):
+        class_key = ""
+    if not isinstance(prepared_limit, int):
+        prepared_limit = 0
+    if not isinstance(current_prepared_spell_ids, list):
+        current_prepared_spell_ids = []
+    else:
+        current_prepared_spell_ids = [
+            spell_id for spell_id in current_prepared_spell_ids if isinstance(spell_id, str)
+        ]
+    if not isinstance(created_at, str):
+        created_at = ""
+    if not isinstance(available_during_rest, bool):
+        available_during_rest = False
+
+    return PendingSpellPreparationRead(
+        source=source,
+        classKey=class_key,
+        preparedLimit=prepared_limit,
+        currentPreparedSpellIds=current_prepared_spell_ids,
+        createdAt=created_at,
+        availableDuringRest=available_during_rest,
+    )
+
+
 def to_state_read(entry: SessionState) -> SessionStateRead:
     state_json = entry.state_json or {}
     return SessionStateRead(
@@ -54,7 +92,9 @@ def to_state_read(entry: SessionState) -> SessionStateRead:
         updatedAt=entry.updated_at,
         activeSpellEffects=state_json.get("active_spell_effects"),
         activeConcentration=derive_active_concentration(state_json),
-        pendingSpellPreparation=state_json.get("pending_spell_preparation"),
+        pendingSpellPreparation=_serialize_pending_spell_preparation(
+            state_json.get("pending_spell_preparation")
+        ),
     )
 
 

--- a/apps/control-server/app/schemas/session_state.py
+++ b/apps/control-server/app/schemas/session_state.py
@@ -3,6 +3,15 @@ from datetime import datetime
 from pydantic import BaseModel
 
 
+class PendingSpellPreparationRead(BaseModel):
+    source: str
+    classKey: str
+    preparedLimit: int
+    currentPreparedSpellIds: list[str]
+    createdAt: str
+    availableDuringRest: bool = False
+
+
 class SessionStateRead(BaseModel):
     id: str
     sessionId: str
@@ -12,7 +21,7 @@ class SessionStateRead(BaseModel):
     updatedAt: datetime | None
     activeSpellEffects: list[dict] | None = None
     activeConcentration: dict | None = None
-    pendingSpellPreparation: dict | None = None
+    pendingSpellPreparation: PendingSpellPreparationRead | None = None
 
 
 class ClearConcentrationRequest(BaseModel):

--- a/apps/control-server/app/services/spell_preparation.py
+++ b/apps/control-server/app/services/spell_preparation.py
@@ -1,7 +1,8 @@
 """Spell preparation logic for prepared and spellbook casters.
 
-Triggered after long rest to prompt players to review their prepared spells.
-v1 is additive: existing prepared flags are preserved as the initial state.
+The long-rest flow seeds a pending preparation prompt at rest start, tracks
+whether the player completed it during that rest, and falls back to the old
+post-rest prompt when needed.
 """
 
 from __future__ import annotations
@@ -13,6 +14,9 @@ _PREPARED_CASTER_CLASSES: set[str] = {"cleric", "druid", "paladin", "wizard"}
 
 # Half-casters use half their character level for spell slot / preparation scaling.
 _HALF_CASTER_CLASSES: set[str] = {"paladin", "ranger"}
+
+_PENDING_SPELL_PREPARATION_KEY = "pending_spell_preparation"
+_LONG_REST_COMPLETION_MARKER_KEY = "spell_preparation_completed_during_long_rest"
 
 
 def _normalize_class(class_id: str | None) -> str | None:
@@ -45,7 +49,11 @@ def compute_prepared_spell_limit(
     return max(1, caster_level + ability_modifier)
 
 
-def create_pending_spell_preparation(data: dict) -> dict | None:
+def create_pending_spell_preparation(
+    data: dict,
+    *,
+    available_during_rest: bool = False,
+) -> dict | None:
     """Build a pending_spell_preparation dict if the character is eligible.
 
     Returns None for non-casters, known-spell casters, or characters without
@@ -92,6 +100,7 @@ def create_pending_spell_preparation(data: dict) -> dict | None:
         "prepared_limit": prepared_limit,
         "current_prepared_spell_ids": current_prepared,
         "created_at": datetime.now(timezone.utc).isoformat(),
+        "available_during_rest": available_during_rest,
     }
 
 
@@ -120,4 +129,47 @@ def apply_prepared_spells(data: dict, prepared_spell_ids: list[str]) -> dict:
 
     next_data["spellcasting"] = {**spellcasting, "spells": spells}
     next_data.pop("pending_spell_preparation", None)
+    return next_data
+
+
+def seed_long_rest_spell_preparation(data: dict) -> dict:
+    """Replace any stale pending spell prep with the active long-rest prompt."""
+    next_data = dict(data)
+    next_data.pop(_LONG_REST_COMPLETION_MARKER_KEY, None)
+    next_data.pop(_PENDING_SPELL_PREPARATION_KEY, None)
+
+    pending = create_pending_spell_preparation(next_data, available_during_rest=True)
+    if pending:
+        next_data[_PENDING_SPELL_PREPARATION_KEY] = pending
+    return next_data
+
+
+def apply_prepared_spells_with_long_rest_tracking(
+    data: dict,
+    prepared_spell_ids: list[str],
+) -> dict:
+    """Apply prepared spells and mark that the player finished the long-rest prompt."""
+    next_data = apply_prepared_spells(data, prepared_spell_ids)
+    pending = data.get(_PENDING_SPELL_PREPARATION_KEY)
+    if (
+        data.get("restState") == "long_rest"
+        and isinstance(pending, dict)
+        and pending.get("available_during_rest") is True
+    ):
+        next_data[_LONG_REST_COMPLETION_MARKER_KEY] = True
+    return next_data
+
+
+def settle_long_rest_spell_preparation(data: dict) -> dict:
+    """Finalize the long-rest spell preparation prompt after the rest ends."""
+    next_data = dict(data)
+    pending = next_data.get(_PENDING_SPELL_PREPARATION_KEY)
+    completed_during_rest = bool(next_data.get(_LONG_REST_COMPLETION_MARKER_KEY))
+
+    if not isinstance(pending, dict) and not completed_during_rest:
+        pending = create_pending_spell_preparation(next_data, available_during_rest=False)
+        if pending:
+            next_data[_PENDING_SPELL_PREPARATION_KEY] = pending
+
+    next_data.pop(_LONG_REST_COMPLETION_MARKER_KEY, None)
     return next_data

--- a/apps/control-server/tests/test_persistent_effects.py
+++ b/apps/control-server/tests/test_persistent_effects.py
@@ -607,6 +607,64 @@ class TestToStateReadActiveConcentration(unittest.TestCase):
         self.assertIsNone(result.activeConcentration)
 
 
+class TestToStateReadPendingSpellPreparation(unittest.TestCase):
+    def test_pending_spell_preparation_is_serialized_in_camel_case(self):
+        from app.api.routes.sessions.state_common import to_state_read
+
+        mock = MagicMock(spec=SessionState)
+        mock.id = "ss-1"
+        mock.session_id = "session-1"
+        mock.player_user_id = "player-1"
+        mock.state_json = {
+            "pending_spell_preparation": {
+                "source": "long_rest",
+                "class_key": "cleric",
+                "prepared_limit": 8,
+                "current_prepared_spell_ids": ["s1", "s2"],
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "available_during_rest": True,
+            }
+        }
+        mock.created_at = "2026-01-01T00:00:00+00:00"
+        mock.updated_at = None
+
+        result = to_state_read(mock)
+
+        self.assertIsNotNone(result.pendingSpellPreparation)
+        self.assertEqual(result.pendingSpellPreparation.classKey, "cleric")
+        self.assertEqual(result.pendingSpellPreparation.preparedLimit, 8)
+        self.assertEqual(
+            result.pendingSpellPreparation.currentPreparedSpellIds,
+            ["s1", "s2"],
+        )
+        self.assertEqual(result.pendingSpellPreparation.createdAt, "2026-01-01T00:00:00+00:00")
+        self.assertTrue(result.pendingSpellPreparation.availableDuringRest)
+
+    def test_pending_spell_preparation_defaults_available_during_rest_to_false(self):
+        from app.api.routes.sessions.state_common import to_state_read
+
+        mock = MagicMock(spec=SessionState)
+        mock.id = "ss-1"
+        mock.session_id = "session-1"
+        mock.player_user_id = "player-1"
+        mock.state_json = {
+            "pending_spell_preparation": {
+                "source": "long_rest",
+                "class_key": "cleric",
+                "prepared_limit": 8,
+                "current_prepared_spell_ids": ["s1"],
+                "created_at": "2026-01-01T00:00:00+00:00",
+            }
+        }
+        mock.created_at = "2026-01-01T00:00:00+00:00"
+        mock.updated_at = None
+
+        result = to_state_read(mock)
+
+        self.assertIsNotNone(result.pendingSpellPreparation)
+        self.assertFalse(result.pendingSpellPreparation.availableDuringRest)
+
+
 class TestRemovePersistedEffect(unittest.TestCase):
     def test_remove_non_concentration_effect(self):
         eff_a = _manual_spell_effect("eff-a")

--- a/apps/control-server/tests/test_spell_preparation.py
+++ b/apps/control-server/tests/test_spell_preparation.py
@@ -12,8 +12,11 @@ import unittest
 
 from app.services.spell_preparation import (
     apply_prepared_spells,
+    apply_prepared_spells_with_long_rest_tracking,
     compute_prepared_spell_limit,
     create_pending_spell_preparation,
+    seed_long_rest_spell_preparation,
+    settle_long_rest_spell_preparation,
 )
 
 
@@ -77,6 +80,7 @@ class TestCreatePendingSpellPreparation(unittest.TestCase):
         self.assertEqual(pending["prepared_limit"], 8)  # 5 + 3
         self.assertEqual(pending["current_prepared_spell_ids"], ["s1"])
         self.assertEqual(pending["source"], "long_rest")
+        self.assertFalse(pending["available_during_rest"])
 
     def test_creates_pending_for_spellbook_caster(self):
         pending = create_pending_spell_preparation(
@@ -146,6 +150,159 @@ class TestCreatePendingSpellPreparation(unittest.TestCase):
     def test_cantrips_excluded_from_current_prepared(self):
         pending = create_pending_spell_preparation(self._base_state())
         self.assertEqual(pending["current_prepared_spell_ids"], ["s1"])
+
+
+class TestLongRestSpellPreparationLifecycle(unittest.TestCase):
+    def _base_state(self, **overrides):
+        defaults = {
+            "restState": "long_rest",
+            "class": "cleric",
+            "level": 5,
+            "abilities": {"wisdom": 16},
+            "spellcasting": {
+                "ability": "wisdom",
+                "spells": [
+                    {
+                        "id": "s1",
+                        "name": "Bless",
+                        "level": 1,
+                        "prepared": True,
+                    },
+                    {
+                        "id": "s2",
+                        "name": "Cure Wounds",
+                        "level": 1,
+                        "prepared": False,
+                    },
+                    {
+                        "id": "s3",
+                        "name": "Guidance",
+                        "level": 0,
+                        "prepared": True,
+                    },
+                ],
+            },
+        }
+        if "class_" in overrides:
+            overrides["class"] = overrides.pop("class_")
+        defaults.update(overrides)
+        return defaults
+
+    def test_seed_long_rest_spell_preparation_clears_stale_marker_and_marks_available(self):
+        seeded = seed_long_rest_spell_preparation(
+            self._base_state(
+                pending_spell_preparation={
+                    "source": "long_rest",
+                    "class_key": "cleric",
+                    "prepared_limit": 8,
+                    "current_prepared_spell_ids": ["old"],
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "available_during_rest": False,
+                },
+                spell_preparation_completed_during_long_rest=True,
+            )
+        )
+
+        self.assertIn("pending_spell_preparation", seeded)
+        self.assertTrue(seeded["pending_spell_preparation"]["available_during_rest"])
+        self.assertEqual(seeded["pending_spell_preparation"]["current_prepared_spell_ids"], ["s1"])
+        self.assertNotIn("spell_preparation_completed_during_long_rest", seeded)
+
+    def test_apply_prepared_spells_during_long_rest_sets_completion_marker(self):
+        state = self._base_state(
+            pending_spell_preparation={
+                "source": "long_rest",
+                "class_key": "cleric",
+                "prepared_limit": 8,
+                "current_prepared_spell_ids": ["s1"],
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "available_during_rest": True,
+            }
+        )
+
+        result = apply_prepared_spells_with_long_rest_tracking(state, ["s2"])
+
+        self.assertNotIn("pending_spell_preparation", result)
+        self.assertTrue(result["spell_preparation_completed_during_long_rest"])
+
+    def test_apply_prepared_spells_outside_long_rest_does_not_set_completion_marker(self):
+        state = self._base_state(
+            restState="exploration",
+            pending_spell_preparation={
+                "source": "long_rest",
+                "class_key": "cleric",
+                "prepared_limit": 8,
+                "current_prepared_spell_ids": ["s1"],
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "available_during_rest": True,
+            },
+        )
+
+        result = apply_prepared_spells_with_long_rest_tracking(state, ["s2"])
+
+        self.assertNotIn("pending_spell_preparation", result)
+        self.assertNotIn("spell_preparation_completed_during_long_rest", result)
+
+    def test_settle_long_rest_spell_preparation_keeps_existing_pending(self):
+        state = self._base_state(
+            restState="exploration",
+            pending_spell_preparation={
+                "source": "long_rest",
+                "class_key": "cleric",
+                "prepared_limit": 8,
+                "current_prepared_spell_ids": ["s1"],
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "available_during_rest": True,
+            },
+        )
+
+        result = settle_long_rest_spell_preparation(state)
+
+        self.assertIn("pending_spell_preparation", result)
+        self.assertTrue(result["pending_spell_preparation"]["available_during_rest"])
+        self.assertNotIn("spell_preparation_completed_during_long_rest", result)
+
+    def test_settle_long_rest_spell_preparation_skips_duplicate_when_marker_exists(self):
+        state = self._base_state(
+            restState="exploration",
+            spell_preparation_completed_during_long_rest=True,
+        )
+
+        result = settle_long_rest_spell_preparation(state)
+
+        self.assertNotIn("pending_spell_preparation", result)
+        self.assertNotIn("spell_preparation_completed_during_long_rest", result)
+
+    def test_settle_long_rest_spell_preparation_creates_fallback_when_missing(self):
+        result = settle_long_rest_spell_preparation(self._base_state(restState="exploration"))
+
+        self.assertIn("pending_spell_preparation", result)
+        self.assertFalse(result["pending_spell_preparation"]["available_during_rest"])
+        self.assertEqual(result["pending_spell_preparation"]["prepared_limit"], 8)
+        self.assertNotIn("spell_preparation_completed_during_long_rest", result)
+
+    def test_next_long_rest_can_create_pending_again_after_marker_cycle(self):
+        first_start = seed_long_rest_spell_preparation(self._base_state())
+        self.assertIn("pending_spell_preparation", first_start)
+        self.assertTrue(first_start["pending_spell_preparation"]["available_during_rest"])
+        self.assertNotIn("spell_preparation_completed_during_long_rest", first_start)
+
+        completed = apply_prepared_spells_with_long_rest_tracking(first_start, ["s2"])
+        self.assertNotIn("pending_spell_preparation", completed)
+        self.assertTrue(completed["spell_preparation_completed_during_long_rest"])
+
+        settled = settle_long_rest_spell_preparation(completed)
+        self.assertNotIn("pending_spell_preparation", settled)
+        self.assertNotIn("spell_preparation_completed_during_long_rest", settled)
+
+        second_start = seed_long_rest_spell_preparation(settled)
+        self.assertIn("pending_spell_preparation", second_start)
+        self.assertTrue(second_start["pending_spell_preparation"]["available_during_rest"])
+        self.assertEqual(
+            second_start["pending_spell_preparation"]["current_prepared_spell_ids"],
+            ["s2"],
+        )
+        self.assertNotIn("spell_preparation_completed_during_long_rest", second_start)
 
 
 class TestApplyPreparedSpells(unittest.TestCase):

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.spellPreparation.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.spellPreparation.test.tsx
@@ -1,0 +1,284 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => ({
+  dialogProps: null as Record<string, unknown> | null,
+  pendingSpellPreparation: {
+    source: "long_rest",
+    classKey: "cleric",
+    preparedLimit: 8,
+    currentPreparedSpellIds: ["s1"],
+    createdAt: "2026-01-01T00:00:00+00:00",
+    availableDuringRest: true,
+  },
+  restState: "long_rest" as "exploration" | "short_rest" | "long_rest",
+}));
+
+vi.mock("../../shared/hooks/useLocale", () => ({
+  useLocale: () => ({
+    locale: "pt",
+    t: (key: string) =>
+      ({
+        "playerBoard.prepareSpellsPrompt": "Preparar magias",
+        "playerBoard.prepareSpellsDescription": "Você concluiu um descanso longo. Revise suas magias preparadas.",
+        "playerBoard.prepareSpellsDuringLongRestPrompt": "Preparar magias durante o descanso",
+        "playerBoard.prepareSpellsDuringLongRestDescription": "O descanso longo ainda está em andamento. Revise suas magias preparadas agora.",
+        "playerBoard.prepareSpellsButton": "Preparar magias",
+        "playerBoard.speedLabel": "Velocidade",
+        "playerBoard.speedPenaltyHint": "Penalidade de carga",
+      }[key] ?? key),
+  }),
+}));
+
+vi.mock("../../features/auth", () => ({
+  useAuth: () => ({
+    user: { userId: "player-1" },
+  }),
+}));
+
+vi.mock("../../features/campaign-select", () => ({
+  useCampaigns: () => ({
+    selectedCampaign: { name: "Campanha" },
+    selectedCampaignId: "campaign-1",
+    setSelectedCampaignLocal: vi.fn(),
+  }),
+}));
+
+vi.mock("../../shared/hooks/useToast", () => ({
+  useToast: () => ({
+    toast: null,
+    showToast: vi.fn(),
+    clearToast: vi.fn(),
+  }),
+}));
+
+vi.mock("../../features/sessions", () => ({
+  useSession: () => ({
+    collapseCombatUi: vi.fn(),
+    combatModeVisible: false,
+    combatUiExpanded: false,
+    toggleCombatUiExpanded: vi.fn(),
+  }),
+  SessionActivityToggle: () => <div data-testid="activity-toggle" />,
+}));
+
+vi.mock("./usePlayerBoardResources", () => ({
+  usePlayerBoardResources: () => ({
+    activeConcentration: null,
+    activeSession: {
+      id: "session-1",
+      status: "ACTIVE",
+      title: "Sessao",
+      number: 1,
+      startedAt: "2026-01-01T00:00:00+00:00",
+      campaignId: "campaign-1",
+    },
+    activeSpellEffects: null,
+    catalogItems: {},
+    clearCommand: vi.fn(),
+    clearSessionEnded: vi.fn(),
+    combatActive: false,
+    effectiveCampaignId: "campaign-1",
+    lastCommand: null,
+    lastEvent: null,
+    myInventory: [],
+    partyPlayers: [],
+    pendingSpellPreparation: mockState.pendingSpellPreparation,
+    playerSheet: {
+      abilities: {
+        strength: 10,
+      },
+      spellcasting: {
+        ability: "wisdom",
+        mode: "prepared",
+        slots: {},
+        spells: [],
+      },
+    },
+    playerWallet: null,
+    refresh: vi.fn(),
+    refreshInventoryData: vi.fn(),
+    refreshPlayerWallet: vi.fn(),
+    restState: mockState.restState,
+    roll: vi.fn(),
+    rollEvents: [],
+    sessionEndedAt: null,
+    setActiveConcentration: vi.fn(),
+    setActiveSpellEffects: vi.fn(),
+    setMyInventory: vi.fn(),
+    setPendingSpellPreparation: vi.fn(),
+    setPlayerSheet: vi.fn(),
+    setPlayerWallet: vi.fn(),
+    setSelectedSessionId: vi.fn(),
+    shopAvailable: false,
+  }),
+}));
+
+vi.mock("./usePlayerBoardRealtime", () => ({
+  usePlayerBoardRealtime: () => ({
+    clearPendingRoll: vi.fn(),
+    handleAuthoritativeRollResolved: vi.fn(),
+    handleManualRoll: vi.fn(),
+    handleOpenShop: vi.fn(),
+    handleRoll: vi.fn(),
+    handleShopClose: vi.fn(),
+    inventoryFlash: false,
+    inventoryOpen: false,
+    manualValue: "",
+    pendingRoll: null,
+    rollMode: "normal",
+    setInventoryFlash: vi.fn(),
+    setInventoryOpen: vi.fn(),
+    setManualValue: vi.fn(),
+    setRollMode: vi.fn(),
+    shopOpen: false,
+  }),
+}));
+
+vi.mock("./usePlayerBoardSummary", () => ({
+  usePlayerBoardSummary: () => ({
+    boardDescription: "Resumo",
+    campaignTitle: "Campanha",
+    inventoryTotal: 0,
+    playerStatus: null,
+    sessionStatusLabel: "Ativa",
+    sessionStatusTone: "active",
+  }),
+}));
+
+vi.mock("./usePlayerBoardLoadout", () => ({
+  usePlayerBoardLoadout: () => ({
+    armorOptions: [],
+    handleArmorChange: vi.fn(),
+    handleWeaponChange: vi.fn(),
+    isSavingLoadout: false,
+    loadoutStatus: null,
+    selectedArmorId: null,
+    selectedWeaponId: null,
+    weaponOptions: [],
+  }),
+}));
+
+vi.mock("./usePlayerBoardRestActions", () => ({
+  usePlayerBoardRestActions: () => ({
+    handleUseHitDie: vi.fn(),
+    usingHitDie: false,
+  }),
+}));
+
+vi.mock("../../features/combat-ui/useCombatUiState", () => ({
+  useCombatUiState: () => ({
+    currentParticipant: null,
+    isMyTurn: false,
+    myParticipant: null,
+    state: null,
+  }),
+}));
+
+vi.mock("./PlayerBoardHero", () => ({
+  PlayerBoardHero: () => <div data-testid="hero" />,
+}));
+
+vi.mock("./PlayerBoardRestBanner", () => ({
+  PlayerBoardRestBanner: () => <div data-testid="rest-banner" />,
+}));
+
+vi.mock("./PlayerBoardStatusPanel", () => ({
+  PlayerBoardStatusPanel: () => <div data-testid="status-panel" />,
+}));
+
+vi.mock("../../features/inventory", () => ({
+  SessionInventoryPanel: () => <div data-testid="inventory-panel" />,
+}));
+
+vi.mock("../../features/shop", () => ({
+  ShopPanel: () => <div data-testid="shop-panel" />,
+}));
+
+vi.mock("../../features/session-entities", () => ({
+  PlayerEntityList: () => <div data-testid="player-entities" />,
+}));
+
+vi.mock("../../features/dice-roller/components/DiceVisualizer", () => ({
+  DiceVisualizer: () => <div data-testid="dice-visualizer" />,
+}));
+
+vi.mock("../../features/rolls/components/AuthoritativeRollDialog", () => ({
+  AuthoritativeRollDialog: () => <div data-testid="authoritative-roll" />,
+}));
+
+vi.mock("./PlayerBoardRollDialog", () => ({
+  PlayerBoardRollDialog: () => <div data-testid="manual-roll" />,
+}));
+
+vi.mock("./SpellPreparationDialog", () => ({
+  SpellPreparationDialog: (props: Record<string, unknown>) => {
+    mockState.dialogProps = props;
+    return <div data-testid="spell-prep-dialog">{String(props.copyMode ?? "fallback")}</div>;
+  },
+}));
+
+vi.mock("../../shared/ui/Toast", () => ({
+  Toast: () => null,
+}));
+
+vi.mock("../../features/combat-ui/components/CombatModeBar", () => ({
+  CombatModeBar: () => <div data-testid="combat-mode-bar" />,
+}));
+
+vi.mock("../../features/combat-ui/player/PlayerCombatModeShell", () => ({
+  PlayerCombatModeShell: () => <div data-testid="combat-shell" />,
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => vi.fn(),
+  useParams: () => ({ partyId: "party-1" }),
+}));
+
+vi.mock("../../shared/lib/navigation", () => ({
+  navigateBackOrFallback: vi.fn(),
+}));
+
+import { PlayerBoardPage } from "./PlayerBoardPage";
+
+describe("PlayerBoardPage spell preparation wiring", () => {
+  beforeEach(() => {
+    mockState.dialogProps = null;
+    mockState.pendingSpellPreparation = {
+      source: "long_rest",
+      classKey: "cleric",
+      preparedLimit: 8,
+      currentPreparedSpellIds: ["s1"],
+      createdAt: "2026-01-01T00:00:00+00:00",
+      availableDuringRest: true,
+    };
+    mockState.restState = "long_rest";
+  });
+
+  it("shows long-rest copy and passes during-long-rest mode to the dialog", () => {
+    const markup = renderToStaticMarkup(<PlayerBoardPage />);
+
+    expect(markup).toContain("Preparar magias durante o descanso");
+    expect(markup).toContain("O descanso longo ainda está em andamento");
+    expect(markup).toContain("during_long_rest");
+    expect(mockState.dialogProps?.copyMode).toBe("during_long_rest");
+  });
+
+  it("falls back to the post-rest copy when the pending prompt was created after the rest", () => {
+    mockState.pendingSpellPreparation = {
+      source: "long_rest",
+      classKey: "cleric",
+      preparedLimit: 8,
+      currentPreparedSpellIds: ["s1"],
+      createdAt: "2026-01-01T00:00:00+00:00",
+      availableDuringRest: false,
+    };
+    mockState.restState = "exploration";
+
+    const markup = renderToStaticMarkup(<PlayerBoardPage />);
+
+    expect(markup).toContain("Você concluiu um descanso longo");
+    expect(markup).toContain("fallback");
+    expect(mockState.dialogProps?.copyMode).toBe("fallback");
+  });
+});

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
@@ -28,6 +28,10 @@ import { sessionStatesRepo } from "../../shared/api/sessionStatesRepo";
 import { usePlayerBoardResources } from "./usePlayerBoardResources";
 import { usePlayerBoardSummary } from "./usePlayerBoardSummary";
 import { getConcentrationReplacementNotice } from "./concentrationLabel";
+import {
+  getSpellPreparationCopyKeys,
+  resolveSpellPreparationCopyMode,
+} from "./spellPreparationCopy";
 import { useSession } from "../../features/sessions";
 import { CombatModeBar } from "../../features/combat-ui/components/CombatModeBar";
 import { PlayerCombatModeShell } from "../../features/combat-ui/player/PlayerCombatModeShell";
@@ -84,6 +88,13 @@ export const PlayerBoardPage = () => {
     setSelectedCampaignLocal,
     userId: user?.userId,
   });
+  const spellPreparationCopyMode = resolveSpellPreparationCopyMode(
+    pendingSpellPreparation,
+    restState,
+  );
+  const spellPreparationCopyKeys = getSpellPreparationCopyKeys(
+    spellPreparationCopyMode,
+  );
   const {
     clearPendingRoll,
     handleAuthoritativeRollResolved,
@@ -426,10 +437,10 @@ export const PlayerBoardPage = () => {
             <div className="flex items-center justify-between gap-4">
               <div>
                 <p className="text-sm font-semibold text-amber-200">
-                  {t("playerBoard.prepareSpellsPrompt")}
+                  {t(spellPreparationCopyKeys.title)}
                 </p>
                 <p className="text-xs text-amber-300/70">
-                  {t("playerBoard.prepareSpellsDescription")}
+                  {t(spellPreparationCopyKeys.description)}
                 </p>
               </div>
               <button
@@ -446,25 +457,25 @@ export const PlayerBoardPage = () => {
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.08fr)_minmax(320px,0.92fr)]">
         <div className="space-y-6">
-      <PlayerBoardStatusPanel
-        activeConcentration={activeConcentration}
-        activeSpellEffects={activeSpellEffects}
-        castableSpells={castableSpells}
-        castingSpell={castingSpell}
-        clearingConcentration={clearingConcentration}
-        combatActive={combatActive}
-        onCastSpell={handleCastSpellOutOfCombat}
-        onClearConcentration={handleClearConcentration}
-        onRemoveEffect={handleRemoveEffect}
-        pendingRoll={pendingRoll}
-        playerSheet={playerSheet}
-        playerStatus={playerStatus}
-        removingEffectId={removingEffectId}
-        restState={restState}
-        targetOptions={targetOptions}
-        usingHitDie={usingHitDie}
-        onUseHitDie={handleUseHitDie}
-      />
+          <PlayerBoardStatusPanel
+            activeConcentration={activeConcentration}
+            activeSpellEffects={activeSpellEffects}
+            castableSpells={castableSpells}
+            castingSpell={castingSpell}
+            clearingConcentration={clearingConcentration}
+            combatActive={combatActive}
+            onCastSpell={handleCastSpellOutOfCombat}
+            onClearConcentration={handleClearConcentration}
+            onRemoveEffect={handleRemoveEffect}
+            pendingRoll={pendingRoll}
+            playerSheet={playerSheet}
+            playerStatus={playerStatus}
+            removingEffectId={removingEffectId}
+            restState={restState}
+            targetOptions={targetOptions}
+            usingHitDie={usingHitDie}
+            onUseHitDie={handleUseHitDie}
+          />
           {activeSession?.id && (
             <PlayerEntityList
               sessionId={activeSession.id}
@@ -536,7 +547,7 @@ export const PlayerBoardPage = () => {
                 campaignId={effectiveCampaignId}
                 inventoryItems={myInventory}
                 wallet={playerWallet}
-                strengthScore={playerSheet?.abilities.strength}
+                strengthScore={playerSheet?.abilities?.strength}
                 currentTotalWeightKg={playerStatus?.totalWeightKg}
                 currentEncumbranceTier={playerStatus?.encumbranceTier}
                 onBuy={(item, inventoryItem) => {
@@ -613,6 +624,7 @@ export const PlayerBoardPage = () => {
         currentPreparedIds={pendingSpellPreparation?.currentPreparedSpellIds ?? []}
         onSubmit={handlePrepareSpells}
         isSubmitting={preparingSpells}
+        copyMode={spellPreparationCopyMode}
       />
       <DiceVisualizer events={rollEvents} />
         </>

--- a/apps/control-web/src/pages/PlayerBoardPage/SpellPreparationDialog.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/SpellPreparationDialog.test.tsx
@@ -1,0 +1,58 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { SpellPreparationDialog } from "./SpellPreparationDialog";
+
+vi.mock("../../shared/hooks/useLocale", () => ({
+  useLocale: () => ({
+    t: (key: string) =>
+      ({
+        "playerBoard.prepareSpellsPrompt": "Preparar magias",
+        "playerBoard.prepareSpellsDescription": "Você concluiu um descanso longo. Revise suas magias preparadas.",
+        "playerBoard.prepareSpellsDuringLongRestPrompt": "Preparar magias durante o descanso",
+        "playerBoard.prepareSpellsDuringLongRestDescription": "O descanso longo ainda está em andamento. Revise suas magias preparadas agora.",
+        "playerBoard.prepareSpellsButton": "Preparar magias",
+        "playerBoard.prepareSpellsSelected": "Selecionadas: {count} / {limit}",
+        "playerBoard.prepareSpellsOverLimit": "Limite excedido",
+        "playerBoard.prepareSpellsCantrips": "Truques",
+        "playerBoard.prepareSpellsLevel": "Nível {level}",
+        "common.cancel": "Cancelar",
+        "common.saving": "Salvando...",
+      }[key] ?? key),
+  }),
+}));
+
+describe("SpellPreparationDialog", () => {
+  it("shows during-long-rest copy when availableDuringRest is true", () => {
+    const markup = renderToStaticMarkup(
+      <SpellPreparationDialog
+        open
+        spells={[]}
+        preparedLimit={3}
+        currentPreparedIds={[]}
+        onClose={() => undefined}
+        onSubmit={() => undefined}
+        copyMode="during_long_rest"
+      />,
+    );
+
+    expect(markup).toContain("Preparar magias durante o descanso");
+    expect(markup).toContain("O descanso longo ainda está em andamento");
+    expect(markup).toContain("Preparar magias");
+  });
+
+  it("falls back to post-rest copy by default", () => {
+    const markup = renderToStaticMarkup(
+      <SpellPreparationDialog
+        open
+        spells={[]}
+        preparedLimit={3}
+        currentPreparedIds={[]}
+        onClose={() => undefined}
+        onSubmit={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Preparar magias");
+    expect(markup).toContain("Você concluiu um descanso longo");
+  });
+});

--- a/apps/control-web/src/pages/PlayerBoardPage/SpellPreparationDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/SpellPreparationDialog.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { useLocale } from "../../shared/hooks/useLocale";
 import type { Spell } from "../../features/character-sheet/model/characterSheet.types";
+import { getSpellPreparationCopyKeys, type SpellPreparationCopyMode } from "./spellPreparationCopy";
 
 type Props = {
   open: boolean;
@@ -10,6 +11,7 @@ type Props = {
   currentPreparedIds: string[];
   onSubmit: (preparedIds: string[]) => void;
   isSubmitting?: boolean;
+  copyMode?: SpellPreparationCopyMode;
 };
 
 export const SpellPreparationDialog = ({
@@ -20,8 +22,10 @@ export const SpellPreparationDialog = ({
   currentPreparedIds,
   onSubmit,
   isSubmitting,
+  copyMode = "fallback",
 }: Props) => {
   const { t } = useLocale();
+  const copyKeys = getSpellPreparationCopyKeys(copyMode);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(
     () => new Set(currentPreparedIds),
   );
@@ -68,10 +72,10 @@ export const SpellPreparationDialog = ({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
       <div className="max-h-[80vh] w-full max-w-md overflow-y-auto rounded-3xl border border-white/10 bg-[#0f172a] p-6 shadow-2xl">
         <h2 className="text-lg font-bold text-white">
-          {t("playerBoard.prepareSpellsPrompt")}
+          {t(copyKeys.title)}
         </h2>
         <p className="mt-1 text-sm text-slate-400">
-          {t("playerBoard.prepareSpellsDescription")}
+          {t(copyKeys.description)}
         </p>
 
         <div className="mt-4 flex items-center justify-between">

--- a/apps/control-web/src/pages/PlayerBoardPage/spellPreparationCopy.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/spellPreparationCopy.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { getSpellPreparationCopyKeys, resolveSpellPreparationCopyMode } from "./spellPreparationCopy";
+
+describe("spellPreparationCopy", () => {
+  it("uses during-long-rest copy only when the pending spell prep is available during rest", () => {
+    expect(
+      resolveSpellPreparationCopyMode(
+        {
+          source: "long_rest",
+          classKey: "cleric",
+          preparedLimit: 8,
+          currentPreparedSpellIds: [],
+          createdAt: "2026-01-01T00:00:00+00:00",
+          availableDuringRest: true,
+        },
+        "long_rest",
+      ),
+    ).toBe("during_long_rest");
+
+    expect(
+      resolveSpellPreparationCopyMode(
+        {
+          source: "long_rest",
+          classKey: "cleric",
+          preparedLimit: 8,
+          currentPreparedSpellIds: [],
+          createdAt: "2026-01-01T00:00:00+00:00",
+          availableDuringRest: true,
+        },
+        "exploration",
+      ),
+    ).toBe("fallback");
+  });
+
+  it("falls back when the pending spell prep was created after the rest", () => {
+    expect(
+      resolveSpellPreparationCopyMode(
+        {
+          source: "long_rest",
+          classKey: "cleric",
+          preparedLimit: 8,
+          currentPreparedSpellIds: [],
+          createdAt: "2026-01-01T00:00:00+00:00",
+          availableDuringRest: false,
+        },
+        "long_rest",
+      ),
+    ).toBe("fallback");
+  });
+
+  it("maps copy keys for both modes", () => {
+    expect(getSpellPreparationCopyKeys("during_long_rest")).toEqual({
+      title: "playerBoard.prepareSpellsDuringLongRestPrompt",
+      description: "playerBoard.prepareSpellsDuringLongRestDescription",
+    });
+    expect(getSpellPreparationCopyKeys("fallback")).toEqual({
+      title: "playerBoard.prepareSpellsPrompt",
+      description: "playerBoard.prepareSpellsDescription",
+    });
+  });
+});

--- a/apps/control-web/src/pages/PlayerBoardPage/spellPreparationCopy.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/spellPreparationCopy.ts
@@ -1,0 +1,33 @@
+import type { PendingSpellPreparation } from "../../shared/api/combatRepo";
+import type { SessionRestState } from "../../features/sessions/hooks/sessionRuntime.types";
+import type { LocaleKey } from "../../shared/i18n";
+
+export type SpellPreparationCopyMode = "during_long_rest" | "fallback";
+
+const SPELL_PREPARATION_COPY_KEYS: Record<
+  SpellPreparationCopyMode,
+  {
+    description: LocaleKey;
+    title: LocaleKey;
+  }
+> = {
+  during_long_rest: {
+    title: "playerBoard.prepareSpellsDuringLongRestPrompt",
+    description: "playerBoard.prepareSpellsDuringLongRestDescription",
+  },
+  fallback: {
+    title: "playerBoard.prepareSpellsPrompt",
+    description: "playerBoard.prepareSpellsDescription",
+  },
+};
+
+export const resolveSpellPreparationCopyMode = (
+  pendingSpellPreparation: PendingSpellPreparation | null | undefined,
+  restState: SessionRestState,
+): SpellPreparationCopyMode =>
+  pendingSpellPreparation?.availableDuringRest === true && restState === "long_rest"
+    ? "during_long_rest"
+    : "fallback";
+
+export const getSpellPreparationCopyKeys = (copyMode: SpellPreparationCopyMode) =>
+  SPELL_PREPARATION_COPY_KEYS[copyMode];

--- a/apps/control-web/src/shared/api/combatRepo.ts
+++ b/apps/control-web/src/shared/api/combatRepo.ts
@@ -67,6 +67,7 @@ export type PendingSpellPreparation = {
   preparedLimit: number;
   currentPreparedSpellIds: string[];
   createdAt: string;
+  availableDuringRest: boolean;
 };
 
 export type CombatSpellContextOrigin =

--- a/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
@@ -201,6 +201,8 @@ export const playerBoardEnUSDictionary = {
   "playerBoard.concentrationReplacedDescription": "Previous concentration ended: {previous}. New concentration: {next}.",
   "playerBoard.prepareSpellsPrompt": "Prepare spells",
   "playerBoard.prepareSpellsDescription": "You completed a long rest. Review your prepared spells.",
+  "playerBoard.prepareSpellsDuringLongRestPrompt": "Prepare spells during long rest",
+  "playerBoard.prepareSpellsDuringLongRestDescription": "The long rest is still in progress. Review your prepared spells now.",
   "playerBoard.prepareSpellsButton": "Prepare spells",
   "playerBoard.prepareSpellsSelected": "Selected: {count} / {limit}",
   "playerBoard.prepareSpellsOverLimit": "Limit exceeded",

--- a/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
@@ -201,6 +201,8 @@ export const playerBoardPtBRDictionary = {
   "playerBoard.concentrationReplacedDescription": "Concentração anterior encerrada: {previous}. Nova concentração: {next}.",
   "playerBoard.prepareSpellsPrompt": "Preparar magias",
   "playerBoard.prepareSpellsDescription": "Você concluiu um descanso longo. Revise suas magias preparadas.",
+  "playerBoard.prepareSpellsDuringLongRestPrompt": "Preparar magias durante o descanso",
+  "playerBoard.prepareSpellsDuringLongRestDescription": "O descanso longo ainda está em andamento. Revise suas magias preparadas agora.",
   "playerBoard.prepareSpellsButton": "Preparar magias",
   "playerBoard.prepareSpellsSelected": "Selecionadas: {count} / {limit}",
   "playerBoard.prepareSpellsOverLimit": "Limite excedido",


### PR DESCRIPTION
# feat(spells): allow spell preparation during long rest

## Summary

Moves prepared spell review/preparation into the active long-rest flow.

Eligible prepared/spellbook casters now receive `pendingSpellPreparation` when a long rest starts, allowing players to prepare spells during the rest instead of only after it ends.

The existing post-rest fallback remains intact.

## Context

Prepared spell lists were already supported after long rest:

- backend creates `pending_spell_preparation`
- PlayerBoard shows a preparation CTA
- player opens `SpellPreparationDialog`
- backend validates prepared spell count
- prepared flags are persisted

However, the prompt was created after the long rest ended.

This PR improves the table flow by making spell preparation available during the long rest, while preserving the existing fallback behavior.

## Backend changes

### Long-rest spell preparation lifecycle

Updated:

```text
apps/control-server/app/services/spell_preparation.py
apps/control-server/app/api/routes/sessions/commands_service.py
````

The backend now supports the full long-rest preparation lifecycle:

* seed `pending_spell_preparation` when long rest starts
* mark preparation as completed when submitted during the long rest
* settle idempotently when long rest ends
* avoid recreating the prompt if the player already prepared
* preserve fallback creation if preparation was not completed

Internal marker:

```text
spell_preparation_completed_during_long_rest
```

This marker prevents duplicate prompts at rest end.

### Session response serialization

Updated:

```text
apps/control-server/app/api/routes/sessions/state_common.py
apps/control-server/app/schemas/session_state.py
```

`SessionStateRead` now exposes `pendingSpellPreparation` in camelCase with UI-compatible fields:

```text
classKey
preparedLimit
currentPreparedSpellIds
createdAt
availableDuringRest
```

Internal state remains snake_case.

## Frontend changes

### Shared copy mode helper

Added:

```text
apps/control-web/src/pages/PlayerBoardPage/spellPreparationCopy.ts
```

The helper derives copy mode from pending preparation state.

This keeps CTA and dialog wording consistent.

### PlayerBoard and dialog copy

Updated:

```text
apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
apps/control-web/src/pages/PlayerBoardPage/SpellPreparationDialog.tsx
```

The UI now uses different copy for:

* preparation during active long rest
* fallback preparation after long rest

### i18n

Updated:

```text
apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
apps/control-web/src/shared/i18n/enUS/playerBoard.ts
```

Added strings for during-rest spell preparation copy.

## Behavior

During long rest:

```text
GM starts long rest
→ eligible caster receives pendingSpellPreparation
→ PlayerBoard shows “prepare spells during rest” CTA
→ player submits prepared spells
→ pending is cleared
→ completion marker prevents duplicate prompt at rest end
```

Fallback:

```text
GM ends long rest
→ if caster did not prepare during rest
→ prompt remains/is created as fallback
```

## Tests

Backend coverage:

```text
apps/control-server/tests/test_spell_preparation.py
apps/control-server/tests/test_persistent_effects.py
```

Frontend coverage:

```text
apps/control-web/src/pages/PlayerBoardPage/spellPreparationCopy.test.ts
apps/control-web/src/pages/PlayerBoardPage/SpellPreparationDialog.test.tsx
apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.spellPreparation.test.tsx
```

## Validation

Backend:

```bash
./.venv/bin/python -m pytest apps/control-server/tests/test_spell_preparation.py apps/control-server/tests/test_persistent_effects.py -q
```

Result:

```text
85 passed
```

Frontend:

```bash
npm test -- --run src/pages/PlayerBoardPage/spellPreparationCopy.test.ts src/pages/PlayerBoardPage/SpellPreparationDialog.test.tsx src/pages/PlayerBoardPage/PlayerBoardPage.spellPreparation.test.tsx
```

Result:

```text
7 passed
```

Python compile:

```bash
./.venv/bin/python -m py_compile apps/control-server/app/services/spell_preparation.py apps/control-server/app/api/routes/sessions/commands_service.py apps/control-server/app/api/routes/sessions/state.py apps/control-server/app/api/routes/sessions/state_common.py apps/control-server/app/schemas/session_state.py
```

Whitespace:

```text
git diff --check clean
```

## Out of scope

This PR intentionally does not change:

* spellcasting rules
* prepared spell limits
* rest recovery rules
* spell slot recovery
* wizard spellbook behavior
* multiclass preparation
* always-prepared spell rules
* out-of-combat casting

## Additional regression

Added explicit marker lifecycle regression:

- long rest start creates pending preparation
- during-rest submit sets `spell_preparation_completed_during_long_rest`
- settle consumes and clears the marker
- next long rest can create a fresh pending preparation

Validation:

`26 passed` in `test_spell_preparation.py`
