### PR TITLE
feat: add Spiritual Weapon follow-up action and UI integration

### DIFF
--- a/apps/control-web/src/features/combat-ui/player/PlayerActionPanels.test.tsx
+++ b/apps/control-web/src/features/combat-ui/player/PlayerActionPanels.test.tsx
@@ -49,9 +49,11 @@ describe("PlayerActionPanels", () => {
         consumableItemId=""
         consumableOptions={[]}
         dragonbornBreathWeaponAction={null}
+        spiritualWeaponFollowUpAction={null}
         handleAttack={async () => undefined}
         handleCast={async () => undefined}
         handleDragonbornBreathWeapon={async () => undefined}
+        handleSpiritualWeaponFollowUp={async () => undefined}
         handleStandardAction={async () => undefined}
         handleUseObject={async () => undefined}
         isSavingLoadout={false}
@@ -136,9 +138,11 @@ describe("PlayerActionPanels", () => {
         consumableItemId=""
         consumableOptions={[]}
         dragonbornBreathWeaponAction={null}
+        spiritualWeaponFollowUpAction={null}
         handleAttack={async () => undefined}
         handleCast={async () => undefined}
         handleDragonbornBreathWeapon={async () => undefined}
+        handleSpiritualWeaponFollowUp={async () => undefined}
         handleStandardAction={async () => undefined}
         handleUseObject={async () => undefined}
         isSavingLoadout

--- a/apps/control-web/src/features/combat-ui/player/PlayerActionPanels.tsx
+++ b/apps/control-web/src/features/combat-ui/player/PlayerActionPanels.tsx
@@ -1,7 +1,8 @@
+import { useState } from "react";
 import { useLocale } from "../../../shared/hooks/useLocale";
 import { localizeDamageType } from "../../../shared/i18n/domainLabels";
 import type { PlayerBoardStatusSummary } from "../../../pages/PlayerBoardPage/playerBoard.types";
-import type { StandardActionType, TurnResources } from "../../../shared/api/combatRepo";
+import type { CombatParticipant, StandardActionType, TurnResources } from "../../../shared/api/combatRepo";
 import { getAbilityLabel } from "../../character-sheet/utils/abilityLabels";
 import { isCombatSpellActionCostAvailable } from "../spellAutomation";
 import { requiresAreaTargetingSelection, spellRequiresExternalTarget } from "../../../pages/PlayerBoardPage/player-combat-debug/areaTargetingUi";
@@ -17,6 +18,8 @@ import type {
   WeaponOption,
 } from "./playerCombatShell.types";
 import { PlayerUseObjectPanel } from "./PlayerUseObjectPanel";
+import { SpiritualWeaponFollowUpDialog } from "./SpiritualWeaponFollowUpDialog";
+import type { SpiritualWeaponFollowUpAction } from "./spiritualWeapon";
 
 type Props = {
   activeActionPanel: "attack" | "spell" | "standard" | "object";
@@ -26,9 +29,16 @@ type Props = {
   consumableItemId: string;
   consumableOptions: ConsumableOption[];
   dragonbornBreathWeaponAction: DragonbornBreathWeaponOption | null;
+  spiritualWeaponFollowUpAction: SpiritualWeaponFollowUpAction | null;
   handleAttack: () => Promise<void>;
   handleCast: () => Promise<void>;
   handleDragonbornBreathWeapon: () => Promise<void>;
+  handleSpiritualWeaponFollowUp: (
+    anchorId: string,
+    destination: { x: number; y: number } | null,
+    targetRefId: string | null,
+    targetKind: string | null,
+  ) => Promise<void>;
   handleStandardAction: (action: StandardActionType, targetId?: string) => Promise<void>;
   handleUseObject: () => Promise<void>;
   myParticipantId?: string | null;
@@ -57,7 +67,9 @@ type Props = {
   useObjectTargetParticipantId: string;
   weaponOptions: WeaponOption[];
   isSavingLoadout?: boolean;
+  isMyTurn?: boolean;
   loadoutStatus?: string | null;
+  participants?: CombatParticipant[];
   onWeaponChange?: (inventoryItemId: string | null) => void;
 };
 
@@ -69,9 +81,11 @@ export const PlayerActionPanels = ({
   consumableItemId,
   consumableOptions,
   dragonbornBreathWeaponAction,
+  spiritualWeaponFollowUpAction,
   handleAttack,
   handleCast,
   handleDragonbornBreathWeapon,
+  handleSpiritualWeaponFollowUp,
   handleStandardAction,
   handleUseObject,
   myParticipantId,
@@ -100,9 +114,13 @@ export const PlayerActionPanels = ({
   useObjectTargetParticipantId,
   weaponOptions,
   isSavingLoadout = false,
+  isMyTurn = false,
   loadoutStatus = null,
+  participants = [],
   onWeaponChange,
 }: Props) => {
+  const [showSpiritualWeaponDialog, setShowSpiritualWeaponDialog] = useState(false);
+  const [spiritualWeaponSubmitting, setSpiritualWeaponSubmitting] = useState(false);
   const { locale, t } = useLocale();
   const selectedSpellActionCost = selectedSpell?.actionCost ?? null;
   const selectedSpellIsArea = requiresAreaTargetingSelection(selectedSpell?.selectionType, selectedSpell?.areaShape);
@@ -140,6 +158,7 @@ export const PlayerActionPanels = ({
   );
 
   return (
+    <>
     <div className="space-y-4">
       <div className="overflow-x-auto">
         <div className="inline-flex min-w-full gap-2 rounded-3xl border border-white/8 bg-white/4 p-2">
@@ -313,6 +332,36 @@ export const PlayerActionPanels = ({
       {activeActionPanel === "standard" ? (
         <article className="min-w-0 rounded-3xl border border-white/8 bg-white/4 p-5">
           <h3 className="text-lg font-semibold text-white">{t("combatUi.standardActions")}</h3>
+          {spiritualWeaponFollowUpAction ? (
+            <div className="mt-4 rounded-3xl border border-violet-500/20 bg-violet-500/8 p-4">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-white">
+                    {t("combatUi.spiritualWeaponAction")}
+                  </p>
+                  <p className="mt-2 text-xs uppercase tracking-[0.2em] text-violet-100/80">
+                    {t("combatUi.bonusAction")}
+                  </p>
+                  {spiritualWeaponFollowUpAction.remainingRounds != null && (
+                    <p className="mt-2 text-xs text-slate-300">
+                      {t("combatUi.spiritualWeaponRoundsLeft").replace(
+                        "{rounds}",
+                        String(spiritualWeaponFollowUpAction.remainingRounds),
+                      )}
+                    </p>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  disabled={!canAct || !isMyTurn || (turnResources?.bonus_action_used ?? false)}
+                  onClick={() => setShowSpiritualWeaponDialog(true)}
+                  className="rounded-full bg-violet-600 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-white transition-colors hover:bg-violet-500 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {t("combatUi.spiritualWeaponAction")}
+                </button>
+              </div>
+            </div>
+          ) : null}
           {dragonbornBreathWeaponAction ? (
             <div className="mt-4 rounded-3xl border border-emerald-500/20 bg-emerald-500/8 p-4">
               <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
@@ -400,5 +449,31 @@ export const PlayerActionPanels = ({
         />
       ) : null}
     </div>
+    {spiritualWeaponFollowUpAction && (
+      <SpiritualWeaponFollowUpDialog
+        open={showSpiritualWeaponDialog}
+        onClose={() => setShowSpiritualWeaponDialog(false)}
+        action={spiritualWeaponFollowUpAction}
+        participants={participants}
+        myParticipantId={myParticipantId}
+        isMyTurn={isMyTurn}
+        bonusActionUsed={turnResources?.bonus_action_used ?? false}
+        onSubmit={async (destination, targetRefId, targetKind) => {
+          setSpiritualWeaponSubmitting(true);
+          try {
+            await handleSpiritualWeaponFollowUp(
+              spiritualWeaponFollowUpAction.anchorId,
+              destination,
+              targetRefId,
+              targetKind,
+            );
+          } finally {
+            setSpiritualWeaponSubmitting(false);
+          }
+        }}
+        isSubmitting={spiritualWeaponSubmitting}
+      />
+    )}
+    </>
   );
 };

--- a/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
+++ b/apps/control-web/src/features/combat-ui/player/PlayerCombatModeShell.tsx
@@ -113,10 +113,12 @@ export const PlayerCombatModeShell = ({
     consumableOptions,
     deathSaveFeedback,
     dragonbornBreathWeaponAction,
+    spiritualWeaponFollowUpAction,
     handleAttack,
     handleRequestReaction,
     handleDeathSave,
     handleDragonbornBreathWeapon,
+    handleSpiritualWeaponFollowUp,
     handleEndTurn,
     handleStandardAction,
     handleUseObject,
@@ -423,10 +425,13 @@ export const PlayerCombatModeShell = ({
             consumableOptions={consumableOptions}
             deathSaveFeedback={deathSaveFeedback}
             dragonbornBreathWeaponAction={dragonbornBreathWeaponAction}
+            spiritualWeaponFollowUpAction={spiritualWeaponFollowUpAction}
+            participants={combat.state?.participants}
             handleAttack={handleAttack}
             handleCast={handleCast}
             handleDeathSave={handleDeathSave}
             handleDragonbornBreathWeapon={handleDragonbornBreathWeapon}
+            handleSpiritualWeaponFollowUp={handleSpiritualWeaponFollowUp}
             handleEndTurn={handleEndTurn}
             handleRequestReaction={handleRequestReaction}
             handleStandardAction={handleStandardAction}

--- a/apps/control-web/src/features/combat-ui/player/PlayerTurnPanel.tsx
+++ b/apps/control-web/src/features/combat-ui/player/PlayerTurnPanel.tsx
@@ -4,6 +4,7 @@ import { useLocale } from "../../../shared/hooks/useLocale";
 import { useTargetingPreview } from "../hooks/useTargetingPreview";
 import type { PlayerBoardStatusSummary } from "../../../pages/PlayerBoardPage/playerBoard.types";
 import type { PendingRoll } from "../../../pages/PlayerBoardPage/playerBoard.types";
+import type { CombatParticipant } from "../../../shared/api/combatRepo";
 import type {
   AttackResult,
   CombatMyParticipant,
@@ -17,6 +18,7 @@ import type {
   UseObjectTargetOption,
   WeaponOption,
 } from "./playerCombatShell.types";
+import type { SpiritualWeaponFollowUpAction } from "./spiritualWeapon";
 import type { TargetingPreviewState } from "../hooks/useTargetingPreview";
 import { PlayerActionPanels } from "./PlayerActionPanels";
 
@@ -27,10 +29,18 @@ type Props = {
   consumableOptions: ConsumableOption[];
   deathSaveFeedback: { message?: string | null } | null;
   dragonbornBreathWeaponAction: DragonbornBreathWeaponOption | null;
+  spiritualWeaponFollowUpAction: SpiritualWeaponFollowUpAction | null;
+  participants?: CombatParticipant[];
   handleAttack: () => Promise<void>;
   handleCast: () => Promise<void>;
   handleDeathSave: () => Promise<void>;
   handleDragonbornBreathWeapon: () => Promise<void>;
+  handleSpiritualWeaponFollowUp: (
+    anchorId: string,
+    destination: { x: number; y: number } | null,
+    targetRefId: string | null,
+    targetKind: string | null,
+  ) => Promise<void>;
   handleEndTurn: () => Promise<void>;
   handleRequestReaction: () => Promise<void>;
   handleStandardAction: (
@@ -97,10 +107,13 @@ export const PlayerTurnPanel = ({
   consumableOptions,
   deathSaveFeedback,
   dragonbornBreathWeaponAction,
+  spiritualWeaponFollowUpAction,
+  participants = [],
   handleAttack,
   handleCast,
   handleDeathSave,
   handleDragonbornBreathWeapon,
+  handleSpiritualWeaponFollowUp,
   handleEndTurn,
   handleRequestReaction,
   handleStandardAction,
@@ -324,9 +337,13 @@ export const PlayerTurnPanel = ({
               consumableItemId={consumableItemId}
               consumableOptions={consumableOptions}
               dragonbornBreathWeaponAction={dragonbornBreathWeaponAction}
+              spiritualWeaponFollowUpAction={spiritualWeaponFollowUpAction}
+              participants={participants}
+              isMyTurn={combat.isMyTurn}
               handleAttack={handleAttack}
               handleCast={handleCast}
               handleDragonbornBreathWeapon={handleDragonbornBreathWeapon}
+              handleSpiritualWeaponFollowUp={handleSpiritualWeaponFollowUp}
               handleStandardAction={handleStandardAction}
               handleUseObject={handleUseObject}
               myParticipantId={myParticipant?.id}

--- a/apps/control-web/src/features/combat-ui/player/SpiritualWeaponFollowUpDialog.tsx
+++ b/apps/control-web/src/features/combat-ui/player/SpiritualWeaponFollowUpDialog.tsx
@@ -1,0 +1,185 @@
+import { useState } from "react";
+import { useLocale } from "../../../shared/hooks/useLocale";
+import type { CombatParticipant } from "../../../shared/api/combatRepo";
+import type { SpiritualWeaponFollowUpAction } from "./spiritualWeapon";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  action: SpiritualWeaponFollowUpAction;
+  participants: CombatParticipant[];
+  myParticipantId?: string | null;
+  isMyTurn: boolean;
+  bonusActionUsed: boolean;
+  onSubmit: (
+    destination: { x: number; y: number } | null,
+    targetRefId: string | null,
+    targetKind: string | null,
+  ) => Promise<void>;
+  isSubmitting?: boolean;
+};
+
+export const SpiritualWeaponFollowUpDialog = ({
+  open,
+  onClose,
+  action,
+  participants,
+  myParticipantId,
+  isMyTurn,
+  bonusActionUsed,
+  onSubmit,
+  isSubmitting = false,
+}: Props) => {
+  const { t } = useLocale();
+  const [moveX, setMoveX] = useState("");
+  const [moveY, setMoveY] = useState("");
+  const [keepPosition, setKeepPosition] = useState(false);
+  const [selectedTargetId, setSelectedTargetId] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  const destination =
+    !keepPosition && moveX !== "" && moveY !== ""
+      ? { x: parseInt(moveX, 10), y: parseInt(moveY, 10) }
+      : null;
+
+  const targetParticipant = participants.find((p) => p.id === selectedTargetId);
+  const targetRefId = targetParticipant?.ref_id ?? null;
+  const targetKind = targetParticipant?.kind ?? null;
+
+  const isNoop = !destination && !targetRefId;
+  const canSubmit = !isNoop && !isSubmitting && isMyTurn && !bonusActionUsed;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setError(null);
+    try {
+      await onSubmit(destination, targetRefId, targetKind);
+      onClose();
+    } catch {
+      setError("Não foi possível executar a ação. Tente novamente.");
+    }
+  };
+
+  const eligibleTargets = participants.filter(
+    (p) => p.id !== myParticipantId && p.status !== "dead" && p.status !== "defeated",
+  );
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+      <div className="w-full max-w-sm rounded-3xl border border-violet-400/30 bg-void-950 p-6 shadow-2xl">
+        <h2 className="text-lg font-semibold text-white">
+          {t("combatUi.spiritualWeaponAction")}
+        </h2>
+
+        <p className="mt-2 text-xs text-slate-400">
+          {t("combatUi.spiritualWeaponCurrentPosition")}:{" "}
+          <span className="font-mono text-slate-200">
+            ({action.position.x}, {action.position.y})
+          </span>
+          {action.remainingRounds != null && (
+            <span className="ml-2 text-violet-300">
+              · {t("combatUi.spiritualWeaponRoundsLeft").replace("{rounds}", String(action.remainingRounds))}
+            </span>
+          )}
+        </p>
+
+        {/* Destino */}
+        <div className="mt-5">
+          <label className="block text-sm font-medium text-slate-200">
+            {t("combatUi.spiritualWeaponDestinationLabel")}
+          </label>
+          <div className="mt-2 flex items-center gap-3">
+            <label className="flex items-center gap-2 text-sm text-slate-300">
+              <input
+                type="checkbox"
+                checked={keepPosition}
+                onChange={(e) => {
+                  setKeepPosition(e.target.checked);
+                  if (e.target.checked) {
+                    setMoveX("");
+                    setMoveY("");
+                  }
+                }}
+                className="accent-violet-500"
+              />
+              {t("combatUi.spiritualWeaponKeepPosition")}
+            </label>
+          </div>
+          {!keepPosition && (
+            <div className="mt-2 flex gap-2">
+              <div className="flex flex-col gap-1">
+                <label className="text-xs text-slate-400">{t("combatUi.spiritualWeaponDestinationX")}</label>
+                <input
+                  type="number"
+                  value={moveX}
+                  onChange={(e) => setMoveX(e.target.value)}
+                  placeholder="0"
+                  className="w-20 rounded-xl border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white focus:border-violet-400 focus:outline-none"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-xs text-slate-400">{t("combatUi.spiritualWeaponDestinationY")}</label>
+                <input
+                  type="number"
+                  value={moveY}
+                  onChange={(e) => setMoveY(e.target.value)}
+                  placeholder="0"
+                  className="w-20 rounded-xl border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white focus:border-violet-400 focus:outline-none"
+                />
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Alvo */}
+        <div className="mt-5">
+          <label className="block text-sm font-medium text-slate-200">
+            {t("combatUi.spiritualWeaponOptionalTarget")}
+          </label>
+          <select
+            value={selectedTargetId}
+            onChange={(e) => setSelectedTargetId(e.target.value)}
+            className="mt-2 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white focus:border-violet-400 focus:outline-none"
+          >
+            <option value="">{t("combatUi.spiritualWeaponNoTarget")}</option>
+            {eligibleTargets.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.display_name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {error && (
+          <p className="mt-3 text-sm text-red-400">{error}</p>
+        )}
+
+        {isNoop && (
+          <p className="mt-3 text-xs text-slate-500">
+            Informe um destino ou selecione um alvo para confirmar a ação.
+          </p>
+        )}
+
+        <div className="mt-6 flex gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 rounded-full border border-white/10 px-4 py-2 text-sm text-slate-300 transition-colors hover:bg-white/5"
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            disabled={!canSubmit}
+            onClick={() => void handleSubmit()}
+            className="flex-1 rounded-full bg-violet-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-violet-500 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {isSubmitting ? "Executando..." : t("combatUi.spiritualWeaponConfirm")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/control-web/src/features/combat-ui/player/spiritualWeapon.test.ts
+++ b/apps/control-web/src/features/combat-ui/player/spiritualWeapon.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { buildSpiritualWeaponFollowUpAction } from "./spiritualWeapon";
+import type { CombatSpellAnchor } from "../../../shared/api/combatRepo";
+
+const makeAnchor = (override: Partial<CombatSpellAnchor> = {}): CombatSpellAnchor => ({
+  id: "anchor-1",
+  source_spell_key: "spiritual_weapon",
+  source_spell_name: "Arma Espiritual",
+  owner_participant_id: "p1",
+  created_by_participant_id: "p1",
+  position: { x: 5, y: 5 },
+  duration_type: "rounds",
+  remaining_rounds: 8,
+  expires_on: "turn_start",
+  expires_at_participant_id: "p1",
+  render_kind: "spiritual_weapon",
+  movement: { max_meters_per_follow_up: 6 },
+  metadata: {},
+  ...override,
+});
+
+describe("buildSpiritualWeaponFollowUpAction", () => {
+  it("returns action when owned spiritual_weapon anchor exists", () => {
+    const action = buildSpiritualWeaponFollowUpAction([makeAnchor()], "p1");
+    expect(action).not.toBeNull();
+    expect(action?.anchorId).toBe("anchor-1");
+    expect(action?.position).toEqual({ x: 5, y: 5 });
+    expect(action?.remainingRounds).toBe(8);
+    expect(action?.maxMovementMeters).toBe(6);
+  });
+
+  it("returns null when there are no anchors", () => {
+    expect(buildSpiritualWeaponFollowUpAction([], "p1")).toBeNull();
+    expect(buildSpiritualWeaponFollowUpAction(null, "p1")).toBeNull();
+    expect(buildSpiritualWeaponFollowUpAction(undefined, "p1")).toBeNull();
+  });
+
+  it("returns null when participant has no spiritual_weapon anchor", () => {
+    const anchor = makeAnchor({ source_spell_key: "hunters_mark" });
+    expect(buildSpiritualWeaponFollowUpAction([anchor], "p1")).toBeNull();
+  });
+
+  it("returns null when anchor belongs to a different owner", () => {
+    const anchor = makeAnchor({ owner_participant_id: "p2" });
+    expect(buildSpiritualWeaponFollowUpAction([anchor], "p1")).toBeNull();
+  });
+
+  it("returns null when myParticipantId is null or undefined", () => {
+    expect(buildSpiritualWeaponFollowUpAction([makeAnchor()], null)).toBeNull();
+    expect(buildSpiritualWeaponFollowUpAction([makeAnchor()], undefined)).toBeNull();
+  });
+
+  it("uses default 6m movement when movement field is absent", () => {
+    const anchor = makeAnchor({ movement: null });
+    const action = buildSpiritualWeaponFollowUpAction([anchor], "p1");
+    expect(action?.maxMovementMeters).toBe(6);
+  });
+
+  it("picks the correct anchor when multiple anchors exist", () => {
+    const otherAnchor = makeAnchor({
+      id: "anchor-other",
+      source_spell_key: "hunters_mark",
+    });
+    const action = buildSpiritualWeaponFollowUpAction([otherAnchor, makeAnchor()], "p1");
+    expect(action?.anchorId).toBe("anchor-1");
+  });
+});

--- a/apps/control-web/src/features/combat-ui/player/spiritualWeapon.ts
+++ b/apps/control-web/src/features/combat-ui/player/spiritualWeapon.ts
@@ -1,0 +1,27 @@
+import type { CombatSpellAnchor } from "../../../shared/api/combatRepo";
+
+export type SpiritualWeaponFollowUpAction = {
+  anchorId: string;
+  position: { x: number; y: number };
+  remainingRounds: number | null | undefined;
+  maxMovementMeters: number;
+};
+
+export const buildSpiritualWeaponFollowUpAction = (
+  spellAnchors: CombatSpellAnchor[] | undefined | null,
+  myParticipantId: string | undefined | null,
+): SpiritualWeaponFollowUpAction | null => {
+  if (!myParticipantId) return null;
+  const anchor = spellAnchors?.find(
+    (a) =>
+      a.source_spell_key === "spiritual_weapon" &&
+      a.owner_participant_id === myParticipantId,
+  );
+  if (!anchor) return null;
+  return {
+    anchorId: anchor.id,
+    position: anchor.position,
+    remainingRounds: anchor.remaining_rounds,
+    maxMovementMeters: anchor.movement?.max_meters_per_follow_up ?? 6,
+  };
+};

--- a/apps/control-web/src/features/combat-ui/player/usePlayerCombatMode.ts
+++ b/apps/control-web/src/features/combat-ui/player/usePlayerCombatMode.ts
@@ -18,6 +18,7 @@ import {
   withActionState,
 } from "./usePlayerCombatModeHelpers";
 import { buildDragonbornBreathWeaponAction } from "./dragonbornBreathWeapon";
+import { buildSpiritualWeaponFollowUpAction } from "./spiritualWeapon";
 import { useConsumables } from "./useConsumables";
 import { spellRequiresExternalTarget } from "../../../pages/PlayerBoardPage/player-combat-debug/areaTargetingUi";
 import type {
@@ -170,6 +171,11 @@ export const usePlayerCombatMode = ({
     [playerSheet],
   );
 
+  const spiritualWeaponFollowUpAction = useMemo(
+    () => buildSpiritualWeaponFollowUpAction(combat.state?.spell_anchors, combat.myParticipant?.id),
+    [combat.state?.spell_anchors, combat.myParticipant?.id],
+  );
+
   const actorParticipant = combat.myParticipant ?? combat.currentParticipant ?? null;
   const actorParticipantId = actorParticipant?.id ?? null;
 
@@ -289,6 +295,25 @@ export const usePlayerCombatMode = ({
     });
   };
 
+  const handleSpiritualWeaponFollowUp = async (
+    anchorId: string,
+    destination: { x: number; y: number } | null,
+    targetRefId: string | null,
+    targetKind: string | null,
+  ) => {
+    if (!actorParticipantId) return;
+    await withActionState(async () => {
+      await combatRepo.spiritualWeaponAction(sessionId, {
+        actor_participant_id: actorParticipantId,
+        anchor_id: anchorId,
+        destination,
+        target_ref_id: targetRefId,
+        target_kind: targetKind,
+      });
+      await combat.refreshState();
+    });
+  };
+
   const handleDeathSave = async () => {
     if (!actorParticipantId) return;
     await withActionState(async () => {
@@ -332,8 +357,10 @@ export const usePlayerCombatMode = ({
     combat,
     deathSaveFeedback,
     dragonbornBreathWeaponAction,
+    spiritualWeaponFollowUpAction,
     handleAttack,
     handleDragonbornBreathWeapon,
+    handleSpiritualWeaponFollowUp,
     handleRequestReaction,
     handleDeathSave,
     handleEndTurn,

--- a/apps/control-web/src/features/combat-ui/spellAutomation.test.ts
+++ b/apps/control-web/src/features/combat-ui/spellAutomation.test.ts
@@ -18,6 +18,13 @@ describe("combat spell automation metadata", () => {
       requiresMap: false,
       handlerKey: "_cast_hunters_mark_automation"
     });
+    expect(getCombatSpellAutomation("spiritual_weapon")).toEqual({
+      automationMode: "special_handler",
+      defaultSpellMode: "spell_attack",
+      requiresEffectInputs: false,
+      requiresMap: true,
+      handlerKey: "_cast_spiritual_weapon_automation",
+    });
     expect(getCombatSpellAutomation("goodberry")).toEqual({
       automationMode: "special_handler",
       defaultSpellMode: "utility",

--- a/apps/control-web/src/features/combat-ui/spellAutomation.ts
+++ b/apps/control-web/src/features/combat-ui/spellAutomation.ts
@@ -95,6 +95,14 @@ export const getCombatSpellAutomation = (
         requiresMap: false,
         handlerKey: "_cast_goodberry_automation"
       };
+    case "spiritual_weapon":
+      return {
+        automationMode: "special_handler",
+        defaultSpellMode: "spell_attack",
+        requiresEffectInputs: false,
+        requiresMap: true,
+        handlerKey: "_cast_spiritual_weapon_automation",
+      };
     default:
       return null;
   }

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
@@ -255,6 +255,7 @@ export const PlayerSpellCastDialog = ({
     SpellInstanceSpatialValidation[]
   >([]);
   const [targetingMode, setTargetingMode] = useState(createInitialTargetingMode(spell.areaShape, spell.selectionType));
+  const [pointSpellInitialTargetId, setPointSpellInitialTargetId] = useState<string | null>(null);
   const handledSaveResolutionKeyRef = useRef<string | null>(null);
   const multiPreviewRequestGateRef = useRef(createPreviewRequestGate());
   const areaPreviewRequestGateRef = useRef(createPreviewRequestGate());
@@ -639,7 +640,9 @@ export const PlayerSpellCastDialog = ({
                   selectedSlotLevel,
                   originCell,
                   anchorCell,
-                  targetRefId: anchorTargetRefId,
+                  targetRefId: spell.areaShape
+                    ? anchorTargetRefId
+                    : pointSpellInitialTargetId,
                   spellEffectDice,
                   spellEffectBonus: parsedBonus,
                   spellDamageType,
@@ -831,9 +834,38 @@ export const PlayerSpellCastDialog = ({
             spellHighlights={highlights}
             onCellSelected={(cell) => {
               setAnchorCell(cell);
+              setPointSpellInitialTargetId(null);
               setTargetingMode("confirming");
             }}
           />
+        ) : null}
+
+        {isAreaSpell && !spell.areaShape && targetingMode === "confirming" && anchorCell && !result ? (
+          <div className="mt-4 rounded-2xl border border-fuchsia-400/20 bg-fuchsia-500/8 px-4 py-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-fuchsia-200">
+              Posição da arma: ({anchorCell.x}, {anchorCell.y})
+            </p>
+            <div className="mt-3">
+              <label className="block text-xs font-medium text-slate-300">Alvo inicial (opcional)</label>
+              <select
+                value={pointSpellInitialTargetId ?? ""}
+                onChange={(e) => setPointSpellInitialTargetId(e.target.value || null)}
+                className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white focus:border-fuchsia-400 focus:outline-none"
+              >
+                <option value="">Sem alvo inicial</option>
+                {participants
+                  .filter((p) => p.id !== actor.id && p.status !== "dead" && p.status !== "defeated")
+                  .map((p) => (
+                    <option key={p.id} value={p.ref_id ?? ""}>
+                      {p.display_name}
+                    </option>
+                  ))}
+              </select>
+              <p className="mt-2 text-xs text-slate-500">
+                O alvo deve estar adjacente à posição da arma. A validação final é feita pelo servidor.
+              </p>
+            </div>
+          </div>
         ) : null}
 
         {result && result.pending_save_id ? (
@@ -879,6 +911,7 @@ export const PlayerSpellCastDialog = ({
             onCancel={onClose}
             onClearArea={() => {
               clearAreaSelection();
+              setPointSpellInitialTargetId(null);
               setTargetingMode("area_target_select");
               setError(null);
             }}

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/areaTargetingUi.test.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/areaTargetingUi.test.ts
@@ -230,10 +230,14 @@ describe("semantic targeting mode routing", () => {
     expect(createInitialTargetingMode("sphere", "none")).toBe("single_target_select");
   });
 
-  it("requires map area targeting only for point/direction area spells", () => {
+  it("requires map area targeting for point spells (with or without areaShape) and direction area spells", () => {
     expect(requiresAreaTargetingSelection("point", "sphere")).toBe(true);
     expect(requiresAreaTargetingSelection("direction", "cone")).toBe(true);
-    expect(requiresAreaTargetingSelection("point", null)).toBe(false);
+    // point spells without areaShape (e.g. Spiritual Weapon) also use map selection
+    expect(requiresAreaTargetingSelection("point", null)).toBe(true);
+    expect(requiresAreaTargetingSelection("point", undefined)).toBe(true);
+    // direction without areaShape does not trigger area targeting
+    expect(requiresAreaTargetingSelection("direction", null)).toBe(false);
     expect(requiresAreaTargetingSelection("creature", "sphere")).toBe(false);
   });
 

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/areaTargetingUi.ts
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/areaTargetingUi.ts
@@ -26,7 +26,7 @@ export const requiresAreaTargetingSelection = (
   selectionType?: string | null,
   areaShape?: string | null,
 ): boolean =>
-  (selectionType === "point" || selectionType === "direction") && isAreaShape(areaShape);
+  selectionType === "point" || (selectionType === "direction" && isAreaShape(areaShape));
 
 export const spellRequiresExternalTarget = (
   selectionType?: string | null,

--- a/apps/control-web/src/shared/api/combatRepo.ts
+++ b/apps/control-web/src/shared/api/combatRepo.ts
@@ -551,6 +551,14 @@ export type CombatSpellAnchor = {
   metadata?: Record<string, unknown>;
 };
 
+export type SpiritualWeaponActionRequest = {
+  actor_participant_id: string;
+  anchor_id: string;
+  destination?: { x: number; y: number } | null;
+  target_ref_id?: string | null;
+  target_kind?: string | null;
+};
+
 export type CombatMapPreviewState = {
   session_id: string;
   version: number;
@@ -940,6 +948,11 @@ export const combatRepo = {
   standardAction: (sessionId: string, payload: CombatStandardActionRequest) =>
     http.post<CombatStandardActionResult>(
       `/sessions/${sessionId}/combat/action/standard`,
+      payload
+    ),
+  spiritualWeaponAction: (sessionId: string, payload: SpiritualWeaponActionRequest) =>
+    http.post<Record<string, unknown>>(
+      `/sessions/${sessionId}/combat/spiritual-weapon-action`,
       payload
     ),
   consumeReaction: (sessionId: string, payload: CombatConsumeReactionRequest) =>

--- a/apps/control-web/src/shared/i18n/enUS/combatUi.ts
+++ b/apps/control-web/src/shared/i18n/enUS/combatUi.ts
@@ -239,6 +239,16 @@ export const combatUiEnUSDictionary = {
   "combatUi.distancesPreset.far": "Far",
   "combatUi.distancesPreset.veryFar": "Very Far",
   "combatUi.distancesPreset.custom": "Custom",
-  "combatUi.combatActionFailed": "Combat action failed"
-  ,"combatUi.endTurnLabel": "End Turn"
+  "combatUi.combatActionFailed": "Combat action failed",
+  "combatUi.endTurnLabel": "End Turn",
+  "combatUi.spiritualWeaponAction": "Move / attack with Spiritual Weapon",
+  "combatUi.spiritualWeaponDestinationLabel": "Weapon destination",
+  "combatUi.spiritualWeaponDestinationX": "X",
+  "combatUi.spiritualWeaponDestinationY": "Y",
+  "combatUi.spiritualWeaponKeepPosition": "Keep current position",
+  "combatUi.spiritualWeaponOptionalTarget": "Target (optional)",
+  "combatUi.spiritualWeaponNoTarget": "No target",
+  "combatUi.spiritualWeaponRoundsLeft": "{rounds} rounds remaining",
+  "combatUi.spiritualWeaponCurrentPosition": "Current position",
+  "combatUi.spiritualWeaponConfirm": "Confirm action"
 } as const;

--- a/apps/control-web/src/shared/i18n/ptBR/combatUi.ts
+++ b/apps/control-web/src/shared/i18n/ptBR/combatUi.ts
@@ -241,6 +241,16 @@ export const combatUiPtBRDictionary = {
   "combatUi.distancesPreset.far": "Longe",
   "combatUi.distancesPreset.veryFar": "Muito Longe",
   "combatUi.distancesPreset.custom": "Personalizado",
-  "combatUi.combatActionFailed": "Falha na ação de combate"
-  ,"combatUi.endTurnLabel": "Encerrar turno"
+  "combatUi.combatActionFailed": "Falha na ação de combate",
+  "combatUi.endTurnLabel": "Encerrar turno",
+  "combatUi.spiritualWeaponAction": "Mover / atacar com Arma Espiritual",
+  "combatUi.spiritualWeaponDestinationLabel": "Destino da arma",
+  "combatUi.spiritualWeaponDestinationX": "X",
+  "combatUi.spiritualWeaponDestinationY": "Y",
+  "combatUi.spiritualWeaponKeepPosition": "Manter posição atual",
+  "combatUi.spiritualWeaponOptionalTarget": "Alvo (opcional)",
+  "combatUi.spiritualWeaponNoTarget": "Sem alvo",
+  "combatUi.spiritualWeaponRoundsLeft": "{rounds} rodadas restantes",
+  "combatUi.spiritualWeaponCurrentPosition": "Posição atual",
+  "combatUi.spiritualWeaponConfirm": "Confirmar ação"
 } as const;


### PR DESCRIPTION
# feat(spells): add Spiritual Weapon cast and follow-up UI

## Summary

Adds the full frontend combat flow for `Spiritual Weapon / Arma Espiritual`.

Players can now:

- cast the spell by selecting the anchor point on the map;
- optionally choose an initial target during cast confirmation;
- see the correct resolved damage preview by slot level;
- use a follow-up action on later turns while the spell anchor is active;
- move and attack with the weapon through the dedicated backend endpoint.

## What changed

### Spell automation UI metadata

Updated:

- `spellAutomation.ts`

Registered `spiritual_weapon` with:

- `defaultSpellMode: "spell_attack"`
- `requiresMap: true`

### Point-spell targeting support

Updated:

- `areaTargetingUi.ts`

`requiresAreaTargetingSelection` now treats any `selectionType === "point"` spell as requiring spatial selection, even when it has no `areaShape`.

This enables non-area point spells such as `Spiritual Weapon`.

### Initial cast flow

Updated:

- `PlayerSpellCastDialog.tsx`

Added optional initial-target selection during the confirmation step for point spells without `areaShape`.

For `Spiritual Weapon`, the player now:

1. selects the anchor point;
2. optionally selects an adjacent initial target;
3. confirms the cast.

### Follow-up API client

Updated:

- `combatRepo.ts`

Added:

- `SpiritualWeaponActionRequest`
- `spiritualWeaponAction(...)`

### Follow-up state + action wiring

Updated:

- `usePlayerCombatMode.ts`
- `PlayerActionPanels.tsx`
- `PlayerTurnPanel.tsx`
- `PlayerCombatModeShell.tsx`

Added detection of active owned anchors through `spellAnchors` and wired the follow-up action into the player combat UI.

### New helpers/components

Created:

- `spiritualWeapon.ts`
  - `buildSpiritualWeaponFollowUpAction`
- `SpiritualWeaponFollowUpDialog.tsx`
  - follow-up dialog with destination coordinates and target picker

### i18n

Updated PT-BR and EN-US dictionaries with new:

- `combatUi.spiritualWeapon*`

strings.

## Tests

Added/updated:

- `spiritualWeapon.test.ts`
  - 7 cases for `buildSpiritualWeaponFollowUpAction`
- `spellAutomation.test.ts`
  - coverage for `spiritual_weapon`
- `areaTargetingUi.test.ts`
  - updated coverage for point-spell targeting behavior

## Validation

```text
949/949 tests passing
0 TypeScript errors
```
## Notes

Spiritual Weapon follow-up actions are derived from spellAnchors, not active effects, matching the backend anchor-based model.

The current follow-up dialog uses coordinate inputs as a functional V1. A future UX refinement may allow direct map-click movement/targeting, but that is intentionally out of scope here.