### PR TITLE
feat(spells) break-on-damage termination and Animal Friendship (#277)

### DIFF
--- a/apps/control-server/app/schemas/base_spell_effects.py
+++ b/apps/control-server/app/schemas/base_spell_effects.py
@@ -139,7 +139,10 @@ class ArmorClassFormulaParams(BaseModel):
     requires_unarmored: bool | None = None
 
 
-SpellDeclarativeTerminationConditionType = Literal["target_dons_armor"]
+SpellDeclarativeTerminationConditionType = Literal[
+    "target_dons_armor",
+    "target_takes_damage_from_caster_or_allies",
+]
 
 
 class TerminationCondition(BaseModel):

--- a/apps/control-server/app/services/combat_service/actions/weapon_attack_damage.py
+++ b/apps/control-server/app/services/combat_service/actions/weapon_attack_damage.py
@@ -63,6 +63,7 @@ class WeaponAttackDamageMixin:
                 damage_type=pending_attack.get("damage_type"),
                 is_crit=bool(pending_attack.get("is_critical")),
                 state=state,
+                attacker_participant_id=attacker.get("id"),
                 **cls._build_concentration_roll_kwargs(req.concentration_roll_source, req.concentration_manual_roll),
             )
         roll_result = RollResult.model_validate(pending_attack.get("roll_result")) if isinstance(pending_attack.get("roll_result"), dict) else None

--- a/apps/control-server/app/services/combat_service/damage_core.py
+++ b/apps/control-server/app/services/combat_service/damage_core.py
@@ -7,6 +7,7 @@ from app.models.campaign_entity import CampaignEntity
 from app.models.combat import CombatState
 from app.services.draconic_ancestry import resolve_draconic_lineage_state
 from app.services.dragonborn_ancestry import resolve_dragonborn_lineage_state
+from app.services.declarative_effect_lifecycle import remove_damage_terminated_effects_from_participant
 from app.services.session_state_finalize import finalize_session_state_data
 
 
@@ -47,6 +48,7 @@ class CombatDamageCoreMixin:
         damage_type: str | None = None,
         concentration_roll_source: str = "system",
         concentration_manual_roll: int | None = None,
+        attacker_participant_id: str | None = None,
     ) -> tuple[int, str, int | None, dict | None]:
         target_model, *_ = cls._get_stats(db, target_ref_id, kind, state.session_id if state else "")
         message = ""
@@ -95,6 +97,8 @@ class CombatDamageCoreMixin:
                 if state:
                     flag_modified(state, "participants")
                     db.add(state)
+                if attacker_participant_id and amount > 0 and target_participant is not None:
+                    remove_damage_terminated_effects_from_participant(state, target_participant, attacker_participant_id)
                 if resistance_msg:
                     message = f"{message} {resistance_msg}".strip()
                 return cls._safe_int(cls._as_dict(target_model.state_json).get("currentHP"), 0), message, None, concentration_check
@@ -131,6 +135,8 @@ class CombatDamageCoreMixin:
             if state:
                 flag_modified(state, "participants")
                 db.add(state)
+            if attacker_participant_id and amount > 0 and target_participant is not None:
+                remove_damage_terminated_effects_from_participant(state, target_participant, attacker_participant_id)
             return cls._safe_int(cls._as_dict(target_model.state_json).get("currentHP"), 0), message, current, concentration_check
         npc = db.exec(select(CampaignEntity).where(CampaignEntity.id == target_model.campaign_entity_id)).first()
         base_hp = npc.max_hp if npc else 0
@@ -154,6 +160,8 @@ class CombatDamageCoreMixin:
         if state:
             flag_modified(state, "participants")
             db.add(state)
+        if attacker_participant_id and amount > 0 and target_participant is not None:
+            remove_damage_terminated_effects_from_participant(state, target_participant, attacker_participant_id)
         return target_model.current_hp, message, current, concentration_check
 
     @classmethod

--- a/apps/control-server/app/services/combat_service/dragonborn_breath.py
+++ b/apps/control-server/app/services/combat_service/dragonborn_breath.py
@@ -114,6 +114,7 @@ class CombatDragonbornBreathMixin:
                 False,
                 state,
                 damage_type=action_state.get("damageType"),
+                attacker_participant_id=actor.get("id"),
             )
             if previous_hp is not None and new_hp is not None:
                 applied_damage = max(0, previous_hp - new_hp)

--- a/apps/control-server/app/services/combat_service/npc_action_resolution.py
+++ b/apps/control-server/app/services/combat_service/npc_action_resolution.py
@@ -287,6 +287,7 @@ class CombatNpcActionResolutionMixin:
                         damage_type=damage_type,
                         is_crit=False,
                         state=state,
