### PR TITLE
feat(spells) mage armor implementation and declarative termination conditions

### DIFF
--- a/Base/base_spells.seed.json
+++ b/Base/base_spells.seed.json
@@ -1901,6 +1901,74 @@
         "dice": "1d8",
         "levelStep": 2
       }
+    },
+    {
+      "system": "DND5E",
+      "canonicalKey": "mage_armor",
+      "nameEn": "Mage Armor",
+      "namePt": "Armadura Arcana",
+      "descriptionEn": "You touch a willing creature who isn't wearing armor, and a protective magical force surrounds it until the spell ends. The target's base AC becomes 13 + its Dexterity modifier. The spell ends if the target dons armor or if you dismiss the spell as an action.",
+      "descriptionPt": "Você toca uma criatura disposta que não está usando armadura, e uma força mágica protetora a envolve até o final da magia. A CA base do alvo se torna 13 + seu modificador de Destreza. A magia termina se o alvo usar armadura ou se você dispensar a magia como uma ação.",
+      "level": 1,
+      "school": "abjuration",
+      "classesJson": [
+        "Sorcerer",
+        "Wizard"
+      ],
+      "castingTimeType": "action",
+      "castingTime": "1 action",
+      "rangeMeters": 1,
+      "rangeText": "Touch",
+      "duration": "8 hours",
+      "componentsJson": [
+        "V",
+        "S",
+        "M"
+      ],
+      "materialComponentText": "a piece of cured leather",
+      "concentration": false,
+      "ritual": false,
+      "resolutionType": "buff",
+      "source": "seed_json_bootstrap",
+      "isSrd": true,
+      "isActive": true,
+      "requiresTargetSight": false,
+      "requiresTargetEffect": false,
+      "requiresPointSight": false,
+      "requiresPointEffect": false,
+      "targetType": "touch",
+      "selectionType": "creature",
+      "originType": "caster",
+      "targetAnchor": "selected_target",
+      "attackType": "none",
+      "rangeKind": "touch",
+      "effectTiming": "immediate",
+      "outOfCombatCastable": true,
+      "outOfCombatTarget": "self_or_ally",
+      "effects": [
+        {
+          "type": "armor_class_formula",
+          "target": "selected_target",
+          "duration": {
+            "type": "timed",
+            "seconds": 28800
+          },
+          "out_of_combat_duration": {
+            "type": "timed",
+            "seconds": 28800
+          },
+          "params": {
+            "base_value": 13,
+            "ability": "dexterity",
+            "requires_unarmored": true
+          },
+          "termination_conditions": [
+            {
+              "type": "target_dons_armor"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/apps/control-server/alembic/versions/0077_mage_armor_data.py
+++ b/apps/control-server/alembic/versions/0077_mage_armor_data.py
@@ -1,0 +1,262 @@
+"""Insert mage_armor into base_spell and campaign_spell catalogs.
+
+Revision ID: 0077_mage_armor_data
+Revises: 0076_combat_game_time_accounting
+Create Date: 2026-05-10 00:00:00.000000
+"""
+
+import json
+from uuid import uuid4
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0077_mage_armor_data"
+down_revision = "0076_combat_game_time_accounting"
+branch_labels = None
+depends_on = None
+
+_SYSTEM = "DND5E"
+_CANONICAL_KEY = "mage_armor"
+
+_EFFECTS_JSON = json.dumps([
+    {
+        "type": "armor_class_formula",
+        "target": "selected_target",
+        "duration": {"type": "timed", "seconds": 28800},
+        "out_of_combat_duration": {"type": "timed", "seconds": 28800},
+        "params": {
+            "base_value": 13,
+            "ability": "dexterity",
+            "requires_unarmored": True,
+        },
+        "termination_conditions": [{"type": "target_dons_armor"}],
+    }
+])
+
+_BASE_SPELL_FIELDS = {
+    "system": _SYSTEM,
+    "canonical_key": _CANONICAL_KEY,
+    "name_en": "Mage Armor",
+    "name_pt": "Armadura Arcana",
+    "description_en": (
+        "You touch a willing creature who isn't wearing armor, and a protective magical "
+        "force surrounds it until the spell ends. The target's base AC becomes "
+        "13 + its Dexterity modifier. The spell ends if the target dons armor or if you "
+        "dismiss the spell as an action."
+    ),
+    "description_pt": (
+        "Você toca uma criatura disposta que não está usando armadura, e uma força mágica "
+        "protetora a envolve até o final da magia. A CA base do alvo se torna "
+        "13 + seu modificador de Destreza. A magia termina se o alvo usar armadura ou se "
+        "você dispensar a magia como uma ação."
+    ),
+    "level": 1,
+    "school": "abjuration",
+    "classes_json": json.dumps(["Sorcerer", "Wizard"]),
+    "casting_time_type": "action",
+    "casting_time": "1 action",
+    "range_meters": 1,
+    "range_text": "Touch",
+    "duration": "8 hours",
+    "components_json": json.dumps(["V", "S", "M"]),
+    "material_component_text": "a piece of cured leather",
+    "concentration": False,
+    "ritual": False,
+    "out_of_combat_castable": True,
+    "out_of_combat_target": "self_or_ally",
+    "resolution_type": "buff",
+    "target_type": "touch",
+    "selection_type": "creature",
+    "origin_type": "caster",
+    "target_anchor": "selected_target",
+    "attack_type": "none",
+    "range_kind": "touch",
+    "effect_timing": "immediate",
+    "requires_target_sight": False,
+    "requires_target_effect": False,
+    "requires_point_sight": False,
+    "requires_point_effect": False,
+    "effects_json": _EFFECTS_JSON,
+    "source": "seed_json_bootstrap",
+    "is_srd": True,
+    "is_active": True,
+}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # ── 1. Upsert base_spell ──────────────────────────────────────────────────
+    existing = conn.execute(
+        sa.text(
+            "SELECT id FROM base_spell WHERE system = :sys AND canonical_key = :key"
+        ),
+        {"sys": _SYSTEM, "key": _CANONICAL_KEY},
+    ).first()
+
+    if existing:
+        base_spell_id = existing[0]
+        conn.execute(
+            sa.text(
+                """
+                UPDATE base_spell SET
+                    name_en = :name_en,
+                    name_pt = :name_pt,
+                    description_en = :description_en,
+                    description_pt = :description_pt,
+                    level = :level,
+                    school = :school,
+                    classes_json = :classes_json::jsonb,
+                    casting_time_type = :casting_time_type,
+                    casting_time = :casting_time,
+                    range_meters = :range_meters,
+                    range_text = :range_text,
+                    duration = :duration,
+                    components_json = :components_json::jsonb,
+                    material_component_text = :material_component_text,
+                    concentration = :concentration,
+                    ritual = :ritual,
+                    out_of_combat_castable = :out_of_combat_castable,
+                    out_of_combat_target = :out_of_combat_target,
+                    resolution_type = :resolution_type,
+                    target_type = :target_type,
+                    selection_type = :selection_type,
+                    origin_type = :origin_type,
+                    target_anchor = :target_anchor,
+                    attack_type = :attack_type,
+                    range_kind = :range_kind,
+                    effect_timing = :effect_timing,
+                    requires_target_sight = :requires_target_sight,
+                    requires_target_effect = :requires_target_effect,
+                    requires_point_sight = :requires_point_sight,
+                    requires_point_effect = :requires_point_effect,
+                    effects_json = :effects_json::jsonb,
+                    source = :source,
+                    is_srd = :is_srd,
+                    is_active = :is_active
+                WHERE id = :id
+                """
+            ),
+            {**_BASE_SPELL_FIELDS, "id": base_spell_id},
+        )
+    else:
+        base_spell_id = str(uuid4())
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO base_spell (
+                    id, system, canonical_key,
+                    name_en, name_pt, description_en, description_pt,
+                    level, school, classes_json,
+                    casting_time_type, casting_time,
+                    range_meters, range_text, duration,
+                    components_json, material_component_text,
+                    concentration, ritual,
+                    out_of_combat_castable, out_of_combat_target,
+                    resolution_type,
+                    target_type, selection_type, origin_type, target_anchor,
+                    attack_type, range_kind, effect_timing,
+                    requires_target_sight, requires_target_effect,
+                    requires_point_sight, requires_point_effect,
+                    effects_json, source, is_srd, is_active
+                ) VALUES (
+                    :id, :system, :canonical_key,
+                    :name_en, :name_pt, :description_en, :description_pt,
+                    :level, :school, :classes_json::jsonb,
+                    :casting_time_type, :casting_time,
+                    :range_meters, :range_text, :duration,
+                    :components_json::jsonb, :material_component_text,
+                    :concentration, :ritual,
+                    :out_of_combat_castable, :out_of_combat_target,
+                    :resolution_type,
+                    :target_type, :selection_type, :origin_type, :target_anchor,
+                    :attack_type, :range_kind, :effect_timing,
+                    :requires_target_sight, :requires_target_effect,
+                    :requires_point_sight, :requires_point_effect,
+                    :effects_json::jsonb, :source, :is_srd, :is_active
+                )
+                """
+            ),
+            {**_BASE_SPELL_FIELDS, "id": base_spell_id},
+        )
+
+    # ── 2. Backfill campaign_spell for campaigns that lack the canonical key ──
+    campaigns = conn.execute(
+        sa.text("SELECT id FROM campaign WHERE system = :sys"),
+        {"sys": _SYSTEM},
+    ).fetchall()
+
+    for (campaign_id,) in campaigns:
+        already = conn.execute(
+            sa.text(
+                "SELECT 1 FROM campaign_spell "
+                "WHERE campaign_id = :cid AND canonical_key = :key"
+            ),
+            {"cid": campaign_id, "key": _CANONICAL_KEY},
+        ).first()
+        if already:
+            continue
+
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO campaign_spell (
+                    id, campaign_id, base_spell_id, canonical_key,
+                    name_en, name_pt, description_en, description_pt,
+                    level, school, classes_json,
+                    casting_time_type, casting_time,
+                    range_meters, range_text, duration,
+                    components_json, material_component_text,
+                    concentration, ritual,
+                    out_of_combat_castable, out_of_combat_target,
+                    resolution_type,
+                    target_type, selection_type, origin_type, target_anchor,
+                    attack_type, range_kind, effect_timing,
+                    requires_target_sight, requires_target_effect,
+                    requires_point_sight, requires_point_effect,
+                    effects_json, source, is_srd, is_enabled, is_custom
+                ) VALUES (
+                    :id, :campaign_id, :base_spell_id, :canonical_key,
+                    :name_en, :name_pt, :description_en, :description_pt,
+                    :level, :school, :classes_json::jsonb,
+                    :casting_time_type, :casting_time,
+                    :range_meters, :range_text, :duration,
+                    :components_json::jsonb, :material_component_text,
+                    :concentration, :ritual,
+                    :out_of_combat_castable, :out_of_combat_target,
+                    :resolution_type,
+                    :target_type, :selection_type, :origin_type, :target_anchor,
+                    :attack_type, :range_kind, :effect_timing,
+                    :requires_target_sight, :requires_target_effect,
+                    :requires_point_sight, :requires_point_effect,
+                    :effects_json::jsonb, :source, :is_srd, :is_enabled, :is_custom
+                )
+                """
+            ),
+            {
+                **_BASE_SPELL_FIELDS,
+                "id": str(uuid4()),
+                "campaign_id": campaign_id,
+                "base_spell_id": base_spell_id,
+                "is_enabled": True,
+                "is_custom": False,
+            },
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "DELETE FROM campaign_spell "
+            "WHERE canonical_key = :key AND source = 'seed_json_bootstrap'"
+        ),
+        {"key": _CANONICAL_KEY},
+    )
+    conn.execute(
+        sa.text(
+            "DELETE FROM base_spell WHERE system = :sys AND canonical_key = :key"
+        ),
+        {"sys": _SYSTEM, "key": _CANONICAL_KEY},
+    )

--- a/apps/control-server/app/api/routes/sessions/state.py
+++ b/apps/control-server/app/api/routes/sessions/state.py
@@ -33,6 +33,7 @@ from app.services.out_of_combat_cast import (
     consume_spell_slot,
     has_castable_effects,
 )
+from app.services.declarative_effect_lifecycle import remove_armor_don_effects_from_combat_participant
 from app.services.session_rest import ensure_rest_state
 from app.services.session_state_finalize import finalize_session_state_data
 from app.services.spell_preparation import apply_prepared_spells_with_long_rest_tracking
@@ -270,6 +271,10 @@ async def _cast_spell_out_of_combat_for_player(
     if is_ally_target and campaign_spell.out_of_combat_target not in ("ally", "self_or_ally"):
         raise HTTPException(status_code=400, detail="Spell cannot target allies out of combat")
 
+    target_state_json_for_check = (
+        target_state.state_json if target_state and isinstance(target_state.state_json, dict)
+        else state_json
+    )
     ok, rejection = check_out_of_combat_cast_eligibility(
         spell=campaign_spell,
         state_json=state_json,
@@ -278,6 +283,7 @@ async def _cast_spell_out_of_combat_for_player(
         out_of_combat_target=campaign_spell.out_of_combat_target,
         target_user_id=target_user_id,
         caster_user_id=caster_user_id,
+        target_state_json=target_state_json_for_check,
     )
     if not ok:
         raise HTTPException(status_code=400, detail=rejection)
@@ -614,6 +620,13 @@ async def update_my_session_loadout(
     })
     state.state_json = next_state
     session.add(state)
+
+    combat_state_for_loadout = CombatService.get_state(session, session_id)
+    if combat_state_for_loadout is not None:
+        if remove_armor_don_effects_from_combat_participant(combat_state_for_loadout, user.id):
+            flag_modified(combat_state_for_loadout, "participants")
+            session.add(combat_state_for_loadout)
+
     session.commit()
     session.refresh(state)
 
@@ -663,7 +676,8 @@ async def update_player_session_state(
         tier_changed = CombatService.recompute_participant_encumbrance_tier(
             session, session_id, combat_state, player_user_id,
         )
-        if tier_changed:
+        armor_don_removed = remove_armor_don_effects_from_combat_participant(combat_state, player_user_id)
+        if tier_changed or armor_don_removed:
             flag_modified(combat_state, "participants")
             session.add(combat_state)
     session.add(state)

--- a/apps/control-server/app/schemas/base_spell_effects.py
+++ b/apps/control-server/app/schemas/base_spell_effects.py
@@ -27,6 +27,7 @@ SpellDeclarativeDurationType = Literal[
     "rounds",
     "until_turn_start",
     "until_turn_end",
+    "timed",
 ]
 SpellDeclarativeDurationAnchor = Literal["target", "caster"]
 SpellDeclarativeConditionType = Literal[
@@ -64,6 +65,7 @@ SpellDeclarativeAgainst = Literal["selected_target", "effect_target", "any"]
 class SpellDeclarativeDuration(BaseModel):
     type: SpellDeclarativeDurationType
     rounds: int | None = Field(default=None, ge=1)
+    seconds: int | None = Field(default=None, ge=1)
     anchor: SpellDeclarativeDurationAnchor | None = None
 
     @model_validator(mode="after")
@@ -74,7 +76,13 @@ class SpellDeclarativeDuration(BaseModel):
         else:
             self.rounds = None
 
-        if self.type == "manual":
+        if self.type == "timed":
+            if self.seconds is None:
+                raise ValueError("seconds is required when duration.type is 'timed'")
+        else:
+            self.seconds = None
+
+        if self.type in {"manual", "timed"}:
             self.anchor = None
         elif self.anchor is None:
             self.anchor = "target"
@@ -131,11 +139,19 @@ class ArmorClassFormulaParams(BaseModel):
     requires_unarmored: bool | None = None
 
 
+SpellDeclarativeTerminationConditionType = Literal["target_dons_armor"]
+
+
+class TerminationCondition(BaseModel):
+    type: SpellDeclarativeTerminationConditionType
+
+
 class SpellDeclarativeEffect(BaseModel):
     type: SpellDeclarativeEffectType
     target: SpellDeclarativeEffectTarget
     duration: SpellDeclarativeDuration | None = None
     out_of_combat_duration: SpellOutOfCombatTimedDuration | None = None
+    termination_conditions: list[TerminationCondition] | None = None
     params: (
         ApplyConditionParams
         | ModifyStatParams

--- a/apps/control-server/app/services/combat_service/concentration.py
+++ b/apps/control-server/app/services/combat_service/concentration.py
@@ -48,6 +48,8 @@ class CombatConcentrationMixin:
         duration_type: str = "manual",
         remaining_rounds: int | None = None,
         expires_at_participant_id: str | None = None,
+        created_at_game_time_seconds: int | None = None,
+        expires_at_game_time_seconds: int | None = None,
         metadata: dict | None = None,
         display_label: str | None = None,
     ) -> dict:
@@ -69,6 +71,8 @@ class CombatConcentrationMixin:
             "remaining_rounds": remaining_rounds,
             "expires_on": expires_on,
             "expires_at_participant_id": expires_at_participant_id,
+            "created_at_game_time_seconds": created_at_game_time_seconds,
+            "expires_at_game_time_seconds": expires_at_game_time_seconds,
             "created_at": datetime.now(timezone.utc).isoformat(),
             "metadata": metadata or None,
             "display_label": display_label,

--- a/apps/control-server/app/services/combat_service/spell_declarative_effects.py
+++ b/apps/control-server/app/services/combat_service/spell_declarative_effects.py
@@ -5,7 +5,10 @@ from typing import Literal
 from uuid import uuid4
 
 from app.models.combat import CombatPhase
+from app.models.session_state import SessionState
 from app.schemas.base_spell import SpellDeclarativeEffect
+from app.services.game_time import get_game_time_seconds
+from app.services.out_of_combat_cast import _target_has_armor, _check_requires_unarmored_eligibility
 
 logger = logging.getLogger(__name__)
 from app.schemas.campaign_entity_shared import AbilityName, SKILL_ABILITY_MAP, SkillName
@@ -138,6 +141,43 @@ class CombatSpellDeclarativeEffectsMixin:
         return list(grouped.values())
 
     @classmethod
+    def _check_declarative_requires_unarmored_for_target(
+        cls,
+        db,
+        session_id: str,
+        *,
+        spell_context: dict,
+        target_participant: dict | None,
+    ) -> None:
+        """Raise CombatServiceError if any declarative effect requires unarmored and target has armor."""
+        effects = spell_context.get("effects") or []
+        if not isinstance(effects, list):
+            return
+        requires_unarmored = any(
+            isinstance(e, dict) and (e.get("params") or {}).get("requires_unarmored") is True
+            for e in effects
+        )
+        if not requires_unarmored:
+            return
+        if not isinstance(target_participant, dict) or target_participant.get("kind") != "player":
+            return
+        ref_id = target_participant.get("ref_id")
+        if not ref_id:
+            return
+        from sqlmodel import select as sa_select
+        session_state = db.exec(
+            sa_select(SessionState).where(
+                SessionState.session_id == session_id,
+                SessionState.player_user_id == ref_id,
+            )
+        ).first()
+        target_state_json = dict(session_state.state_json or {}) if session_state else {}
+        if _target_has_armor(target_state_json):
+            raise CombatServiceError(
+                "Target is wearing armor and this spell requires an unarmored target", 400
+            )
+
+    @classmethod
     def _normalize_declarative_effects(cls, raw_effects: object) -> list[SpellDeclarativeEffect]:
         if not isinstance(raw_effects, list):
             return []
@@ -194,6 +234,7 @@ class CombatSpellDeclarativeEffectsMixin:
         effect: SpellDeclarativeEffect,
         attacker: dict,
         target_participant: dict | None,
+        game_time_seconds: int | None = None,
     ) -> dict:
         duration = effect.duration
         if duration is None:
@@ -201,6 +242,17 @@ class CombatSpellDeclarativeEffectsMixin:
                 "duration_type": "manual",
                 "remaining_rounds": None,
                 "expires_at_participant_id": None,
+                "created_at_game_time_seconds": None,
+                "expires_at_game_time_seconds": None,
+            }
+        if duration.type == "timed":
+            gt = game_time_seconds if isinstance(game_time_seconds, int) else 0
+            return {
+                "duration_type": "timed",
+                "remaining_rounds": None,
+                "expires_at_participant_id": None,
+                "created_at_game_time_seconds": gt,
+                "expires_at_game_time_seconds": gt + (duration.seconds or 0),
             }
         anchor = duration.anchor or "target"
         expires_at = (
@@ -212,6 +264,8 @@ class CombatSpellDeclarativeEffectsMixin:
             "duration_type": duration.type,
             "remaining_rounds": duration.rounds,
             "expires_at_participant_id": expires_at,
+            "created_at_game_time_seconds": None,
+            "expires_at_game_time_seconds": None,
         }
 
     @classmethod
@@ -240,6 +294,7 @@ class CombatSpellDeclarativeEffectsMixin:
         effect: SpellDeclarativeEffect,
         effect_group_id: str,
         on_end_effects: list[SpellDeclarativeEffect],
+        game_time_seconds: int | None = None,
     ) -> list[dict]:
         metadata = {
             "declarative_effect_group_id": effect_group_id,
@@ -289,6 +344,7 @@ class CombatSpellDeclarativeEffectsMixin:
             effect=effect,
             attacker=attacker,
             target_participant=resolved_target,
+            game_time_seconds=game_time_seconds,
         )
 
         created: list[dict] = []
@@ -352,6 +408,7 @@ class CombatSpellDeclarativeEffectsMixin:
         target_participant: dict | None,
         spell_context: dict,
         effect_group_id: str | None = None,
+        game_time_seconds: int | None = None,
     ) -> dict:
         effects = cls._spell_context_declarative_effects(spell_context)
         on_end_effects = cls._spell_context_on_end_effects(spell_context)
@@ -370,6 +427,7 @@ class CombatSpellDeclarativeEffectsMixin:
                     effect=effect,
                     effect_group_id=effect_group_id,
                     on_end_effects=on_end_effects,
+                    game_time_seconds=game_time_seconds,
                 )
             )
         return {"applied_effects": applied, "effect_group_id": effect_group_id}
