### PR TITLE
feat(spells): prompt initial spell preparation for prepared casters

### DIFF
--- a/apps/control-server/app/api/routes/sessions/state.py
+++ b/apps/control-server/app/api/routes/sessions/state.py
@@ -909,7 +909,10 @@ async def prepare_my_spells(
             detail=f"Prepared spell count ({leveled_count}) exceeds limit ({limit}).",
         )
 
+    was_initial_setup = (pending or {}).get("source") == "initial_setup"
     state.state_json = apply_prepared_spells_with_long_rest_tracking(state.state_json, payload.preparedSpellIds)
+    if was_initial_setup:
+        state.state_json["spell_preparation_initial_completed"] = True
     state.state_json = finalize_session_state_data(state.state_json)
     flag_modified(state, "state_json")
     session.add(state)

--- a/apps/control-server/app/api/routes/sessions/state_common.py
+++ b/apps/control-server/app/api/routes/sessions/state_common.py
@@ -22,6 +22,7 @@ from app.services.combat_service.persistent_effects import derive_active_concent
 from app.services.session_rest import ensure_rest_state
 from app.services.session_state_finalize import finalize_session_state_data
 from app.services.session_state_merge import merge_session_state_data
+from app.services.spell_preparation import seed_initial_spell_preparation
 from ._shared import require_identifier
 
 REQUIRED_SHEET_KEYS = {
@@ -200,13 +201,15 @@ def seed_state_from_character_sheet(
     ).first()
     if not base_sheet:
         return None
+    state_json = finalize_session_state_data(
+        base_sheet.data if isinstance(base_sheet.data, dict) else {}
+    )
+    seed_initial_spell_preparation(state_json)
     entry = SessionState(
         id=str(uuid4()),
         session_id=session_id,
         player_user_id=player_user_id,
-        state_json=finalize_session_state_data(
-            base_sheet.data if isinstance(base_sheet.data, dict) else {}
-        ),
+        state_json=state_json,
         created_at=datetime.now(timezone.utc),
         updated_at=None,
     )

--- a/apps/control-server/app/services/spell_preparation.py
+++ b/apps/control-server/app/services/spell_preparation.py
@@ -17,6 +17,7 @@ _HALF_CASTER_CLASSES: set[str] = {"paladin", "ranger"}
 
 _PENDING_SPELL_PREPARATION_KEY = "pending_spell_preparation"
 _LONG_REST_COMPLETION_MARKER_KEY = "spell_preparation_completed_during_long_rest"
+_INITIAL_COMPLETED_MARKER_KEY = "spell_preparation_initial_completed"
 
 
 def _normalize_class(class_id: str | None) -> str | None:
@@ -53,6 +54,7 @@ def create_pending_spell_preparation(
     data: dict,
     *,
     available_during_rest: bool = False,
+    source: str = "long_rest",
 ) -> dict | None:
     """Build a pending_spell_preparation dict if the character is eligible.
 
@@ -95,7 +97,7 @@ def create_pending_spell_preparation(
     ]
 
     return {
-        "source": "long_rest",
+        "source": source,
         "class_key": normalized,
         "prepared_limit": prepared_limit,
         "current_prepared_spell_ids": current_prepared,
@@ -173,3 +175,22 @@ def settle_long_rest_spell_preparation(data: dict) -> dict:
 
     next_data.pop(_LONG_REST_COMPLETION_MARKER_KEY, None)
     return next_data
+
+
+def seed_initial_spell_preparation(state_json: dict) -> None:
+    """Seed pending spell preparation on first session init for prepared casters.
+
+    No-ops if the initial prompt was already completed or if a pending already exists.
+    Mutates state_json in-place — safe only before the first DB persist.
+    """
+    if state_json.get(_INITIAL_COMPLETED_MARKER_KEY):
+        return
+    if state_json.get(_PENDING_SPELL_PREPARATION_KEY):
+        return
+    pending = create_pending_spell_preparation(
+        state_json,
+        available_during_rest=False,
+        source="initial_setup",
+    )
+    if pending:
+        state_json[_PENDING_SPELL_PREPARATION_KEY] = pending

--- a/apps/control-server/tests/test_spell_preparation.py
+++ b/apps/control-server/tests/test_spell_preparation.py
@@ -3,6 +3,7 @@
 Covers:
 - compute_prepared_spell_limit
 - create_pending_spell_preparation
+- seed_initial_spell_preparation
 - apply_prepared_spells
 """
 
@@ -15,6 +16,7 @@ from app.services.spell_preparation import (
     apply_prepared_spells_with_long_rest_tracking,
     compute_prepared_spell_limit,
     create_pending_spell_preparation,
+    seed_initial_spell_preparation,
     seed_long_rest_spell_preparation,
     settle_long_rest_spell_preparation,
 )
@@ -351,6 +353,93 @@ class TestApplyPreparedSpells(unittest.TestCase):
         )
         self.assertEqual(result["spellcasting"]["spells"], [])
         self.assertNotIn("pending_spell_preparation", result)