+                        attacker_participant_id=attacker.get("id"),
                     )
             context.update(
                 {

--- a/apps/control-server/app/services/combat_service/npc_actions.py
+++ b/apps/control-server/app/services/combat_service/npc_actions.py
@@ -138,6 +138,7 @@ class CombatNpcActionMixin(
                 damage_type=pending_attack.get("damage_type"),
                 is_crit=bool(pending_attack.get("is_critical")),
                 state=state,
+                attacker_participant_id=attacker.get("id"),
                 **cls._build_concentration_roll_kwargs(
                     req.concentration_roll_source,
                     req.concentration_manual_roll,

--- a/apps/control-server/app/services/combat_service/save_resolve.py
+++ b/apps/control-server/app/services/combat_service/save_resolve.py
@@ -151,6 +151,7 @@ class CombatSaveResolveMixin:
                     db, state, target_p["ref_id"], target_p["kind"], effect_kind, amount,
                     damage_type=damage_type,
                     concentration_roll_source=concentration_roll_source,
+                    attacker_participant_id=attacker_participant_id,
                 )
 
         db.add(state)

--- a/apps/control-server/app/services/combat_service/spell_automation.py
+++ b/apps/control-server/app/services/combat_service/spell_automation.py
@@ -15,6 +15,7 @@ from app.services.goodberry_inventory import (
     build_goodberry_expiration,
     grant_catalog_item_to_player_inventory,
 )
+from app.services.game_time import get_game_time_seconds
 from app.services.roll_resolution import resolve_attack_base, resolve_saving_throw
 
 from .exceptions import CombatServiceError
@@ -275,6 +276,7 @@ class CombatSpellAutomationMixin:
         roll_total = roll_result.total
         is_saved = bool(roll_result.success)
 
+        game_time = get_game_time_seconds(session_id, db)
         if not is_saved:
             cls._append_effect_to_participant(
                 target_participant,
@@ -282,11 +284,16 @@ class CombatSpellAutomationMixin:
                     kind="condition",
                     condition_type="charmed",
                     source_participant_id=attacker["id"],
-                    duration_type="manual",
-                    expires_at_participant_id=target_participant["id"],
+                    duration_type="timed",
+                    created_at_game_time_seconds=game_time,
+                    expires_at_game_time_seconds=game_time + 86400,
                     metadata={
                         "source_spell_key": "animal_friendship",
+                        "caster_participant_id": attacker["id"],
                         "charmer_participant_id": attacker["id"],
+                        "termination_conditions": [
+                            {"type": "target_takes_damage_from_caster_or_allies"},
+                        ],
                     },
                 ),
             )
@@ -449,6 +456,7 @@ class CombatSpellAutomationMixin:
                     damage,
                     damage_type="force",
                     is_critical=roll_result.selected_roll == 20,
+                    attacker_participant_id=attacker.get("id"),
                 )
 
         target_name = target_participant["display_name"] if target_participant else None
@@ -573,6 +581,7 @@ class CombatSpellAutomationMixin:
                     damage,
                     damage_type="force",
                     is_critical=roll_result.selected_roll == 20,
+                    attacker_participant_id=attacker.get("id"),
                 )
 
         flag_modified(state, "participants")

--- a/apps/control-server/app/services/combat_service/spells/cast_area_effect.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_area_effect.py
@@ -95,6 +95,7 @@ class CastAreaEffectMixin:
                     is_critical=bool(pending_spell.get("is_critical")),
                     concentration_roll_source=req.concentration_roll_source,
                     concentration_manual_roll=req.concentration_manual_roll,
+                    attacker_participant_id=attacker.get("id"),
                 )
                 if effect_kind == "healing":
                     total_healing += amount

--- a/apps/control-server/app/services/combat_service/spells/cast_target.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target.py
@@ -646,6 +646,7 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
                 damage_type=damage_type,
                 concentration_roll_source=req.concentration_roll_source,
                 concentration_manual_roll=req.concentration_manual_roll,
+                attacker_participant_id=attacker.get("id"),
             )
 
         return {
@@ -734,6 +735,7 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
                     is_critical=is_critical,
                     concentration_roll_source=req.concentration_roll_source,
                     concentration_manual_roll=req.concentration_manual_roll,
+                    attacker_participant_id=attacker.get("id"),
                 )
                 if effect_kind == "healing":
                     healing = amount

--- a/apps/control-server/app/services/combat_service/spells/cast_target_effect.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target_effect.py
@@ -134,6 +134,7 @@ class CastTargetEffectMixin:
                 is_critical=bool(pending_spell.get("is_critical")),
                 concentration_roll_source=req.concentration_roll_source,
                 concentration_manual_roll=req.concentration_manual_roll,
