### PR TITLE
feat(spells) plain multi-target automation and animal friendship upcast (#279)

### DIFF
--- a/Base/base_spells.seed.json
+++ b/Base/base_spells.seed.json
@@ -284,6 +284,7 @@
       "ritual": false,
       "resolutionType": "control",
       "savingThrow": "WIS",
+      "maxTargets": 1,
       "upcast": {
         "mode": "additional_targets",
         "perLevel": 1

--- a/apps/control-server/alembic/versions/0078_animal_friendship_max_targets.py
+++ b/apps/control-server/alembic/versions/0078_animal_friendship_max_targets.py
@@ -1,0 +1,53 @@
+"""Set max_targets = 1 for Animal Friendship to enable upcast target scaling.
+
+Revision ID: 0078_animal_friendship_max_targets
+Revises: 0077_mage_armor_data
+Create Date: 2026-05-10 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0078_animal_friendship_max_targets"
+down_revision = "0077_mage_armor_data"
+branch_labels = None
+depends_on = None
+
+_SYSTEM = "DND5E"
+_CANONICAL_KEY = "animal_friendship"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE base_spell SET max_targets = 1 "
+            "WHERE system = :sys AND canonical_key = :key AND max_targets IS NULL"
+        ),
+        {"sys": _SYSTEM, "key": _CANONICAL_KEY},
+    )
+    conn.execute(
+        sa.text(
+            "UPDATE campaign_spell SET max_targets = 1 "
+            "WHERE canonical_key = :key AND is_custom = false AND max_targets IS NULL"
+        ),
+        {"key": _CANONICAL_KEY},
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE base_spell SET max_targets = NULL "
+            "WHERE system = :sys AND canonical_key = :key AND max_targets = 1"
+        ),
+        {"sys": _SYSTEM, "key": _CANONICAL_KEY},
+    )
+    conn.execute(
+        sa.text(
+            "UPDATE campaign_spell SET max_targets = NULL "
+            "WHERE canonical_key = :key AND is_custom = false AND max_targets = 1"
+        ),
+        {"key": _CANONICAL_KEY},
+    )

--- a/apps/control-server/app/schemas/combat_spells.py
+++ b/apps/control-server/app/schemas/combat_spells.py
@@ -59,6 +59,7 @@ class TargetVariantAssignment(BaseModel):
 class CombatCastSpellRequest(BaseModel):
     actor_participant_id: Optional[str] = None
     target_ref_id: str | None = None
+    target_ref_ids: list[str] | None = None
     origin_cell: "CombatGridCell | None" = None
     anchor_cell: "CombatGridCell | None" = None
     inventory_item_id: str | None = None

--- a/apps/control-server/app/services/combat_service/spells/cast_target.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target.py
@@ -1696,6 +1696,299 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
             "elemental_affinity_bonus": spell_context.get("elemental_affinity_bonus"),
         }
 
+    # ------------------------------------------------------------------
+    # Plain multi-target automation cast (no variants, no effect instances)
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _validate_plain_multi_target_refs(
+        cls,
+        *,
+        req,
+        spell_context: dict,
+        state,
+    ) -> list[dict] | None:
+        """Return resolved participant list or None if not applicable.
+
+        Raises CombatServiceError on invalid requests.
+        """
+        ref_ids = getattr(req, "target_ref_ids", None)
+        if not ref_ids:
+            return None
+
+        # Mutual exclusion with other targeting fields
+        if (
+            getattr(req, "target_ref_id", None)
+            or getattr(req, "target_variant_assignments", None)
+            or getattr(req, "effect_instance_targets", None)
+        ):
+            raise CombatServiceError(
+                "target_ref_ids cannot be combined with target_ref_id, "
+                "target_variant_assignments, or effect_instance_targets.",
+                400,
+            )
+
+        # Spell must be configured for multi-target
+        effective_max = spell_context.get("max_targets")
+        if not isinstance(effective_max, int):
+            raise CombatServiceError(
+                "This spell is not configured for multi-target casting.", 400
+            )
+
+        # Duplicate check
+        if len(ref_ids) != len(set(ref_ids)):
+            raise CombatServiceError("Duplicate target IDs are not allowed.", 400)
+
+        # Count check (against resolved effective_max_targets)
+        if len(ref_ids) > effective_max:
+            raise CombatServiceError(
+                f"This cast allows at most {effective_max} target(s); "
+                f"{len(ref_ids)} were provided.",
+                400,
+            )
+
+        # Resolve each ref_id to a participant
+        resolved: list[dict] = []
+        for ref_id in ref_ids:
+            participant = next(
+                (p for p in state.participants if p.get("ref_id") == ref_id),
+                None,
+            )
+            if participant is None:
+                raise CombatServiceError(
+                    f"Target '{ref_id}' not found in combat.", 400
+                )
+            resolved.append(participant)
+
+        return resolved
+
+    @classmethod
+    def _validate_plain_multi_target_spatial(
+        cls,
+        *,
+        db,
+        state,
+        attacker: dict,
+        spell_context: dict,
+        targets: list[dict],
+        session_id: str,
+    ) -> dict[str, "TargetingResult"]:
+        """Fan out spatial validation (range, LoS, LoE) for each plain target.
+
+        Runs before resource consumption.  Raises CombatServiceError if any
+        target fails.  Mirrors _validate_modal_variant_spatial_targets.
+        """
+        targeting_service = get_combat_targeting_service(state.use_map)
+        results: dict[str, "TargetingResult"] = {}
+
+        for participant in targets:
+            target_ref_id = participant.get("ref_id", "")
+            intent = SpellCastIntent(
+                session_id=session_id,
+                action_id=f"targeting-plain:{participant.get('id')}",
+                actor_ref_id=attacker["ref_id"],
+                actor_kind=attacker["kind"],
+                requested_target_ref_id=target_ref_id,
+                spell_canonical_key=spell_context["spell_canonical_key"],
+                spell_mode=spell_context["spell_mode"],
+                target_type=spell_context.get("target_type"),
+                selection_type=spell_context.get("selection_type"),
+                attack_type=spell_context.get("attack_type"),
+                range_kind=spell_context.get("range_kind"),
+                area_shape=spell_context.get("area_shape"),
+                range_meters=spell_context.get("range_meters"),
+                requires_sight=bool(spell_context.get("requires_target_sight")),
+                requires_effect=bool(spell_context.get("requires_target_effect")),
+            )
+            result = targeting_service.validate(intent, state)
+            if not result.is_valid:
+                diag = result.diagnostics
+                cls._record_spell_cast_rejected_activity(
+                    db,
+                    session_id=session_id,
+                    actor_user_id=attacker.get("actor_user_id"),
+                    actor_ref_id=attacker["ref_id"],
+                    actor_display_name=attacker.get("display_name") or attacker["ref_id"],
+                    spell_context=spell_context,
+                    reason=cls._map_spell_rejection_reason(
+                        diag.primary_failure() if diag else None
+                    ),
+                    target_ref_id=target_ref_id,
+                    target_display_name=cls._participant_display_name(participant),
+                )
+                raise CombatServiceError(
+                    f"Target {cls._participant_display_name(participant)} "
+                    f"{_resolve_instance_spatial_error_phrase(result)}.",
+                    400,
+                )
+            results[participant["id"]] = result
+
+        return results
+
+    @classmethod
+    async def _resolve_plain_multi_target_automation_cast(
+        cls,
+        db,
+        session_id: str,
+        req,
+        state,
+        attacker: dict,
+        attacker_model,
+        spell_context: dict,
+        actor_user_id: str,
+        is_gm: bool,
+        targets: list[dict],
+        *,
+        spatial_results: dict | None = None,
+    ) -> dict:
+        """Consume resources once then invoke the automation handler per target.
+
+        Modeled after _resolve_modal_multi_target_cast.  No variants.
+        """
+        from sqlalchemy.orm.attributes import flag_modified
+
+        slot_spent = False
+        action_cost = spell_context.get("action_cost") or "action"
+        was_overridden = cls._consume_turn_resource(
+            attacker,
+            action_cost,
+            is_gm=is_gm,
+            override_resource_limit=req.override_resource_limit,
+        )
+        if isinstance(spell_context.get("slot_level"), int):
+            cls._consume_player_spell_slot(attacker_model, spell_context["slot_level"])
+            db.add(attacker_model)
+            slot_spent = True
+
+        spell_mode = spell_context["spell_mode"]
+        is_hostile_spell = spell_mode in ("spell_attack", "saving_throw", "direct_damage")
+        player_state_ids_to_emit: set[str] = set()
+        entity_previous_hp_map: dict[str, int] = {}
+        total_damage = 0
+        total_healing = 0
+        outcomes: list[dict] = []
+
+        # Per-target mechanical validation (before resolving any)
+        for participant in targets:
+            if is_hostile_spell:
+                cls._assert_hostile_action_allowed(
+                    attacker, participant, action_label="a hostile spell"
+                )
+            cls._validate_spell_automation_target(
+                db,
+                session_id,
+                spell_canonical_key=spell_context["spell_canonical_key"],
+                target_participant=participant,
+            )
+
+        # Per-target automation resolution
+        for participant in targets:
+            outcome = await cls._cast_spell_via_automation(
+                db,
+                session_id,
+                attacker=attacker,
+                attacker_model=attacker_model,
+                actor_user_id=actor_user_id,
+                is_gm=is_gm,
+                req=req,
+                state=state,
+                spell_context=spell_context,
+                target_participant=participant,
+            )
+            if outcome:
+                outcomes.append(outcome)
+                total_damage += cls._safe_int(outcome.get("damage"), 0)
+                total_healing += cls._safe_int(outcome.get("healing"), 0)
+                if participant.get("kind") == "player":
+                    player_state_ids_to_emit.add(participant["ref_id"])
+                elif participant.get("kind") == "session_entity":
+                    prev = outcome.get("previous_hp")
+                    new = outcome.get("new_hp")
+                    if isinstance(prev, int) and isinstance(new, int) and prev != new:
+                        entity_previous_hp_map[participant["ref_id"]] = prev
+
+        flag_modified(state, "participants")
+        db.add(state)
+        db.commit()
+        db.refresh(state)
+
+        if slot_spent:
+            player_state_ids_to_emit.add(attacker["ref_id"])
+
+        for player_ref_id in player_state_ids_to_emit:
+            target_state, *_ = cls._get_stats(db, player_ref_id, "player", session_id)
+            await cls._emit_player_state_update(db, session_id, player_ref_id, target_state)
+
+        for ref_id, prev_hp in entity_previous_hp_map.items():
+            await cls._emit_entity_hp_update(db, session_id, ref_id, prev_hp)
+
+        await cls._emit_state(session_id, state)
+
+        target_count = len(targets)
+        target_names = ", ".join(cls._participant_display_name(p) for p in targets)
+        log_message = (
+            f"{attacker['display_name']} conjurou {spell_context['spell_name']} em "
+            f"{target_count} alvo{'s' if target_count != 1 else ''}: {target_names}."
+        )
+        if was_overridden:
+            log_message = f"[OVERRIDE: Limit for '{action_cost}' ignored] {log_message}"
+        await cls._emit_and_persist_log(
+            db, session_id, actor_user_id, attacker.get("display_name"),
+            {
+                "message": log_message,
+                "actorUserId": actor_user_id,
+                "source": "gm_override" if is_gm else "player_turn",
+                "is_override": was_overridden,
+                "overridden_resource": action_cost if was_overridden else None,
+            },
+        )
+
+        return {
+            "spell_name": spell_context["spell_name"],
+            "spell_canonical_key": spell_context["spell_canonical_key"],
+            "selected_variant_key": None,
+            "selected_variant_label": None,
+            "context_origin": "initial_cast",
+            "concentration_group": None,
+            "action_kind": spell_mode,
+            "effect_kind": spell_context.get("effect_kind"),
+            "damage": total_damage,
+            "healing": total_healing,
+            "damage_type": spell_context.get("damage_type"),
+            "is_critical": None,
+            "is_hit": None,
+            "is_saved": None,
+            "new_hp": None,
+            "roll": None,
+            "roll_result": None,
+            "target_ac": None,
+            "target_display_name": f"{target_count} alvos",
+            "target_kind": "session_entity",
+            "save_ability": spell_context.get("save_ability"),
+            "save_dc": spell_context.get("save_dc"),
+            "save_success_outcome": spell_context.get("save_success_outcome"),
+            "effect_dice": spell_context.get("effect_dice"),
+            "effect_bonus": cls._safe_int(spell_context.get("effect_bonus"), 0),
+            "pending_spell_id": None,
+            "pending_save_id": None,
+            "effect_roll_required": False,
+            "base_effect": None,
+            "action_cost": action_cost,
+            "summary_text": (
+                f"{spell_context['spell_name']} resolvido em {target_count} "
+                f"alvo{'s' if target_count != 1 else ''}."
+            ),
+            "inventory_refresh_required": False,
+            "concentration_check": None,
+            "concentration_checks": [],
+            "area_shape": None,
+            "affected_target_ref_ids": [p.get("ref_id") for p in targets],
+            "affected_cells": [],
+            "area_target_outcomes": [],
+            "target_count": target_count,
+            "plain_multi_target_outcomes": outcomes,
+        }
+
     @classmethod
     async def cast_spell(
         cls,
@@ -1737,6 +2030,33 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
                 is_gm,
                 validated_variant_assignments,
                 spatial_results_by_participant_id=spatial_results_by_participant_id,
+            )
+        validated_plain_targets = cls._validate_plain_multi_target_refs(
+            req=req,
+            spell_context=spell_context,
+            state=state,
+        )
+        if validated_plain_targets is not None:
+            plain_spatial_results = cls._validate_plain_multi_target_spatial(
+                db=db,
+                state=state,
+                attacker=attacker,
+                spell_context=spell_context,
+                targets=validated_plain_targets,
+                session_id=session_id,
+            )
+            return await cls._resolve_plain_multi_target_automation_cast(
+                db,
+                session_id,
+                req,
+                state,
+                attacker,
+                attacker_model,
+                spell_context,
+                actor_user_id,
+                is_gm,
+                validated_plain_targets,
+                spatial_results=plain_spatial_results,
             )
         variant_map = cls._get_spell_variants_map(spell_context)
         if variant_map:

--- a/apps/control-server/tests/test_animal_friendship_upcast.py
+++ b/apps/control-server/tests/test_animal_friendship_upcast.py
@@ -1,0 +1,550 @@
+"""Tests for Animal Friendship upcast target-count scaling (issue #279).
+
+Covers:
+- effective_max_targets computation at slot levels 1–3
+- _validate_plain_multi_target_refs: mutual exclusion, duplicates, count
+- _resolve_plain_multi_target_automation_cast: handler called per target,
+  independent save outcomes
+- Non-regression: single-target automation path unchanged
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.models.combat import CombatPhase, CombatState
+from app.models.session_state import SessionState
+from app.schemas.roll import RollActorStats
+from app.schemas.combat_spells import CombatCastSpellRequest
+from app.services.combat import CombatService, CombatServiceError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_participant(pid: str, ref_id: str, team: str = "enemies", kind: str = "session_entity") -> dict:
+    return {
+        "id": pid,
+        "ref_id": ref_id,
+        "kind": kind,
+        "display_name": f"Beast {pid}",
+        "initiative": 5,
+        "status": "active",
+        "team": team,
+        "visible": True,
+        "actor_user_id": None,
+        "active_effects": [],
+        "turn_resources": {
+            "action_used": False,
+            "bonus_action_used": False,
+            "reaction_used": False,
+            "colossus_slayer_used": False,
+        },
+    }
+
+
+def _make_player(pid: str = "p1", ref_id: str = "player-1") -> dict:
+    return {
+        "id": pid,
+        "ref_id": ref_id,
+        "kind": "player",
+        "display_name": "Ranger",
+        "initiative": 15,
+        "status": "active",
+        "team": "players",
+        "visible": True,
+        "actor_user_id": "user-1",
+        "active_effects": [],
+        "turn_resources": {
+            "action_used": False,
+            "bonus_action_used": False,
+            "reaction_used": False,
+            "colossus_slayer_used": False,
+        },
+    }
+
+
+def _make_state(participants):
+    return CombatState(
+        id="combat-1",
+        session_id="session-1",
+        phase=CombatPhase.active,
+        round=1,
+        current_turn_index=0,
+        participants=participants,
+        use_map=False,
+    )
+
+
+def _make_af_catalog_spell(max_targets: int = 1, slot_level: int = 1):
+    """Return a SimpleNamespace mimicking an animal_friendship CampaignSpell."""
+    return SimpleNamespace(
+        canonical_key="animal_friendship",
+        name_en="Animal Friendship",
+        name_pt="Amizade Animal",
+        level=1,
+        resolution_type="saving_throw",
+        saving_throw="wisdom",
+        save_success_outcome="none",
+        damage_type=None,
+        damage_dice=None,
+        heal_dice=None,
+        upcast_json={"mode": "additional_targets", "perLevel": 1},
+        cantrip_scaling_json=None,
+        casting_time_type="action",
+        target_type="ranged",
+        selection_type="creature",
+        origin_type="caster",
+        target_anchor="selected_target",
+        attack_type="none",
+        range_kind="distance",
+        effect_timing="immediate",
+        area_shape=None,
+        range_meters=9,
+        radius_meters=None,
+        length_meters=None,
+        side_meters=None,
+        duration="24 hours",
+        concentration=False,
+        cover_applies_to_save="none",
+        max_targets=max_targets,
+        variants_json=None,
+        persistent_area_json=None,
+        requires_target_sight=True,
+        requires_target_effect=True,
+        requires_point_sight=False,
+        requires_point_effect=False,
+        save_ability="wisdom",
+        save_dc=14,
+        effect_dice=None,
+        effect_bonus=0,
+        spell_mode="saving_throw",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Upcast: effective_max_targets scaling
+# ---------------------------------------------------------------------------
+
+class TestAnimalFriendshipUpcastContext(unittest.TestCase):
+    """Verify that effective_max_targets = base + upcast_added per slot level."""
+
+    def _resolve_context(self, slot_level: int, max_targets: int = 1) -> dict:
+        from app.schemas.combat_spells import CombatResolveSpellContextRequest
+
+        db = MagicMock()
+        player = _make_player()
+        state = _make_state([player])
+        catalog_spell = _make_af_catalog_spell(max_targets=max_targets, slot_level=slot_level)
+        attacker_state = SessionState(
+            id="ss-1",
+            session_id="session-1",
+            player_user_id="player-1",
+            state_json={
+                "spellcasting": {
+                    "spells": [
+                        {"canonicalKey": "animal_friendship", "level": 1, "prepared": True}
+                    ],
+                    "slots": {
+                        str(slot_level): {"used": 0, "max": 3},
+                    },
+                }
+            },
+        )
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=state),
+            patch(
+                "app.services.combat.CombatService._get_spell_catalog_entry_for_session",
+                return_value=catalog_spell,
+            ),
+            patch(
+                "app.services.combat.CombatService._get_stats",
+                return_value=(attacker_state, 12, 10, 10, 3, 4),
+            ),
+        ):
+            return CombatService.resolve_spell_context(
+                db,
+                "session-1",
+                CombatResolveSpellContextRequest(
+                    actor_participant_id="p1",
+                    spell_canonical_key="animal_friendship",
+                    spell_mode="saving_throw",
+                    slot_level=slot_level,
+                ),
+                "user-1",
+                False,
+            )
+
+    def test_slot_1_effective_max_targets_is_1(self):
+        result = self._resolve_context(slot_level=1, max_targets=1)
+        self.assertEqual(result["max_targets"], 1)
+
+    def test_slot_2_effective_max_targets_is_2(self):
+        result = self._resolve_context(slot_level=2, max_targets=1)
+        self.assertEqual(result["max_targets"], 2)
+
+    def test_slot_3_effective_max_targets_is_3(self):
+        result = self._resolve_context(slot_level=3, max_targets=1)
+        self.assertEqual(result["max_targets"], 3)
+
+    def test_base_max_targets_exposed(self):
+        result = self._resolve_context(slot_level=2, max_targets=1)
+        self.assertEqual(result["base_max_targets"], 1)
+
+    # Golden chain tests: resolve_spell_context → _validate_plain_multi_target_refs
+
+    def test_animal_friendship_upcast_slot_2_accepts_two_targets(self):
+        """End-to-end: slot 2 resolves max_targets=2 which allows target_ref_ids of length 2."""
+        beast1 = _make_participant("e1", "wolf-1")
+        beast2 = _make_participant("e2", "wolf-2")
+        state = _make_state([_make_player(), beast1, beast2])
+        # max_targets=2 is what resolve_spell_context returns at slot 2 (confirmed above)
+        spell_context = {
+            "max_targets": 2,
+            "spell_canonical_key": "animal_friendship",
+            "spell_mode": "saving_throw",
+        }
+        req = CombatCastSpellRequest(
+            actor_participant_id="p1",
+            spell_canonical_key="animal_friendship",
+            target_ref_ids=["wolf-1", "wolf-2"],
+            slot_level=2,
+        )
+        result = CombatService._validate_plain_multi_target_refs(
+            req=req, spell_context=spell_context, state=state
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 2)
+        self.assertEqual({p["ref_id"] for p in result}, {"wolf-1", "wolf-2"})
+
+    def test_animal_friendship_upcast_slot_2_rejects_three_targets(self):
+        """max_targets=2 (slot 2) must reject target_ref_ids of length 3."""
+        beasts = [_make_participant(f"e{i}", f"wolf-{i}") for i in range(1, 4)]
+        state = _make_state([_make_player()] + beasts)
+        spell_context = {
+            "max_targets": 2,
+            "spell_canonical_key": "animal_friendship",
+            "spell_mode": "saving_throw",
+        }
+        req = CombatCastSpellRequest(
+            actor_participant_id="p1",
+            spell_canonical_key="animal_friendship",
+            target_ref_ids=["wolf-1", "wolf-2", "wolf-3"],
+            slot_level=2,
+        )
+        with self.assertRaises(CombatServiceError):
+            CombatService._validate_plain_multi_target_refs(
+                req=req, spell_context=spell_context, state=state
+            )
+
+    def test_animal_friendship_upcast_slot_3_accepts_three_targets(self):
+        """max_targets=3 (slot 3) allows target_ref_ids of length 3."""
+        beasts = [_make_participant(f"e{i}", f"wolf-{i}") for i in range(1, 4)]
+        state = _make_state([_make_player()] + beasts)
+        spell_context = {
+            "max_targets": 3,
+            "spell_canonical_key": "animal_friendship",
+            "spell_mode": "saving_throw",
+        }
+        req = CombatCastSpellRequest(
+            actor_participant_id="p1",
+            spell_canonical_key="animal_friendship",
+            target_ref_ids=["wolf-1", "wolf-2", "wolf-3"],
+            slot_level=3,
+        )
+        result = CombatService._validate_plain_multi_target_refs(
+            req=req, spell_context=spell_context, state=state
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 3)
+
+
+# ---------------------------------------------------------------------------
+# _validate_plain_multi_target_refs: unit tests
+# ---------------------------------------------------------------------------
+
+class TestValidatePlainMultiTargetRefs(unittest.TestCase):
+    """Unit tests for the validation helper (no async needed)."""
+
+    def _state(self, participants):
+        return _make_state(participants)
+
+    def _req(self, target_ref_ids=None, target_ref_id=None, target_variant_assignments=None, effect_instance_targets=None):
+        return CombatCastSpellRequest(
+            actor_participant_id="p1",
+            spell_canonical_key="animal_friendship",
+            target_ref_ids=target_ref_ids,
+            target_ref_id=target_ref_id,
+            target_variant_assignments=target_variant_assignments,
+            effect_instance_targets=effect_instance_targets,
+        )
+
+    def _spell_context(self, max_targets=2):
+        return {"max_targets": max_targets, "spell_canonical_key": "animal_friendship", "spell_mode": "saving_throw"}
+
+    def test_returns_none_when_target_ref_ids_absent(self):
+        state = self._state([_make_player()])
+        result = CombatService._validate_plain_multi_target_refs(
+            req=self._req(), spell_context=self._spell_context(), state=state
+        )
+        self.assertIsNone(result)
+
+    def test_returns_none_when_target_ref_ids_empty(self):
+        state = self._state([_make_player()])
+        result = CombatService._validate_plain_multi_target_refs(
+            req=self._req(target_ref_ids=[]), spell_context=self._spell_context(), state=state
+        )
+        self.assertIsNone(result)
+
+    def test_resolves_valid_refs(self):
+        beast1 = _make_participant("e1", "wolf-1")
+        beast2 = _make_participant("e2", "wolf-2")
+        state = self._state([_make_player(), beast1, beast2])
+        result = CombatService._validate_plain_multi_target_refs(
+            req=self._req(target_ref_ids=["wolf-1", "wolf-2"]),
+            spell_context=self._spell_context(max_targets=2),
+            state=state,
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 2)
+
+    def test_raises_on_duplicate_target_ref_ids(self):
+        beast1 = _make_participant("e1", "wolf-1")
+        state = self._state([_make_player(), beast1])
+        with self.assertRaises(CombatServiceError) as ctx:
+            CombatService._validate_plain_multi_target_refs(
+                req=self._req(target_ref_ids=["wolf-1", "wolf-1"]),
+                spell_context=self._spell_context(max_targets=3),
+                state=state,
+            )
+        self.assertIn("Duplicate", str(ctx.exception))
+
+    def test_raises_when_count_exceeds_effective_max(self):
+        beast1 = _make_participant("e1", "wolf-1")
+        beast2 = _make_participant("e2", "wolf-2")
+        beast3 = _make_participant("e3", "wolf-3")
+        state = self._state([_make_player(), beast1, beast2, beast3])
+        with self.assertRaises(CombatServiceError) as ctx:
+            CombatService._validate_plain_multi_target_refs(
+                req=self._req(target_ref_ids=["wolf-1", "wolf-2", "wolf-3"]),
+                spell_context=self._spell_context(max_targets=2),
+                state=state,
+            )
+        self.assertIn("2", str(ctx.exception))
+
+    def test_raises_when_ref_id_not_found(self):
+        state = self._state([_make_player()])
+        with self.assertRaises(CombatServiceError) as ctx:
+            CombatService._validate_plain_multi_target_refs(
+                req=self._req(target_ref_ids=["nonexistent"]),
+                spell_context=self._spell_context(max_targets=3),
+                state=state,
+            )
+        self.assertIn("nonexistent", str(ctx.exception))
+
+    def test_raises_when_spell_has_no_max_targets(self):
+        beast = _make_participant("e1", "wolf-1")
+        state = self._state([_make_player(), beast])
+        ctx_no_max = {"max_targets": None, "spell_canonical_key": "other_spell", "spell_mode": "saving_throw"}
+        with self.assertRaises(CombatServiceError):
+            CombatService._validate_plain_multi_target_refs(
+                req=self._req(target_ref_ids=["wolf-1"]),
+                spell_context=ctx_no_max,
+                state=state,
+            )
+
+    def test_raises_on_mutual_exclusion_with_target_ref_id(self):
+        beast = _make_participant("e1", "wolf-1")
+        state = self._state([_make_player(), beast])
+        with self.assertRaises(CombatServiceError) as ctx:
+            CombatService._validate_plain_multi_target_refs(
+                req=self._req(target_ref_ids=["wolf-1"], target_ref_id="wolf-1"),
+                spell_context=self._spell_context(max_targets=3),
+                state=state,
+            )
+        self.assertIn("cannot be combined", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# Integration: _resolve_plain_multi_target_automation_cast (handler per target)
+# ---------------------------------------------------------------------------
+
+class TestResolvePlainMultiTargetAutomationCast(unittest.IsolatedAsyncioTestCase):
+    """Verify that _resolve_plain_multi_target_automation_cast calls the
+    automation handler independently for each target."""
+
+    def _make_beast_db(self, ref_id: str) -> MagicMock:
+        """Return a MagicMock DB that resolves SessionEntity+CampaignEntity as beast."""
+        from app.models.campaign_entity import CampaignEntity
+        from app.models.session_entity import SessionEntity
+
+        se_result = MagicMock()
+        se_result.first.return_value = SessionEntity(
+            id=ref_id,
+            session_id="session-1",
+            campaign_entity_id=f"ce-{ref_id}",
+            overrides={},
+        )
+        ce_result = MagicMock()
+        ce_result.first.return_value = CampaignEntity(
+            id=f"ce-{ref_id}",
+            campaign_id="camp-1",
+            name="Wolf",
+            creature_type="beast",
+        )
+        db = MagicMock()
+        db.exec.side_effect = [se_result, ce_result] * 10  # enough for multiple targets
+        return db
+
+    def _make_multi_beast_db(self, ref_ids: list[str]) -> MagicMock:
+        """Return a DB mock that always resolves as a beast entity."""
+        from app.models.campaign_entity import CampaignEntity
+        from app.models.session_entity import SessionEntity
+        import itertools
+
+        # Build per-ref_id results, then cycle so we never exhaust
+        results = []
+        for ref_id in ref_ids:
+            se = MagicMock()
+            se.first.return_value = SessionEntity(
+                id=ref_id,
+                session_id="session-1",
+                campaign_entity_id=f"ce-{ref_id}",
+                overrides={},
+            )
+            ce = MagicMock()
+            ce.first.return_value = CampaignEntity(
+                id=f"ce-{ref_id}",
+                campaign_id="camp-1",
+                name="Wolf",
+                creature_type="beast",
+            )
+            results.extend([se, ce])
+
+        db = MagicMock()
+        call_iter = itertools.cycle(results)
+        db.exec.side_effect = lambda *a, **kw: next(call_iter)
+        return db
+
+    async def _resolve(self, targets: list[dict], roll_side_effect=None):
+        player = _make_player()
+        state = _make_state([player] + targets)
+        state.phase = CombatPhase.active
+
+        attacker_state = SessionState(
+            id="ss-1",
+            session_id="session-1",
+            player_user_id="player-1",
+            state_json={
+                "spellcasting": {
+                    "slots": {"2": {"used": 0, "max": 3}},
+                }
+            },
+        )
+        target_stats = RollActorStats(
+            display_name="Wolf",
+            abilities={"wisdom": 10},
+            actor_kind="session_entity",
+            actor_ref_id=targets[0]["ref_id"],
+        )
+        spell_context = {
+            "spell_canonical_key": "animal_friendship",
+            "spell_name": "Amizade Animal",
+            "spell_mode": "saving_throw",
+            "action_kind": "saving_throw",
+            "action_cost": "action",
+            "effect_kind": None,
+            "effect_dice": None,
+            "effect_bonus": 0,
+            "damage_type": None,
+            "save_ability": "wisdom",
+            "save_dc": 14,
+            "save_success_outcome": "none",
+            "slot_level": 2,
+            "max_targets": len(targets) + 1,
+            "source_kind": "standard",
+            "concentration": False,
+        }
+
+        roll_fn = roll_side_effect or (lambda *a, **kw: 5)
+        db = self._make_multi_beast_db([t["ref_id"] for t in targets])
+
+        with (
+            patch(
+                "app.services.combat.CombatService._build_roll_actor_stats_for_save",
+                return_value=target_stats,
+            ),
+            patch(
+                "app.services.combat.CombatService._get_stats",
+                return_value=(attacker_state, 12, 10, 10, 2, 3),
+            ),
+            patch(
+                "app.services.combat_service.spell_automation.get_game_time_seconds",
+                return_value=1000,
+            ),
+            patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock),
+            patch("app.services.combat.CombatService._emit_player_state_update", new_callable=AsyncMock),
+            patch("app.services.combat.CombatService._emit_entity_hp_update", new_callable=AsyncMock),
+            patch("app.services.combat.CombatService._emit_and_persist_log", new_callable=AsyncMock),
+            patch("random.randint", side_effect=roll_fn),
+        ):
+            req = CombatCastSpellRequest(
+                actor_participant_id="p1",
+                target_ref_ids=[t["ref_id"] for t in targets],
+                spell_canonical_key="animal_friendship",
+            )
+            result = await CombatService._resolve_plain_multi_target_automation_cast(
+                db, "session-1", req, state, player, attacker_state,
+                spell_context, "user-1", False, targets,
+            )
+        return result, state
+
+    async def test_both_targets_charmed_on_failed_saves(self):
+        beast1 = _make_participant("e1", "wolf-1")
+        beast2 = _make_participant("e2", "wolf-2")
+        result, state = await self._resolve([beast1, beast2], roll_side_effect=lambda *a, **kw: 2)
+
+        self.assertEqual(result["target_count"], 2)
+        wolf1 = next(p for p in state.participants if p["ref_id"] == "wolf-1")
+        wolf2 = next(p for p in state.participants if p["ref_id"] == "wolf-2")
+        self.assertTrue(any(e.get("condition_type") == "charmed" for e in wolf1["active_effects"]))
+        self.assertTrue(any(e.get("condition_type") == "charmed" for e in wolf2["active_effects"]))
+
+    async def test_targets_resolve_independently(self):
+        """Alternating rolls: first fails, second passes."""
+        import itertools
+        beast1 = _make_participant("e1", "wolf-1")
+        beast2 = _make_participant("e2", "wolf-2")
+        # roll_d20_pair calls randint TWICE per target (returns d20_a, d20_b)
+        # In normal mode, d20_a is used.  DC 14 → roll < 14 fails, >= 14 passes.
+        # Pair [2, 2] for wolf-1 → d20_a=2 → fail.  [18, 18] for wolf-2 → d20_a=18 → pass.
+        rolls = itertools.cycle([2, 2, 18, 18])
+        result, state = await self._resolve(
+            [beast1, beast2], roll_side_effect=lambda *a, **kw: next(rolls)
+        )
+
+        wolf1 = next(p for p in state.participants if p["ref_id"] == "wolf-1")
+        wolf2 = next(p for p in state.participants if p["ref_id"] == "wolf-2")
+        self.assertTrue(any(e.get("condition_type") == "charmed" for e in wolf1["active_effects"]))
+        self.assertFalse(any(e.get("condition_type") == "charmed" for e in wolf2["active_effects"]))
+
+    async def test_result_includes_affected_target_refs(self):
+        beast1 = _make_participant("e1", "wolf-1")
+        beast2 = _make_participant("e2", "wolf-2")
+        result, _ = await self._resolve([beast1, beast2], roll_side_effect=lambda *a, **kw: 5)
+        self.assertIn("wolf-1", result.get("affected_target_ref_ids", []))
+        self.assertIn("wolf-2", result.get("affected_target_ref_ids", []))
+
+    async def test_single_target_still_works(self):
+        beast = _make_participant("e1", "wolf-1")
+        result, state = await self._resolve([beast], roll_side_effect=lambda *a, **kw: 2)
+        self.assertEqual(result["target_count"], 1)
+        wolf = next(p for p in state.participants if p["ref_id"] == "wolf-1")
+        self.assertTrue(any(e.get("condition_type") == "charmed" for e in wolf["active_effects"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlainMultiTargetSelector.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlainMultiTargetSelector.test.tsx
@@ -1,0 +1,362 @@
+/**
+ * Tests for PlainMultiTargetSelector and isPlainMultiTargetAutomationSpell discriminator (issue #279).
+ *
+ * UI / dialog tests:
+ *   - test_spiritual_weapon_follow_up_* pattern reused for plain-multi-target selector:
+ *   - multi-target selector appears when maxTargets > 1 and no variants/instances/area
+ *   - selector renders correct number of slots
+ *   - first slot pre-populated with initial target
+ *   - excludes already-selected targets from other slots
+ *   - excludes dead/defeated participants
+ *   - payload discriminator: isPlainMultiTargetAutomationSpell logic
+ *   - buildNonAreaSpellCastPayload includes target_ref_ids when plain multi-target
+ */
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { PlainMultiTargetSelector } from "./PlainMultiTargetSelector";
+import { buildNonAreaSpellCastPayload } from "./PlayerSpellCastDialog";
+import type { CombatParticipant } from "../../../shared/api/combatRepo";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const makeParticipant = (
+  override: Partial<CombatParticipant> = {},
+): CombatParticipant => ({
+  id: "p-1",
+  kind: "session_entity",
+  ref_id: "wolf-1",
+  display_name: "Wolf",
+  initiative: 5,
+  status: "active",
+  team: "enemies",
+  visible: true,
+  actor_user_id: null,
+  ...override,
+});
+
+const wolf1 = makeParticipant({ id: "wolf-p1", ref_id: "wolf-1", display_name: "Wolf 1" });
+const wolf2 = makeParticipant({ id: "wolf-p2", ref_id: "wolf-2", display_name: "Wolf 2" });
+const wolf3 = makeParticipant({ id: "wolf-p3", ref_id: "wolf-3", display_name: "Wolf 3" });
+const deadWolf = makeParticipant({ id: "wolf-dead", ref_id: "wolf-dead", display_name: "Dead Wolf", status: "dead" });
+
+// ---------------------------------------------------------------------------
+// PlainMultiTargetSelector component tests
+// ---------------------------------------------------------------------------
+
+describe("test_plain_multi_target_selector_renders_correct_slots", () => {
+  it("renders maxTargets=2 dropdowns", () => {
+    const markup = renderToStaticMarkup(
+      <PlainMultiTargetSelector
+        maxTargets={2}
+        participants={[wolf1, wolf2]}
+        value={[]}
+        onChange={() => undefined}
+      />,
+    );
+    // Two <select> elements
+    const selectCount = (markup.match(/<select/g) ?? []).length;
+    expect(selectCount).toBe(2);
+  });
+
+  it("renders maxTargets=3 dropdowns", () => {
+    const markup = renderToStaticMarkup(
+      <PlainMultiTargetSelector
+        maxTargets={3}
+        participants={[wolf1, wolf2, wolf3]}
+        value={[]}
+        onChange={() => undefined}
+      />,
+    );
+    const selectCount = (markup.match(/<select/g) ?? []).length;
+    expect(selectCount).toBe(3);
+  });
+
+  it("renders maxTargets=1 for single target slot", () => {
+    const markup = renderToStaticMarkup(
+      <PlainMultiTargetSelector
+        maxTargets={1}
+        participants={[wolf1]}
+        value={[]}
+        onChange={() => undefined}
+      />,
+    );
+    const selectCount = (markup.match(/<select/g) ?? []).length;
+    expect(selectCount).toBe(1);
+  });
+});
+
+describe("test_plain_multi_target_selector_pre_populates_first_slot", () => {
+  it("first slot shows pre-selected target", () => {
+    const markup = renderToStaticMarkup(
+      <PlainMultiTargetSelector
+        maxTargets={2}
+        participants={[wolf1, wolf2]}
+        value={["wolf-1"]}
+        onChange={() => undefined}
+      />,
+    );
+    // wolf-1 should be selected in the first slot
+    expect(markup).toContain('value="wolf-1"');
+    expect(markup).toContain("Wolf 1");
+  });
+
+  it("all slots empty when value is empty", () => {
+    const markup = renderToStaticMarkup(
+      <PlainMultiTargetSelector
+        maxTargets={2}
+        participants={[wolf1, wolf2]}
+        value={[]}
+        onChange={() => undefined}
+      />,
+    );
+    // placeholder options shown
+    expect(markup).toContain("Alvo 1");
+    expect(markup).toContain("Alvo 2");
+  });
+});
+
+describe("test_plain_multi_target_selector_excludes_already_selected", () => {
+  it("wolf-1 selected in slot 1 is excluded from slot 2 options", () => {
+    const markup = renderToStaticMarkup(
+      <PlainMultiTargetSelector
+        maxTargets={2}
+        participants={[wolf1, wolf2]}
+        value={["wolf-1"]}
+        onChange={() => undefined}
+      />,
+    );
+    // Wolf 1 should appear in slot 1 (selected) but slot 2 should not offer it as unselected option
+    // The selected option value "wolf-1" appears once (in slot 1)
+    const wolf1OccurrenceCount = (markup.match(/value="wolf-1"/g) ?? []).length;
+    // wolf-1 appears in slot 1 select (as option value) but not in slot 2 (excluded)
+    expect(wolf1OccurrenceCount).toBe(1);
+  });
+
+  it("when both slots selected, each participant excluded from the other slot", () => {
+    const markup = renderToStaticMarkup(
+      <PlainMultiTargetSelector
+        maxTargets={2}
+        participants={[wolf1, wolf2, wolf3]}
+        value={["wolf-1", "wolf-2"]}
+        onChange={() => undefined}
+      />,
+    );
+    // wolf-1 selected in slot 1, wolf-2 selected in slot 2
+    // wolf-2 should NOT appear as an option in slot 1, wolf-1 should NOT appear in slot 2
+    // wolf-3 should appear in both slots
+    expect(markup).toContain("Wolf 3");
+  });
+});
+
+describe("test_plain_multi_target_selector_excludes_dead_participants", () => {
+  it("excludes dead participants from all slots", () => {
+    const markup = renderToStaticMarkup(
+      <PlainMultiTargetSelector
+        maxTargets={2}
+        participants={[wolf1, deadWolf, wolf2]}
+        value={[]}
+        onChange={() => undefined}
+      />,
+    );
+    expect(markup).not.toContain("Dead Wolf");
+  });
+
+  it("excludes defeated participants from all slots", () => {
+    const defeatedWolf = makeParticipant({
+      id: "wolf-defeated",
+      ref_id: "wolf-defeated",
+      display_name: "Defeated Wolf",
+      status: "defeated",
+    });
+    const markup = renderToStaticMarkup(
+      <PlainMultiTargetSelector
+        maxTargets={2}
+        participants={[wolf1, defeatedWolf]}
+        value={[]}
+        onChange={() => undefined}
+      />,
+    );
+    expect(markup).not.toContain("Defeated Wolf");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isPlainMultiTargetAutomationSpell discriminator
+// ---------------------------------------------------------------------------
+
+describe("test_plain_multi_target_discriminator", () => {
+  const makeDiscriminator = ({
+    isAreaSpell = false,
+    isMultiInstanceSpell = false,
+    isVariantSpell = false,
+    maxTargets = 1,
+  }) => !isAreaSpell && !isMultiInstanceSpell && !isVariantSpell && maxTargets > 1;
+
+  it("true when maxTargets > 1 and no variants, no instances, no area", () => {
+    expect(
+      makeDiscriminator({ maxTargets: 2 }),
+    ).toBe(true);
+  });
+
+  it("false when maxTargets === 1 (single target automation)", () => {
+    expect(
+      makeDiscriminator({ maxTargets: 1 }),
+    ).toBe(false);
+  });
+
+  it("false when isAreaSpell is true", () => {
+    expect(
+      makeDiscriminator({ maxTargets: 3, isAreaSpell: true }),
+    ).toBe(false);
+  });
+
+  it("false when isVariantSpell is true (variant multi-target path handles that)", () => {
+    expect(
+      makeDiscriminator({ maxTargets: 2, isVariantSpell: true }),
+    ).toBe(false);
+  });
+
+  it("false when isMultiInstanceSpell is true (instance path handles that)", () => {
+    expect(
+      makeDiscriminator({ maxTargets: 2, isMultiInstanceSpell: true }),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildNonAreaSpellCastPayload: target_ref_ids in payload
+// ---------------------------------------------------------------------------
+
+describe("test_build_non_area_spell_cast_payload_plain_multi_target", () => {
+  const baseParams = {
+    actorParticipantId: "p1",
+    concentrationManualRoll: null,
+    concentrationRollMode: "system" as const,
+    effectInstanceTargets: [],
+    isMultiInstanceSpell: false,
+    parsedBonus: 0,
+    selectedSlotLevel: 2,
+    spell: {
+      canonicalKey: "animal_friendship",
+      level: 1,
+      sourceType: "standard",
+      campaignSpellId: "cs-1",
+    } as any,
+    spellDamageType: "",
+    spellEffectDice: "",
+    spellMode: "saving_throw" as const,
+    spellSaveAbility: "" as any,
+    targetRefId: "wolf-1",
+  };
+
+  it("includes target_ref_ids when isPlainMultiTargetAutomationSpell is true", () => {
+    const payload = buildNonAreaSpellCastPayload({
+      ...baseParams,
+      isPlainMultiTargetAutomationSpell: true,
+      plainTargetRefIds: ["wolf-1", "wolf-2"],
+    });
+    expect(payload.target_ref_ids).toEqual(["wolf-1", "wolf-2"]);
+    expect(payload.target_ref_id).toBeNull();
+  });
+
+  it("target_ref_ids is null when plain multi-target is false (single target)", () => {
+    const payload = buildNonAreaSpellCastPayload({
+      ...baseParams,
+      isPlainMultiTargetAutomationSpell: false,
+    });
+    expect(payload.target_ref_ids).toBeNull();
+    expect(payload.target_ref_id).toBe("wolf-1");
+  });
+
+  it("target_ref_ids is null when plainTargetRefIds is empty", () => {
+    const payload = buildNonAreaSpellCastPayload({
+      ...baseParams,
+      isPlainMultiTargetAutomationSpell: true,
+      plainTargetRefIds: [],
+    });
+    expect(payload.target_ref_ids).toBeNull();
+  });
+
+  it("slot_level is set correctly for upcast", () => {
+    const payload = buildNonAreaSpellCastPayload({
+      ...baseParams,
+      isPlainMultiTargetAutomationSpell: true,
+      plainTargetRefIds: ["wolf-1", "wolf-2"],
+      selectedSlotLevel: 3,
+    });
+    expect(payload.slot_level).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Golden chain: slot N → resolved maxTargets → N selectors rendered
+// ---------------------------------------------------------------------------
+
+describe("test_animal_friendship_upcast_slot_2_renders_two_selectors", () => {
+  it("renders 2 target selectors when resolved max_targets is 2 (slot 2)", () => {
+    // resolved max_targets = base(1) + upcast_added(1) = 2 at slot 2
+    const resolvedMaxTargets = 2;
+    const markup = renderToStaticMarkup(
+      <PlainMultiTargetSelector
+        maxTargets={resolvedMaxTargets}
+        participants={[wolf1, wolf2, wolf3]}
+        value={[]}
+        onChange={() => undefined}
+      />,
+    );
+    const selectCount = (markup.match(/<select/g) ?? []).length;
+    expect(selectCount).toBe(2);
+  });
+
+  it("renders 3 target selectors when resolved max_targets is 3 (slot 3)", () => {
+    const resolvedMaxTargets = 3;
+    const markup = renderToStaticMarkup(
+      <PlainMultiTargetSelector
+        maxTargets={resolvedMaxTargets}
+        participants={[wolf1, wolf2, wolf3]}
+        value={[]}
+        onChange={() => undefined}
+      />,
+    );
+    const selectCount = (markup.match(/<select/g) ?? []).length;
+    expect(selectCount).toBe(3);
+  });
+
+  it("payload at slot 2 includes 2 ref_ids when 2 targets selected", () => {
+    const baseParams = {
+      actorParticipantId: "p1",
+      concentrationManualRoll: null,
+      concentrationRollMode: "system" as const,
+      effectInstanceTargets: [],
+      isMultiInstanceSpell: false,
+      parsedBonus: 0,
+      selectedSlotLevel: 2,
+      spell: {
+        canonicalKey: "animal_friendship",
+        level: 1,
+        sourceType: "standard",
+        campaignSpellId: "cs-1",
+      } as any,
+      spellDamageType: "",
+      spellEffectDice: "",
+      spellMode: "saving_throw" as const,
+      spellSaveAbility: "" as any,
+      targetRefId: null,
+    };
+
+    const payload = buildNonAreaSpellCastPayload({
+      ...baseParams,
+      isPlainMultiTargetAutomationSpell: true,
+      plainTargetRefIds: ["wolf-1", "wolf-2"],  // 2 targets at slot 2
+    });
+
+    expect(payload.target_ref_ids).toHaveLength(2);
+    expect(payload.target_ref_ids).toContain("wolf-1");
+    expect(payload.target_ref_ids).toContain("wolf-2");
+    expect(payload.slot_level).toBe(2);
+    expect(payload.target_ref_id).toBeNull();
+  });
+});

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlainMultiTargetSelector.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlainMultiTargetSelector.tsx
@@ -1,0 +1,64 @@
+import type { CombatParticipant } from "../../../shared/api/combatRepo";
+
+type Props = {
+  disabled?: boolean;
+  maxTargets: number;
+  participants: CombatParticipant[];
+  value: string[];
+  onChange: (value: string[]) => void;
+};
+
+/**
+ * Target selector for plain multi-target automation spells (no variants).
+ * Renders one dropdown per target slot up to maxTargets.
+ * Each slot excludes targets already selected in other slots.
+ */
+export const PlainMultiTargetSelector = ({
+  disabled = false,
+  maxTargets,
+  participants,
+  value,
+  onChange,
+}: Props) => {
+  const eligible = participants.filter(
+    (p) => p.status !== "dead" && p.status !== "defeated",
+  );
+
+  const rows = Array.from({ length: maxTargets }, (_, i) => value[i] ?? "");
+
+  const handleChange = (index: number, refId: string) => {
+    const next = [...rows];
+    next[index] = refId;
+    onChange(next.filter(Boolean));
+  };
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs font-medium text-slate-300">
+        Selecione até {maxTargets} alvo{maxTargets !== 1 ? "s" : ""}
+      </p>
+      {rows.map((selectedRefId, index) => {
+        const otherSelected = new Set(rows.filter((_, i) => i !== index));
+        const options = eligible.filter(
+          (p) => !otherSelected.has(p.ref_id) || p.ref_id === selectedRefId,
+        );
+        return (
+          <select
+            key={index}
+            disabled={disabled}
+            value={selectedRefId}
+            onChange={(e) => handleChange(index, e.target.value)}
+            className="w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white focus:border-fuchsia-400 focus:outline-none"
+          >
+            <option value="">— Alvo {index + 1} —</option>
+            {options.map((p) => (
+              <option key={p.id} value={p.ref_id}>
+                {p.display_name}
+              </option>
+            ))}
+          </select>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
@@ -36,6 +36,7 @@ import {
   VariantTargetAssignmentSelector,
   type TargetVariantAssignmentInput,
 } from "./VariantTargetAssignmentSelector";
+import { PlainMultiTargetSelector } from "./PlainMultiTargetSelector";
 import { SpellCastDialogActions } from "./SpellCastDialogActions";
 import { parseBonus } from "./spellCastHelpers";
 import { SpellCastDialogHeader } from "./SpellCastDialogHeader";
@@ -95,6 +96,8 @@ type BuildNonAreaSpellCastPayloadParams = {
   effectInstanceTargets: EffectInstanceTargetInput[];
   isMultiInstanceSpell: boolean;
   isVariantMultiTargetSpell?: boolean;
+  isPlainMultiTargetAutomationSpell?: boolean;
+  plainTargetRefIds?: string[];
   manualRoll?: number | null;
   parsedBonus: number;
   rollSource?: "manual" | "system";
@@ -116,6 +119,8 @@ export const buildNonAreaSpellCastPayload = ({
   effectInstanceTargets,
   isMultiInstanceSpell,
   isVariantMultiTargetSpell = false,
+  isPlainMultiTargetAutomationSpell = false,
+  plainTargetRefIds = [],
   manualRoll = null,
   parsedBonus,
   rollSource = "system",
@@ -130,11 +135,12 @@ export const buildNonAreaSpellCastPayload = ({
   targetRefId = null,
 }: BuildNonAreaSpellCastPayloadParams): CombatCastSpellRequest => ({
   actor_participant_id: actorParticipantId,
-  target_ref_id: isVariantMultiTargetSpell
+  target_ref_id: isVariantMultiTargetSpell || isPlainMultiTargetAutomationSpell
     ? null
     : isMultiInstanceSpell
       ? effectInstanceTargets[0]?.target_ref_id ?? targetRefId ?? null
       : targetRefId,
+  target_ref_ids: isPlainMultiTargetAutomationSpell && plainTargetRefIds.length > 0 ? plainTargetRefIds : null,
   effect_instance_targets: isMultiInstanceSpell ? effectInstanceTargets : null,
   variant_key: isVariantMultiTargetSpell ? null : selectedVariantKey,
   target_variant_assignments: isVariantMultiTargetSpell ? targetVariantAssignments : null,
@@ -249,6 +255,9 @@ export const PlayerSpellCastDialog = ({
   const [selectedVariantKey, setSelectedVariantKey] = useState<string>("");
   const [targetVariantAssignments, setTargetVariantAssignments] = useState<TargetVariantAssignmentInput[]>([]);
   const [effectInstanceTargets, setEffectInstanceTargets] = useState<EffectInstanceTargetInput[]>([]);
+  const [selectedTargetIds, setSelectedTargetIds] = useState<string[]>(
+    target ? [target.ref_id] : [],
+  );
   const [result, setResult] = useState<CombatSpellResult | null>(null);
   const [spellMapState, setSpellMapState] = useState<Awaited<ReturnType<typeof combatRepo.getMapState>> | null>(null);
   const [multiInstanceSpatialValidations, setMultiInstanceSpatialValidations] = useState<
@@ -326,6 +335,7 @@ export const PlayerSpellCastDialog = ({
   const maxTargets = Math.max(1, resolvedSpellContextState.context?.max_targets ?? 1);
   const isVariantSpell = spellVariants.length > 0;
   const isVariantMultiTargetSpell = isVariantSpell && !isAreaSpell && !isMultiInstanceSpell && maxTargets > 1;
+  const isPlainMultiTargetAutomationSpell = !isAreaSpell && !isMultiInstanceSpell && !isVariantSpell && maxTargets > 1;
   const hasCompleteVariantAssignments = hasCompleteTargetVariantAssignments(targetVariantAssignments, maxTargets);
   const selectableParticipants = participants.filter((participant) => participant.id !== actor.id);
   const normalizedEffectInstanceTargets = normalizeEffectInstanceTargets(
@@ -621,6 +631,10 @@ export const PlayerSpellCastDialog = ({
       setError("Escolha ao menos dois alvos e uma variante para cada um.");
       return;
     }
+    if (isPlainMultiTargetAutomationSpell && selectedTargetIds.length === 0) {
+      setError("Selecione ao menos um alvo.");
+      return;
+    }
 
     setLoading(true);
     setError(null);
@@ -661,6 +675,8 @@ export const PlayerSpellCastDialog = ({
               effectInstanceTargets: normalizedEffectInstanceTargets,
               isMultiInstanceSpell,
               isVariantMultiTargetSpell,
+              isPlainMultiTargetAutomationSpell,
+              plainTargetRefIds: selectedTargetIds,
               manualRoll: payload?.manual_roll ?? null,
               parsedBonus,
               rollSource: payload?.roll_source ?? "system",
@@ -798,6 +814,19 @@ export const PlayerSpellCastDialog = ({
           />
         ) : null}
 
+        {!result && isPlainMultiTargetAutomationSpell ? (
+          <PlainMultiTargetSelector
+            disabled={loading}
+            maxTargets={maxTargets}
+            participants={selectableParticipants}
+            value={selectedTargetIds}
+            onChange={(nextValue) => {
+              setSelectedTargetIds(nextValue);
+              setError(null);
+            }}
+          />
+        ) : null}
+
         {!result && isMultiInstanceSpell ? (
           <InstanceTargetSelector
             disabled={loading}
@@ -930,7 +959,8 @@ export const PlayerSpellCastDialog = ({
               !spellContextReady ||
               (isMultiInstanceSpell && !effectInstanceTargetsComplete) ||
               (isVariantSpell && !isVariantMultiTargetSpell && !selectedVariantKey) ||
-              (isVariantMultiTargetSpell && !hasCompleteVariantAssignments)
+              (isVariantMultiTargetSpell && !hasCompleteVariantAssignments) ||
+              (isPlainMultiTargetAutomationSpell && selectedTargetIds.length === 0)
             }
             validationMessage={
               !spellContextReady

--- a/apps/control-web/src/shared/api/combatRepo.ts
+++ b/apps/control-web/src/shared/api/combatRepo.ts
@@ -288,6 +288,7 @@ export type CombatAttackResult = {
 export type CombatCastSpellRequest = {
   actor_participant_id?: string | null;
   target_ref_id?: string | null;
+  target_ref_ids?: string[] | null;
   effect_instance_targets?: Array<{
     instance_index: number;
     target_ref_id: string;


### PR DESCRIPTION
# PR: feat(spells) plain multi-target automation and animal friendship upcast (#279)

## Description

Este PR finaliza a cadeia de suporte para magias de automação com múltiplos alvos ("Plain Multi-Target"). A implementação permite que magias como *Animal Friendship* escalem o número de alvos permitidos com base no nível do slot de conjuração utilizado (Upcast), garantindo validações rigorosas de distância, linha de visão e duplicatas.

## Changes

### Backend
- **Schema Update:** Adicionado campo `target_ref_ids: list[str]` ao schema de requisição de combate para suportar múltiplos IDs de referência.
- **Validation Engine (`cast_target.py`):**
    - `_validate_plain_multi_target_refs`: Garante exclusão mútua de alvos, impede duplicatas e valida se o total de alvos respeita o `max_targets` calculado para o slot.
    - `_validate_plain_multi_target_spatial`: Executa validações de Range, LoS (Linha de Visão) e LoE (Linha de Efeito) individualmente para cada alvo **antes** do consumo de recursos.
- **Resolution Logic:** `_resolve_plain_multi_target_automation_cast` consome a ação e o slot uma única vez, mas dispara a automação, verificações de hostilidade e casting para cada alvo individualmente.
- **Data & Migration:** Atualizada a semente de *Animal Friendship* para `maxTargets: 1` e criada migração `0078` para backfill conservador.

### Frontend
- **Dynamic Selector:** Criado o componente `PlainMultiTargetSelector.tsx` que renderiza N seletores baseados no `max_targets` do slot, filtrando automaticamente alvos já selecionados e entidades mortas/derrotadas.
- **Dialog Integration:** `PlayerSpellCastDialog.tsx` agora identifica magias multi-alvo e gerencia o estado de múltiplos IDs, bloqueando o envio se os alvos obrigatórios não forem preenchidos.

## Summary of Changes

| Component | Change |
| :--- | :--- |
| **`combat_spells.py`** | Suporte a `target_ref_ids` no contrato da API |
| **`cast_target.py`** | Nova lógica genérica para roteamento de multi-alvo |
| **`PlainMultiTargetSelector`** | UI inteligente para seleção múltipla sem duplicatas |
| **`base_spells.seed`** | Configuração de escala de alvos para Animal Friendship |

## Test Coverage

A cadeia foi verificada por "testes de ouro" (Golden Tests) cobrindo o fluxo de ponta a ponta:

### Backend (TestAnimalFriendshipUpcastContext)
- **Slot 2:** Aceita exatamente 2 alvos e retorna 2 participantes afetados. Rejeita 3 alvos com `CombatServiceError`.
- **Slot 3:** Aceita 3 alvos conforme a escala de upcast.
- **Total:** 2233 testes backend passando.

### Frontend (PlainMultiTargetSelector.test.tsx)
- Validação de renderização dinâmica de `<select>` conforme o `maxTargets` resolvido pelo slot.
- Verificação do payload final incluindo o array correto de `ref_ids`.
- **Total:** 1022 testes frontend passando.

## Validation Result
- **Backend:** 2233 passed, zero regressions.
- **Frontend:** 1022 passed, zero regressions.

> [!CHECK] 
> O sistema agora impede nativamente que o jogador tente selecionar o mesmo lobo duas vezes ou use um slot de nível 1 para afetar dois alvos.