### PR TITLE
feat(combat) expiration of timed effects during active combat (#271)

### DIFF
--- a/apps/control-server/app/api/routes/sessions/commands_service.py
+++ b/apps/control-server/app/api/routes/sessions/commands_service.py
@@ -14,6 +14,7 @@ from app.services.game_time import (
     LONG_REST_GAME_TIME_SECONDS,
     SHORT_REST_GAME_TIME_SECONDS,
     advance_game_time_seconds,
+    get_game_time_seconds,
 )
 from app.services.session_rest import (
     SessionRestError,
@@ -310,6 +311,8 @@ async def send_session_command_service(
         return {"ok": True}
 
     if payload.type == "advance_game_time":
+        from app.services.combat import CombatService
+
         seconds = payload_data.get("seconds")
         if not isinstance(seconds, int) or seconds <= 0:
             raise HTTPException(status_code=400, detail="seconds must be a positive integer")
@@ -330,12 +333,35 @@ async def send_session_command_service(
                 session.add(state)
                 modified_states.append(state)
 
+        combat_state = None
+        combat_changed = False
+        if runtime.combat_active:
+            combat_state = session.exec(
+                select(CombatState).where(
+                    CombatState.session_id == entry_id,
+                    CombatState.phase == CombatPhase.active,
+                )
+            ).first()
+            if combat_state is not None:
+                prune_result = CombatService._prune_expired_timed_combat_effects(
+                    session,
+                    entry_id,
+                    combat_state,
+                    game_time_seconds=get_game_time_seconds(entry_id, session),
+                )
+                combat_changed = bool(prune_result["changed"])
+                modified_states.extend(prune_result["modified_states"])
+                if combat_changed:
+                    session.add(combat_state)
+
         activity_payload["seconds"] = seconds
         activity_payload["gameTimeSeconds"] = runtime.game_time_seconds
         activity_payload["reason"] = "manual"
         record_gm_activity(entry, member, user, "advance_game_time", activity_payload, issued_at, session)
         session.add(runtime)
         session.commit()
+        if combat_changed and combat_state is not None:
+            session.refresh(combat_state)
         for state in modified_states:
             session.refresh(state)
 
@@ -343,7 +369,18 @@ async def send_session_command_service(
         event_payload["seconds"] = seconds
         event_payload["gameTimeSeconds"] = runtime.game_time_seconds
         if modified_states:
+            deduped_states: list[SessionState] = []
+            seen_state_models: set[int] = set()
+            for state in modified_states:
+                marker = id(state)
+                if marker in seen_state_models:
+                    continue
+                seen_state_models.add(marker)
+                deduped_states.append(state)
+            modified_states = deduped_states
             await publish_state_updates(entry, modified_states, issued_at)
+        if combat_changed and combat_state is not None:
+            await CombatService._emit_state(entry_id, combat_state)
         await publish_command_event(entry, event_type, event_payload, issued_at)
         return {"ok": True}
 

--- a/apps/control-server/app/services/combat_service/lifecycle.py
+++ b/apps/control-server/app/services/combat_service/lifecycle.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from sqlalchemy.orm.attributes import flag_modified
+
 from app.models.combat import CombatPhase
 from app.schemas.combat import CombatMapSelection
 from app.services.game_time import get_game_time_seconds
+from app.services.persistent_effect_expiry import should_prune_timed_effect
 
 from .lifecycle_initiative import CombatLifecycleInitiativeMixin
 from .lifecycle_turns import CombatLifecycleTurnsMixin
@@ -44,3 +47,78 @@ class CombatLifecycleMixin(CombatLifecycleInitiativeMixin, CombatLifecycleTurnsM
             existing_accounted_rounds = 0
         legacy_completed_rounds = max(0, int(getattr(state, "round", 1) or 1) - 1)
         state.accounted_game_time_rounds = max(existing_accounted_rounds, legacy_completed_rounds)
+
+    @classmethod
+    def _prune_expired_timed_combat_effects(
+        cls,
+        db,
+        session_id: str,
+        state,
+        *,
+        game_time_seconds: int,
+    ) -> dict:
+        from .persistent_effects import sync_persisted_effects_from_combat_participants
+
+        expired_concentration_groups: set[str] = set()
+        removed_effects: list[dict] = []
+        removed_area_effects: list[dict] = []
+        changed = False
+
+        for participant in state.participants:
+            for effect in cls._get_participant_effects(participant):
+                if not should_prune_timed_effect(effect, game_time_seconds):
+                    continue
+                metadata = cls._get_effect_metadata(effect)
+                concentration_group = metadata.get("concentration_group")
+                if metadata.get("concentration") is True and isinstance(concentration_group, str):
+                    expired_concentration_groups.add(concentration_group)
+
+        for concentration_group in expired_concentration_groups:
+            result = cls._remove_effect_group(state, concentration_group=concentration_group)
+            if result["removed_effects"] or result["removed_area_effects"]:
+                changed = True
+            removed_effects.extend(result["removed_effects"])
+            removed_area_effects.extend(result["removed_area_effects"])
+
+        for participant in state.participants:
+            effects = cls._get_participant_effects(participant)
+            if not effects:
+                continue
+            kept: list[dict] = []
+            participant_changed = False
+            for effect in effects:
+                if should_prune_timed_effect(effect, game_time_seconds):
+                    removed_effects.append(
+                        {
+                            **effect,
+                            "target_participant_id": participant.get("id"),
+                            "target_display_name": participant.get("display_name", ""),
+                        }
+                    )
+                    participant_changed = True
+                    continue
+                kept.append(effect)
+            if participant_changed:
+                cls._set_participant_effects(participant, kept)
+                changed = True
+
+        if removed_effects:
+            cls._execute_on_end_effects_for_removed(
+                state=state,
+                removed_effects=removed_effects,
+            )
+        if removed_area_effects:
+            cls._sync_area_effects_if_changed(session_id, state, removed_area_effects)
+        if changed:
+            flag_modified(state, "participants")
+        modified_states = sync_persisted_effects_from_combat_participants(
+            db,
+            state,
+            game_time_seconds=game_time_seconds,
+        ) if changed else []
+        return {
+            "changed": changed,
+            "removed_effects": removed_effects,
+            "removed_area_effects": removed_area_effects,
+            "modified_states": modified_states,
+        }

--- a/apps/control-server/app/services/combat_service/lifecycle_turns.py
+++ b/apps/control-server/app/services/combat_service/lifecycle_turns.py
@@ -4,6 +4,7 @@ from app.models.combat import CombatPhase
 from app.services.game_time import (
     COMBAT_ROUND_GAME_TIME_SECONDS,
     advance_game_time_seconds,
+    get_game_time_seconds,
 )
 
 from .exceptions import CombatServiceError
@@ -100,6 +101,12 @@ class CombatLifecycleTurnsMixin:
                         db,
                     )
                     state.accounted_game_time_rounds += missing_rounds
+                    cls._prune_expired_timed_combat_effects(
+                        db,
+                        session_id,
+                        state,
+                        game_time_seconds=get_game_time_seconds(session_id, db),
+                    )
                 await cls._emit_log(session_id, {"message": f"Round {state.round} started!"})
             status = state.participants[state.current_turn_index].get("status", "active")
             if status not in ("dead", "defeated", "stable"):
@@ -155,6 +162,12 @@ class CombatLifecycleTurnsMixin:
                     db,
                 )
                 state.accounted_game_time_rounds += missing_rounds
+                cls._prune_expired_timed_combat_effects(
+                    db,
+                    session_id,
+                    state,
+                    game_time_seconds=get_game_time_seconds(session_id, db),
+                )
 
         concentration_source_ids: set[str] = set()
         for participant in state.participants:

--- a/apps/control-server/app/services/combat_service/persistent_effects.py
+++ b/apps/control-server/app/services/combat_service/persistent_effects.py
@@ -34,29 +34,29 @@ _PERSISTABLE_DURATION_TYPES = {
 }
 
 
-def persist_surviving_spell_effects(db: DbSession, state: CombatState) -> None:
-    """Transfer manual-duration spell effects (including concentration) to state_json.
+def _persistable_effects_for_participant(participant: dict) -> list[dict]:
+    effects = participant.get("active_effects")
+    if not isinstance(effects, list):
+        return []
+    surviving = [
+        effect
+        for effect in effects
+        if effect.get("kind") in _PERSISTABLE_KINDS
+        and effect.get("duration_type") in _PERSISTABLE_DURATION_TYPES
+    ]
+    return enforce_single_persisted_concentration_group(surviving)
 
-    Called during end_combat() AFTER concentration has been cleared but BEFORE
-    remaining participant effects are wiped.
-    """
-    current_game_time_seconds: int | None = None
+
+def sync_persisted_effects_from_combat_participants(
+    db: DbSession,
+    state: CombatState,
+    *,
+    game_time_seconds: int,
+) -> list[SessionState]:
+    modified: list[SessionState] = []
     for participant in state.participants:
         if participant.get("kind") != "player":
             continue
-        effects = participant.get("active_effects")
-        if not isinstance(effects, list):
-            continue
-        surviving = [
-            e for e in effects
-            if e.get("kind") in _PERSISTABLE_KINDS
-            and e.get("duration_type") in _PERSISTABLE_DURATION_TYPES
-        ]
-        surviving = enforce_single_persisted_concentration_group(surviving)
-        if not surviving:
-            continue
-        if current_game_time_seconds is None:
-            current_game_time_seconds = get_game_time_seconds(state.session_id, db)
         ref_id = participant.get("ref_id")
         if not ref_id:
             continue
@@ -68,14 +68,36 @@ def persist_surviving_spell_effects(db: DbSession, state: CombatState) -> None:
         ).first()
         if not session_state:
             continue
-        data = dict(session_state.state_json or {})
-        data["active_spell_effects"] = surviving
-        session_state.state_json = finalize_session_state_data(
-            data,
-            game_time_seconds=current_game_time_seconds,
+        next_data = dict(session_state.state_json or {})
+        surviving = _persistable_effects_for_participant(participant)
+        if surviving:
+            next_data["active_spell_effects"] = surviving
+        else:
+            next_data.pop("active_spell_effects", None)
+        finalized = finalize_session_state_data(
+            next_data,
+            game_time_seconds=game_time_seconds,
         )
+        if finalized == (session_state.state_json or {}):
+            continue
+        session_state.state_json = finalized
         flag_modified(session_state, "state_json")
         db.add(session_state)
+        modified.append(session_state)
+    return modified
+
+
+def persist_surviving_spell_effects(db: DbSession, state: CombatState) -> None:
+    """Transfer manual-duration spell effects (including concentration) to state_json.
+
+    Called during end_combat() AFTER concentration has been cleared but BEFORE
+    remaining participant effects are wiped.
+    """
+    sync_persisted_effects_from_combat_participants(
+        db,
+        state,
+        game_time_seconds=get_game_time_seconds(state.session_id, db),
+    )
 
 
 def restore_persisted_effects(

--- a/apps/control-server/app/services/persistent_effect_expiry.py
+++ b/apps/control-server/app/services/persistent_effect_expiry.py
@@ -1,7 +1,19 @@
 from __future__ import annotations
 
 
-def prune_expired_persisted_effects(
+def should_prune_timed_effect(
+    effect: dict,
+    game_time_seconds: int,
+) -> bool:
+    if effect.get("duration_type") != "timed":
+        return False
+    expires_at = effect.get("expires_at_game_time_seconds")
+    if not isinstance(expires_at, int):
+        return True
+    return expires_at <= game_time_seconds
+
+
+def prune_expired_timed_effects(
     effects: list[dict],
     game_time_seconds: int,
 ) -> list[dict]:
@@ -10,16 +22,17 @@ def prune_expired_persisted_effects(
         if not isinstance(effect, dict):
             remaining.append(effect)
             continue
-        if effect.get("duration_type") != "timed":
-            remaining.append(effect)
-            continue
-        expires_at = effect.get("expires_at_game_time_seconds")
-        if not isinstance(expires_at, int):
-            continue
-        if expires_at <= game_time_seconds:
+        if should_prune_timed_effect(effect, game_time_seconds):
             continue
         remaining.append(effect)
     return remaining
+
+
+def prune_expired_persisted_effects(
+    effects: list[dict],
+    game_time_seconds: int,
+) -> list[dict]:
+    return prune_expired_timed_effects(effects, game_time_seconds)
 
 
 def prune_expired_persisted_effects_from_state(
@@ -31,7 +44,7 @@ def prune_expired_persisted_effects_from_state(
     if not isinstance(effects, list):
         return data
 
-    remaining = prune_expired_persisted_effects(effects, game_time_seconds)
+    remaining = prune_expired_timed_effects(effects, game_time_seconds)
     if remaining:
         data["active_spell_effects"] = remaining
     else:

--- a/apps/control-server/tests/_combat_test_flow.py
+++ b/apps/control-server/tests/_combat_test_flow.py
@@ -702,6 +702,52 @@ class CombatFlowTestsMixin:
         self.assertEqual(state.accounted_game_time_rounds, 3)
         mock_advance.assert_not_called()
 
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_log")
+    async def test_round_wrap_prunes_timed_effects_before_incoming_turn_start(
+        self,
+        mock_emit_log,
+        mock_emit_state,
+    ):
+        self.state.phase = CombatPhase.active
+        self.state.round = 1
+        self.state.current_turn_index = 1
+        self.state.active_started_at_game_time_seconds = 0
+        self.state.accounted_game_time_rounds = 0
+        self.state.participants[0]["active_effects"] = [
+            {
+                "id": "eff-timed",
+                "kind": "spell_effect",
+                "duration_type": "timed",
+                "created_at_game_time_seconds": 0,
+                "expires_at_game_time_seconds": 6,
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "metadata": {"source_spell_name": "Mage Armor"},
+            }
+        ]
+        self.state.participants[1]["active_effects"] = []
+
+        async def expire_side_effect(session_id, state, participant_id, trigger):
+            if trigger == "turn_start":
+                self.assertEqual(state.participants[0].get("active_effects"), [])
+            return []
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat.CombatService._expire_effects_for_participant", side_effect=expire_side_effect),
+            patch("app.services.combat_service.lifecycle_turns.advance_game_time_seconds") as mock_advance,
+            patch("app.services.combat_service.lifecycle_turns.get_game_time_seconds", return_value=6),
+            patch("app.services.combat_service.persistent_effects.sync_persisted_effects_from_combat_participants", return_value=[]),
+        ):
+            state = await CombatService.next_turn(
+                self.db, "session-123", actor_user_id="user-xyz", is_gm=True
+            )
+
+        self.assertEqual(state.current_turn_index, 0)
+        self.assertEqual(state.round, 2)
+        self.assertEqual(state.participants[0].get("active_effects"), [])
+        mock_advance.assert_called_once_with("session-123", 6, self.db)
+
     @patch("app.services.combat_service.lifecycle_turns.persist_surviving_spell_effects")
     @patch("app.services.combat.CombatService._emit_state", new_callable=unittest.mock.AsyncMock)
     @patch("app.services.combat.CombatService._emit_log", new_callable=unittest.mock.AsyncMock)

--- a/apps/control-server/tests/test_game_time.py
+++ b/apps/control-server/tests/test_game_time.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi import HTTPException
 
 from app.models.campaign_member import RoleMode
+from app.models.combat import CombatPhase, CombatState
 from app.models.session import SessionStatus
 from app.models.session_runtime import SessionRuntime
 from app.schemas.session import (
@@ -147,6 +148,7 @@ class AdvanceGameTimeCommandTests(unittest.TestCase):
     def _make_runtime(self, game_time=0):
         runtime = SessionRuntime(session_id="s1")
         runtime.game_time_seconds = game_time
+        runtime.combat_active = False
         return runtime
 
     def _make_entry(self):
@@ -362,6 +364,83 @@ class AdvanceGameTimeCommandTests(unittest.TestCase):
         self.assertEqual(published_entry.id, "s1")
         self.assertEqual(len(published_states), 1)
         self.assertIs(published_states[0], state)
+
+    @patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock)
+    @patch("app.services.combat.CombatService._prune_expired_timed_combat_effects")
+    @patch("app.api.routes.sessions.commands_service.publish_state_updates", new_callable=AsyncMock)
+    @patch("app.api.routes.sessions.commands_service.publish_command_event", new_callable=AsyncMock)
+    @patch("app.api.routes.sessions.commands_service.advance_game_time_seconds")
+    @patch("app.api.routes.sessions.commands_service.get_game_time_seconds")
+    @patch("app.api.routes.sessions.commands_service.get_session_rest_state", return_value="exploration")
+    @patch("app.api.routes.sessions.commands_service.get_or_create_session_runtime")
+    @patch("app.api.routes.sessions.commands_service.require_active_gm_session")
+    def test_manual_advancement_during_active_combat_publishes_updated_combat_state(
+        self,
+        mock_require,
+        mock_runtime,
+        mock_rest_state,
+        mock_get_game_time_seconds,
+        mock_advance,
+        mock_publish_cmd,
+        mock_publish_state,
+        mock_prune,
+        mock_emit_combat_state,
+    ):
+        from app.api.routes.sessions.commands_service import send_session_command_service
+
+        runtime = self._make_runtime(game_time=100)
+        runtime.combat_active = True
+        session_state = MagicMock()
+        session_state.session_id = "s1"
+        session_state.player_user_id = "player-1"
+        session_state.state_json = {}
+        combat_state = CombatState(
+            id="combat-1",
+            session_id="s1",
+            phase=CombatPhase.active,
+            round=1,
+            current_turn_index=0,
+            participants=[
+                {
+                    "id": "p1",
+                    "ref_id": "player-1",
+                    "kind": "player",
+                    "display_name": "Hero",
+                    "status": "active",
+                    "team": "players",
+                    "active_effects": [],
+                }
+            ],
+        )
+        mock_require.return_value = (self._make_entry(), self._make_member())
+        mock_runtime.return_value = runtime
+        mock_get_game_time_seconds.return_value = 106
+        mock_advance.side_effect = lambda sid, delta, db: setattr(runtime, "game_time_seconds", runtime.game_time_seconds + delta)
+        mock_prune.return_value = {
+            "changed": True,
+            "removed_effects": [{"id": "eff-expired"}],
+            "removed_area_effects": [],
+            "modified_states": [session_state],
+        }
+
+        states_result = MagicMock()
+        states_result.all.return_value = [session_state]
+        combat_result = MagicMock()
+        combat_result.first.return_value = combat_state
+        db = MagicMock()
+        db.exec.side_effect = [states_result, combat_result]
+
+        _run_async(
+            send_session_command_service("s1", self._make_payload(seconds=6), self._make_user(), db)
+        )
+
+        mock_prune.assert_called_once()
+        mock_emit_combat_state.assert_awaited_once_with("s1", combat_state)
+        mock_publish_state.assert_awaited_once()
+        published_entry, published_states, issued_at = mock_publish_state.await_args.args
+        self.assertEqual(published_entry.id, "s1")
+        self.assertEqual(published_states, [session_state])
+        mock_publish_cmd.assert_awaited_once()
 
     @patch("app.api.routes.sessions.commands_service.publish_command_event", new_callable=AsyncMock)
     @patch("app.api.routes.sessions.commands_service.get_session_rest_state", return_value="exploration")

--- a/apps/control-server/tests/test_persistent_effects.py
+++ b/apps/control-server/tests/test_persistent_effects.py
@@ -21,6 +21,7 @@ from app.services.combat_service.persistent_effects import (
     persist_surviving_spell_effects,
     remove_persisted_effect,
     restore_persisted_effects,
+    sync_persisted_effects_from_combat_participants,
     sync_effect_removal_to_state_json,
 )
 
@@ -298,18 +299,22 @@ class TestPersistSurvivingSpellEffects(unittest.TestCase):
         state = _make_state_with_participants()
         state.participants[1]["active_effects"] = [_manual_spell_effect("eff-1")]
         db = MagicMock()
+        session_state = _make_session_state({})
+        db.exec.return_value.first.return_value = session_state
 
         persist_surviving_spell_effects(db, state)
 
-        db.exec.assert_not_called()
+        self.assertNotIn("active_spell_effects", session_state.state_json)
 
     def test_no_persist_when_no_surviving(self):
         state = _make_state_with_participants([_rounds_spell_effect()])
         db = MagicMock()
+        session_state = _make_session_state({"active_spell_effects": [_manual_spell_effect("eff-stale")]})
+        db.exec.return_value.first.return_value = session_state
 
         persist_surviving_spell_effects(db, state)
 
-        db.exec.assert_not_called()
+        self.assertNotIn("active_spell_effects", session_state.state_json)
 
 
 class TestRestorePersistedEffects(unittest.TestCase):
@@ -426,6 +431,44 @@ class TestSyncEffectRemovalToStateJson(unittest.TestCase):
         sync_effect_removal_to_state_json(db, "session-1", participant, "eff-1")
 
         db.exec.assert_not_called()
+
+
+class TestSyncPersistedEffectsFromCombatParticipants(unittest.TestCase):
+    def test_syncs_remaining_persistable_effects_back_to_state_json(self):
+        effect = _timed_effect("eff-timed", expires_at_game_time_seconds=400)
+        state = _make_state_with_participants([effect])
+        db = MagicMock()
+        session_state = _make_session_state({})
+        db.exec.return_value.first.return_value = session_state
+
+        modified = sync_persisted_effects_from_combat_participants(
+            db,
+            state,
+            game_time_seconds=100,
+        )
+
+        self.assertEqual(modified, [session_state])
+        self.assertEqual(
+            session_state.state_json["active_spell_effects"][0]["id"],
+            "eff-timed",
+        )
+
+    def test_sync_removes_stale_state_when_player_has_no_persistable_effects(self):
+        state = _make_state_with_participants([_rounds_spell_effect("eff-rounds")])
+        db = MagicMock()
+        session_state = _make_session_state(
+            {"active_spell_effects": [_manual_spell_effect("eff-stale")]}
+        )
+        db.exec.return_value.first.return_value = session_state
+
+        modified = sync_persisted_effects_from_combat_participants(
+            db,
+            state,
+            game_time_seconds=100,
+        )
+
+        self.assertEqual(modified, [session_state])
+        self.assertNotIn("active_spell_effects", session_state.state_json)
 
 
 class TestPersistSurvivingConcentrationEffects(unittest.TestCase):


### PR DESCRIPTION
# PR: feat(combat) expiration of timed effects during active combat (#271)

## Description

Este PR implementa a expiração dinâmica de efeitos temporais (`timed`) durante o combate ativo, utilizando o relógio autoritativo de `game_time_seconds`. A mudança garante que buffs e debuffs com duração em segundos expirem corretamente conforme os rounds passam, mantendo a consistência entre o tempo tático e o tempo de jogo.

## Changes

### Backend & Combat Logic
- **Lifecycle Integration:** O pruning de efeitos agora ocorre de forma nativa no wrap de rodada e no `end_combat`.
- **Canonical Cleanup:** Em vez de uma remoção silenciosa, a expiração no combate utiliza o fluxo canônico em `lifecycle.py`. Isso garante que triggers de `onEndEffects`, limpeza de grupos e quebra de concentração sejam processados corretamente.
- **State Persistence:** Atualizada a lógica em `persistent_effects.py` para reescrever o estado persistido do jogador a partir do `CombatState`. Isso evita que efeitos expirados durante a luta "ressuscitagem" no `state_json` após o fim do combate.

### Manual Advancement Hardening
- **Command Extension:** O comando manual `advance_game_time` foi estendido. Se houver um combate ativo ao avançar o tempo:
  - O sistema poda os efeitos `timed` dentro do combate.
  - Sincroniza o `state_json`.
  - Publica o snapshot atualizado via realtime (`_emit_state`), evitando que a UI exiba informações obsoletas até o próximo turno.

## Summary of Changes

| Component | Change |
| :--- | :--- |
| **`persistent_effect_expiry.py`** | Reuso da lógica central de expiração para o contexto de combate |
| **`lifecycle_turns.py`** | Injeção de pruning no round wrap e no encerramento de combate |
| **`commands_service.py`** | Sincronização de realtime ao avançar tempo manualmente durante lutas |
| **`persistent_effects.py`** | Reescrita de segurança do estado persistido pós-expiração |

## Test Coverage

Validação realizada através de testes focados e suíte completa:
- Expiração de efeitos ao completar rodadas (round wrap).
- Remoção de efeitos expirados ao encerrar combate.
- Verificação de que efeitos expirados não persistem no `state_json`.
- Teste de avanço manual de tempo com combate ativo e atualização de realtime.
- Garantia de que `onEndEffects` e concentração são processados na expiração por tempo.

## Validation

- **Focada:** `test_combat.py`, `test_persistent_effects.py` e `test_game_time.py`.
- **Suíte Completa:** `2142 passed, 1 skipped`.
- **Realtime:** Verificado disparo de snapshots de combate em avanços de tempo manuais.

> [!NOTE]  
> Esta implementação fecha o ciclo de vida dos efeitos temporais, garantindo que o tempo de jogo seja o único "source of truth" tanto dentro quanto fora de combate.