+                attacker_participant_id=attacker.get("id"),
             )
         if target_participant is not None and cls._spell_context_has_declarative_effects(
             pending_spell_context

--- a/apps/control-server/app/services/combat_service/spells/spell_resolution_attack.py
+++ b/apps/control-server/app/services/combat_service/spells/spell_resolution_attack.py
@@ -90,6 +90,7 @@ class SpellResolutionAttackMixin(SpellResolutionCommonMixin):
                 is_critical=result.is_critical,
                 concentration_roll_source=req.concentration_roll_source,
                 concentration_manual_roll=req.concentration_manual_roll,
+                attacker_participant_id=attacker.get("id"),
             )
             if effect_kind == "healing":
                 result.healing = amount

--- a/apps/control-server/app/services/combat_service/spells/spell_resolution_common.py
+++ b/apps/control-server/app/services/combat_service/spells/spell_resolution_common.py
@@ -288,6 +288,7 @@ class SpellResolutionCommonMixin:
         is_critical: bool = False,
         concentration_roll_source: str = "system",
         concentration_manual_roll: int | None = None,
+        attacker_participant_id: str | None = None,
     ) -> tuple[int | None, str, int | None, dict | None]:
         if amount <= 0:
             return None, "", None, None
@@ -302,6 +303,7 @@ class SpellResolutionCommonMixin:
             damage_type=damage_type,
             is_crit=is_critical,
             state=state,
+            attacker_participant_id=attacker_participant_id,
             **cls._build_concentration_roll_kwargs(concentration_roll_source, concentration_manual_roll),
         )
 

--- a/apps/control-server/app/services/combat_service/spells/spell_resolution_save.py
+++ b/apps/control-server/app/services/combat_service/spells/spell_resolution_save.py
@@ -75,6 +75,7 @@ class SpellResolutionSaveMixin(SpellResolutionCommonMixin):
                 damage_type=spell_context.get("damage_type"),
                 concentration_roll_source=req.concentration_roll_source,
                 concentration_manual_roll=req.concentration_manual_roll,
+                attacker_participant_id=attacker.get("id"),
             )
             if effect_kind == "healing":
                 result.healing = amount
@@ -120,6 +121,7 @@ class SpellResolutionSaveMixin(SpellResolutionCommonMixin):
                 damage_type=spell_context.get("damage_type"),
                 concentration_roll_source=req.concentration_roll_source,
                 concentration_manual_roll=req.concentration_manual_roll,
+                attacker_participant_id=attacker.get("id"),
             )
             if effect_kind == "healing":
                 result.healing = amount

--- a/apps/control-server/app/services/declarative_effect_lifecycle.py
+++ b/apps/control-server/app/services/declarative_effect_lifecycle.py
@@ -1,12 +1,14 @@
 """Lifecycle helpers for declarative spell effects.
 
 Handles applicability (requires_unarmored → AC formula skipped) separately from
-termination (target_dons_armor → effect permanently removed).
+termination (target_dons_armor, target_takes_damage_from_caster_or_allies → effect
+permanently removed).
 """
 
 from __future__ import annotations
 
 _ARMOR_TYPES = {"light", "medium", "heavy"}
+_FRIENDLY_TEAMS = frozenset({"players", "allies"})
 
 
 def _has_equipped_armor(state_json: dict) -> bool:
@@ -65,6 +67,117 @@ def find_armor_don_terminated_effect_ids(participant_effects: list[dict]) -> lis
         and isinstance(e.get("id"), str)
         and _effect_has_target_dons_armor_termination(e)
     ]