@@ -492,6 +550,7 @@ class CombatSpellDeclarativeEffectsMixin:
             target_participant=target_participant,
             spell_context=spell_context,
             effect_group_id=effect_group_id,
+            game_time_seconds=get_game_time_seconds(session_id, db),
         )
         applied_effects = application["applied_effects"]
         cls._apply_temp_hp_from_granted_effects(db, state, applied_effects)

--- a/apps/control-server/app/services/combat_service/spells/cast_target.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target.py
@@ -1364,6 +1364,12 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
             spell_canonical_key=spell_context["spell_canonical_key"],
             target_participant=target_p,
         )
+        cls._check_declarative_requires_unarmored_for_target(
+            db,
+            session_id,
+            spell_context=spell_context,
+            target_participant=target_p,
+        )
 
         slot_spent = False
         if spell_context.get("source_kind") == "magic_item":

--- a/apps/control-server/app/services/declarative_effect_lifecycle.py
+++ b/apps/control-server/app/services/declarative_effect_lifecycle.py
@@ -1,0 +1,92 @@
+"""Lifecycle helpers for declarative spell effects.
+
+Handles applicability (requires_unarmored → AC formula skipped) separately from
+termination (target_dons_armor → effect permanently removed).
+"""
+
+from __future__ import annotations
+
+_ARMOR_TYPES = {"light", "medium", "heavy"}
+
+
+def _has_equipped_armor(state_json: dict) -> bool:
+    armor = state_json.get("equippedArmor") or {}
+    if not isinstance(armor, dict):
+        return False
+    armor_type = (armor.get("armorType") or "").strip().lower()
+    return armor_type in _ARMOR_TYPES
+
+
+def _effect_has_target_dons_armor_termination(effect: dict) -> bool:
+    """Return True if a persisted effect carries a target_dons_armor termination rule."""
+    if not isinstance(effect, dict):
+        return False
+    metadata = effect.get("metadata") or {}
+    declarative = metadata.get("declarative_effect") or {}
+    termination_conditions = declarative.get("termination_conditions") or []
+    return any(
+        isinstance(cond, dict) and cond.get("type") == "target_dons_armor"
+        for cond in termination_conditions
+    )
+
+
+def terminate_armor_don_effects_from_state(state_json: dict) -> dict:
+    """Remove persisted declarative effects that end when the target dons armor.
+
+    Only removes effects when the state already reflects armor being equipped.
+    Idempotent and non-destructive: returns state_json unchanged when no
+    termination is needed.
+    """
+    if not _has_equipped_armor(state_json):
+        return state_json
+
+    effects = state_json.get("active_spell_effects")
+    if not isinstance(effects, list) or not effects:
+        return state_json
+
+    surviving = [e for e in effects if not _effect_has_target_dons_armor_termination(e)]
+    if len(surviving) == len(effects):
+        return state_json
+
+    data = dict(state_json)
+    if surviving:
+        data["active_spell_effects"] = surviving
+    else:
+        data.pop("active_spell_effects", None)
+    return data
+
+
+def find_armor_don_terminated_effect_ids(participant_effects: list[dict]) -> list[str]:
+    """Return IDs of active combat effects that carry a target_dons_armor termination rule."""
+    return [
+        e["id"]
+        for e in participant_effects
+        if isinstance(e, dict)
+        and isinstance(e.get("id"), str)
+        and _effect_has_target_dons_armor_termination(e)
+    ]
+
+
+def remove_armor_don_effects_from_combat_participant(
+    combat_state,
+    player_user_id: str,
+) -> bool:
+    """Remove active combat effects with target_dons_armor termination from a player participant.
+
+    Returns True if any effects were removed. Mutates combat_state.participants in place.
+    """
+    participant = next(
+        (
+            p for p in (combat_state.participants if combat_state else [])
+            if p.get("kind") == "player" and p.get("ref_id") == player_user_id
+        ),
+        None,
+    )
+    if not participant:
+        return False
+    effects = participant.get("active_effects") or []
+    terminated_ids = set(find_armor_don_terminated_effect_ids(effects))
+    if not terminated_ids:
+        return False
+    participant["active_effects"] = [e for e in effects if e.get("id") not in terminated_ids]
+    return True

