### PR TITLE
feat(spell-anchor): add spell anchor schema and integration sync tests

### DIFF
--- a/apps/map-server/tests/integration/spell-anchor-sync.integration.test.ts
+++ b/apps/map-server/tests/integration/spell-anchor-sync.integration.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { createApp } from "../../src/app";
+import { registerIntegrationRoutes } from "../../src/routes/integration-routes";
+
+const anchorA = {
+  id: "spell_anchor:a",
+  sourceSpellKey: "spiritual_weapon",
+  sourceSpellName: "Arma Espiritual",
+  ownerParticipantId: "p1",
+  createdByParticipantId: "p1",
+  position: { x: 12, y: 10 },
+  durationType: "rounds",
+  remainingRounds: 10,
+  expiresOn: "turn_start",
+  expiresAtParticipantId: "p1",
+  renderKind: "generic",
+  metadata: {},
+};
+
+const anchorB = {
+  id: "spell_anchor:b",
+  sourceSpellKey: "moonbeam",
+  sourceSpellName: "Moonbeam",
+  ownerParticipantId: "p2",
+  createdByParticipantId: "p2",
+  position: { x: 7, y: 4 },
+  durationType: "rounds",
+  remainingRounds: 5,
+  expiresOn: "turn_end",
+  expiresAtParticipantId: "p2",
+  renderKind: "generic",
+  metadata: { debugLabel: "replacement" },
+};
+
+describe("spell anchor sync integration", () => {
+  it("syncs spell anchors through the integration route", async () => {
+    const { app, repository } = createApp();
+    registerIntegrationRoutes(app, repository);
+    repository.ensureEncounter("session-123");
+
+    const response = await app.inject({
+      method: "PUT",
+      url: "/integration/sessions/session-123/spell-anchors",
+      payload: {
+        spellAnchors: [anchorA],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().spellAnchors).toHaveLength(1);
+    expect(response.json().spellAnchors[0]).toMatchObject({
+      id: "spell_anchor:a",
+      sourceSpellKey: "spiritual_weapon",
+      ownerParticipantId: "p1",
+      position: { x: 12, y: 10 },
+      renderKind: "generic",
+    });
+
+    const stateResponse = await app.inject({
+      method: "GET",
+      url: "/integration/sessions/session-123/state",
+    });
+    expect(stateResponse.statusCode).toBe(200);
+    expect(stateResponse.json().spellAnchors).toEqual([anchorA]);
+
+    await app.close();
+  });
+
+  it("replaces spell anchors authoritatively on later sync", async () => {
+    const { app, repository } = createApp();
+    registerIntegrationRoutes(app, repository);
+    repository.ensureEncounter("session-123");
+
+    const firstResponse = await app.inject({
+      method: "PUT",
+      url: "/integration/sessions/session-123/spell-anchors",
+      payload: {
+        spellAnchors: [anchorA],
+      },
+    });
+    expect(firstResponse.statusCode).toBe(200);
+
+    const secondResponse = await app.inject({
+      method: "PUT",
+      url: "/integration/sessions/session-123/spell-anchors",
+      payload: {
+        spellAnchors: [anchorB],
+      },
+    });
+    expect(secondResponse.statusCode).toBe(200);
+    expect(secondResponse.json().spellAnchors).toEqual([anchorB]);
+
+    const stateResponse = await app.inject({
+      method: "GET",
+      url: "/integration/sessions/session-123/state",
+    });
+    expect(stateResponse.statusCode).toBe(200);
+    expect(stateResponse.json().spellAnchors).toEqual([anchorB]);
+
+    await app.close();
+  });
+
+  it("clears spell anchors when synced with an empty collection", async () => {
+    const { app, repository } = createApp();
+    registerIntegrationRoutes(app, repository);
+    repository.ensureEncounter("session-123");
+
+    const firstResponse = await app.inject({
+      method: "PUT",
+      url: "/integration/sessions/session-123/spell-anchors",
+      payload: {
+        spellAnchors: [anchorA],
+      },
+    });
+    expect(firstResponse.statusCode).toBe(200);
+
+    const clearResponse = await app.inject({
+      method: "PUT",
+      url: "/integration/sessions/session-123/spell-anchors",
+      payload: {
+        spellAnchors: [],
+      },
+    });
+    expect(clearResponse.statusCode).toBe(200);
+    expect(clearResponse.json().spellAnchors).toEqual([]);
+
+    const stateResponse = await app.inject({
+      method: "GET",
+      url: "/integration/sessions/session-123/state",
+    });
+    expect(stateResponse.statusCode).toBe(200);
+    expect(stateResponse.json().spellAnchors).toEqual([]);
+
+    await app.close();
+  });
+});

--- a/packages/shared-contracts/src/domain.js
+++ b/packages/shared-contracts/src/domain.js
@@ -156,6 +156,24 @@ export const activeAreaEffectSchema = z.object({
     damageType: z.string().nullable().optional(),
     damagePerMeters: z.number().positive().nullable().optional()
 });
+export const spellAnchorMovementSchema = z.object({
+    maxMetersPerFollowUp: z.number().positive().nullable().optional()
+});
+export const spellAnchorSchema = z.object({
+    id: z.string(),
+    sourceSpellKey: z.string(),
+    sourceSpellName: z.string().nullable().optional(),
+    ownerParticipantId: z.string(),
+    createdByParticipantId: z.string(),
+    position: coordinateSchema,
+    durationType: z.literal("rounds"),
+    remainingRounds: z.number().int().positive().nullable().optional(),
+    expiresOn: z.enum(["turn_start", "turn_end"]).nullable().optional(),
+    expiresAtParticipantId: z.string().nullable().optional(),
+    renderKind: z.string().default("generic"),
+    movement: spellAnchorMovementSchema.nullable().optional(),
+    metadata: z.record(z.unknown()).default({})
+});
 export const realtimeActionEventSchema = z.object({
     eventId: z.string(),
     eventType: z.string(),

--- a/packages/shared-contracts/src/http.js
+++ b/packages/shared-contracts/src/http.js
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { activeAreaEffectSchema, battleMapSchema, combatStateSchema, edgeObstacleSchema, obstacleSchema, tokenSchema } from "./domain";
+import { activeAreaEffectSchema, battleMapSchema, combatStateSchema, edgeObstacleSchema, obstacleSchema, spellAnchorSchema, tokenSchema } from "./domain";
 export const encounterSnapshotResponseSchema = z.object({
     sessionId: z.string(),
     battleMap: battleMapSchema,
@@ -7,7 +7,8 @@ export const encounterSnapshotResponseSchema = z.object({
     tokens: z.array(tokenSchema),
     obstacles: z.array(obstacleSchema),
     edgeObstacles: z.array(edgeObstacleSchema).default([]),
-    activeAreaEffects: z.array(activeAreaEffectSchema).default([])
+    activeAreaEffects: z.array(activeAreaEffectSchema).default([]),
+    spellAnchors: z.array(spellAnchorSchema).default([])
 });
 export const resyncRequestSchema = z.object({
     lastKnownVersion: z.number().int().nonnegative(),

--- a/packages/shared-contracts/src/integration.js
+++ b/packages/shared-contracts/src/integration.js
@@ -8,6 +8,7 @@ import {
     edgeObstacleSchema,
     obstacleCoverSchema,
     obstacleSchema,
+    spellAnchorSchema,
     tokenSchema
 } from "./domain";
 export const initiativeEntrySchema = z.object({
@@ -76,6 +77,9 @@ export const syncTokensRequestSchema = z.object({
 export const syncActiveAreaEffectsRequestSchema = z.object({
     activeAreaEffects: z.array(activeAreaEffectSchema)
 });
+export const syncSpellAnchorsRequestSchema = z.object({
+    spellAnchors: z.array(spellAnchorSchema)
+});
 export const singleTargetRequestSchema = z.object({
     actionId: z.string(),
     combatantId: z.string(),
@@ -104,7 +108,8 @@ export const integrationStateResponseSchema = z.object({
     tokens: z.array(tokenSchema),
     obstacles: z.array(obstacleSchema),
     edgeObstacles: z.array(edgeObstacleSchema).default([]),
-    activeAreaEffects: z.array(activeAreaEffectSchema).default([])
+    activeAreaEffects: z.array(activeAreaEffectSchema).default([]),
+    spellAnchors: z.array(spellAnchorSchema).default([])
 });
 export const singleTargetResponseSchema = z.object({
     isValid: z.boolean(),


### PR DESCRIPTION
# test(map): cover spell-anchor integration sync route

## Summary

Adds dedicated integration coverage for the new spell-anchor sync route and fixes a runtime shared-contract export gap uncovered by that test.

## What changed

### Map-server integration coverage

Added:

`apps/map-server/tests/integration/spell-anchor-sync.integration.test.ts`

The new suite covers:

- syncing anchors through  
  `PUT /integration/sessions/:sessionId/spell-anchors`
- authoritative replacement on later sync
- clearing stored anchors with an empty collection

### Runtime shared-contract fix

While adding route coverage, the test exposed a real runtime issue:

- `syncSpellAnchorsRequestSchema` existed in the TypeScript shared contracts
- but the versioned runtime JavaScript artifacts were stale
- so the route attempted to call `.safeParse` on `undefined` under Vitest/runtime execution

Fixed the missing JS exports in:

- `packages/shared-contracts/src/domain.js`
- `packages/shared-contracts/src/http.js`
- `packages/shared-contracts/src/integration.js`

## Why this matters

The previous spell-anchor work already covered authoritative storage/snapshot behavior, but the dedicated public integration route itself still lacked automated coverage.

This PR closes that gap and also ensures the runtime JS contract surface matches the TypeScript source surface.

## Validation

```bash
npm exec vitest run \
  apps/map-server/tests/integration/spell-anchor-sync.integration.test.ts \
  apps/map-server/tests/integration/active-area-effects.integration.test.ts
````

## Scope

This PR is intentionally limited to:

* route-level regression coverage
* fixing the runtime contract export mismatch discovered by that coverage

No spell-anchor behavior or spell-specific functionality was expanded.