+
+
+class TestSeedInitialSpellPreparation(unittest.TestCase):
+    def _base_state(self, **overrides):
+        defaults = {
+            "class": "cleric",
+            "level": 5,
+            "abilities": {"wisdom": 16},
+            "spellcasting": {
+                "ability": "wisdom",
+                "spells": [
+                    {"id": "s1", "name": "Bless", "level": 1, "prepared": True},
+                    {"id": "s2", "name": "Guidance", "level": 0, "prepared": True},
+                ],
+            },
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def test_creates_pending_for_prepared_casters(self):
+        for class_id in ("cleric", "druid", "paladin", "wizard"):
+            with self.subTest(class_id=class_id):
+                state = self._base_state(**{"class": class_id})
+                seed_initial_spell_preparation(state)
+                self.assertIn("pending_spell_preparation", state)
+                self.assertEqual(state["pending_spell_preparation"]["source"], "initial_setup")
+
+    def test_does_not_create_pending_for_known_casters(self):
+        for class_id in ("sorcerer", "bard", "warlock"):
+            with self.subTest(class_id=class_id):
+                state = self._base_state(**{"class": class_id})
+                seed_initial_spell_preparation(state)
+                self.assertNotIn("pending_spell_preparation", state)
+
+    def test_does_not_create_pending_for_non_caster(self):
+        state = {"class": "fighter", "level": 5}
+        seed_initial_spell_preparation(state)
+        self.assertNotIn("pending_spell_preparation", state)
+
+    def test_source_is_initial_setup(self):
+        state = self._base_state()
+        seed_initial_spell_preparation(state)
+        self.assertEqual(state["pending_spell_preparation"]["source"], "initial_setup")
+
+    def test_available_during_rest_is_false(self):
+        state = self._base_state()
+        seed_initial_spell_preparation(state)
+        self.assertFalse(state["pending_spell_preparation"]["available_during_rest"])
+
+    def test_no_op_when_initial_completed_marker_present(self):
+        state = self._base_state(spell_preparation_initial_completed=True)
+        seed_initial_spell_preparation(state)
+        self.assertNotIn("pending_spell_preparation", state)
+
+    def test_no_op_when_pending_already_exists(self):
+        existing = {"source": "long_rest", "class_key": "cleric", "prepared_limit": 1,
+                    "current_prepared_spell_ids": [], "created_at": "", "available_during_rest": False}
+        state = self._base_state(pending_spell_preparation=existing)
+        seed_initial_spell_preparation(state)
+        self.assertEqual(state["pending_spell_preparation"]["source"], "long_rest")
+
+    def test_long_rest_still_creates_pending_after_initial_completed(self):
+        state = self._base_state(spell_preparation_initial_completed=True)
+        seeded = seed_long_rest_spell_preparation(state)
+        self.assertIn("pending_spell_preparation", seeded)
+        self.assertEqual(seeded["pending_spell_preparation"]["source"], "long_rest")
+
+    def test_apply_initial_sets_completed_marker(self):
+        state = self._base_state()
+        seed_initial_spell_preparation(state)
+        self.assertEqual(state["pending_spell_preparation"]["source"], "initial_setup")
+
+        # Simulate the endpoint: capture was_initial_setup, then apply
+        pending = (state or {}).get("pending_spell_preparation") or {}
+        was_initial_setup = pending.get("source") == "initial_setup"
+        result = apply_prepared_spells_with_long_rest_tracking(state, ["s1"])
+        if was_initial_setup:
+            result["spell_preparation_initial_completed"] = True
+
+        self.assertNotIn("pending_spell_preparation", result)
+        self.assertTrue(result["spell_preparation_initial_completed"])
+
+    def test_apply_initial_does_not_set_long_rest_marker(self):
+        state = self._base_state()
+        seed_initial_spell_preparation(state)
+        result = apply_prepared_spells_with_long_rest_tracking(state, ["s1"])
+        self.assertNotIn("spell_preparation_completed_during_long_rest", result)
 
 
 if __name__ == "__main__":

--- a/apps/control-web/src/pages/PlayerBoardPage/spellPreparationCopy.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/spellPreparationCopy.test.ts
@@ -58,4 +58,25 @@ describe("spellPreparationCopy", () => {
       description: "playerBoard.prepareSpellsDescription",
     });
   });
