### PR TITLE
feat(effects) declarative armor class formulas (#273)

### DIFF
--- a/apps/control-server/app/schemas/base_spell_effects.py
+++ b/apps/control-server/app/schemas/base_spell_effects.py
@@ -10,6 +10,7 @@ from app.schemas.campaign_entity_shared import AbilityName
 SpellDeclarativeEffectType = Literal[
     "apply_condition",
     "modify_stat",
+    "armor_class_formula",
     "advantage_on_checks",
     "disadvantage_on_checks",
     "restrict_action",
@@ -124,6 +125,12 @@ class ModifyMovementSpeedParams(BaseModel):
     bonus_meters: float
 
 
+class ArmorClassFormulaParams(BaseModel):
+    base_value: int = Field(ge=0)
+    ability: AbilityName
+    requires_unarmored: bool | None = None
+
+
 class SpellDeclarativeEffect(BaseModel):
     type: SpellDeclarativeEffectType
     target: SpellDeclarativeEffectTarget
@@ -132,6 +139,7 @@ class SpellDeclarativeEffect(BaseModel):
     params: (
         ApplyConditionParams
         | ModifyStatParams
+        | ArmorClassFormulaParams
         | CheckModifierParams
         | RestrictActionParams
         | GrantTempHpParams
@@ -148,6 +156,8 @@ class SpellDeclarativeEffect(BaseModel):
             raise ValueError("apply_condition effects require ApplyConditionParams")
         if self.type == "modify_stat" and not isinstance(self.params, ModifyStatParams):
             raise ValueError("modify_stat effects require ModifyStatParams")
+        if self.type == "armor_class_formula" and not isinstance(self.params, ArmorClassFormulaParams):
+            raise ValueError("armor_class_formula effects require ArmorClassFormulaParams")
         if self.type in {"advantage_on_checks", "disadvantage_on_checks"} and not isinstance(
             self.params, CheckModifierParams
         ):

--- a/apps/control-server/app/services/combat_service/actions/weapon_attack_roll.py
+++ b/apps/control-server/app/services/combat_service/actions/weapon_attack_roll.py
@@ -61,8 +61,14 @@ class WeaponAttackRollMixin:
         cls._assert_hostile_action_allowed(attacker, target, action_label="an attack")
         was_overridden = cls._consume_turn_resource(attacker, "action", is_gm=is_gm, override_resource_limit=req.override_resource_limit)
         cls._clear_participant_pending_attack(attacker)
-        _, target_ac, *_ = cls._get_stats(db, target["ref_id"], target["kind"], session_id)
-        target_ac = (target_ac or 10) + cls._sum_numeric_effects(target, "temp_ac_bonus")
+        _, target_ac, *_ = cls._get_stats(
+            db,
+            target["ref_id"],
+            target["kind"],
+            session_id,
+            combat_state=state,
+        )
+        target_ac = target_ac or 10
         cover = targeting_result.spatial_metadata.cover
         target_ac += resolve_cover_modifier(cover)
         attack_context["attack_bonus"] += cls._sum_numeric_effects(attacker, "attack_bonus")

--- a/apps/control-server/app/services/combat_service/actions/wild_shape.py
+++ b/apps/control-server/app/services/combat_service/actions/wild_shape.py
@@ -159,9 +159,14 @@ class WildShapeMixin:
         target_kind = "session_entity" if target_p.get("kind") == "entity" else target_p.get("kind")
         # ─────────────────────────────────────────────────────────────────────
 
-        _, target_ac, *_ = cls._get_stats(db, target_p["ref_id"], target_p["kind"], session_id)
+        _, target_ac, *_ = cls._get_stats(
+            db,
+            target_p["ref_id"],
+            target_p["kind"],
+            session_id,
+            combat_state=state,
+        )
         target_ac = target_ac or 10
-        target_ac += cls._sum_numeric_effects(target_p, "temp_ac_bonus")
 
         # Build attack bonus: beast's fixed attack_bonus (includes STR/DEX mod + prof)
         attack_bonus = natural_attack.attack_bonus

--- a/apps/control-server/app/services/combat_service/core.py
+++ b/apps/control-server/app/services/combat_service/core.py
@@ -107,8 +107,16 @@ class CombatCoreMixin:
         return value if isinstance(value, int) else default
 
     @classmethod
-    def calculate_player_armor_class_from_state(cls, data: dict | None) -> int:
-        return calculate_player_armor_class_from_state(data)
+    def calculate_player_armor_class_from_state(
+        cls,
+        data: dict | None,
+        *,
+        active_effects: list[dict] | None = None,
+    ) -> int:
+        return calculate_player_armor_class_from_state(
+            data,
+            active_effects=active_effects,
+        )
 
     @classmethod
     def _build_roll_actor_stats_for_save(

--- a/apps/control-server/app/services/combat_service/npc_action_resolution.py
+++ b/apps/control-server/app/services/combat_service/npc_action_resolution.py
@@ -109,8 +109,14 @@ class CombatNpcActionResolutionMixin:
 
         if action_kind in ("weapon_attack", "spell_attack"):
             cls._clear_participant_pending_attack(attacker)
-            _, target_ac, *_ = cls._get_stats(db, target_p["ref_id"], target_p["kind"], session_id)
-            target_ac = (target_ac or 10) + cls._sum_numeric_effects(target_p, "temp_ac_bonus")
+            _, target_ac, *_ = cls._get_stats(
+                db,
+                target_p["ref_id"],
+                target_p["kind"],
+                session_id,
+                combat_state=state,
+            )
+            target_ac = target_ac or 10
             if context["cover"]:
                 target_ac += resolve_cover_modifier(context["cover"])
             attack_bonus = cls._safe_int(

--- a/apps/control-server/app/services/combat_service/spell_automation.py
+++ b/apps/control-server/app/services/combat_service/spell_automation.py
@@ -418,7 +418,11 @@ class CombatSpellAutomationMixin:
 
         if target_participant:
             _, target_ac, *_ = cls._get_stats(
-                db, target_participant["ref_id"], target_participant["kind"], session_id
+                db,
+                target_participant["ref_id"],
+                target_participant["kind"],
+                session_id,
+                combat_state=state,
             )
             roll_result = resolve_attack_base(
                 RollActorStats(
@@ -537,7 +541,11 @@ class CombatSpellAutomationMixin:
             if not target_p:
                 raise CombatServiceError("Alvo não encontrado no combate.", 404)
             _, target_ac, *_ = cls._get_stats(
-                db, target_p["ref_id"], target_p["kind"], session_id
+                db,
+                target_p["ref_id"],
+                target_p["kind"],
+                session_id,
+                combat_state=state,
             )
             roll_result = resolve_attack_base(
                 RollActorStats(

--- a/apps/control-server/app/services/combat_service/spells/cast_target.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target.py
@@ -678,7 +678,13 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
         damage_type = spell_context.get("damage_type")
         attack_bonus = cls._safe_int(spell_context.get("attack_bonus"), 0)
 
-        _, target_ac_raw, *_ = cls._get_stats(db, target_p["ref_id"], target_p["kind"], session_id)
+        _, target_ac_raw, *_ = cls._get_stats(
+            db,
+            target_p["ref_id"],
+            target_p["kind"],
+            session_id,
+            combat_state=state,
+        )
         cover = targeting_result.spatial_metadata.cover if targeting_result else None
         cover_modifier = resolve_cover_modifier(cover)
         base_ac = target_ac_raw if target_ac_raw is not None else 10

--- a/apps/control-server/app/services/combat_service/spells/spell_resolution_attack.py
+++ b/apps/control-server/app/services/combat_service/spells/spell_resolution_attack.py
@@ -31,7 +31,13 @@ class SpellResolutionAttackMixin(SpellResolutionCommonMixin):
         targeting_result,
     ) -> SpellResolutionResult:
         result = SpellResolutionResult()
-        _, base_ac, *_ = cls._get_stats(db, target_p["ref_id"], target_p["kind"], session_id)
+        _, base_ac, *_ = cls._get_stats(
+            db,
+            target_p["ref_id"],
+            target_p["kind"],
+            session_id,
+            combat_state=state,
+        )
         result.cover = targeting_result.spatial_metadata.cover
         result.cover_modifier = resolve_cover_modifier(result.cover)
         result.base_ac = base_ac if base_ac is not None else 10

--- a/apps/control-server/app/services/combat_service/stat_lookup.py
+++ b/apps/control-server/app/services/combat_service/stat_lookup.py
@@ -15,7 +15,15 @@ from .exceptions import CombatServiceError
 class CombatStatLookupMixin:
 
     @classmethod
-    def _get_stats(cls, db: Session, ref_id: str, kind: str, session_id: str = ""):
+    def _get_stats(
+        cls,
+        db: Session,
+        ref_id: str,
+        kind: str,
+        session_id: str = "",
+        *,
+        combat_state=None,
+    ):
         if kind == "player":
             target = (
                 db.exec(
@@ -36,7 +44,22 @@ class CombatStatLookupMixin:
             spellcasting = cls._as_dict(data.get("spellcasting"))
             str_val = abilities.get("strength", 10)
             dex_val = abilities.get("dexterity", 10)
-            ac = cls.calculate_player_armor_class_from_state(data)
+            combat_effects = None
+            if combat_state is not None:
+                participant = next(
+                    (
+                        entry
+                        for entry in combat_state.participants
+                        if entry.get("kind") == "player" and entry.get("ref_id") == ref_id
+                    ),
+                    None,
+                )
+                effects = participant.get("active_effects") if isinstance(participant, dict) else None
+                combat_effects = effects if isinstance(effects, list) else None
+            ac = cls.calculate_player_armor_class_from_state(
+                data,
+                active_effects=combat_effects,
+            )
 
             wild_shape = cls._as_dict(data.get("wildShape"))
             if wild_shape.get("active"):

--- a/apps/control-server/app/services/session_state_finalize.py
+++ b/apps/control-server/app/services/session_state_finalize.py
@@ -8,6 +8,15 @@ from app.services.session_rest import ensure_rest_state
 
 
 _PLAYER_SHIELD_BONUS = 2
+_ARMOR_BASE_PRIORITY = {
+    "heavy_armor": 70,
+    "medium_armor": 60,
+    "light_armor": 50,
+    "active_formula": 40,
+    "barbarian_unarmored_defense": 30,
+    "monk_unarmored_defense": 20,
+    "default": 10,
+}
 
 
 def _as_dict(value: object) -> dict:
@@ -41,8 +50,70 @@ def _ability_modifier(score: int) -> int:
     return (score - 10) // 2
 
 
-def calculate_player_armor_class_from_state(data: dict | None) -> int:
+def _active_effects_from_state(
+    payload: dict,
+    active_effects: list[dict] | None,
+) -> list[dict]:
+    if isinstance(active_effects, list):
+        return active_effects
+    effects = payload.get("active_spell_effects")
+    return effects if isinstance(effects, list) else []
+
+
+def _normalize_armor_type(payload: dict) -> str:
+    armor = _as_dict(payload.get("equippedArmor"))
+    return _normalize_lookup(armor.get("armorType"))
+
+
+def _has_equipped_armor(payload: dict) -> bool:
+    return _normalize_armor_type(payload) in {"light", "medium", "heavy"}
+
+
+def _sum_temp_ac_bonus_effects(effects: list[dict]) -> int:
+    total = 0
+    for effect in effects:
+        if (
+            isinstance(effect, dict)
+            and effect.get("kind") == "temp_ac_bonus"
+            and isinstance(effect.get("numeric_value"), int)
+        ):
+            total += effect["numeric_value"]
+    return total
+
+
+def _iter_active_armor_class_formula_effects(effects: list[dict]):
+    for effect in effects:
+        if not isinstance(effect, dict) or effect.get("kind") != "spell_effect":
+            continue
+        metadata = _as_dict(effect.get("metadata"))
+        declarative = _as_dict(metadata.get("declarative_effect"))
+        if declarative.get("type") != "armor_class_formula":
+            continue
+        params = _as_dict(declarative.get("params"))
+        base_value = params.get("base_value")
+        ability = params.get("ability")
+        if not isinstance(base_value, int) or not isinstance(ability, str):
+            continue
+        yield {
+            "base_value": base_value,
+            "ability": ability,
+            "requires_unarmored": params.get("requires_unarmored") is True,
+        }
+
+
+def _is_armor_class_formula_applicable(payload: dict, formula: dict) -> bool:
+    if formula.get("requires_unarmored") is True and _has_equipped_armor(payload):
+        return False
+    return True
+
+
+def calculate_player_armor_class_from_state(
+    data: dict | None,
+    *,
+    active_effects: list[dict] | None = None,
+) -> int:
     payload = _as_dict(data)
+    effects = _active_effects_from_state(payload, active_effects)
     dex_mod = _ability_modifier(_get_ability_score(payload, "dexterity"))
     con_mod = _ability_modifier(_get_ability_score(payload, "constitution"))
     wis_mod = _ability_modifier(_get_ability_score(payload, "wisdom"))
@@ -55,20 +126,72 @@ def calculate_player_armor_class_from_state(data: dict | None) -> int:
     if not isinstance(allows_dex, bool):
         allows_dex = armor_type != "heavy"
 
+    candidates: list[dict] = []
+
     if armor_type == "heavy":
-        base_total = base_ac
+        candidates.append({"value": base_ac, "priority": _ARMOR_BASE_PRIORITY["heavy_armor"], "order": len(candidates)})
     elif armor_type == "medium":
         dex_contribution = dex_mod if dex_cap is None else min(dex_mod, dex_cap)
-        base_total = base_ac + (dex_contribution if allows_dex else 0)
+        candidates.append(
+            {
+                "value": base_ac + (dex_contribution if allows_dex else 0),
+                "priority": _ARMOR_BASE_PRIORITY["medium_armor"],
+                "order": len(candidates),
+            }
+        )
     elif armor_type == "light":
-        base_total = base_ac + (dex_mod if allows_dex else 0)
+        candidates.append(
+            {
+                "value": base_ac + (dex_mod if allows_dex else 0),
+                "priority": _ARMOR_BASE_PRIORITY["light_armor"],
+                "order": len(candidates),
+            }
+        )
     else:
-        base_total = 10 + dex_mod
+        candidates.append(
+            {
+                "value": 10 + dex_mod,
+                "priority": _ARMOR_BASE_PRIORITY["default"],
+                "order": len(candidates),
+            }
+        )
         player_class = _normalize_lookup(payload.get("class"))
         if player_class == "barbarian":
-            base_total = max(base_total, 10 + dex_mod + con_mod)
+            candidates.append(
+                {
+                    "value": 10 + dex_mod + con_mod,
+                    "priority": _ARMOR_BASE_PRIORITY["barbarian_unarmored_defense"],
+                    "order": len(candidates),
+                }
+            )
         if player_class == "monk" and not isinstance(payload.get("equippedShield"), dict):
-            base_total = max(base_total, 10 + dex_mod + wis_mod)
+            candidates.append(
+                {
+                    "value": 10 + dex_mod + wis_mod,
+                    "priority": _ARMOR_BASE_PRIORITY["monk_unarmored_defense"],
+                    "order": len(candidates),
+                }
+            )
+
+    for formula in _iter_active_armor_class_formula_effects(effects):
+        if not _is_armor_class_formula_applicable(payload, formula):
+            continue
+        candidates.append(
+            {
+                "value": formula["base_value"] + _ability_modifier(_get_ability_score(payload, formula["ability"])),
+                "priority": _ARMOR_BASE_PRIORITY["active_formula"],
+                "order": len(candidates),
+            }
+        )
+
+    winning_base = max(
+        candidates,
+        key=lambda candidate: (
+            candidate["value"],
+            candidate["priority"],
+            -candidate["order"],
+        ),
+    )
 
     shield = _as_dict(payload.get("equippedShield"))
     shield_bonus = _safe_int(shield.get("bonus"), 0) if shield else 0
@@ -78,8 +201,9 @@ def calculate_player_armor_class_from_state(data: dict | None) -> int:
     misc_bonus = _safe_int(payload.get("miscACBonus"), 0)
     fighting_style = _normalize_lookup(payload.get("fightingStyle"))
     defense_bonus = 1 if fighting_style == "defense" and armor_type in {"light", "medium", "heavy"} else 0
+    temp_ac_bonus = _sum_temp_ac_bonus_effects(effects)
 
-    return max(0, base_total + shield_bonus + misc_bonus + defense_bonus)
+    return max(0, winning_base["value"] + shield_bonus + misc_bonus + defense_bonus + temp_ac_bonus)
 
 
 def finalize_session_state_data(

--- a/apps/control-server/tests/_combat_test_effects.py
+++ b/apps/control-server/tests/_combat_test_effects.py
@@ -262,9 +262,9 @@ class CombatEffectsTestsMixin:
             ):
                 with patch(
                     "app.services.combat.CombatService._get_stats",
-                    return_value=(SessionState(id="s1", session_id="session-123", player_user_id="player-123", state_json={}), 15, 10, 10, 2, 0),
+                    return_value=(SessionState(id="s1", session_id="session-123", player_user_id="player-123", state_json={}), 17, 10, 10, 2, 0),
                 ):
-                    # Roll 12 + 5 = 17 vs AC 15+2=17 → hit (equal to AC)
+                    # Roll 12 + 5 = 17 vs AC 17 → hit (equal to AC)
                     with patch("random.randint", return_value=12):
                         result = await CombatService.entity_action(
                             self.db, "session-123",
@@ -276,7 +276,7 @@ class CombatEffectsTestsMixin:
                             "gm-user", True,
                         )
 
-        # 12 + 5 = 17, AC is 15 + 2 = 17 → should hit
+        # 12 + 5 = 17, AC is 17 → should hit
         self.assertTrue(result["is_hit"])
         self.assertEqual(result["target_ac"], 17)
 

--- a/apps/control-server/tests/_combat_test_entity_stats.py
+++ b/apps/control-server/tests/_combat_test_entity_stats.py
@@ -94,6 +94,79 @@ class CombatEntityStatsTestsMixin:
 
         self.assertEqual(ac, 20)
 
+    def test_get_stats_uses_combat_participant_formula_effects_for_player_ac(self):
+        session_state = MagicMock()
+        session_state.state_json = {
+            "abilities": {
+                "strength": 10,
+                "dexterity": 14,
+                "constitution": 10,
+                "intelligence": 10,
+                "wisdom": 10,
+                "charisma": 10,
+            },
+            "equippedArmor": {
+                "name": "None",
+                "baseAC": 0,
+                "dexCap": None,
+                "armorType": "none",
+            },
+            "equippedShield": {"name": "Shield", "bonus": 2},
+            "miscACBonus": 0,
+            "level": 1,
+            "spellcasting": None,
+        }
+        result = MagicMock()
+        result.first.return_value = session_state
+        self.db.exec.return_value = result
+        combat_state = CombatState(
+            id="combat-1",
+            session_id="session-123",
+            phase=CombatPhase.active,
+            round=1,
+            current_turn_index=0,
+            participants=[
+                {
+                    "id": "p1",
+                    "ref_id": "player-123",
+                    "kind": "player",
+                    "display_name": "Hero",
+                    "status": "active",
+                    "active_effects": [
+                        {
+                            "id": "eff-formula",
+                            "kind": "spell_effect",
+                            "metadata": {
+                                "declarative_effect": {
+                                    "type": "armor_class_formula",
+                                    "params": {
+                                        "base_value": 13,
+                                        "ability": "dexterity",
+                                        "requires_unarmored": True,
+                                    },
+                                },
+                            },
+                        },
+                        {
+                            "id": "eff-ac",
+                            "kind": "temp_ac_bonus",
+                            "numeric_value": 1,
+                        },
+                    ],
+                }
+            ],
+        )
+
+        _, ac, *_ = CombatService._get_stats(
+            self.db,
+            "player-123",
+            "player",
+            "session-123",
+            combat_state=combat_state,
+        )
+
+        self.assertEqual(ac, 18)
+
     def test_build_player_attack_context_uses_current_weapon_proficiency_and_magic_bonus(self):
         session_entry_result = MagicMock()
         session_entry_result.first.return_value = MagicMock(

--- a/apps/control-server/tests/_combat_test_flow.py
+++ b/apps/control-server/tests/_combat_test_flow.py
@@ -1147,7 +1147,7 @@ class CombatFlowTestsMixin:
                 ),
             ):
 
-                def get_stats_side_effect(_db, ref_id, kind, _session_id=""):
+                def get_stats_side_effect(_db, ref_id, kind, _session_id="", **_kwargs):
                     if ref_id == "player-123" and kind == "player":
                         return (attacker_state, 12, 10, 10, 2, 3)
                     return (MagicMock(), 14, 10, 10, 2, 0)
@@ -1852,7 +1852,7 @@ class CombatFlowTestsMixin:
                 ),
             ):
 
-                def get_stats_side_effect(_db, ref_id, kind, _session_id=""):
+                def get_stats_side_effect(_db, ref_id, kind, _session_id="", **_kwargs):
                     if ref_id == "player-123" and kind == "player":
                         return (attacker_state, 12, 10, 10, 2, 3)
                     if ref_id == "player-ally" and kind == "player":
@@ -2293,7 +2293,7 @@ class CombatFlowTestsMixin:
                 ),
             ):
 
-                def get_stats_side_effect(_db, ref_id, kind, _session_id=""):
+                def get_stats_side_effect(_db, ref_id, kind, _session_id="", **_kwargs):
                     if ref_id == "player-123" and kind == "player":
                         return (attacker_state, 12, 10, 10, 2, 3)
                     if ref_id == "enemy-123" and kind == "session_entity":

--- a/apps/control-server/tests/test_out_of_combat_cast.py
+++ b/apps/control-server/tests/test_out_of_combat_cast.py
@@ -185,6 +185,24 @@ def _ac_bonus_effect(value: int = 2) -> dict:
     }
 
 
+def _armor_class_formula_effect(
+    *,
+    base_value: int = 13,
+    ability: str = "dexterity",
+    requires_unarmored: bool = True,
+) -> dict:
+    return {
+        "type": "armor_class_formula",
+        "target": "selected_target",
+        "params": {
+            "base_value": base_value,
+            "ability": ability,
+            "requires_unarmored": requires_unarmored,
+        },
+        "stacking": "replace",
+    }
+
+
 def _slots_state(level: int = 2, used: int = 0, max_slots: int = 3) -> dict:
     return {
         "spellcasting": {
@@ -477,6 +495,33 @@ class TestBuildPersistedEffects(unittest.TestCase):
         self.assertTrue(e["metadata"]["concentration"])
         self.assertIsNotNone(e["metadata"]["concentration_group"])
         self.assertEqual(e["metadata"]["declarative_effect"]["type"], "modify_stat")
+
+    def test_armor_class_formula_effect_shape(self):
+        spell = self._spell(
+            canonical_key="mage_armor",
+            level=1,
+            concentration=False,
+            effects_json=[_armor_class_formula_effect()],
+            name_pt="Armadura Arcana",
+        )
+        effects = build_persisted_effects(
+            spell=spell,
+            caster_user_id="user-1",
+            target_user_id="user-1",
+            variant_key=None,
+            game_time_seconds=0,
+        )
+        self.assertEqual(len(effects), 1)
+        effect = effects[0]
+        self.assertEqual(effect["kind"], "spell_effect")
+        self.assertIsNone(effect.get("numeric_value"))
+        self.assertEqual(
+            effect["metadata"]["declarative_effect"]["type"],
+            "armor_class_formula",
+        )
+        self.assertEqual(effect["metadata"]["base_value"], 13)
+        self.assertEqual(effect["metadata"]["ability"], "dexterity")
+        self.assertTrue(effect["metadata"]["requires_unarmored"])
 
     def test_variant_selects_correct_effects(self):
         spell = self._spell(
@@ -3274,6 +3319,22 @@ class TestLongstriderOutOfCombatCast(unittest.TestCase):
                 "out_of_combat_duration": {"type": "timed", "seconds": 0},
                 "params": {"stat": "temp_ac_bonus", "value": 1},
             })
+
+    def test_armor_class_formula_validates_shape(self):
+        effect = SpellDeclarativeEffect.model_validate(
+            {
+                "type": "armor_class_formula",
+                "target": "selected_target",
+                "params": {
+                    "base_value": 13,
+                    "ability": "dexterity",
+                    "requires_unarmored": True,
+                },
+            }
+        )
+
+        self.assertEqual(effect.type, "armor_class_formula")
+        self.assertEqual(effect.params.base_value, 13)
 
     def test_build_persisted_effects_materializes_timed_duration(self):
         spell = _make_campaign_spell(

--- a/apps/control-server/tests/test_session_state_finalize.py
+++ b/apps/control-server/tests/test_session_state_finalize.py
@@ -57,6 +57,173 @@ class SessionStateFinalizeTests(unittest.TestCase):
 
         self.assertEqual(armor_class, 15)
 
+    def test_active_armor_class_formula_beats_default_unarmored(self):
+        armor_class = calculate_player_armor_class_from_state(
+            {
+                "abilities": {
+                    "dexterity": 14,
+                },
+                "active_spell_effects": [
+                    {
+                        "id": "eff-mage-armor",
+                        "kind": "spell_effect",
+                        "metadata": {
+                            "declarative_effect": {
+                                "type": "armor_class_formula",
+                                "params": {
+                                    "base_value": 13,
+                                    "ability": "dexterity",
+                                    "requires_unarmored": True,
+                                },
+                            },
+                        },
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(armor_class, 15)
+
+    def test_armor_class_formula_competes_as_base_not_additive_bonus(self):
+        armor_class = calculate_player_armor_class_from_state(
+            {
+                "abilities": {
+                    "dexterity": 14,
+                },
+                "equippedArmor": {
+                    "name": "Leather",
+                    "baseAC": 11,
+                    "dexCap": None,
+                    "armorType": "light",
+                    "allowsDex": True,
+                },
+                "active_spell_effects": [
+                    {
+                        "id": "eff-mage-armor",
+                        "kind": "spell_effect",
+                        "metadata": {
+                            "declarative_effect": {
+                                "type": "armor_class_formula",
+                                "params": {
+                                    "base_value": 13,
+                                    "ability": "dexterity",
+                                    "requires_unarmored": True,
+                                },
+                            },
+                        },
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(armor_class, 13)
+
+    def test_armor_class_formula_requires_unarmored(self):
+        armor_class = calculate_player_armor_class_from_state(
+            {
+                "abilities": {
+                    "dexterity": 16,
+                },
+                "equippedArmor": {
+                    "name": "Scale Mail",
+                    "baseAC": 14,
+                    "dexCap": 2,
+                    "armorType": "medium",
+                    "allowsDex": True,
+                },
+                "active_spell_effects": [
+                    {
+                        "id": "eff-mage-armor",
+                        "kind": "spell_effect",
+                        "metadata": {
+                            "declarative_effect": {
+                                "type": "armor_class_formula",
+                                "params": {
+                                    "base_value": 13,
+                                    "ability": "dexterity",
+                                    "requires_unarmored": True,
+                                },
+                            },
+                        },
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(armor_class, 16)
+
+    def test_temp_ac_bonus_applies_after_formula_selection(self):
+        armor_class = calculate_player_armor_class_from_state(
+            {
+                "abilities": {
+                    "dexterity": 14,
+                },
+                "equippedShield": {"name": "Shield", "bonus": 2},
+                "active_spell_effects": [
+                    {
+                        "id": "eff-mage-armor",
+                        "kind": "spell_effect",
+                        "metadata": {
+                            "declarative_effect": {
+                                "type": "armor_class_formula",
+                                "params": {
+                                    "base_value": 13,
+                                    "ability": "dexterity",
+                                    "requires_unarmored": True,
+                                },
+                            },
+                        },
+                    },
+                    {
+                        "id": "eff-ac",
+                        "kind": "temp_ac_bonus",
+                        "numeric_value": 1,
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual(armor_class, 18)
+
+    def test_equal_formula_tie_breaking_is_stable_and_deterministic(self):
+        armor_class = calculate_player_armor_class_from_state(
+            {
+                "abilities": {
+                    "dexterity": 14,
+                },
+                "active_spell_effects": [
+                    {
+                        "id": "eff-b",
+                        "kind": "spell_effect",
+                        "metadata": {
+                            "declarative_effect": {
+                                "type": "armor_class_formula",
+                                "params": {
+                                    "base_value": 12,
+                                    "ability": "dexterity",
+                                },
+                            },
+                        },
+                    },
+                    {
+                        "id": "eff-a",
+                        "kind": "spell_effect",
+                        "metadata": {
+                            "declarative_effect": {
+                                "type": "armor_class_formula",
+                                "params": {
+                                    "base_value": 12,
+                                    "ability": "dexterity",
+                                },
+                            },
+                        },
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual(armor_class, 14)
+
     def test_finalize_prunes_expired_timed_effects_when_game_time_is_provided(self):
         state = finalize_session_state_data(
             {

--- a/apps/control-web/src/entities/base-spell/baseSpell.types.ts
+++ b/apps/control-web/src/entities/base-spell/baseSpell.types.ts
@@ -227,6 +227,7 @@ export type SaveSuccessOutcome =
 export const SpellDeclarativeEffectType = {
   APPLY_CONDITION: "apply_condition",
   MODIFY_STAT: "modify_stat",
+  ARMOR_CLASS_FORMULA: "armor_class_formula",
   ADVANTAGE_ON_CHECKS: "advantage_on_checks",
   DISADVANTAGE_ON_CHECKS: "disadvantage_on_checks",
   RESTRICT_ACTION: "restrict_action",
@@ -327,6 +328,18 @@ export type SpellDeclarativeEffect =
       duration?: SpellDeclarativeDuration | null;
       out_of_combat_duration?: SpellOutOfCombatTimedDuration | null;
       params: { stat: SpellDeclarativeModifyStat; value: number };
+      stacking?: "stack" | "replace" | null;
+    }
+  | {
+      type: "armor_class_formula";
+      target: SpellDeclarativeEffectTarget;
+      duration?: SpellDeclarativeDuration | null;
+      out_of_combat_duration?: SpellOutOfCombatTimedDuration | null;
+      params: {
+        base_value: number;
+        ability: "strength" | "dexterity" | "constitution" | "intelligence" | "wisdom" | "charisma";
+        requires_unarmored?: boolean | null;
+      };
       stacking?: "stack" | "replace" | null;
     }
   | {

--- a/apps/control-web/src/features/shop/components/SpellCatalogDeclarativeEffectsFields.tsx
+++ b/apps/control-web/src/features/shop/components/SpellCatalogDeclarativeEffectsFields.tsx
@@ -51,6 +51,7 @@ const Section = ({ title, children }: { title: string; children: React.ReactNode
 const EFFECT_TYPE_OPTIONS: SpellDeclarativeEffectType[] = [
   "apply_condition",
   "modify_stat",
+  "armor_class_formula",
   "advantage_on_checks",
   "disadvantage_on_checks",
   "restrict_action",
@@ -110,6 +111,8 @@ const retargetParams = (effectType: SpellDeclarativeEffectType): SpellDeclarativ
       return { condition: "charmed" };
     case "modify_stat":
       return { stat: "temp_ac_bonus", value: 1 };
+    case "armor_class_formula":
+      return { base_value: 13, ability: "dexterity", requires_unarmored: true };
     case "advantage_on_checks":
     case "disadvantage_on_checks":
       return { ability: "charisma", against: "any" };
@@ -391,7 +394,89 @@ export const SpellCatalogEffectEditor = ({
             </div>
           ) : null}
 
-          {"ability" in effect.params ? (
+          {effect.type === "armor_class_formula" && "base_value" in effect.params ? (
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div className="space-y-1.5">
+                <FieldLabel label="Base" tooltip="Valor base da fórmula de CA: por exemplo, 13 em 13 + DEX." />
+                <input
+                  type="number"
+                  min={0}
+                  value={effect.params.base_value}
+                  onChange={(event) =>
+                    onChange(
+                      updateEffectAtIndex(effects, index, (entry) =>
+                        entry.type === "armor_class_formula" && "base_value" in entry.params
+                          ? ({
+                              ...entry,
+                              params: {
+                                ...entry.params,
+                                base_value: event.target.value === "" ? 0 : Math.max(0, Number(event.target.value) || 0),
+                              },
+                            } as SpellDeclarativeEffect)
+                          : entry,
+                      ),
+                    )
+                  }
+                  className={fieldClassName}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <FieldLabel label="Habilidade" tooltip="Modificador somado à base: normalmente Destreza para fórmulas como Armadura Arcana." />
+                <select
+                  value={effect.params.ability}
+                  onChange={(event) =>
+                    onChange(
+                      updateEffectAtIndex(effects, index, (entry) =>
+                        entry.type === "armor_class_formula" && "ability" in entry.params
+                          ? ({
+                              ...entry,
+                              params: { ...entry.params, ability: event.target.value as (typeof ABILITY_OPTIONS)[number] },
+                            } as SpellDeclarativeEffect)
+                          : entry,
+                      ),
+                    )
+                  }
+                  className={fieldClassName}
+                >
+                  {ABILITY_OPTIONS.map((option) => (
+                    <option key={option} value={option}>
+                      {localizeSpellAdminValue(option, locale)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <label className="flex items-center gap-2 rounded-2xl border border-white/8 bg-slate-950/40 px-4 py-3 text-sm text-slate-200">
+                <input
+                  type="checkbox"
+                  checked={effect.params.requires_unarmored === true}
+                  onChange={(event) =>
+                    onChange(
+                      updateEffectAtIndex(effects, index, (entry) =>
+                        entry.type === "armor_class_formula" && "requires_unarmored" in entry.params
+                          ? ({
+                              ...entry,
+                              params: {
+                                ...entry.params,
+                                requires_unarmored: event.target.checked,
+                              },
+                            } as SpellDeclarativeEffect)
+                          : entry,
+                      ),
+                    )
+                  }
+                  className="h-4 w-4 rounded border-white/10 bg-slate-900 text-violet-400"
+                />
+                <span>Requer estar sem armadura</span>
+              </label>
+            </div>
+          ) : null}
+
+          {(
+            (effect.type === "advantage_on_checks" || effect.type === "disadvantage_on_checks")
+            && "ability" in effect.params
+          ) ? (
             <div className="grid gap-3 sm:grid-cols-2">
               <div className="space-y-1.5">
                 <FieldLabel label="Habilidade" tooltip="Qual teste: Força, Destreza, Constituição, Inteligência, Sabedoria, Carisma" />

--- a/apps/control-web/src/features/shop/utils/spellVariantEditor.ts
+++ b/apps/control-web/src/features/shop/utils/spellVariantEditor.ts
@@ -207,6 +207,9 @@ const summarizeEffect = (variant: SpellVariant, locale: "pt" | "en") => {
     if (effect.type === "modify_stat" && "stat" in effect.params) {
       return `modify_stat (${effect.params.stat})`;
     }
+    if (effect.type === "armor_class_formula" && "base_value" in effect.params) {
+      return `armor_class_formula (${effect.params.base_value} + ${String(effect.params.ability).slice(0, 3).toUpperCase()})`;
+    }
     if (effect.type === "restrict_action" && "action" in effect.params) {
       return `restrict_action (${effect.params.action})`;
     }

--- a/apps/control-web/src/shared/i18n/domain/spell.ts
+++ b/apps/control-web/src/shared/i18n/domain/spell.ts
@@ -135,6 +135,7 @@ const SPELL_ADMIN_VALUE_LABELS: Record<string, LabelEntry> = {
   selected_target: label("Only against spell's selected target", "Apenas contra o alvo selecionado da magia"),
   apply_condition: label("Apply condition", "Aplicar condição"),
   modify_stat: label("Modify stat", "Modificar atributo"),
+  armor_class_formula: label("Armor class formula", "Fórmula de classe de armadura"),
   advantage_on_checks: label("Advantage on checks", "Vantagem em testes"),
   disadvantage_on_checks: label("Disadvantage on checks", "Desvantagem em testes"),
   restrict_action: label("Restrict action", "Restringir ação"),


### PR DESCRIPTION
# PR: feat(effects) declarative armor class formulas (#273)

## Description

Este PR implementa o suporte para `armor_class_formula` como um efeito declarativo genérico. A refatoração centraliza a resolução de CA (Classe de Armadura) tanto dentro quanto fora de combate, permitindo que efeitos ativos (como *Mage Armor*) definam uma base de cálculo (ex: `13 + DEX`) de forma autoritativa antes da aplicação de bônus aditivos.

## Changes

### Backend & Core Logic
- **Declarative Schema:** Adicionado `armor_class_formula` ao `base_spell_effects.py` como um efeito genérico suportado.
- **Refatoração de AC:** Em `session_state_finalize.py`, a lógica de cálculo de CA foi reconstruída para:
    1. Identificar a fórmula-base válida (vinda de efeitos ativos ou equipamentos).
    2. Aplicar bônus aditivos (`temp_ac_bonus`) sobre essa base.
- **Combat Integration:** Os fluxos de ataque e magias agora passam o `CombatState` ao resolver a CA, garantindo que bônus temporários e fórmulas ativas sejam respeitados em tempo real durante o combate.
- **Generic Support:** A solução cobre `active_spell_effects` (OOC) e efeitos em combate via `stat_lookup`, mantendo compatibilidade com as regras existentes de Wild Shape.

### Frontend
- **Contract & Types:** Atualizado o `baseSpell.types.ts` para incluir o novo campo de fórmula.
- **UI/Editor:** O editor de efeitos declarativos no `SpellCatalogDeclarativeEffectsFields.tsx` agora permite a configuração direta de `armor_class_formula`, facilitando a criação de novas magias e itens pelo painel administrativo.

## Summary of Changes

| Component | Change |
| :--- | :--- |
| **`base_spell_effects.py`** | Suporte declarativo para fórmulas de CA |
| **`session_state_finalize.py`** | Refatoração do resolver de CA autoritativa |
| **`combat_service`** | Injeção de estado de combate na consulta de atributos de defesa |
| **`control-web`** | Atualização do editor de efeitos e contratos de API |

## Validation

A validação foi executada em ambas as frentes para garantir que a mudança na resolução de atributos não quebrou os cálculos base de personagens sem efeitos ativos.

- **Backend (control-server):** `2150 passed, 1 skipped` (via pytest).
- **Frontend (control-web):** `170 passed / 1664 tests` (via npm test).
- **Manual:** Verificado que magias como *Mage Armor* substituem a base `10 + DEX` corretamente sem duplicar bônus de armadura.

> [!TIP]
> Esta implementação mantém o suporte nativo a regras de classe (Bárbaro/Monge) conforme o resolver já processava, apenas expondo a capacidade de magias "sequestrarem" o cálculo da base de forma declarativa.