+
+
+# ---------------------------------------------------------------------------
+# Damage-break termination (target_takes_damage_from_caster_or_allies)
+# ---------------------------------------------------------------------------
+
+def _get_effect_termination_conditions(effect: dict) -> list[dict]:
+    """Return termination_conditions for an effect, checking both storage locations.
+
+    Automation-built effects (e.g. Animal Friendship charmed) store them directly
+    in metadata.  Declarative effects store them inside metadata.declarative_effect.
+    """
+    if not isinstance(effect, dict):
+        return []
+    metadata = effect.get("metadata") or {}
+    # Direct metadata (automation-built effects)
+    direct = metadata.get("termination_conditions")
+    if isinstance(direct, list):
+        return direct
+    # Nested inside declarative_effect (SpellDeclarativeEffect)
+    declarative = metadata.get("declarative_effect") or {}
+    nested = declarative.get("termination_conditions")
+    return nested if isinstance(nested, list) else []
+
+
+def _get_caster_participant_id_for_effect(effect: dict) -> str | None:
+    """Return the participant ID of the spell's caster stored in effect metadata."""
+    if not isinstance(effect, dict):
+        return None
+    metadata = effect.get("metadata") or {}
+    # Standard key used by declarative effects and new automation effects
+    caster_id = metadata.get("caster_participant_id")
+    if isinstance(caster_id, str):
+        return caster_id
+    # Legacy key kept for old Animal Friendship effects in DB
+    charmer_id = metadata.get("charmer_participant_id")
+    return charmer_id if isinstance(charmer_id, str) else None
+
+
+def _are_friendly_participants(p1: dict, p2: dict) -> bool:
+    """Return True if p1 and p2 are on the same side (allies of each other)."""
+    if p1.get("id") == p2.get("id"):
+        return True
+    t1, t2 = p1.get("team"), p2.get("team")
+    if t1 == t2 and t1 is not None:
+        return True
+    return t1 in _FRIENDLY_TEAMS and t2 in _FRIENDLY_TEAMS
+
+
+def _effect_has_damage_termination(effect: dict) -> bool:
+    return any(
+        isinstance(c, dict) and c.get("type") == "target_takes_damage_from_caster_or_allies"
+        for c in _get_effect_termination_conditions(effect)
+    )
+
+
+def _find_participant_by_id(participants: list, participant_id: str | None) -> dict | None:
+    if not participant_id:
+        return None
+    return next((p for p in participants if isinstance(p, dict) and p.get("id") == participant_id), None)
+
+
+def find_damage_terminated_effect_ids(
+    participants: list,
+    target_participant: dict,
+    attacker_participant_id: str,
+) -> list[str]:
+    """Return IDs of effects that should terminate because attacker is caster or ally.
+
+    Only considers effects with `target_takes_damage_from_caster_or_allies` termination
+    condition.
+    """
+    attacker = _find_participant_by_id(participants, attacker_participant_id)
+    if attacker is None:
+        return []
+
+    terminated: list[str] = []
+    for effect in (target_participant.get("active_effects") or []):
+        if not isinstance(effect, dict) or not _effect_has_damage_termination(effect):
+            continue
+        effect_id = effect.get("id")
+        if not isinstance(effect_id, str):
+            continue
+        caster_id = _get_caster_participant_id_for_effect(effect)
+        caster = _find_participant_by_id(participants, caster_id)
+        if caster is None:
+            continue
+        if _are_friendly_participants(attacker, caster):
+            terminated.append(effect_id)
+    return terminated
+
+
+def remove_damage_terminated_effects_from_participant(
+    state,
+    target_participant: dict,
+    attacker_participant_id: str,
+) -> bool:
+    """Remove effects from target_participant that break on damage from caster/allies.
+
+    Mutates target_participant["active_effects"] in place.
+    Returns True if any effects were removed.
+    """
+    participants = state.participants if state is not None else []
+    terminated_ids = set(
+        find_damage_terminated_effect_ids(participants, target_participant, attacker_participant_id)
+    )
+    if not terminated_ids:
+        return False
+    surviving = [e for e in (target_participant.get("active_effects") or []) if e.get("id") not in terminated_ids]
+    target_participant["active_effects"] = surviving
+    return True
 
 
 def remove_armor_don_effects_from_combat_participant(

--- a/apps/control-server/tests/_combat_test_flow.py
+++ b/apps/control-server/tests/_combat_test_flow.py
@@ -1006,6 +1006,7 @@ class CombatFlowTestsMixin:
             damage_type="slashing",
             is_crit=False,
             state=self.state,
+            attacker_participant_id="p1",
         )
 
     @patch("app.services.combat.CombatService._emit_entity_hp_update")
@@ -1436,6 +1437,7 @@ class CombatFlowTestsMixin:
             damage_type="cold",
             is_crit=False,
             state=self.state,
+            attacker_participant_id="p1",
         )
         final_log = mock_emit_log.await_args_list[-1].args[1]["message"]
         self.assertIn("Dano rolado 9", final_log)
@@ -1583,6 +1585,7 @@ class CombatFlowTestsMixin:
             damage_type="fire",
             is_crit=False,
             state=self.state,
+            attacker_participant_id="p1",
         )
         mock_emit_state.assert_awaited()
 
@@ -2245,6 +2248,7 @@ class CombatFlowTestsMixin:
             damage_type="force",
             is_crit=False,
             state=self.state,
+            attacker_participant_id="p1",
         )
 
     @patch("app.services.combat.CombatService._emit_player_state_update")
@@ -2359,6 +2363,7 @@ class CombatFlowTestsMixin:
             damage_type="fire",
             is_crit=False,
             state=self.state,
+            attacker_participant_id="p1",
         )
 
     @patch("app.services.combat.CombatService._emit_player_state_update")
