### PR TITLE
feat(game-time) integrate game time with rest and manual advancement

### DIFF
--- a/apps/control-server/app/api/routes/sessions/activity.py
+++ b/apps/control-server/app/api/routes/sessions/activity.py
@@ -18,6 +18,7 @@ from app.schemas.session import (
     CombatLogEntryActivityEvent,
     ConsumableActivityEvent,
     EntityActivityEvent,
+    GameTimeActivityEvent,
     HitDiceActivityEvent,
     LevelUpActivityEvent,
     OutOfCombatEffectRemovedActivityEvent,
@@ -202,6 +203,20 @@ def get_session_activity(
                 username=command_user.username if command_user else None,
                 displayName=actor_name,
                 action=action,
+                secondsAdvanced=payload.get("secondsAdvanced") if isinstance(payload.get("secondsAdvanced"), int) else None,
+                gameTimeSeconds=payload.get("gameTimeSeconds") if isinstance(payload.get("gameTimeSeconds"), int) else None,
+                timestamp=command.created_at,
+                sessionOffsetSeconds=offset(command.created_at),
+            ))
+            continue
+        if command.command_type == "advance_game_time":
+            events.append(GameTimeActivityEvent(
+                userId=command.user_id,
+                username=command_user.username if command_user else None,
+                displayName=actor_name,
+                seconds=int(payload.get("seconds", 0) or 0),
+                gameTimeSeconds=int(payload.get("gameTimeSeconds", 0) or 0),
+                reason=payload.get("reason") if isinstance(payload.get("reason"), str) else None,
                 timestamp=command.created_at,
                 sessionOffsetSeconds=offset(command.created_at),
             ))

--- a/apps/control-server/app/api/routes/sessions/commands_common.py
+++ b/apps/control-server/app/api/routes/sessions/commands_common.py
@@ -28,6 +28,7 @@ VALID_COMMANDS = {
     "start_short_rest",
     "start_long_rest",
     "end_rest",
+    "advance_game_time",
 }
 
 

--- a/apps/control-server/app/api/routes/sessions/commands_service.py
+++ b/apps/control-server/app/api/routes/sessions/commands_service.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime, timezone
 
 from fastapi import HTTPException
+from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import Session as DbSession, select
 
 from app.models.campaign_member import CampaignMember
@@ -9,6 +10,11 @@ from app.models.combat import CombatPhase, CombatState
 from app.models.session import Session
 from app.models.session_state import SessionState
 from app.schemas.session import SessionCommandRequest