+
+  it("returns initial_setup mode when source is initial_setup regardless of restState", () => {
+    const pending = {
+      source: "initial_setup",
+      classKey: "cleric",
+      preparedLimit: 8,
+      currentPreparedSpellIds: [],
+      createdAt: "2026-01-01T00:00:00+00:00",
+      availableDuringRest: false,
+    };
+    expect(resolveSpellPreparationCopyMode(pending, "exploration")).toBe("initial_setup");
+    expect(resolveSpellPreparationCopyMode(pending, "long_rest")).toBe("initial_setup");
+    expect(resolveSpellPreparationCopyMode(pending, "short_rest")).toBe("initial_setup");
+  });
+
+  it("maps copy keys for initial_setup mode", () => {
+    expect(getSpellPreparationCopyKeys("initial_setup")).toEqual({
+      title: "playerBoard.prepareSpellsInitialPrompt",
+      description: "playerBoard.prepareSpellsInitialDescription",
+    });
+  });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/spellPreparationCopy.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/spellPreparationCopy.ts
@@ -2,7 +2,7 @@ import type { PendingSpellPreparation } from "../../shared/api/combatRepo";
 import type { SessionRestState } from "../../features/sessions/hooks/sessionRuntime.types";
 import type { LocaleKey } from "../../shared/i18n";
 
-export type SpellPreparationCopyMode = "during_long_rest" | "fallback";
+export type SpellPreparationCopyMode = "initial_setup" | "during_long_rest" | "fallback";
 
 const SPELL_PREPARATION_COPY_KEYS: Record<
   SpellPreparationCopyMode,