@@ -2695,6 +2700,7 @@ class CombatFlowTestsMixin:
             damage_type="piercing",
             is_crit=False,
             state=self.state,
+            attacker_participant_id="p1",
         )
 
     async def test_attack_is_blocked_when_attacker_is_charmed_by_target(self):
@@ -2895,6 +2901,10 @@ class CombatFlowTestsMixin:
                 "app.services.combat.CombatService._build_roll_actor_stats_for_save",
                 return_value=target_stats,
             ),
+            patch(
+                "app.services.combat_service.spell_automation.get_game_time_seconds",
+                return_value=1000,
+            ),
         ):
             self.db.exec.side_effect = [
                 session_entity_result,
@@ -2937,6 +2947,10 @@ class CombatFlowTestsMixin:
 
         self.assertFalse(failed_result["is_saved"])
         self.assertEqual(failed_effects[0]["condition_type"], "charmed")
+        self.assertEqual(failed_effects[0]["duration_type"], "timed")
+        self.assertEqual(failed_effects[0]["created_at_game_time_seconds"], 1000)
+        self.assertEqual(failed_effects[0]["expires_at_game_time_seconds"], 1000 + 86400)
+        self.assertIsNone(failed_effects[0]["expires_at_participant_id"])
         self.assertEqual(self.state.participants[1]["active_effects"], [])
         self.assertTrue(saved_result["is_saved"])
 

--- a/apps/control-server/tests/_combat_test_structured_actions.py
+++ b/apps/control-server/tests/_combat_test_structured_actions.py
@@ -289,6 +289,7 @@ class CombatStructuredActionTestsMixin:
             damage_type="piercing",
             is_crit=False,
             state=self.state,
+            attacker_participant_id="e1",
         )
 
     @patch("app.services.combat.CombatService._emit_player_state_update")
@@ -527,6 +528,7 @@ class CombatStructuredActionTestsMixin:
             damage_type="cold",
             is_crit=False,
             state=self.state,
+            attacker_participant_id="e1",
         )
         final_log = mock_emit_log.await_args_list[-1].args[1]["message"]
         self.assertIn("half damage: 5", final_log)

