### PR TITLE
feat(combat) authoritative game time accounting (#269)

### DIFF
--- a/apps/control-server/alembic/versions/0076_combat_game_time_accounting.py
+++ b/apps/control-server/alembic/versions/0076_combat_game_time_accounting.py
@@ -1,0 +1,40 @@
+"""add combat game-time accounting fields
+
+Revision ID: 0076_combat_game_time_accounting
+Revises: 0075_game_time_seconds
+Create Date: 2026-05-10 00:30:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0076_combat_game_time_accounting"
+down_revision = "0075_game_time_seconds"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "combat_state",
+        sa.Column(
+            "active_started_at_game_time_seconds",
+            sa.BigInteger(),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "combat_state",
+        sa.Column(
+            "accounted_game_time_rounds",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("combat_state", "accounted_game_time_rounds")
+    op.drop_column("combat_state", "active_started_at_game_time_seconds")

--- a/apps/control-server/app/models/combat.py
+++ b/apps/control-server/app/models/combat.py
@@ -28,6 +28,8 @@ class CombatState(SQLModel, table=True):
     )
     round: int = Field(default=1)
     current_turn_index: int = Field(default=0)
+    active_started_at_game_time_seconds: int | None = Field(default=None, exclude=True)
+    accounted_game_time_rounds: int = Field(default=0, exclude=True)
     participants: list[dict] = Field(
         default_factory=list,
         sa_column=Column(JSONB, nullable=False, server_default="[]"),

--- a/apps/control-server/app/services/combat_service/lifecycle.py
+++ b/apps/control-server/app/services/combat_service/lifecycle.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from app.models.combat import CombatPhase
 from app.schemas.combat import CombatMapSelection
+from app.services.game_time import get_game_time_seconds
 
 from .lifecycle_initiative import CombatLifecycleInitiativeMixin
 from .lifecycle_turns import CombatLifecycleTurnsMixin
@@ -22,3 +24,23 @@ class CombatLifecycleMixin(CombatLifecycleInitiativeMixin, CombatLifecycleTurnsM
         gridHeight=14,
         calibration={"x": 0, "y": 0, "width": 1, "height": 1},
     )
+
+    @classmethod
+    def _mark_active_combat_time_started(cls, db, session_id: str, state) -> None:
+        state.active_started_at_game_time_seconds = get_game_time_seconds(session_id, db)
+        state.accounted_game_time_rounds = 0
+
+    @classmethod
+    def _ensure_active_combat_time_accounting_started(cls, db, session_id: str, state) -> None:
+        if state.phase not in (CombatPhase.active, "active"):
+            return
+        if state.active_started_at_game_time_seconds is not None:
+            if not isinstance(state.accounted_game_time_rounds, int) or state.accounted_game_time_rounds < 0:
+                state.accounted_game_time_rounds = 0
+            return
+        state.active_started_at_game_time_seconds = get_game_time_seconds(session_id, db)
+        existing_accounted_rounds = state.accounted_game_time_rounds
+        if not isinstance(existing_accounted_rounds, int) or existing_accounted_rounds < 0:
+            existing_accounted_rounds = 0
+        legacy_completed_rounds = max(0, int(getattr(state, "round", 1) or 1) - 1)
+        state.accounted_game_time_rounds = max(existing_accounted_rounds, legacy_completed_rounds)

--- a/apps/control-server/app/services/combat_service/lifecycle_initiative.py
+++ b/apps/control-server/app/services/combat_service/lifecycle_initiative.py
@@ -125,6 +125,8 @@ class CombatLifecycleInitiativeMixin:
             return state
         participant["initiative"] = initiative
         transition = cls._maybe_advance_from_initiative(state)
+        if transition == "active":
+            cls._mark_active_combat_time_started(db, session_id, state)
         from sqlalchemy.orm.attributes import flag_modified
 
         flag_modified(state, "participants")
@@ -288,6 +290,8 @@ class CombatLifecycleInitiativeMixin:
             if participant["id"] in updates:
                 participant["initiative"] = updates[participant["id"]]
         transition = cls._maybe_advance_from_initiative(state)
+        if transition == "active":
+            cls._mark_active_combat_time_started(db, session_id, state)
         from sqlalchemy.orm.attributes import flag_modified
 
         flag_modified(state, "participants")
@@ -321,6 +325,7 @@ class CombatLifecycleInitiativeMixin:
         state.phase = CombatPhase.active
         state.round = 1
         state.current_turn_index = 0
+        cls._mark_active_combat_time_started(db, session_id, state)
         cls._reset_turn_resources(state.participants[0])
 
         from sqlalchemy.orm.attributes import flag_modified

--- a/apps/control-server/app/services/combat_service/lifecycle_turns.py
+++ b/apps/control-server/app/services/combat_service/lifecycle_turns.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from app.models.combat import CombatPhase
+from app.services.game_time import (
+    COMBAT_ROUND_GAME_TIME_SECONDS,
+    advance_game_time_seconds,
+)
 
 from .exceptions import CombatServiceError
 from .limiar_map_projection import (
@@ -52,6 +56,7 @@ class CombatLifecycleTurnsMixin:
     ):
         state = cls.get_state(db, session_id)
         cls._require_active(state)
+        cls._ensure_active_combat_time_accounting_started(db, session_id, state)
         attacker = cls._resolve_actor_participant(state, actor_user_id, is_gm, actor_participant_id)
         if not is_gm and not skip_turn_end_validation:
             if attacker.get("status") == "downed":
@@ -86,6 +91,15 @@ class CombatLifecycleTurnsMixin:
             if state.current_turn_index >= len(state.participants):
                 state.current_turn_index = 0
                 state.round += 1
+                completed_round_count = max(0, state.round - 1)
+                if state.accounted_game_time_rounds < completed_round_count:
+                    missing_rounds = completed_round_count - state.accounted_game_time_rounds
+                    advance_game_time_seconds(
+                        session_id,
+                        missing_rounds * COMBAT_ROUND_GAME_TIME_SECONDS,
+                        db,
+                    )
+                    state.accounted_game_time_rounds += missing_rounds
                 await cls._emit_log(session_id, {"message": f"Round {state.round} started!"})
             status = state.participants[state.current_turn_index].get("status", "active")
             if status not in ("dead", "defeated", "stable"):
@@ -130,6 +144,17 @@ class CombatLifecycleTurnsMixin:
         state = cls.get_state(db, session_id)
         if not state:
             raise CombatServiceError("Combat not found", 404)
+        if state.phase in (CombatPhase.active, "active"):
+            cls._ensure_active_combat_time_accounting_started(db, session_id, state)
+            started_rounds = max(1, state.round)
+            missing_rounds = started_rounds - state.accounted_game_time_rounds
+            if missing_rounds > 0:
+                advance_game_time_seconds(
+                    session_id,
+                    missing_rounds * COMBAT_ROUND_GAME_TIME_SECONDS,
+                    db,
+                )
+                state.accounted_game_time_rounds += missing_rounds
 
         concentration_source_ids: set[str] = set()
         for participant in state.participants:

--- a/apps/control-server/app/services/game_time.py
+++ b/apps/control-server/app/services/game_time.py
@@ -4,6 +4,7 @@ from app.models.session_runtime import SessionRuntime
 
 SHORT_REST_GAME_TIME_SECONDS = 60 * 60
 LONG_REST_GAME_TIME_SECONDS = 8 * 60 * 60
+COMBAT_ROUND_GAME_TIME_SECONDS = 6
 
 
 def _require_runtime(session_id: str, db: DbSession) -> SessionRuntime:

--- a/apps/control-server/tests/_combat_test_flow.py
+++ b/apps/control-server/tests/_combat_test_flow.py
@@ -196,8 +196,9 @@ class CombatFlowTestsMixin:
     @patch("app.services.combat.CombatService._emit_log")
     async def test_set_initiative(self, mock_emit_log, mock_emit_state):
         self.state.use_map = False
-        with patch(
-            "app.services.combat.CombatService.get_state", return_value=self.state
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat_service.lifecycle.get_game_time_seconds", return_value=120),
         ):
             req = CombatSetInitiativeRequest(
                 initiatives=[
@@ -211,6 +212,8 @@ class CombatFlowTestsMixin:
             self.assertEqual(state.phase, CombatPhase.active)
             self.assertEqual(state.participants[0]["id"], "e1")
             self.assertEqual(state.participants[1]["id"], "p1")
+            self.assertEqual(state.active_started_at_game_time_seconds, 120)
+            self.assertEqual(state.accounted_game_time_rounds, 0)
 
     @patch("app.services.combat.CombatService._emit_state")
     @patch("app.services.combat.CombatService._emit_log")
@@ -583,6 +586,8 @@ class CombatFlowTestsMixin:
     ):
         self.state.phase = CombatPhase.placement
         self.state.use_map = True
+        self.state.active_started_at_game_time_seconds = None
+        self.state.accounted_game_time_rounds = 9
         self.state.participants[0]["initiative"] = 20
         self.state.participants[0]["turn_resources"] = {
             "action_used": True,
@@ -590,7 +595,10 @@ class CombatFlowTestsMixin:
             "reaction_used": True,
         }
 
-        with patch("app.services.combat.CombatService.get_state", return_value=self.state):
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat_service.lifecycle.get_game_time_seconds", return_value=240),
+        ):
             updated = await CombatService.confirm_placement(
                 self.db,
                 "session-123",
@@ -601,7 +609,184 @@ class CombatFlowTestsMixin:
         self.assertFalse(updated.participants[0]["turn_resources"]["action_used"])
         self.assertFalse(updated.participants[0]["turn_resources"]["bonus_action_used"])
         self.assertFalse(updated.participants[0]["turn_resources"]["reaction_used"])
+        self.assertEqual(updated.active_started_at_game_time_seconds, 240)
+        self.assertEqual(updated.accounted_game_time_rounds, 0)
         mock_project_start.assert_called_once()
+
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_log")
+    async def test_next_turn_wrap_advances_authoritative_game_time(
+        self,
+        mock_emit_log,
+        mock_emit_state,
+    ):
+        self.state.phase = CombatPhase.active
+        self.state.current_turn_index = 0
+        self.state.active_started_at_game_time_seconds = 100
+        self.state.accounted_game_time_rounds = 0
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat_service.lifecycle_turns.advance_game_time_seconds") as mock_advance,
+        ):
+            state = await CombatService.next_turn(
+                self.db, "session-123", actor_user_id="user-xyz", is_gm=True
+            )
+            self.assertEqual(state.current_turn_index, 1)
+            mock_advance.assert_not_called()
+
+            state = await CombatService.next_turn(
+                self.db, "session-123", actor_user_id="user-xyz", is_gm=True
+            )
+
+        self.assertEqual(state.current_turn_index, 0)
+        self.assertEqual(state.round, 2)
+        self.assertEqual(state.accounted_game_time_rounds, 1)
+        mock_advance.assert_called_once_with("session-123", 6, self.db)
+
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_log")
+    async def test_next_turn_second_wrap_advances_second_round_chunk(
+        self,
+        mock_emit_log,
+        mock_emit_state,
+    ):
+        self.state.phase = CombatPhase.active
+        self.state.current_turn_index = 0
+        self.state.active_started_at_game_time_seconds = 100
+        self.state.accounted_game_time_rounds = 0
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat_service.lifecycle_turns.advance_game_time_seconds") as mock_advance,
+        ):
+            for _ in range(4):
+                state = await CombatService.next_turn(
+                    self.db, "session-123", actor_user_id="user-xyz", is_gm=True
+                )
+
+        self.assertEqual(state.round, 3)
+        self.assertEqual(state.accounted_game_time_rounds, 2)
+        self.assertEqual(
+            mock_advance.call_args_list,
+            [
+                unittest.mock.call("session-123", 6, self.db),
+                unittest.mock.call("session-123", 6, self.db),
+            ],
+        )
+
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_log")
+    async def test_next_turn_lazily_initializes_legacy_active_clock_state(
+        self,
+        mock_emit_log,
+        mock_emit_state,
+    ):
+        self.state.phase = CombatPhase.active
+        self.state.round = 4
+        self.state.current_turn_index = 0
+        self.state.active_started_at_game_time_seconds = None
+        self.state.accounted_game_time_rounds = 0
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat_service.lifecycle.get_game_time_seconds", return_value=700),
+            patch("app.services.combat_service.lifecycle_turns.advance_game_time_seconds") as mock_advance,
+        ):
+            state = await CombatService.next_turn(
+                self.db, "session-123", actor_user_id="user-xyz", is_gm=True
+            )
+
+        self.assertEqual(state.current_turn_index, 1)
+        self.assertEqual(state.active_started_at_game_time_seconds, 700)
+        self.assertEqual(state.accounted_game_time_rounds, 3)
+        mock_advance.assert_not_called()
+
+    @patch("app.services.combat_service.lifecycle_turns.persist_surviving_spell_effects")
+    @patch("app.services.combat.CombatService._emit_state", new_callable=unittest.mock.AsyncMock)
+    @patch("app.services.combat.CombatService._emit_log", new_callable=unittest.mock.AsyncMock)
+    async def test_end_combat_round_one_charges_partial_round_once(
+        self,
+        mock_emit_log,
+        mock_emit_state,
+        mock_persist,
+    ):
+        self.state.phase = CombatPhase.active
+        self.state.round = 1
+        self.state.active_started_at_game_time_seconds = 500
+        self.state.accounted_game_time_rounds = 0
+        for participant in self.state.participants:
+            participant["active_effects"] = []
+            participant["turn_resources"] = dict(CombatService._DEFAULT_TURN_RESOURCES)
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat_service.lifecycle_turns.advance_game_time_seconds") as mock_advance,
+        ):
+            result = await CombatService.end_combat(self.db, "session-123", is_gm=True)
+            second_result = await CombatService.end_combat(self.db, "session-123", is_gm=True)
+
+        self.assertEqual(result.phase, CombatPhase.ended)
+        self.assertEqual(second_result.phase, CombatPhase.ended)
+        self.assertEqual(self.state.accounted_game_time_rounds, 1)
+        mock_advance.assert_called_once_with("session-123", 6, self.db)
+        mock_persist.assert_called()
+
+    @patch("app.services.combat_service.lifecycle_turns.persist_surviving_spell_effects")
+    @patch("app.services.combat.CombatService._emit_state", new_callable=unittest.mock.AsyncMock)
+    @patch("app.services.combat.CombatService._emit_log", new_callable=unittest.mock.AsyncMock)
+    async def test_end_combat_without_active_phase_does_not_advance_game_time(
+        self,
+        mock_emit_log,
+        mock_emit_state,
+        mock_persist,
+    ):
+        self.state.phase = CombatPhase.initiative
+        self.state.active_started_at_game_time_seconds = None
+        self.state.accounted_game_time_rounds = 0
+        for participant in self.state.participants:
+            participant["active_effects"] = []
+            participant["turn_resources"] = dict(CombatService._DEFAULT_TURN_RESOURCES)
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat_service.lifecycle_turns.advance_game_time_seconds") as mock_advance,
+        ):
+            result = await CombatService.end_combat(self.db, "session-123", is_gm=True)
+
+        self.assertEqual(result.phase, CombatPhase.ended)
+        mock_advance.assert_not_called()
+        mock_persist.assert_called_once()
+
+    @patch("app.services.combat_service.lifecycle_turns.persist_surviving_spell_effects")
+    @patch("app.services.combat.CombatService._emit_state", new_callable=unittest.mock.AsyncMock)
+    @patch("app.services.combat.CombatService._emit_log", new_callable=unittest.mock.AsyncMock)
+    async def test_end_combat_lazily_initializes_legacy_active_clock_state(
+        self,
+        mock_emit_log,
+        mock_emit_state,
+        mock_persist,
+    ):
+        self.state.phase = CombatPhase.active
+        self.state.round = 4
+        self.state.active_started_at_game_time_seconds = None
+        self.state.accounted_game_time_rounds = 0
+        for participant in self.state.participants:
+            participant["active_effects"] = []
+            participant["turn_resources"] = dict(CombatService._DEFAULT_TURN_RESOURCES)
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat_service.lifecycle.get_game_time_seconds", return_value=700),
+            patch("app.services.combat_service.lifecycle_turns.advance_game_time_seconds") as mock_advance,
+        ):
+            result = await CombatService.end_combat(self.db, "session-123", is_gm=True)
+
+        self.assertEqual(result.phase, CombatPhase.ended)
+        self.assertEqual(self.state.active_started_at_game_time_seconds, 700)
+        self.assertEqual(self.state.accounted_game_time_rounds, 4)
+        mock_advance.assert_called_once_with("session-123", 6, self.db)
+        mock_persist.assert_called_once()
 
     @patch("app.services.combat.CombatService._emit_entity_hp_update")
     @patch("app.services.combat.CombatService._emit_state")


### PR DESCRIPTION
# PR: feat(combat) authoritative game time accounting (#269)

## Description

Este PR implementa o rastreamento autoritativo de tempo de jogo durante o combate, conforme a issue #269. O sistema agora converte rounds de combate em progressão real de tempo de jogo, garantindo que efeitos temporais (Timed Effects) expirem corretamente com base na duração das lutas.

## Changes

### Backend & Core Logic
- **Constants:** Definido `COMBAT_ROUND_GAME_TIME_SECONDS = 6` em `game_time.py`.
- **Database:** Nova migração `0076` adicionando campos de accounting ao modelo `Combat` para rastrear o tempo já processado.
- **Lifecycle Management:**
    - O tempo começa a contar apenas na transição efetiva para o estado `active`.
    - Implementado accounting idempotente em `lifecycle_turns.py` para processar rodadas completas (wrap) e parciais.
    - Adicionado **Hardening/Lazy Init** em `lifecycle.py` para garantir que combates ativos criados antes deste PR não tentem "inventar" tempo passado ou quebrar por falta de marcadores.

### Accounting Rules
- Round Wrap: **+6s** ao completar uma rodada.
- Combat End: Cobrança proporcional/parcial do tempo decorrido no encerramento.
- Pre-Combat: Sem cobrança de tempo enquanto o combate estiver em setup ou iniciativa.

## Summary of Changes

| File | Change |
| :--- | :--- |
| `app/models/combat.py` | Added accounting fields for game time tracking |
| `alembic/.../0076_...` | Migration for combat time accounting columns |
| `services/game_time.py` | Added `COMBAT_ROUND_GAME_TIME_SECONDS = 6` |
| `combat_service/lifecycle_turns.py` | Idempotent round and partial turn time advancement |
| `combat_service/lifecycle.py` | Centralized legacy combat hardening and lazy init |

## Test Coverage

Cobertura explícita adicionada em `tests/_combat_test_flow.py` validando:
- Transição para `active` sem cobrança imediata (evita double-dip).
- Acréscimo correto de 6s por wrap de rodada.
- Cobrança parcial de tempo no `end_combat`.
- Garantia de ausência de cobrança em estados pré-ativos.
- Segurança no `lazy init` para estados de combate legados.

## Validation

- **Focada:** `test_combat.py` e `test_combat_effects_cleanup.py`.
- **Suíte Completa:** `2138 passed, 1 skipped`.
- **Migration:** Cadeia de migração verificada e estável.

> [!IMPORTANT]  
> O sistema foi desenhado para ser resiliente: se um combate legado for retomado, o contador de tempo inicia do zero a partir da próxima interação, sem retroatividade.