@@ -11,6 +11,10 @@ const SPELL_PREPARATION_COPY_KEYS: Record<
     title: LocaleKey;
   }
 > = {
+  initial_setup: {
+    title: "playerBoard.prepareSpellsInitialPrompt",
+    description: "playerBoard.prepareSpellsInitialDescription",
+  },
   during_long_rest: {
     title: "playerBoard.prepareSpellsDuringLongRestPrompt",
     description: "playerBoard.prepareSpellsDuringLongRestDescription",
@@ -24,10 +28,12 @@ const SPELL_PREPARATION_COPY_KEYS: Record<
 export const resolveSpellPreparationCopyMode = (
   pendingSpellPreparation: PendingSpellPreparation | null | undefined,
   restState: SessionRestState,
-): SpellPreparationCopyMode =>
-  pendingSpellPreparation?.availableDuringRest === true && restState === "long_rest"
-    ? "during_long_rest"
-    : "fallback";
+): SpellPreparationCopyMode => {
+  if (pendingSpellPreparation?.source === "initial_setup") return "initial_setup";
+  if (pendingSpellPreparation?.availableDuringRest === true && restState === "long_rest")
+    return "during_long_rest";
+  return "fallback";
+};
 
 export const getSpellPreparationCopyKeys = (copyMode: SpellPreparationCopyMode) =>
   SPELL_PREPARATION_COPY_KEYS[copyMode];

--- a/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
@@ -202,6 +202,8 @@ export const playerBoardEnUSDictionary = {
   "playerBoard.lifecycleLongRest": "Clears on long rest",
   "playerBoard.concentrationReplacedTitle": "Concentration replaced",
   "playerBoard.concentrationReplacedDescription": "Previous concentration ended: {previous}. New concentration: {next}.",
+  "playerBoard.prepareSpellsInitialPrompt": "Prepare initial spells",
+  "playerBoard.prepareSpellsInitialDescription": "Choose the spells your character has prepared to start the session.",
   "playerBoard.prepareSpellsPrompt": "Prepare spells",
   "playerBoard.prepareSpellsDescription": "You completed a long rest. Review your prepared spells.",
   "playerBoard.prepareSpellsDuringLongRestPrompt": "Prepare spells during long rest",

--- a/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
@@ -202,6 +202,8 @@ export const playerBoardPtBRDictionary = {
   "playerBoard.lifecycleLongRest": "Limpa no descanso longo",
   "playerBoard.concentrationReplacedTitle": "Concentração substituída",
   "playerBoard.concentrationReplacedDescription": "Concentração anterior encerrada: {previous}. Nova concentração: {next}.",
+  "playerBoard.prepareSpellsInitialPrompt": "Preparar magias iniciais",
+  "playerBoard.prepareSpellsInitialDescription": "Escolha as magias que seu personagem terá preparadas para começar a sessão.",
   "playerBoard.prepareSpellsPrompt": "Preparar magias",
   "playerBoard.prepareSpellsDescription": "Você concluiu um descanso longo. Revise suas magias preparadas.",
   "playerBoard.prepareSpellsDuringLongRestPrompt": "Preparar magias durante o descanso",


### PR DESCRIPTION
# feat(spells): prompt initial spell preparation for prepared casters

## Summary

Adds initial spell preparation for prepared/spellbook casters when their session state is first initialized.

Prepared casters now receive a `pendingSpellPreparation` prompt with `source: "initial_setup"` before needing a long rest. This lets players choose their starting prepared spells at the beginning of the session.

## Context

Spell preparation was already supported during and after long rests, but a prepared caster entering a session for the first time could have no formal preparation prompt until the first long rest.

This PR fixes that onboarding gap.

## Backend changes

### Spell preparation source

Updated:

`apps/control-server/app/services/spell_preparation.py`

`create_pending_spell_preparation` now accepts a custom `source` parameter.

Added:

`seed_initial_spell_preparation`

Behavior:

- skips if `spell_preparation_initial_completed` is already set
- skips if a pending preparation already exists
- creates pending preparation with `source: "initial_setup"` for eligible prepared/spellbook casters

### Initial state seeding

Updated:

`apps/control-server/app/api/routes/sessions/state_common.py`

`seed_state_from_character_sheet` now calls `seed_initial_spell_preparation` before the first persist.

This means prepared casters can receive the initial prompt as soon as their session state is created.

### Submit handling

Updated:

`apps/control-server/app/api/routes/sessions/state.py`

The prepare endpoint now captures whether the pending preparation was `initial_setup` before calling `apply_prepared_spells_with_long_rest_tracking`.

If it was initial setup, it sets:

`spell_preparation_initial_completed: true`

after applying prepared spells.

This avoids the classic “pending got cleared before I checked its source” bug. Tiny little swamp creature avoided.

## Frontend changes

### Copy mode

Updated:

`apps/control-web/src/pages/PlayerBoardPage/spellPreparationCopy.ts`

Added copy mode:

`initial_setup`

This mode takes priority over during-rest/fallback modes when:

`pendingSpellPreparation.source === "initial_setup"`

### i18n

Updated:

`apps/control-web/src/shared/i18n/ptBR/playerBoard.ts`
`apps/control-web/src/shared/i18n/enUS/playerBoard.ts`

Added copy for initial spell preparation.

PT-BR:

`Preparar magias iniciais`

EN-US:

`Prepare initial spells`

## Behavior

Initial setup:

```text
SessionState is created
→ character is a prepared/spellbook caster
→ backend creates pendingSpellPreparation with source initial_setup
→ PlayerBoard shows initial preparation copy
→ player submits prepared spells
→ pending is cleared
→ spell_preparation_initial_completed is set