--- a/apps/control-server/tests/test_animal_friendship_break_on_damage.py
+++ b/apps/control-server/tests/test_animal_friendship_break_on_damage.py
@@ -1,0 +1,347 @@
+"""Tests for Animal Friendship break-on-damage termination (issue #277).
+
+Covers:
+- Schema: target_takes_damage_from_caster_or_allies termination condition type
+- declarative_effect_lifecycle: team checking, condition detection, effect removal
+- spell_automation: Animal Friendship effect carries termination_conditions in metadata
+- Integration: charm removed when caster or ally deals damage; not when enemy does
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from app.schemas.base_spell_effects import (
+    SpellDeclarativeTerminationConditionType,
+    TerminationCondition,
+)
+from app.services.declarative_effect_lifecycle import (
+    _are_friendly_participants,
+    _effect_has_damage_termination,
+    _get_caster_participant_id_for_effect,
+    _get_effect_termination_conditions,
+    find_damage_terminated_effect_ids,
+    remove_damage_terminated_effects_from_participant,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_participant(
+    pid: str,
+    ref_id: str = "ref",
+    kind: str = "session_entity",
+    team: str = "enemies",
+) -> dict:
+    return {"id": pid, "ref_id": ref_id, "kind": kind, "team": team}
+
+
+def _make_charmed_effect(
+    *,
+    effect_id: str | None = None,
+    caster_participant_id: str = "caster-p",
+    has_damage_termination: bool = True,
+    store_in_metadata_direct: bool = True,
+) -> dict:
+    """Build an effect like the one produced by _cast_animal_friendship_automation."""
+    termination = (
+        [{"type": "target_takes_damage_from_caster_or_allies"}]
+        if has_damage_termination
+        else []
+    )
+    if store_in_metadata_direct:
+        metadata: dict = {
+            "source_spell_key": "animal_friendship",
+            "caster_participant_id": caster_participant_id,
+            "charmer_participant_id": caster_participant_id,
+        }
+        if termination:
+            metadata["termination_conditions"] = termination
+    else:
+        # Nested inside declarative_effect (declarative effects path)
+        metadata = {
+            "caster_participant_id": caster_participant_id,
+            "declarative_effect": {
+                "type": "apply_condition",
+                "params": {"condition": "charmed"},
+                "termination_conditions": termination if has_damage_termination else None,
+            },
+        }
+    return {
+        "id": effect_id or str(uuid4()),
+        "kind": "condition",
+        "condition_type": "charmed",
+        "duration_type": "timed",
+        "metadata": metadata,
+    }
+
+
+def _make_state_with_participants(*participants: dict):
+    state = MagicMock()
+    state.participants = list(participants)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Schema: new termination condition type
+# ---------------------------------------------------------------------------
+
+class TestTerminationConditionSchemaExtension(unittest.TestCase):
+
+    def test_target_takes_damage_validates(self):
+        cond = TerminationCondition.model_validate(
+            {"type": "target_takes_damage_from_caster_or_allies"}
+        )
+        self.assertEqual(cond.type, "target_takes_damage_from_caster_or_allies")
+
+    def test_both_types_in_literal(self):
+        # Ensure both types are accepted
+        for t in ("target_dons_armor", "target_takes_damage_from_caster_or_allies"):
+            cond = TerminationCondition.model_validate({"type": t})
+            self.assertEqual(cond.type, t)
+
+    def test_unknown_type_rejected(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            TerminationCondition.model_validate({"type": "unknown_termination"})
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle helpers: team checking
+# ---------------------------------------------------------------------------
+
+class TestAreFriendlyParticipants(unittest.TestCase):
+
+    def test_same_participant_is_friendly(self):
+        p = _make_participant("p1", team="players")
+        self.assertTrue(_are_friendly_participants(p, p))
+
+    def test_same_id_is_friendly(self):
+        p1 = _make_participant("p1", team="players")
+        p2 = _make_participant("p1", team="enemies")  # same id, different team (hypothetical)
+        self.assertTrue(_are_friendly_participants(p1, p2))
+
+    def test_players_are_friendly(self):
+        p1 = _make_participant("p1", team="players")
+        p2 = _make_participant("p2", team="players")
+        self.assertTrue(_are_friendly_participants(p1, p2))
+
+    def test_player_and_ally_are_friendly(self):
+        p = _make_participant("p1", team="players")
+        a = _make_participant("a1", team="allies")
+        self.assertTrue(_are_friendly_participants(p, a))
+
+    def test_ally_and_ally_are_friendly(self):
+        a1 = _make_participant("a1", team="allies")
+        a2 = _make_participant("a2", team="allies")
+        self.assertTrue(_are_friendly_participants(a1, a2))
+
+    def test_enemies_are_not_friendly_to_players(self):
+        p = _make_participant("p1", team="players")
+        e = _make_participant("e1", team="enemies")
+        self.assertFalse(_are_friendly_participants(p, e))
+
+    def test_enemies_are_friendly_to_each_other(self):
+        e1 = _make_participant("e1", team="enemies")
+        e2 = _make_participant("e2", team="enemies")
+        self.assertTrue(_are_friendly_participants(e1, e2))
+
+    def test_neutral_is_not_friendly_to_players(self):
+        p = _make_participant("p1", team="players")
+        n = _make_participant("n1", team="neutral")
+        self.assertFalse(_are_friendly_participants(p, n))
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle helpers: condition detection
+# ---------------------------------------------------------------------------
+
+class TestEffectHasDamageTermination(unittest.TestCase):
+
+    def test_automation_effect_with_termination(self):
+        effect = _make_charmed_effect(has_damage_termination=True, store_in_metadata_direct=True)
+        self.assertTrue(_effect_has_damage_termination(effect))
+
+    def test_declarative_effect_with_termination(self):
+        effect = _make_charmed_effect(has_damage_termination=True, store_in_metadata_direct=False)
+        self.assertTrue(_effect_has_damage_termination(effect))
+
+    def test_effect_without_termination(self):
+        effect = _make_charmed_effect(has_damage_termination=False)
+        self.assertFalse(_effect_has_damage_termination(effect))
+
+    def test_get_caster_from_caster_participant_id(self):
+        effect = _make_charmed_effect(caster_participant_id="caster-123")
+        cid = _get_caster_participant_id_for_effect(effect)
+        self.assertEqual(cid, "caster-123")
+
+    def test_get_caster_from_charmer_participant_id_legacy(self):
+        # Old effects may only have charmer_participant_id
+        effect = {
+            "id": "e1",
+            "kind": "condition",
+            "metadata": {
+                "charmer_participant_id": "old-caster-99",
+                # No caster_participant_id
+            },
+        }
+        cid = _get_caster_participant_id_for_effect(effect)
+        self.assertEqual(cid, "old-caster-99")
+
+    def test_get_termination_conditions_from_metadata_direct(self):
+        effect = _make_charmed_effect(store_in_metadata_direct=True)
+        conds = _get_effect_termination_conditions(effect)
+        self.assertEqual(len(conds), 1)
+        self.assertEqual(conds[0]["type"], "target_takes_damage_from_caster_or_allies")
+
+    def test_get_termination_conditions_from_declarative(self):
+        effect = _make_charmed_effect(store_in_metadata_direct=False)
+        conds = _get_effect_termination_conditions(effect)
+        self.assertEqual(len(conds), 1)
+        self.assertEqual(conds[0]["type"], "target_takes_damage_from_caster_or_allies")
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle helpers: find and remove terminated effects
+# ---------------------------------------------------------------------------
+
+class TestFindDamageTerminatedEffectIds(unittest.TestCase):
+
+    def _setup(self):
+        caster = _make_participant("caster-p", ref_id="user-caster", kind="player", team="players")
+        ally = _make_participant("ally-p", ref_id="user-ally", kind="player", team="players")
+        enemy = _make_participant("enemy-p", ref_id="enemy-npc", kind="session_entity", team="enemies")
+        beast = _make_participant("beast-p", ref_id="wolf-npc", kind="session_entity", team="enemies")
+        charmed_effect = _make_charmed_effect(effect_id="charm-1", caster_participant_id="caster-p")
+        beast["active_effects"] = [charmed_effect]
+        participants = [caster, ally, enemy, beast]
+        return participants, beast
+
+    def test_caster_damaging_target_terminates_effect(self):
+        participants, beast = self._setup()
+        ids = find_damage_terminated_effect_ids(participants, beast, "caster-p")
+        self.assertEqual(ids, ["charm-1"])
+
+    def test_ally_damaging_target_terminates_effect(self):
+        participants, beast = self._setup()
+        ids = find_damage_terminated_effect_ids(participants, beast, "ally-p")
+        self.assertEqual(ids, ["charm-1"])
+
+    def test_enemy_damaging_target_does_not_terminate_effect(self):
+        participants, beast = self._setup()
+        ids = find_damage_terminated_effect_ids(participants, beast, "enemy-p")
+        self.assertEqual(ids, [])
+
+    def test_unknown_attacker_does_not_terminate(self):
+        participants, beast = self._setup()
+        ids = find_damage_terminated_effect_ids(participants, beast, "unknown-participant")
+        self.assertEqual(ids, [])
+
+    def test_effect_without_termination_not_terminated_by_ally(self):
+        caster = _make_participant("caster-p", team="players")
+        ally = _make_participant("ally-p", team="players")
+        non_terminating_effect = _make_charmed_effect(
+            effect_id="charm-no", caster_participant_id="caster-p", has_damage_termination=False
+        )
+        beast = _make_participant("beast-p", team="enemies")
+        beast["active_effects"] = [non_terminating_effect]
+        participants = [caster, ally, beast]
+        ids = find_damage_terminated_effect_ids(participants, beast, "ally-p")
+        self.assertEqual(ids, [])
+
+
+class TestRemoveDamageTerminatedEffects(unittest.TestCase):
+
+    def test_removes_charmed_when_caster_deals_damage(self):
+        caster = _make_participant("caster-p", team="players")
+        beast = _make_participant("beast-p", team="enemies")
+        charm = _make_charmed_effect(effect_id="charm-1", caster_participant_id="caster-p")
+        beast["active_effects"] = [charm]
+        state = _make_state_with_participants(caster, beast)
+        removed = remove_damage_terminated_effects_from_participant(state, beast, "caster-p")
+        self.assertTrue(removed)
+        self.assertEqual(beast["active_effects"], [])
+
+    def test_preserves_other_effects_when_removing(self):
+        caster = _make_participant("caster-p", team="players")
+        beast = _make_participant("beast-p", team="enemies")
+        charm = _make_charmed_effect(effect_id="charm-1", caster_participant_id="caster-p")
+        other_effect = {"id": "other-1", "kind": "condition", "condition_type": "poisoned", "metadata": {}}
+        beast["active_effects"] = [charm, other_effect]
+        state = _make_state_with_participants(caster, beast)
+        remove_damage_terminated_effects_from_participant(state, beast, "caster-p")
+        remaining = beast["active_effects"]
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0]["id"], "other-1")
+
+    def test_no_op_when_enemy_deals_damage(self):
+        caster = _make_participant("caster-p", team="players")
+        enemy = _make_participant("enemy-p", team="enemies")
+        beast = _make_participant("beast-p", team="enemies")
+        charm = _make_charmed_effect(effect_id="charm-1", caster_participant_id="caster-p")
+        beast["active_effects"] = [charm]
+        state = _make_state_with_participants(caster, enemy, beast)
+        removed = remove_damage_terminated_effects_from_participant(state, beast, "enemy-p")
+        self.assertFalse(removed)
+        self.assertEqual(len(beast["active_effects"]), 1)
+
+    def test_no_op_when_no_terminating_effects(self):
+        caster = _make_participant("caster-p", team="players")
+        beast = _make_participant("beast-p", team="enemies")
+        beast["active_effects"] = []
+        state = _make_state_with_participants(caster, beast)
+        removed = remove_damage_terminated_effects_from_participant(state, beast, "caster-p")
+        self.assertFalse(removed)
+
+
+# ---------------------------------------------------------------------------
+# Animal Friendship effect metadata validation
+# ---------------------------------------------------------------------------
+
+class TestAnimalFriendshipEffectMetadata(unittest.TestCase):
+    """Verify that the effect created by _cast_animal_friendship_automation
+    carries the correct termination_conditions and caster_participant_id."""
+
+    def _build_charmed_effect_like_handler(self, caster_id: str) -> dict:
+        from app.services.combat_service.concentration import CombatConcentrationMixin
+
+        class Dummy(CombatConcentrationMixin):
+            pass
+
+        return Dummy._build_active_effect(
+            kind="condition",
+            condition_type="charmed",
+            source_participant_id=caster_id,
+            duration_type="timed",
+            created_at_game_time_seconds=1000,
+            expires_at_game_time_seconds=1000 + 86400,
+            metadata={
+                "source_spell_key": "animal_friendship",
+                "caster_participant_id": caster_id,
+                "charmer_participant_id": caster_id,
+                "termination_conditions": [
+                    {"type": "target_takes_damage_from_caster_or_allies"}
+                ],
+            },
+        )
+
+    def test_effect_has_termination_condition(self):
+        effect = self._build_charmed_effect_like_handler("caster-p")
+        self.assertTrue(_effect_has_damage_termination(effect))
+
+    def test_effect_has_caster_participant_id(self):
+        effect = self._build_charmed_effect_like_handler("caster-p")
+        self.assertEqual(_get_caster_participant_id_for_effect(effect), "caster-p")
+
+    def test_effect_has_timed_duration_86400s(self):
+        effect = self._build_charmed_effect_like_handler("caster-p")
+        self.assertEqual(effect["duration_type"], "timed")
+        self.assertEqual(effect["expires_at_game_time_seconds"], 1000 + 86400)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PR: feat(spells) break-on-damage termination and Animal Friendship (#277)

## Description

Este PR implementa a mecânica genérica de interrupção de efeitos ao receber dano ("Break-on-damage") e a automação completa da magia *Animal Friendship*. A implementação introduz uma lógica de detecção de aliança para garantir que apenas danos causados pelo conjurador ou seus aliados removam o efeito, conforme as regras da 5e.

## Changes

### Break-on-Damage (Generic Implementation)
- **Schema Update:** Adicionado o tipo `target_takes_damage_from_caster_or_allies` ao `SpellDeclarativeTerminationConditionType`.
- **Lifecycle Logic:** Desenvolvidas 6 novas funções em `declarative_effect_lifecycle.py` para gerenciar a identificação de condições de término, verificação de amizade entre participantes e remoção seletiva de efeitos baseada em dano.
- **Damage Pipeline:** Refatoração profunda em `damage_core.py` e `spell_resolution_common.py`. O `attacker_participant_id` agora é propagado por **13 pontos de chamada**, incluindo ataques de arma, magias, ações de NPC, sopros (Dragonborn) e testes de resistência (Saves).

### Animal Friendship Implementation
- **Automation:** O handler de *Animal Friendship* em `spell_automation.py` agora gera efeitos de `charmed` com:
    - `duration_type`: "timed" (86400s / 24 horas).
    - `caster_participant_id`: Vinculado ao conjurador para validação de dano.
    - `termination_conditions`: Configurado para quebrar se o conjurador ou aliados ferirem o alvo.

## Summary of Changes

| Component | Change |
| :--- | :--- |
| **`damage_core.py`** | Propagation of attacker ID across all damage paths |
| **`lifecycle.py`** | New generic helpers for damage-triggered effect termination |
| **`automation.py`** | Full implementation of Animal Friendship with 24h duration |
| **Schema** | New declarative termination type for ally-aware damage |

## Test Coverage

- **New Tests:** 30 testes em `test_animal_friendship_break_on_damage.py`.
- **Scenarios Covered:**
    - Validação de schema e detecção de condições.
    - Verificação de time (garantindo que dano de terceiros/inimigos do caster não quebre o efeito).
    - Remoção automática de efeitos ao final do processamento de dano (amount > 0).
    - Shape do efeito produzido pelo handler de automação.

## Out of Scope / Gaps
- **Upcast UI:** Embora a matemática para `additional_targets` via upcast já exista no backend, a ponte de comunicação com a UI do frontend ainda não foi implementada e será tratada em uma issue separada.

## Validation
- **Backend:** Todas as suítes integradas passando com a nova propagação de IDs de atacante.