+from app.services.game_time import (
+    LONG_REST_GAME_TIME_SECONDS,
+    SHORT_REST_GAME_TIME_SECONDS,
+    advance_game_time_seconds,
+)
 from app.services.session_rest import (
     SessionRestError,
     end_rest as end_rest_state,
@@ -303,6 +309,26 @@ async def send_session_command_service(
         await publish_command_event(entry, event_type, event_payload, issued_at)
         return {"ok": True}
 
+    if payload.type == "advance_game_time":
+        seconds = payload_data.get("seconds")
+        if not isinstance(seconds, int) or seconds <= 0:
+            raise HTTPException(status_code=400, detail="seconds must be a positive integer")
+
+        advance_game_time_seconds(entry_id, seconds, session)
+
+        activity_payload["seconds"] = seconds
+        activity_payload["gameTimeSeconds"] = runtime.game_time_seconds
+        activity_payload["reason"] = "manual"
+        record_gm_activity(entry, member, user, "advance_game_time", activity_payload, issued_at, session)
+        session.add(runtime)
+        session.commit()
+
+        event_type = "game_time_advanced"
+        event_payload["seconds"] = seconds
+        event_payload["gameTimeSeconds"] = runtime.game_time_seconds
+        await publish_command_event(entry, event_type, event_payload, issued_at)
+        return {"ok": True}
+
     if payload.type in {"start_short_rest", "start_long_rest"}:
         if runtime.combat_active:
             raise HTTPException(status_code=400, detail="Cannot start a rest during combat")
@@ -361,6 +387,16 @@ async def send_session_command_service(
             raise HTTPException(status_code=400, detail=str(error)) from error
         session.add(state)
 
+    rest_delta = (
+        LONG_REST_GAME_TIME_SECONDS
+        if current_rest_state == "long_rest"
+        else SHORT_REST_GAME_TIME_SECONDS
+    )
+    advance_game_time_seconds(entry_id, rest_delta, session)
+    activity_payload["secondsAdvanced"] = rest_delta
+    activity_payload["gameTimeSeconds"] = runtime.game_time_seconds
+    session.add(runtime)
+
     session.commit()
     for state in states:
         session.refresh(state)
@@ -387,6 +423,8 @@ async def send_session_command_service(
     event_type = "rest_ended"
     event_payload["restType"] = ended_rest_type
     event_payload["issuedAt"] = issued_at.isoformat()
+    event_payload["secondsAdvanced"] = rest_delta
+    event_payload["gameTimeSeconds"] = runtime.game_time_seconds
     await publish_state_updates(entry, states, issued_at)
     await publish_command_event(entry, event_type, event_payload, issued_at)
     return {"ok": True}

--- a/apps/control-server/app/schemas/session.py
+++ b/apps/control-server/app/schemas/session.py
@@ -142,6 +142,8 @@ class RestActivityEvent(BaseModel):
     username: Optional[str] = None
     displayName: Optional[str] = None
     action: Literal["short_started", "short_ended", "long_started", "long_ended"]
+    secondsAdvanced: Optional[int] = None
+    gameTimeSeconds: Optional[int] = None
     timestamp: datetime
     sessionOffsetSeconds: int
 
@@ -333,6 +335,18 @@ class OutOfCombatEffectRemovedActivityEvent(BaseModel):
     sessionOffsetSeconds: int
 
 
+class GameTimeActivityEvent(BaseModel):
+    type: Literal["game_time"] = "game_time"
+    userId: Optional[str] = None
+    username: Optional[str] = None
+    displayName: Optional[str] = None
+    seconds: int
+    gameTimeSeconds: int
+    reason: Optional[str] = None
+    timestamp: datetime
+    sessionOffsetSeconds: int
+
+
 ActivityEvent = Union[
     RollActivityEvent,
     PurchaseActivityEvent,
@@ -351,6 +365,7 @@ ActivityEvent = Union[
     CombatLogEntryActivityEvent,
     OutOfCombatSpellCastActivityEvent,
     OutOfCombatEffectRemovedActivityEvent,
+    GameTimeActivityEvent,
 ]
 
 

--- a/apps/control-server/app/services/game_time.py
+++ b/apps/control-server/app/services/game_time.py
@@ -2,6 +2,9 @@ from sqlmodel import Session as DbSession, select
 
 from app.models.session_runtime import SessionRuntime
 
+SHORT_REST_GAME_TIME_SECONDS = 60 * 60
+LONG_REST_GAME_TIME_SECONDS = 8 * 60 * 60
+
 
 def _require_runtime(session_id: str, db: DbSession) -> SessionRuntime:
     runtime = db.exec(

--- a/apps/control-server/tests/test_game_time.py
+++ b/apps/control-server/tests/test_game_time.py
@@ -1,14 +1,33 @@
+import asyncio
 import unittest
-from unittest.mock import MagicMock
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from fastapi import HTTPException
+
+from app.models.campaign_member import RoleMode
 from app.models.session import SessionStatus
 from app.models.session_runtime import SessionRuntime
-from app.schemas.session import SessionRuntimeRead
+from app.schemas.session import (
+    GameTimeActivityEvent,
+    RestActivityEvent,
+    SessionRuntimeRead,
+)
 from app.services.game_time import (
+    LONG_REST_GAME_TIME_SECONDS,
+    SHORT_REST_GAME_TIME_SECONDS,
     advance_game_time_seconds,
     get_game_time_seconds,
     set_game_time_seconds,
 )
+
+
+def _run_async(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 def _mock_db(runtime=None):
@@ -99,3 +118,516 @@ class ResetRuntimeTests(unittest.TestCase):
         runtime.game_time_seconds = 9999
         reset_runtime(runtime)
         self.assertEqual(runtime.game_time_seconds, 0)
+
+
+class GameTimeConstantsTests(unittest.TestCase):
+    def test_short_rest_constant_is_3600(self):
+        self.assertEqual(SHORT_REST_GAME_TIME_SECONDS, 3600)
+
+    def test_long_rest_constant_is_28800(self):
+        self.assertEqual(LONG_REST_GAME_TIME_SECONDS, 28800)
+
+
+class AdvanceValidationTests(unittest.TestCase):
+    def test_advance_accepts_zero_as_no_op(self):
+        runtime = SessionRuntime(session_id="s1")
+        runtime.game_time_seconds = 100
+        db = _mock_db(runtime=runtime)
+        advance_game_time_seconds("s1", 0, db)
+        self.assertEqual(runtime.game_time_seconds, 100)
+
+
+class AdvanceGameTimeCommandTests(unittest.TestCase):
+    def _make_payload(self, seconds=None):
+        payload = MagicMock()
+        payload.type = "advance_game_time"
+        payload.payload = {"seconds": seconds} if seconds is not None else {}
+        return payload
+
+    def _make_runtime(self, game_time=0):
+        runtime = SessionRuntime(session_id="s1")
+        runtime.game_time_seconds = game_time
+        return runtime
+
+    def _make_entry(self):
+        entry = MagicMock()
+        entry.id = "s1"
+        entry.campaign_id = "c1"
+        entry.party_id = None
+        entry.status = SessionStatus.ACTIVE
+        return entry
+
+    def _make_member(self):
+        member = MagicMock()
+        member.id = "member-1"
+        member.display_name = "GM"
+        member.role_mode = RoleMode.GM
+        return member
+
+    def _make_user(self):
+        user = MagicMock()
+        user.id = "gm-1"
+        return user
+
+    @patch("app.api.routes.sessions.commands_service.publish_command_event", new_callable=AsyncMock)
+    @patch("app.api.routes.sessions.commands_service.advance_game_time_seconds")
+    @patch("app.api.routes.sessions.commands_service.get_session_rest_state", return_value="exploration")
+    @patch("app.api.routes.sessions.commands_service.get_or_create_session_runtime")
+    @patch("app.api.routes.sessions.commands_service.require_active_gm_session")
+    def test_valid_seconds_advances_game_time(
+        self, mock_require, mock_runtime, mock_rest_state, mock_advance, mock_publish,
+    ):
+        from app.api.routes.sessions.commands_service import send_session_command_service
+
+        runtime = self._make_runtime(game_time=100)
+        mock_require.return_value = (self._make_entry(), self._make_member())
+        mock_runtime.return_value = runtime
+        mock_advance.side_effect = lambda sid, delta, db: setattr(runtime, "game_time_seconds", runtime.game_time_seconds + delta)
+
+        db = MagicMock()
+
+        result = _run_async(
+            send_session_command_service("s1", self._make_payload(seconds=3600), self._make_user(), db)
+        )
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(runtime.game_time_seconds, 3700)
+        mock_publish.assert_awaited_once()
+        published_entry, event_type, event_payload, issued_at = mock_publish.await_args.args
+        self.assertEqual(published_entry.id, "s1")
+        self.assertEqual(event_type, "game_time_advanced")
+        self.assertEqual(event_payload["seconds"], 3600)
+        self.assertEqual(event_payload["gameTimeSeconds"], 3700)
+        self.assertIsNotNone(issued_at)
+
+    @patch("app.api.routes.sessions.commands_service.publish_command_event", new_callable=AsyncMock)
+    @patch("app.api.routes.sessions.commands_service.get_session_rest_state", return_value="exploration")
+    @patch("app.api.routes.sessions.commands_service.get_or_create_session_runtime")
+    @patch("app.api.routes.sessions.commands_service.require_active_gm_session")
+    def test_rejects_zero_seconds(
+        self, mock_require, mock_runtime, mock_rest_state, mock_publish,
+    ):
+        from app.api.routes.sessions.commands_service import send_session_command_service
+        import asyncio
+
+        mock_require.return_value = (self._make_entry(), self._make_member())
+        mock_runtime.return_value = self._make_runtime()
+
+        db = MagicMock()
+
+        with self.assertRaises(HTTPException) as ctx:
+            _run_async(
+                send_session_command_service("s1", self._make_payload(seconds=0), self._make_user(), db)
+            )
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    @patch("app.api.routes.sessions.commands_service.publish_command_event", new_callable=AsyncMock)
+    @patch("app.api.routes.sessions.commands_service.get_session_rest_state", return_value="exploration")
+    @patch("app.api.routes.sessions.commands_service.get_or_create_session_runtime")
+    @patch("app.api.routes.sessions.commands_service.require_active_gm_session")
+    def test_rejects_negative_seconds(
+        self, mock_require, mock_runtime, mock_rest_state, mock_publish,
+    ):
+        from app.api.routes.sessions.commands_service import send_session_command_service
+        import asyncio
+
+        mock_require.return_value = (self._make_entry(), self._make_member())
+        mock_runtime.return_value = self._make_runtime()
+
+        db = MagicMock()
+
+        with self.assertRaises(HTTPException) as ctx:
+            _run_async(
+                send_session_command_service("s1", self._make_payload(seconds=-100), self._make_user(), db)
+            )
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    @patch("app.api.routes.sessions.commands_service.publish_command_event", new_callable=AsyncMock)
+    @patch("app.api.routes.sessions.commands_service.get_session_rest_state", return_value="exploration")
+    @patch("app.api.routes.sessions.commands_service.get_or_create_session_runtime")
+    @patch("app.api.routes.sessions.commands_service.require_active_gm_session")
+    def test_rejects_missing_seconds(
+        self, mock_require, mock_runtime, mock_rest_state, mock_publish,
+    ):
+        from app.api.routes.sessions.commands_service import send_session_command_service
+        import asyncio
+
+        mock_require.return_value = (self._make_entry(), self._make_member())
+        mock_runtime.return_value = self._make_runtime()
+
+        payload = MagicMock()
+        payload.type = "advance_game_time"
+        payload.payload = {}
+
+        db = MagicMock()
+
+        with self.assertRaises(HTTPException) as ctx:
+            _run_async(
+                send_session_command_service("s1", payload, self._make_user(), db)
+            )
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    @patch("app.api.routes.sessions.commands_service.publish_command_event", new_callable=AsyncMock)
+    @patch("app.api.routes.sessions.commands_service.get_session_rest_state", return_value="exploration")
+    @patch("app.api.routes.sessions.commands_service.get_or_create_session_runtime")
+    @patch("app.api.routes.sessions.commands_service.require_active_gm_session")
+    def test_rejects_non_integer_seconds(
+        self, mock_require, mock_runtime, mock_rest_state, mock_publish,
+    ):
+        from app.api.routes.sessions.commands_service import send_session_command_service
+        import asyncio
+
+        mock_require.return_value = (self._make_entry(), self._make_member())
+        mock_runtime.return_value = self._make_runtime()
+
+        db = MagicMock()
+
+        with self.assertRaises(HTTPException) as ctx:
+            _run_async(
+                send_session_command_service("s1", self._make_payload(seconds=3.5), self._make_user(), db)
+            )
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    @patch("app.api.routes.sessions.commands_service.publish_command_event", new_callable=AsyncMock)
+    @patch("app.api.routes.sessions.commands_service.advance_game_time_seconds")
+    @patch("app.api.routes.sessions.commands_service.get_session_rest_state", return_value="exploration")
+    @patch("app.api.routes.sessions.commands_service.get_or_create_session_runtime")
+    @patch("app.api.routes.sessions.commands_service.require_active_gm_session")
+    def test_records_activity_with_reason_and_game_time(
+        self, mock_require, mock_runtime, mock_rest_state, mock_advance, mock_publish,
+    ):
+        from app.api.routes.sessions.commands_service import send_session_command_service
+        import asyncio
+
+        runtime = self._make_runtime(game_time=0)
+        mock_require.return_value = (self._make_entry(), self._make_member())
+        mock_runtime.return_value = runtime
+        mock_advance.side_effect = lambda sid, delta, db: setattr(runtime, "game_time_seconds", runtime.game_time_seconds + delta)
+
+        db = MagicMock()
+
+        _run_async(
+            send_session_command_service("s1", self._make_payload(seconds=3600), self._make_user(), db)
+        )
+
+        activity_adds = [c.args[0] for c in db.add.call_args_list]
+        cmd_events = [a for a in activity_adds if hasattr(a, "command_type")]
+        self.assertTrue(any(e.command_type == "advance_game_time" for e in cmd_events))
+        cmd = next(e for e in cmd_events if e.command_type == "advance_game_time")
+        self.assertEqual(cmd.payload_json["seconds"], 3600)
+        self.assertEqual(cmd.payload_json["gameTimeSeconds"], 3600)
+        self.assertEqual(cmd.payload_json["reason"], "manual")
+
+    @patch("app.api.routes.sessions.commands_service.publish_command_event", new_callable=AsyncMock)
+    @patch("app.api.routes.sessions.commands_service.get_session_rest_state", return_value="exploration")
+    @patch("app.api.routes.sessions.commands_service.get_or_create_session_runtime")
+    @patch("app.api.routes.sessions.commands_service.require_active_gm_session")
+    def test_requires_gm_authorization_for_manual_advancement(
+        self, mock_require, mock_runtime, mock_rest_state, mock_publish,
+    ):
+        from app.api.routes.sessions.commands_service import send_session_command_service
+
+        mock_require.side_effect = HTTPException(status_code=403, detail="GM required")
+        db = MagicMock()
+
+        with self.assertRaises(HTTPException) as ctx:
+            _run_async(
+                send_session_command_service("s1", self._make_payload(seconds=3600), self._make_user(), db)
+            )
+
+        self.assertEqual(ctx.exception.status_code, 403)
+        mock_runtime.assert_not_called()
+        mock_publish.assert_not_awaited()
+
+
+class RestGameTimeAdvanceTests(unittest.TestCase):
+    def _make_runtime(self, game_time=0):
+        runtime = SessionRuntime(session_id="s1")
+        runtime.game_time_seconds = game_time
+        return runtime
+
+    def _make_entry(self):
+        entry = MagicMock()
+        entry.id = "s1"
+        entry.campaign_id = "c1"
+        entry.party_id = None
+        entry.status = SessionStatus.ACTIVE
+        return entry
+
+    def _make_member(self):
+        member = MagicMock()
+        member.id = "member-1"
+        member.display_name = "GM"
+        member.role_mode = RoleMode.GM
+        return member
+
+    def _make_user(self):
+        user = MagicMock()
+        user.id = "gm-1"
+        return user
+
+    def _make_state(self, rest_state="exploration"):
+        state = MagicMock()
+        state.session_id = "s1"
+        state.player_user_id = "player-1"
+        state.state_json = {"restState": rest_state}
+        return state
+
+    def _make_end_rest_payload(self):
+        payload = MagicMock()
+        payload.type = "end_rest"
+        payload.payload = {}
+        return payload
+
+    @patch("app.api.routes.sessions.commands_service.publish_state_updates", new_callable=AsyncMock)
+    @patch("app.api.routes.sessions.commands_service.publish_command_event", new_callable=AsyncMock)
+    @patch("app.api.routes.sessions.commands_service.advance_game_time_seconds")
+    @patch("app.api.routes.sessions.commands_service.get_session_rest_state", return_value="short_rest")
+    @patch("app.api.routes.sessions.commands_service.get_or_create_session_runtime")
+    @patch("app.api.routes.sessions.commands_service.require_active_gm_session")
+    def test_short_rest_end_advances_by_3600(
+        self, mock_require, mock_runtime, mock_rest_state, mock_advance, mock_publish_cmd, mock_publish_state,
+    ):
+        from app.api.routes.sessions.commands_service import send_session_command_service
+        import asyncio
+
+        runtime = self._make_runtime(game_time=0)
+        entry = self._make_entry()
+        member = self._make_member()
+        user = self._make_user()
+        state = self._make_state(rest_state="short_rest")
+
+        mock_require.return_value = (entry, member)
+        mock_runtime.return_value = runtime
+
+        def advance_side_effect(session_id, delta, db):
+            runtime.game_time_seconds += delta
+
+        mock_advance.side_effect = advance_side_effect
+
+        db = MagicMock()
+        db.exec.return_value.all.return_value = [state]
+        db.exec.return_value.first.return_value = None
+
+        result = _run_async(
+            send_session_command_service("s1", self._make_end_rest_payload(), user, db)
+        )
+        self.assertEqual(result, {"ok": True})
+        mock_advance.assert_called_once_with("s1", SHORT_REST_GAME_TIME_SECONDS, db)
+        self.assertEqual(runtime.game_time_seconds, SHORT_REST_GAME_TIME_SECONDS)
+        self.assertEqual(state.state_json["restState"], "exploration")
+        mock_publish_state.assert_awaited_once()
+        published_entry, published_states, issued_at = mock_publish_state.await_args.args
+        self.assertEqual(published_entry.id, "s1")
+        self.assertEqual(len(published_states), 1)
+        self.assertIs(published_states[0], state)
+        self.assertIsNotNone(issued_at)
+        mock_publish_cmd.assert_awaited_once()
+        cmd_entry, event_type, event_payload, cmd_issued_at = mock_publish_cmd.await_args.args
+        self.assertEqual(cmd_entry.id, "s1")
+        self.assertEqual(event_type, "rest_ended")
+        self.assertEqual(event_payload["restType"], "short_rest")
+        self.assertEqual(event_payload["secondsAdvanced"], SHORT_REST_GAME_TIME_SECONDS)
+        self.assertEqual(event_payload["gameTimeSeconds"], SHORT_REST_GAME_TIME_SECONDS)
+        self.assertEqual(event_payload["issuedAt"], cmd_issued_at.isoformat())
+
+    @patch("app.api.routes.sessions.commands_service.publish_state_updates", new_callable=AsyncMock)
+    @patch("app.api.routes.sessions.commands_service.publish_command_event", new_callable=AsyncMock)
+    @patch("app.api.routes.sessions.commands_service.advance_game_time_seconds")
+    @patch("app.api.routes.sessions.commands_service.get_session_rest_state", return_value="long_rest")
+    @patch("app.api.routes.sessions.commands_service.get_or_create_session_runtime")
+    @patch("app.api.routes.sessions.commands_service.require_active_gm_session")
+    def test_long_rest_end_advances_by_28800(
+        self, mock_require, mock_runtime, mock_rest_state, mock_advance, mock_publish_cmd, mock_publish_state,
+    ):
+        from app.api.routes.sessions.commands_service import send_session_command_service
+        import asyncio
+
+        runtime = self._make_runtime(game_time=1000)
+        entry = self._make_entry()
+        member = self._make_member()
+        user = self._make_user()
+        state = self._make_state(rest_state="long_rest")
+
+        mock_require.return_value = (entry, member)
+        mock_runtime.return_value = runtime
+
+        def advance_side_effect(session_id, delta, db):
+            runtime.game_time_seconds += delta
+
+        mock_advance.side_effect = advance_side_effect
+
+        db = MagicMock()
+        db.exec.return_value.all.return_value = [state]
+        db.exec.return_value.first.return_value = None
+
+        result = _run_async(
+            send_session_command_service("s1", self._make_end_rest_payload(), user, db)
+        )
+        self.assertEqual(result, {"ok": True})
+        mock_advance.assert_called_once_with("s1", LONG_REST_GAME_TIME_SECONDS, db)
+        self.assertEqual(runtime.game_time_seconds, 1000 + LONG_REST_GAME_TIME_SECONDS)
+        self.assertEqual(state.state_json["restState"], "exploration")
+        mock_publish_cmd.assert_awaited_once()
+        published_entry, event_type, event_payload, issued_at = mock_publish_cmd.await_args.args
+        self.assertEqual(published_entry.id, "s1")
+        self.assertEqual(event_type, "rest_ended")
+        self.assertEqual(event_payload["restType"], "long_rest")
+        self.assertEqual(event_payload["secondsAdvanced"], LONG_REST_GAME_TIME_SECONDS)
+        self.assertEqual(event_payload["gameTimeSeconds"], 1000 + LONG_REST_GAME_TIME_SECONDS)
+        self.assertEqual(event_payload["issuedAt"], issued_at.isoformat())
+
+    @patch("app.api.routes.sessions.commands_service.publish_state_updates", new_callable=AsyncMock)
+    @patch("app.api.routes.sessions.commands_service.publish_command_event", new_callable=AsyncMock)
+    @patch("app.api.routes.sessions.commands_service.advance_game_time_seconds")
+    @patch("app.api.routes.sessions.commands_service.get_session_rest_state", return_value="short_rest")
+    @patch("app.api.routes.sessions.commands_service.get_or_create_session_runtime")
+    @patch("app.api.routes.sessions.commands_service.require_active_gm_session")
+    def test_rest_end_activity_payload_includes_game_time(
+        self, mock_require, mock_runtime, mock_rest_state, mock_advance, mock_publish_cmd, mock_publish_state,
+    ):
+        from app.api.routes.sessions.commands_service import send_session_command_service
+        import asyncio
+
+        runtime = self._make_runtime(game_time=500)
+        entry = self._make_entry()
+        member = self._make_member()
+        user = self._make_user()
+        state = self._make_state(rest_state="short_rest")
+
+        mock_require.return_value = (entry, member)
+        mock_runtime.return_value = runtime
+
+        def advance_side_effect(session_id, delta, db):
+            runtime.game_time_seconds += delta
+
+        mock_advance.side_effect = advance_side_effect
+
+        db = MagicMock()
+        db.exec.return_value.all.return_value = [state]
+        db.exec.return_value.first.return_value = None
+
+        _run_async(
+            send_session_command_service("s1", self._make_end_rest_payload(), user, db)
+        )
+
+        activity_adds = [c.args[0] for c in db.add.call_args_list]
+        cmd_events = [a for a in activity_adds if hasattr(a, "command_type")]
+        end_rest_cmd = next(e for e in cmd_events if e.command_type == "end_rest")
+        self.assertEqual(end_rest_cmd.payload_json["secondsAdvanced"], SHORT_REST_GAME_TIME_SECONDS)
+        self.assertEqual(end_rest_cmd.payload_json["gameTimeSeconds"], 500 + SHORT_REST_GAME_TIME_SECONDS)
+
+
+class GameTimeActivityMappingTests(unittest.TestCase):
+    def test_advance_game_time_maps_to_game_time_event(self):
+        from app.api.routes.sessions.activity import get_session_activity
+
+        entry = MagicMock()
+        entry.id = "session-1"
+        entry.campaign_id = "camp-1"
+        entry.started_at = None
+        entry.created_at = None
+
+        member = MagicMock()
+        member.id = "member-1"
+
+        cmd = MagicMock()
+        cmd.user_id = "gm-1"
+        cmd.actor_name = "GM"
+        cmd.command_type = "advance_game_time"
+        cmd.created_at = datetime(2026, 5, 10, 12, 0, 0, tzinfo=timezone.utc)
+        cmd.payload_json = {
+            "seconds": 3600,
+            "gameTimeSeconds": 3600,
+            "reason": "manual",
+        }
+
+        gm_user = MagicMock()
+        gm_user.username = "gm"
+        gm_user.display_name = "GM"
+
+        db = MagicMock()
+        call_count = [0]
+
+        def exec_side(query):
+            result = MagicMock()
+            idx = call_count[0]
+            call_count[0] += 1
+            if idx == 0:
+                result.first.return_value = entry
+            elif idx == 1:
+                result.first.return_value = member
+            elif idx in (2, 3):
+                result.all.return_value = []
+            else:
+                result.all.return_value = [(cmd, gm_user)]
+            return result
+
+        db.exec.side_effect = exec_side
+
+        user = MagicMock()
+        user.id = "gm-1"
+        events = get_session_activity("session-1", user=user, session=db)
+
+        self.assertEqual(len(events), 1)
+        event = events[0]
+        self.assertIsInstance(event, GameTimeActivityEvent)
+        self.assertEqual(event.seconds, 3600)
+        self.assertEqual(event.gameTimeSeconds, 3600)
+        self.assertEqual(event.reason, "manual")
+
+    def test_rest_end_maps_with_game_time_fields(self):
+        from app.api.routes.sessions.activity import get_session_activity
+
+        entry = MagicMock()
+        entry.id = "session-1"
+        entry.campaign_id = "camp-1"
+        entry.started_at = None
+        entry.created_at = None
+
+        member = MagicMock()
+        member.id = "member-1"
+
+        cmd = MagicMock()
+        cmd.user_id = "gm-1"
+        cmd.actor_name = "GM"
+        cmd.command_type = "end_rest"
+        cmd.created_at = datetime(2026, 5, 10, 12, 0, 0, tzinfo=timezone.utc)
+        cmd.payload_json = {
+            "restType": "short_rest",
+            "secondsAdvanced": 3600,
+            "gameTimeSeconds": 3600,
+        }
+
+        gm_user = MagicMock()
+        gm_user.username = "gm"
+        gm_user.display_name = "GM"
+
+        db = MagicMock()
+        call_count = [0]
+
+        def exec_side(query):
+            result = MagicMock()
+            idx = call_count[0]
+            call_count[0] += 1
+            if idx == 0:
+                result.first.return_value = entry
+            elif idx == 1:
+                result.first.return_value = member
+            elif idx in (2, 3):
+                result.all.return_value = []
+            else:
+                result.all.return_value = [(cmd, gm_user)]
+            return result
+
+        db.exec.side_effect = exec_side
+
+        user = MagicMock()
+        user.id = "gm-1"
+        events = get_session_activity("session-1", user=user, session=db)
+
+        self.assertEqual(len(events), 1)
+        event = events[0]
+        self.assertIsInstance(event, RestActivityEvent)
+        self.assertEqual(event.action, "short_ended")
+        self.assertEqual(event.secondsAdvanced, 3600)
+        self.assertEqual(event.gameTimeSeconds, 3600)

--- a/apps/control-web/src/features/sessions/hooks/sessionRuntime.reducer.test.ts
+++ b/apps/control-web/src/features/sessions/hooks/sessionRuntime.reducer.test.ts
@@ -59,4 +59,53 @@ describe("sessionRuntime.reducer", () => {
     expect(ended.lastCommand).toBeNull();
     expect(ended.sessionEndedAt).toBe("2026-03-24T10:00:00.000Z");
   });
+
+  it("updates gameTimeSeconds on game_time_advanced", () => {
+    const result = reduceSessionRuntimeMessage(createInitialSessionRuntimeState(), {
+      type: "game_time_advanced",
+      payload: { seconds: 3600, gameTimeSeconds: 3600 },
+    });
+    expect(result.gameTimeSeconds).toBe(3600);
+  });
+
+  it("preserves gameTimeSeconds if payload has no gameTimeSeconds on game_time_advanced", () => {
+    const state = { ...createInitialSessionRuntimeState(), gameTimeSeconds: 500 };
+    const result = reduceSessionRuntimeMessage(state, {
+      type: "game_time_advanced",
+      payload: { seconds: 100 },
+    });
+    expect(result.gameTimeSeconds).toBe(500);
+  });
+
+  it("updates gameTimeSeconds on rest_ended", () => {
+    const state = {
+      ...createInitialSessionRuntimeState(),
+      restState: "short_rest" as const,
+      gameTimeSeconds: 0,
+    };
+    const result = reduceSessionRuntimeMessage(state, {
+      type: "rest_ended",
+      payload: { restType: "short_rest", gameTimeSeconds: 3600, secondsAdvanced: 3600 },
+    });
+    expect(result.restState).toBe("exploration");
+    expect(result.gameTimeSeconds).toBe(3600);
+  });
+
+  it("preserves gameTimeSeconds if rest_ended has no gameTimeSeconds", () => {
+    const state = {
+      ...createInitialSessionRuntimeState(),
+      restState: "short_rest" as const,
+      gameTimeSeconds: 500,
+    };
+    const result = reduceSessionRuntimeMessage(state, {
+      type: "rest_ended",
+      payload: { restType: "short_rest" },
+    });
+    expect(result.restState).toBe("exploration");
+    expect(result.gameTimeSeconds).toBe(500);
+  });
+
+  it("defaults gameTimeSeconds to 0", () => {
+    expect(createInitialSessionRuntimeState().gameTimeSeconds).toBe(0);
+  });
 });

--- a/apps/control-web/src/features/sessions/hooks/sessionRuntime.reducer.ts
+++ b/apps/control-web/src/features/sessions/hooks/sessionRuntime.reducer.ts
@@ -60,6 +60,12 @@ export const reduceSessionRuntimeMessage = (
       return {
         ...current,
         restState: "exploration",
+        gameTimeSeconds: typeof payload?.gameTimeSeconds === "number" ? payload.gameTimeSeconds : current.gameTimeSeconds,
+      };
+    case "game_time_advanced":
+      return {
+        ...current,
+        gameTimeSeconds: typeof payload?.gameTimeSeconds === "number" ? payload.gameTimeSeconds : current.gameTimeSeconds,
       };
     case "gm_command": {
       const commandPayload = payload?.command && typeof payload.command === "string"

--- a/apps/control-web/src/features/sessions/hooks/sessionRuntime.types.ts
+++ b/apps/control-web/src/features/sessions/hooks/sessionRuntime.types.ts
@@ -7,7 +7,8 @@ export type SessionCommand = {
     | "request_roll"
     | "start_short_rest"
     | "start_long_rest"
-    | "end_rest";
+    | "end_rest"
+    | "advance_game_time";
   data?: Record<string, unknown>;
   issuedBy?: string;
   issuedAt?: string;
@@ -22,6 +23,7 @@ export type SessionRuntimeState = {
   shopOpen: boolean;
   combatActive: boolean;
   restState: SessionRestState;
+  gameTimeSeconds: number;
 };
 
 export const createInitialSessionRuntimeState = (): SessionRuntimeState => ({
@@ -31,4 +33,5 @@ export const createInitialSessionRuntimeState = (): SessionRuntimeState => ({
   shopOpen: false,
   combatActive: false,
   restState: "exploration",
+  gameTimeSeconds: 0,
 });

--- a/apps/control-web/src/pages/GmDashboardPage/gmDashboard.types.ts
+++ b/apps/control-web/src/pages/GmDashboardPage/gmDashboard.types.ts
@@ -10,7 +10,8 @@ export type CommandFeedback = {
     | "end_combat"
     | "start_short_rest"
     | "start_long_rest"
-    | "end_rest";
+    | "end_rest"
+    | "advance_game_time";
   message: string;
 };
 

--- a/apps/control-web/src/pages/GmDashboardPage/useGmDashboardActions.ts
+++ b/apps/control-web/src/pages/GmDashboardPage/useGmDashboardActions.ts
@@ -192,7 +192,9 @@ export const useGmDashboardActions = ({
                     ? "Long rest started for the whole table."
                     : type === "end_rest"
                       ? "The active rest was ended for the whole table."
-                      : "Roll request accepted by the server.";
+                      : type === "advance_game_time"
+                        ? "Game time advanced."
+                        : "Roll request accepted by the server.";
       if (commandFeedbackTimeoutRef.current) window.clearTimeout(commandFeedbackTimeoutRef.current);
       setCommandFeedback({ tone: "success", type, message });
       commandFeedbackTimeoutRef.current = window.setTimeout(() => {

--- a/apps/control-web/src/shared/api/sessionsRepo.ts
+++ b/apps/control-web/src/shared/api/sessionsRepo.ts
@@ -105,6 +105,8 @@ export type RestActivityEvent = {
   username?: string | null;
   displayName?: string | null;
   action: "short_started" | "short_ended" | "long_started" | "long_ended";
+  secondsAdvanced?: number | null;
+  gameTimeSeconds?: number | null;
   timestamp: string;
   sessionOffsetSeconds: number;
 };
@@ -379,6 +381,18 @@ export type OutOfCombatEffectRemovedActivityEvent = {
   sessionOffsetSeconds: number;
 };
 
+export type GameTimeActivityEvent = {
+  type: "game_time";
+  userId?: string | null;
+  username?: string | null;
+  displayName?: string | null;
+  seconds: number;
+  gameTimeSeconds: number;
+  reason?: string | null;
+  timestamp: string;
+  sessionOffsetSeconds: number;
+};
+
 export type ActivityEvent =
   | RollActivityEvent
   | PurchaseActivityEvent
@@ -396,7 +410,8 @@ export type ActivityEvent =
   | RollResolvedActivityEvent
   | CombatLogEntryActivityEvent
   | OutOfCombatSpellCastActivityEvent
-  | OutOfCombatEffectRemovedActivityEvent;
+  | OutOfCombatEffectRemovedActivityEvent
+  | GameTimeActivityEvent;
 
 export type SessionJoinResponse = {
   campaignId: string;


### PR DESCRIPTION
# PR: feat(game-time) integrate game time with rest and manual advancement

## Description

Este PR integra o sistema de tempo de jogo (`game_time_seconds`) com as mecânicas de descanso (Short e Long Rest) e introduz a capacidade para o Mestre (GM) avançar o tempo manualmente. A implementação garante que o tempo de jogo seja um reflexo fiel das atividades realizadas na sessão.

## Changes

### Backend
- **Constants:** Definidos tempos canônicos de descanso:
  - `SHORT_REST_GAME_TIME_SECONDS = 3600` (1 hora)
  - `LONG_REST_GAME_TIME_SECONDS = 28800` (8 horas)
- **Commands:** Adicionado comando `advance_game_time` exclusivo para GMs com validação de inteiros positivos.
- **Rest Integration:** O fim de um descanso agora avança automaticamente o relógio global dentro da mesma transação.
- **Events & Realtime:**
  - Adicionado `GameTimeActivityEvent` para registrar avanços manuais no log de atividades.
  - Payloads de `rest_ended` e `game_time_advanced` agora incluem `secondsAdvanced` e o novo `gameTimeSeconds` total.

### Frontend
- **State Management:** Adicionado `gameTimeSeconds` ao estado de runtime da sessão.
- **Typing:** Definidas tipagens para o comando de avanço de tempo e para os novos eventos de atividade.
- **Reducers:** Atualizada a manipulação de eventos em tempo real para sincronizar o relógio do frontend imediatamente após descansos ou ajustes manuais.

## Implementation Summary

| Scope | Details |
| :--- | :--- |
| **Logic** | Automatic time progression on `end_rest` (Short: 1h, Long: 8h) |
| **Security** | GM-only authorization for manual time adjustments |
| **Payloads** | Enriched activity/realtime events with `secondsAdvanced` |
| **Database** | Integrated advancement into existing rest transactions |

## Test Coverage

- **Advancement:** Sucesso no avanço manual e validação de payloads em tempo real.
- **Guards:** Validação estrita contra valores negativos, zero, ausentes ou não-inteiros.
- **Auth:** Verificação de permissões de GM (sem efeitos colaterais em caso de rejeição).
- **Rests:** Garantia de que o tempo avança corretamente em ambos os tipos de descanso sem quebrar o comportamento atual.
- **Events:** Mapeamento correto de eventos de atividade para auditoria da sessão.

## Validation

- **Tests:** `2094` testes passando.
- **Migrations:** Single clean Alembic head.
- **Realtime:** Contrato de payload validado para `game_time_advanced` e `rest_ended`.