--- a/apps/control-server/app/services/out_of_combat_cast.py
+++ b/apps/control-server/app/services/out_of_combat_cast.py
@@ -25,6 +25,7 @@ def check_out_of_combat_cast_eligibility(
     out_of_combat_target: str | None = None,
     target_user_id: str | None = None,
     caster_user_id: str | None = None,
+    target_state_json: dict | None = None,
 ) -> tuple[bool, str | None]:
     """Return (ok, rejection_reason).  ok=True means the cast may proceed."""
     if not spell.out_of_combat_castable:
@@ -57,6 +58,12 @@ def check_out_of_combat_cast_eligibility(
         and target_user_id != caster_user_id
     ):
         return False, "This spell can only target yourself"
+
+    effective_target_state = target_state_json if target_state_json is not None else state_json
+    effects = _resolve_effects(spell, variant_key)
+    rejection = _check_requires_unarmored_eligibility(effects, effective_target_state)
+    if rejection:
+        return False, rejection
 
     return True, None
 
@@ -283,3 +290,28 @@ def _resolve_kind_and_value(effect_type: str, params: dict) -> tuple[str | None,
         stat = params.get("stat", "")
         return stat, int(params.get("value", 0))
     return "spell_effect", None
+
+
+_ARMOR_TYPES = {"light", "medium", "heavy"}
+
+
+def _target_has_armor(target_state_json: dict) -> bool:
+    armor = target_state_json.get("equippedArmor") or {}
+    if not isinstance(armor, dict):
+        return False
+    armor_type = (armor.get("armorType") or "").strip().lower()
+    return armor_type in _ARMOR_TYPES
+
+
+def _check_requires_unarmored_eligibility(
+    effects: list[dict],
+    target_state_json: dict,
+) -> str | None:
+    """Return an error string if any effect requires unarmored and target has armor, else None."""
+    for effect in effects:
+        if not isinstance(effect, dict):
+            continue
+        params = effect.get("params") or {}
+        if params.get("requires_unarmored") is True and _target_has_armor(target_state_json):
+            return "Target is wearing armor and this spell requires an unarmored target"
+    return None

--- a/apps/control-server/app/services/session_state_finalize.py
+++ b/apps/control-server/app/services/session_state_finalize.py
@@ -5,6 +5,7 @@ import unicodedata
 from app.services.persistent_effect_expiry import prune_expired_persisted_effects_from_state
 from app.services.dragonborn_breath_weapon import apply_dragonborn_breath_weapon_canonical_state
 from app.services.session_rest import ensure_rest_state
+from app.services.declarative_effect_lifecycle import terminate_armor_don_effects_from_state
 
 
 _PLAYER_SHIELD_BONUS = 2
@@ -214,6 +215,7 @@ def finalize_session_state_data(
     next_data = ensure_rest_state(data)
     if isinstance(game_time_seconds, int):
         next_data = prune_expired_persisted_effects_from_state(next_data, game_time_seconds)
+    next_data = terminate_armor_don_effects_from_state(next_data)
     next_data = apply_dragonborn_breath_weapon_canonical_state(next_data)
 
     # Wild Shape: use beast form AC instead of equipment-derived AC

--- a/apps/control-server/tests/test_mage_armor.py
+++ b/apps/control-server/tests/test_mage_armor.py
@@ -1,0 +1,619 @@
+"""Tests for Mage Armor (issue #275) automation.
+
+Covers:
+- Timed combat duration schema (SpellDeclarativeDuration with type='timed')
+- termination_conditions field on SpellDeclarativeEffect
+- OOC cast validation: armored target rejected before slot consumption
+- OOC cast: persisted effect shape with timed duration
+- Armor-don lifecycle termination from state_json via finalize
+- Combat combat participant armor-don removal
+- AC applicability: requires_unarmored makes formula inapplicable without removing effect
+- Removing armor does NOT restore a terminated effect
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from pydantic import ValidationError
+
+from app.schemas.base_spell_effects import (
+    SpellDeclarativeEffect,
+    SpellDeclarativeDuration,
+    TerminationCondition,
+)
+from app.services.declarative_effect_lifecycle import (
+    _effect_has_target_dons_armor_termination,
+    _has_equipped_armor,
+    find_armor_don_terminated_effect_ids,
+    remove_armor_don_effects_from_combat_participant,
+    terminate_armor_don_effects_from_state,
+)
+from app.services.out_of_combat_cast import (
+    _check_requires_unarmored_eligibility,
+    _target_has_armor,
+    build_persisted_effects,
+    check_out_of_combat_cast_eligibility,
+)
+from app.services.session_state_finalize import (
+    calculate_player_armor_class_from_state,
+    finalize_session_state_data,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mage_armor_effect(
+    *,
+    requires_unarmored: bool = True,
+    has_termination: bool = True,
+    duration_type: str = "timed",
+    seconds: int = 28800,
+) -> dict:
+    termination = [{"type": "target_dons_armor"}] if has_termination else None
+    return {
+        "type": "armor_class_formula",
+        "target": "selected_target",
+        "duration": {"type": duration_type, "seconds": seconds} if duration_type == "timed" else {"type": duration_type},
+        "out_of_combat_duration": {"type": "timed", "seconds": seconds},
+        "params": {
+            "base_value": 13,
+            "ability": "dexterity",
+            "requires_unarmored": requires_unarmored,
+        },
+        **({"termination_conditions": termination} if termination is not None else {}),
+    }
+
+
+def _make_campaign_spell(
+    *,
+    canonical_key: str = "mage_armor",
+    level: int = 1,
+    effects_json: list | None = None,
+    out_of_combat_castable: bool = True,
+    out_of_combat_target: str = "self_or_ally",
+    concentration: bool = False,
+):
+    spell = MagicMock()
+    spell.canonical_key = canonical_key
+    spell.level = level
+    spell.concentration = concentration
+    spell.out_of_combat_castable = out_of_combat_castable
+    spell.out_of_combat_target = out_of_combat_target
+    spell.effects_json = effects_json if effects_json is not None else [_mage_armor_effect()]
+    spell.variants_json = []
+    spell.name_pt = "Armadura Arcana"
+    spell.name_en = "Mage Armor"
+    return spell
+
+
+def _make_active_spell_effect(
+    *,
+    base_value: int = 13,
+    ability: str = "dexterity",
+    requires_unarmored: bool = True,
+    has_termination: bool = True,
+    duration_type: str = "timed",
+    expires_at: int | None = 28800,
+    effect_id: str | None = None,
+) -> dict:
+    termination = [{"type": "target_dons_armor"}] if has_termination else []
+    return {
+        "id": effect_id or str(uuid4()),
+        "kind": "spell_effect",
+        "duration_type": duration_type,
+        "created_at_game_time_seconds": 0,
+        "expires_at_game_time_seconds": expires_at,
+        "metadata": {
+            "declarative_effect": {
+                "type": "armor_class_formula",
+                "target": "selected_target",
+                "params": {
+                    "base_value": base_value,
+                    "ability": ability,
+                    "requires_unarmored": requires_unarmored,
+                },
+                "termination_conditions": termination,
+            },
+            "source_spell_key": "mage_armor",
+            "concentration": False,
+        },
+    }
+
+
+def _player_state(
+    *,
+    dexterity: int = 14,
+    equipped_armor: dict | None = None,
+    active_spell_effects: list | None = None,
+) -> dict:
+    state = {
+        "abilities": {
+            "strength": 10, "dexterity": dexterity, "constitution": 10,
+            "intelligence": 10, "wisdom": 10, "charisma": 10,
+        },
+        "currentHP": 20,
+        "maxHP": 20,
+    }
+    if equipped_armor is not None:
+        state["equippedArmor"] = equipped_armor
+    if active_spell_effects is not None:
+        state["active_spell_effects"] = active_spell_effects
+    return state
+
+
+def _leather_armor() -> dict:
+    return {"armorType": "light", "baseAC": 11, "allowsDex": True}
+
+
+def _scale_mail() -> dict:
+    return {"armorType": "medium", "baseAC": 14, "dexCap": 2, "allowsDex": True}
+
+
+# ---------------------------------------------------------------------------
+# Schema: SpellDeclarativeDuration with type='timed'
+# ---------------------------------------------------------------------------
+
+class TestTimedCombatDurationSchema(unittest.TestCase):
+
+    def test_timed_duration_valid(self):
+        dur = SpellDeclarativeDuration.model_validate({"type": "timed", "seconds": 28800})
+        self.assertEqual(dur.type, "timed")
+        self.assertEqual(dur.seconds, 28800)
+        self.assertIsNone(dur.rounds)
+        self.assertIsNone(dur.anchor)
+
+    def test_timed_duration_requires_seconds(self):
+        with self.assertRaises(ValidationError):
+            SpellDeclarativeDuration.model_validate({"type": "timed"})
+
+    def test_timed_duration_rejects_negative_seconds(self):
+        with self.assertRaises(ValidationError):
+            SpellDeclarativeDuration.model_validate({"type": "timed", "seconds": 0})
+
+    def test_timed_duration_strips_anchor(self):
+        dur = SpellDeclarativeDuration.model_validate(
+            {"type": "timed", "seconds": 100, "anchor": "target"}
+        )
+        self.assertIsNone(dur.anchor)
+
+    def test_rounds_duration_unaffected(self):
+        dur = SpellDeclarativeDuration.model_validate({"type": "rounds", "rounds": 10})
+        self.assertEqual(dur.type, "rounds")
+        self.assertEqual(dur.rounds, 10)
+        self.assertIsNone(dur.seconds)
+
+    def test_manual_duration_unaffected(self):
+        dur = SpellDeclarativeDuration.model_validate({"type": "manual"})
+        self.assertEqual(dur.type, "manual")
+        self.assertIsNone(dur.seconds)
+        self.assertIsNone(dur.rounds)
+
+
+# ---------------------------------------------------------------------------
+# Schema: termination_conditions on SpellDeclarativeEffect
+# ---------------------------------------------------------------------------
+
+class TestTerminationConditionSchema(unittest.TestCase):
+
+    def test_effect_with_target_dons_armor_termination(self):
+        effect = SpellDeclarativeEffect.model_validate({
+            "type": "armor_class_formula",
+            "target": "selected_target",
+            "duration": {"type": "timed", "seconds": 28800},
+            "out_of_combat_duration": {"type": "timed", "seconds": 28800},
+            "params": {"base_value": 13, "ability": "dexterity", "requires_unarmored": True},
+            "termination_conditions": [{"type": "target_dons_armor"}],
+        })
+        self.assertIsNotNone(effect.termination_conditions)
+        self.assertEqual(len(effect.termination_conditions), 1)
+        self.assertEqual(effect.termination_conditions[0].type, "target_dons_armor")
+
+    def test_effect_without_termination_conditions(self):
+        effect = SpellDeclarativeEffect.model_validate({
+            "type": "armor_class_formula",
+            "target": "selected_target",
+            "params": {"base_value": 13, "ability": "dexterity"},
+        })
+        self.assertIsNone(effect.termination_conditions)
+
+    def test_unknown_termination_type_rejected(self):
+        with self.assertRaises(ValidationError):
+            SpellDeclarativeEffect.model_validate({
+                "type": "armor_class_formula",
+                "target": "selected_target",
+                "params": {"base_value": 13, "ability": "dexterity"},
+                "termination_conditions": [{"type": "unknown_condition"}],
+            })
+
+    def test_termination_condition_model(self):
+        cond = TerminationCondition.model_validate({"type": "target_dons_armor"})
+        self.assertEqual(cond.type, "target_dons_armor")
+
+
+# ---------------------------------------------------------------------------
+# OOC cast validation: requires_unarmored
+# ---------------------------------------------------------------------------
+
+class TestOOCRequiresUnarmoredEligibility(unittest.TestCase):
+
+    def test_check_rejects_armored_target(self):
+        effects = [_mage_armor_effect()]
+        target_state = _player_state(equipped_armor=_leather_armor())
+        result = _check_requires_unarmored_eligibility(effects, target_state)
+        self.assertIsNotNone(result)
+
+    def test_check_allows_unarmored_target(self):
+        effects = [_mage_armor_effect()]
+        target_state = _player_state(equipped_armor=None)
+        result = _check_requires_unarmored_eligibility(effects, target_state)
+        self.assertIsNone(result)
+
+    def test_check_ignores_effect_without_requires_unarmored(self):
+        effects = [{"type": "armor_class_formula", "target": "selected_target",
+                    "params": {"base_value": 13, "ability": "dexterity"}}]
+        target_state = _player_state(equipped_armor=_scale_mail())
+        result = _check_requires_unarmored_eligibility(effects, target_state)
+        self.assertIsNone(result)
+
+    def test_target_has_armor_helper_light_armor(self):
+        self.assertTrue(_target_has_armor({"equippedArmor": {"armorType": "light"}}))
+
+    def test_target_has_armor_helper_medium_armor(self):
+        self.assertTrue(_target_has_armor({"equippedArmor": {"armorType": "medium"}}))
+
+    def test_target_has_armor_helper_heavy_armor(self):
+        self.assertTrue(_target_has_armor({"equippedArmor": {"armorType": "heavy"}}))
+
+    def test_target_has_armor_helper_no_armor(self):
+        self.assertFalse(_target_has_armor({}))
+
+    def test_target_has_armor_helper_empty_armor(self):
+        self.assertFalse(_target_has_armor({"equippedArmor": {}}))
+
+    def test_check_eligibility_with_armored_target_state_json(self):
+        spell = _make_campaign_spell()
+        state_json = _player_state(
+            dexterity=14,
+            equipped_armor=None,
+        )
+        state_json["spellcasting"] = {
+            "slots": {"1": {"used": 0, "max": 2}},
+            "spells": [],
+        }
+        ok, reason = check_out_of_combat_cast_eligibility(
+            spell=spell,
+            state_json=state_json,
+            slot_level=1,
+            variant_key=None,
+            target_state_json=_player_state(equipped_armor=_leather_armor()),
+        )
+        self.assertFalse(ok)
+        self.assertIn("armor", reason.lower())
+
+    def test_check_eligibility_unarmored_target_passes(self):
+        spell = _make_campaign_spell()
+        state_json = _player_state(dexterity=14)
+        state_json["spellcasting"] = {
+            "slots": {"1": {"used": 0, "max": 2}},
+            "spells": [],
+        }
+        ok, reason = check_out_of_combat_cast_eligibility(
+            spell=spell,
+            state_json=state_json,
+            slot_level=1,
+            variant_key=None,
+            target_state_json=_player_state(equipped_armor=None),
+        )
+        self.assertTrue(ok)
+        self.assertIsNone(reason)
+
+
+# ---------------------------------------------------------------------------
+# OOC cast: persisted effect shape with timed duration
+# ---------------------------------------------------------------------------
+
+class TestOOCMageArmorEffectShape(unittest.TestCase):
+
+    def test_build_persisted_effects_timed_duration(self):
+        spell = _make_campaign_spell()
+        game_time = 1000
+        effects = build_persisted_effects(
+            spell=spell,
+            caster_user_id="caster-1",
+            target_user_id="target-1",
+            variant_key=None,
+            game_time_seconds=game_time,
+        )
+        self.assertEqual(len(effects), 1)
+        e = effects[0]
+        self.assertEqual(e["duration_type"], "timed")
+        self.assertEqual(e["created_at_game_time_seconds"], game_time)
+        self.assertEqual(e["expires_at_game_time_seconds"], game_time + 28800)
+        self.assertEqual(e["kind"], "spell_effect")
+
+    def test_build_persisted_effects_metadata_contains_declarative_effect(self):
+        spell = _make_campaign_spell()
+        effects = build_persisted_effects(
+            spell=spell,
+            caster_user_id="caster-1",
+            target_user_id="target-1",
+            variant_key=None,
+            game_time_seconds=0,
+        )
+        self.assertEqual(len(effects), 1)
+        metadata = effects[0]["metadata"]
+        declarative = metadata["declarative_effect"]
+        self.assertEqual(declarative["type"], "armor_class_formula")
+        params = declarative["params"]
+        self.assertEqual(params["base_value"], 13)
+        self.assertEqual(params["ability"], "dexterity")
+        self.assertTrue(params["requires_unarmored"])
+
+    def test_build_persisted_effects_includes_termination_conditions(self):
+        spell = _make_campaign_spell()
+        effects = build_persisted_effects(
+            spell=spell,
+            caster_user_id="caster-1",
+            target_user_id="target-1",
+            variant_key=None,
+            game_time_seconds=0,
+        )
+        declarative = effects[0]["metadata"]["declarative_effect"]
+        self.assertIn("termination_conditions", declarative)
+        self.assertEqual(declarative["termination_conditions"], [{"type": "target_dons_armor"}])
+
+
+# ---------------------------------------------------------------------------
+# AC calculation: requires_unarmored applicability (no removal)
+# ---------------------------------------------------------------------------
+
+class TestACApplicabilityVsTermination(unittest.TestCase):
+
+    def test_formula_applies_when_unarmored(self):
+        state = _player_state(dexterity=14, active_spell_effects=[_make_active_spell_effect()])
+        ac = calculate_player_armor_class_from_state(state)
+        # 13 + DEX(14→+2) = 15
+        self.assertEqual(ac, 15)
+
+    def test_formula_inapplicable_when_armored_not_removed(self):
+        # Effect stays in state but doesn't contribute to AC
+        effect = _make_active_spell_effect()
+        state = _player_state(
+            dexterity=14,
+            equipped_armor=_leather_armor(),
+            active_spell_effects=[effect],
+        )
+        ac = calculate_player_armor_class_from_state(state)
+        # leather armor: 11 + 2 DEX = 13 (formula ignored, not 15)
+        self.assertEqual(ac, 13)
+        # Effect still in state (applicability ≠ termination)
+        self.assertEqual(len(state["active_spell_effects"]), 1)
+
+    def test_formula_beats_default_unarmored(self):
+        state = _player_state(dexterity=14, active_spell_effects=[_make_active_spell_effect()])
+        ac = calculate_player_armor_class_from_state(state)
+        self.assertEqual(ac, 15)
+
+    def test_additive_bonuses_stack_on_formula(self):
+        effects = [
+            _make_active_spell_effect(),
+            {
+                "id": str(uuid4()),
+                "kind": "temp_ac_bonus",
+                "numeric_value": 2,
+                "duration_type": "manual",
+            },
+        ]
+        state = _player_state(dexterity=14, active_spell_effects=effects)
+        ac = calculate_player_armor_class_from_state(state)
+        # 13 + 2 (DEX) + 2 (temp bonus) = 17
+        self.assertEqual(ac, 17)
+
+
+# ---------------------------------------------------------------------------
+# Armor-don termination: declarative_effect_lifecycle helpers
+# ---------------------------------------------------------------------------
+
+class TestArmorDonLifecycleHelpers(unittest.TestCase):
+
+    def test_effect_has_target_dons_armor_termination_true(self):
+        effect = _make_active_spell_effect(has_termination=True)
+        self.assertTrue(_effect_has_target_dons_armor_termination(effect))
+
+    def test_effect_has_target_dons_armor_termination_false(self):
+        effect = _make_active_spell_effect(has_termination=False)
+        self.assertFalse(_effect_has_target_dons_armor_termination(effect))
+
+    def test_has_equipped_armor_light(self):
+        state = _player_state(equipped_armor=_leather_armor())
+        self.assertTrue(_has_equipped_armor(state))
+
+    def test_has_equipped_armor_none(self):
+        state = _player_state()
+        self.assertFalse(_has_equipped_armor(state))
+
+    def test_find_armor_don_terminated_effect_ids(self):
+        e1 = _make_active_spell_effect(effect_id="e1", has_termination=True)
+        e2 = _make_active_spell_effect(effect_id="e2", has_termination=False)
+        ids = find_armor_don_terminated_effect_ids([e1, e2])
+        self.assertEqual(ids, ["e1"])
+
+    def test_terminate_armor_don_effects_removes_when_armored(self):
+        effect = _make_active_spell_effect()
+        state = _player_state(
+            equipped_armor=_leather_armor(),
+            active_spell_effects=[effect],
+        )
+        result = terminate_armor_don_effects_from_state(state)
+        self.assertNotIn("active_spell_effects", result)
+
+    def test_terminate_armor_don_effects_keeps_when_unarmored(self):
+        effect = _make_active_spell_effect()
+        state = _player_state(active_spell_effects=[effect])
+        result = terminate_armor_don_effects_from_state(state)
+        self.assertIn("active_spell_effects", result)
+        self.assertEqual(len(result["active_spell_effects"]), 1)
+
+    def test_terminate_armor_don_preserves_non_terminating_effects(self):
+        e1 = _make_active_spell_effect(effect_id="e1", has_termination=True)
+        e2 = _make_active_spell_effect(effect_id="e2", has_termination=False)
+        state = _player_state(
+            equipped_armor=_leather_armor(),
+            active_spell_effects=[e1, e2],
+        )
+        result = terminate_armor_don_effects_from_state(state)
+        remaining = result.get("active_spell_effects", [])
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0]["id"], "e2")
+
+    def test_removing_armor_does_not_restore_terminated_effect(self):
+        # Effect was removed when armor was equipped; then armor removed.
+        # No effect to restore — termination is permanent.
+        state = _player_state(active_spell_effects=[])  # effect already gone
+        result = terminate_armor_don_effects_from_state(state)
+        self.assertEqual(result.get("active_spell_effects", []), [])
+
+    def test_idempotent_when_no_armor(self):
+        effect = _make_active_spell_effect()
+        state = _player_state(active_spell_effects=[effect])
+        result = terminate_armor_don_effects_from_state(state)
+        self.assertIs(result, state)  # unchanged object
+
+    def test_idempotent_when_no_effects(self):
+        state = _player_state(equipped_armor=_leather_armor())
+        result = terminate_armor_don_effects_from_state(state)
+        self.assertIs(result, state)
+
+
+# ---------------------------------------------------------------------------
+# finalize_session_state_data: armor-don termination integrated
+# ---------------------------------------------------------------------------
+
+class TestFinalizeArmorDonTermination(unittest.TestCase):
+
+    def test_finalize_removes_armor_don_effects_on_armor_equip(self):
+        effect = _make_active_spell_effect()
+        state = _player_state(
+            dexterity=14,
+            equipped_armor=_leather_armor(),
+            active_spell_effects=[effect],
+        )
+        result = finalize_session_state_data(state)
+        self.assertNotIn("active_spell_effects", result)
+
+    def test_finalize_keeps_effects_when_unarmored(self):
+        effect = _make_active_spell_effect()
+        state = _player_state(dexterity=14, active_spell_effects=[effect])
+        result = finalize_session_state_data(state)
+        self.assertIn("active_spell_effects", result)
+
+    def test_finalize_recalculates_ac_after_armor_don_termination(self):
+        # With Mage Armor and leather equipped, Mage Armor is terminated,
+        # AC should be from leather (11 + 2 DEX = 13).
+        effect = _make_active_spell_effect()
+        state = _player_state(
+            dexterity=14,
+            equipped_armor=_leather_armor(),
+            active_spell_effects=[effect],
+        )
+        result = finalize_session_state_data(state)
+        # Mage Armor gone; leather: 11 + 2 = 13
+        self.assertEqual(result["armorClass"], 13)
+
+
+# ---------------------------------------------------------------------------
+# Combat participant armor-don removal
+# ---------------------------------------------------------------------------
+
+class TestCombatArmorDonRemoval(unittest.TestCase):
+
+    def _make_combat_state(self, effects: list[dict], player_user_id: str = "user-1"):
+        state = MagicMock()
+        state.participants = [
+            {
+                "id": "p-1",
+                "kind": "player",
+                "ref_id": player_user_id,
+                "display_name": "Alice",
+                "active_effects": list(effects),
+            }
+        ]
+        return state
+
+    def test_removes_armor_don_effects_from_participant(self):
+        e1 = _make_active_spell_effect(effect_id="e1", has_termination=True)
+        combat_state = self._make_combat_state([e1])
+        removed = remove_armor_don_effects_from_combat_participant(combat_state, "user-1")
+        self.assertTrue(removed)
+        self.assertEqual(combat_state.participants[0]["active_effects"], [])
+
+    def test_no_op_when_no_terminating_effects(self):
+        e1 = _make_active_spell_effect(effect_id="e1", has_termination=False)
+        combat_state = self._make_combat_state([e1])
+        removed = remove_armor_don_effects_from_combat_participant(combat_state, "user-1")
+        self.assertFalse(removed)
+        self.assertEqual(len(combat_state.participants[0]["active_effects"]), 1)
+
+    def test_no_op_when_participant_not_found(self):
+        e1 = _make_active_spell_effect(has_termination=True)
+        combat_state = self._make_combat_state([e1], player_user_id="user-1")
+        removed = remove_armor_don_effects_from_combat_participant(combat_state, "user-9")
+        self.assertFalse(removed)
+
+    def test_preserves_non_terminating_effects(self):
+        e1 = _make_active_spell_effect(effect_id="e1", has_termination=True)
+        e2 = _make_active_spell_effect(effect_id="e2", has_termination=False)
+        combat_state = self._make_combat_state([e1, e2])
+        remove_armor_don_effects_from_combat_participant(combat_state, "user-1")
+        remaining = combat_state.participants[0]["active_effects"]
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0]["id"], "e2")
+
+    def test_handles_none_combat_state(self):
+        removed = remove_armor_don_effects_from_combat_participant(None, "user-1")
+        self.assertFalse(removed)
+
+
+# ---------------------------------------------------------------------------
+# Full mage_armor seed entry schema validation
+# ---------------------------------------------------------------------------
+
+class TestMageArmorSeedEntry(unittest.TestCase):
+
+    def _mage_armor_seed_effect(self) -> dict:
+        return {
+            "type": "armor_class_formula",
+            "target": "selected_target",
+            "duration": {"type": "timed", "seconds": 28800},
+            "out_of_combat_duration": {"type": "timed", "seconds": 28800},
+            "params": {
+                "base_value": 13,
+                "ability": "dexterity",
+                "requires_unarmored": True,
+            },
+            "termination_conditions": [{"type": "target_dons_armor"}],
+        }
+
+    def test_seed_effect_validates_as_spell_declarative_effect(self):
+        effect = SpellDeclarativeEffect.model_validate(self._mage_armor_seed_effect())
+        self.assertEqual(effect.type, "armor_class_formula")
+        self.assertIsNotNone(effect.termination_conditions)
+        self.assertEqual(effect.duration.type, "timed")
+        self.assertEqual(effect.duration.seconds, 28800)
+
+    def test_seed_effect_round_trips(self):
+        raw = self._mage_armor_seed_effect()
+        effect = SpellDeclarativeEffect.model_validate(raw)
+        dumped = effect.model_dump(mode="json", exclude_none=True)
+        self.assertEqual(dumped["termination_conditions"], [{"type": "target_dons_armor"}])
+        self.assertEqual(dumped["duration"]["type"], "timed")
+        self.assertEqual(dumped["duration"]["seconds"], 28800)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PR: feat(spells) mage armor implementation and declarative termination conditions

## Description

Este PR finaliza a implementação completa de magias como *Mage Armor* (Armadura Arcana), introduzindo condições de terminação declarativas e validações de elegibilidade de conjuração baseadas no estado do alvo (uso de armadura). O sistema agora é capaz de remover efeitos automaticamente quando uma condição de encerramento é atingida, tanto em combate quanto em exploração.

## Changes

### Schema & Data Model (`base_spell_effects.py`)
- **Duration Type:** Adicionado `timed` ao `SpellDeclarativeDurationType` com validação de campo `seconds`.
- **Termination Conditions:** Introduzido o modelo `TerminationCondition` e o campo `termination_conditions` no `SpellDeclarativeEffect`, permitindo que efeitos sejam marcados para remoção automática (ex: ao vestir uma armadura).

### Combat & Timed Duration Logic
- **Timestamp Computation:** `_declarative_duration_kwargs` agora computa dinamicamente `created_at_game_time_seconds` e `expires_at_game_time_seconds` durante o cast.
- **Propagation:** A cadeia de execução de `_cast_spell_via_declarative_effects` agora propaga o `game_time` para garantir que o snapshot de tempo seja preciso no momento da criação do efeito.

### Cast Validation (Armor Checks)
- **OOC Casting:** `check_out_of_combat_cast_eligibility` agora valida o `target_state_json` e rejeita a conjuração se o alvo estiver vestindo armadura, impedindo o gasto indevido de slots.
- **Combat Casting:** Integrado `_check_declarative_requires_unarmored_for_target` no mixin de resolução de magias, validando a elegibilidade antes do consumo de recursos.

### Lifecycle & Pruning (`declarative_effect_lifecycle.py`)
- **Auto-Termination:** Implementadas funções para remover efeitos com a condição `target_dons_armor` quando uma armadura é equipada.
- **Integration Points:** A limpeza automática foi integrada nos fluxos autoritativos:
    - `finalize_session_state_data`
    - `update_my_session_loadout`
    - `update_player_session_state`

### Data & Seeding
- **Base Spells:** Atualizada a semente de *Armadura Arcana* com:
    - `armor_class_formula`: 13 + DEX.
    - `requires_unarmored`: true.
    - `duration`: timed (28800s / 8 horas).
- **Migration:** Nova migração `0077` para upsert de dados e backfill conservador em campanhas ativas.

## Summary of Changes

| Component | Change |
| :--- | :--- |
| **Logic** | Declarative duration and conditional termination triggers |
| **Validation** | Cross-check of target armor state before and after casting |
| **Lifecycle** | Automated pruning of armor-incompatible effects |
| **Migration** | `0077_mage_armor_data.py` providing the new spell definition |

## Validation

- **Total:** 2184 testes passando sem regressões.
- **Novos Testes:** 48 subtestes adicionados cobrindo os novos cenários de validação de armadura e expiração timed.
- **Coverage:** Validado o bloqueio de cast em alvos blindados e a remoção imediata do efeito ao equipar armadura no loadout.

> [!NOTE]
> A implementação de `termination_conditions` é genérica, permitindo que futuras condições (como tomar dano ou sair de uma área) sejam adicionadas sem refatoração do motor de efeitos.