### PR TITLE
feat(combat) structured weapon damage breakdown (#283)

### DIFF
--- a/apps/control-server/app/schemas/combat.py
+++ b/apps/control-server/app/schemas/combat.py
@@ -58,11 +58,15 @@ from .combat_spells import (
     CombatSpellResult,
 )
 
+from app.schemas.roll import WeaponDamageBreakdown
+
 _combat_schema_types = {
     "CombatConcentrationCheckResult": CombatConcentrationCheckResult,
+    "WeaponDamageBreakdown": WeaponDamageBreakdown,
 }
 CombatAttackResult.model_rebuild(_types_namespace=_combat_schema_types)
 CombatSpellResult.model_rebuild(_types_namespace=_combat_schema_types)
+CombatEntityActionResult.model_rebuild(_types_namespace=_combat_schema_types)
 
 __all__ = [
     "ActiveEffect",

--- a/apps/control-server/app/schemas/combat_actions.py
+++ b/apps/control-server/app/schemas/combat_actions.py
@@ -54,6 +54,9 @@ class CombatEntityActionResult(BaseModel):
     base_damage: int | None = None
     damage_roll_source: RollSource | None = None
     concentration_check: "CombatConcentrationCheckResult | None" = None
+    damage_breakdown: "WeaponDamageBreakdown | None" = None
+    extra_damage_rolls: list[int] = Field(default_factory=list)
+    extra_damage_label: str | None = None
 
 
 class CombatConcentrationCheckResult(BaseModel):

--- a/apps/control-server/app/schemas/combat_spells.py
+++ b/apps/control-server/app/schemas/combat_spells.py
@@ -44,6 +44,9 @@ class CombatAttackResult(BaseModel):
     base_damage: int | None = None
     damage_roll_source: RollSource | None = None
     concentration_check: "CombatConcentrationCheckResult | None" = None
+    damage_breakdown: "WeaponDamageBreakdown | None" = None
+    extra_damage_rolls: list[int] = Field(default_factory=list)
+    extra_damage_label: str | None = None
 
 
 class EffectInstanceTarget(BaseModel):

--- a/apps/control-server/app/schemas/roll.py
+++ b/apps/control-server/app/schemas/roll.py
@@ -11,6 +11,33 @@ AdvantageMode = Literal["normal", "advantage", "disadvantage"]
 ActorKind = Literal["player", "session_entity"]
 RollType = Literal["ability", "save", "skill", "initiative", "attack"]
 RollSource = Literal["system", "manual"]
+WeaponDamageOperation = Literal["add", "subtract"]
+WeaponDamageComponentKind = Literal[
+    "base_weapon",
+    "ability_modifier",
+    "flat_modifier",
+    "extra_damage",
+    "weapon_damage_modifier"
+]
+
+class WeaponDamageComponent(BaseModel):
+    id: str
+    kind: WeaponDamageComponentKind
+    source_key: str | None = None
+    source_label: str
+    dice: str | None = None
+    rolls: list[int]
+    operation: WeaponDamageOperation
+    signed_total: int
+    damage_type: str | None = None
+    doubled_on_critical: bool = False
+    minimum_total_damage: int | None = None
+
+class WeaponDamageBreakdown(BaseModel):
+    total_before_minimum: int
+    minimum_applied: int | None = None
+    total: int
+    components: list[WeaponDamageComponent]
 
 
 # ---------------------------------------------------------------------------

--- a/apps/control-server/app/services/combat_service/actions/weapon_attack_damage.py
+++ b/apps/control-server/app/services/combat_service/actions/weapon_attack_damage.py
@@ -22,7 +22,6 @@ class WeaponAttackDamageMixin:
             manual_rolls=req.manual_rolls,
         )
         damage_bonus = cls._safe_int(pending_attack.get("damage_bonus"), 0)
-        effect_damage_bonus = cls._sum_numeric_effects(attacker, "damage_bonus")
 
         target_ref_id = pending_attack.get("target_ref_id")
         target_kind = pending_attack.get("target_kind")
@@ -34,14 +33,58 @@ class WeaponAttackDamageMixin:
         attacker_data = cls._as_dict(attacker_model.state_json)
         target_current_hp, target_max_hp = cls._get_target_hp_snapshot(db, session_id, target_ref_id, target_kind)
         
-        extra_damage = 0
-        extra_damage_rolls: list[int] = []
-        extra_damage_label = ""
+        import uuid
+        components = []
         
+        components.append({
+            "id": str(uuid.uuid4()),
+            "kind": "base_weapon",
+            "source_key": pending_attack.get("weapon_item_id"),
+            "source_label": pending_attack.get("weapon_name") or "Ataque",
+            "dice": pending_attack.get("damage_dice") or "unarmed",
+            "rolls": damage_rolls,
+            "operation": "add",
+            "signed_total": base_damage,
+            "damage_type": pending_attack.get("damage_type"),
+            "doubled_on_critical": bool(pending_attack.get("is_critical")),
+            "minimum_total_damage": None,
+        })
+        
+        if damage_bonus != 0:
+            components.append({
+                "id": str(uuid.uuid4()),
+                "kind": "ability_modifier",
+                "source_key": None,
+                "source_label": "Modificador",
+                "dice": None,
+                "rolls": [],
+                "operation": "add" if damage_bonus >= 0 else "subtract",
+                "signed_total": damage_bonus,
+                "damage_type": pending_attack.get("damage_type"),
+                "doubled_on_critical": False,
+                "minimum_total_damage": None,
+            })
+
         min_damage = 1
 
         for effect in cls._get_participant_effects(attacker):
-            if effect.get("kind") == "modify_weapon_damage":
+            if effect.get("kind") == "damage_bonus" and isinstance(effect.get("numeric_value"), int):
+                val = effect["numeric_value"]
+                if val != 0:
+                    components.append({
+                        "id": str(uuid.uuid4()),
+                        "kind": "flat_modifier",
+                        "source_key": effect.get("id"),
+                        "source_label": cls._effect_label(effect),
+                        "dice": None,
+                        "rolls": [],
+                        "operation": "add" if val >= 0 else "subtract",
+                        "signed_total": val,
+                        "damage_type": pending_attack.get("damage_type"),
+                        "doubled_on_critical": False,
+                        "minimum_total_damage": None,
+                    })
+            elif effect.get("kind") == "modify_weapon_damage":
                 params = effect.get("metadata", {}).get("declarative_effect", {}).get("params", {})
                 dice = params.get("dice")
                 operation = params.get("operation") or "add"
@@ -52,47 +95,86 @@ class WeaponAttackDamageMixin:
 
                 if dice:
                     rolls, total = cls._resolve_damage_roll(dice, critical=bool(pending_attack.get("is_critical")), roll_source=req.roll_source)
-                    effective_total = abs(total) if operation == "subtract" else total
-                    
-                    if operation == "subtract":
-                        effect_damage_bonus -= effective_total
-                        if effective_total != 0:
-                            effect_label = cls._effect_label(effect)
-                            extra_damage_label += f" {effect_label}: -{effective_total}."
-                    else:
-                        effect_damage_bonus += effective_total
-                        if effective_total != 0:
-                            effect_label = cls._effect_label(effect)
-                            extra_damage_label += f" {effect_label}: +{effective_total}."
-                    
-                    extra_damage_rolls.extend(rolls)
-
-        damage = max(min_damage, base_damage + damage_bonus + effect_damage_bonus)
+                    signed_total = total if operation == "add" else -total
+                    components.append({
+                        "id": str(uuid.uuid4()),
+                        "kind": "weapon_damage_modifier",
+                        "source_key": effect.get("id"),
+                        "source_label": cls._effect_label(effect),
+                        "dice": dice,
+                        "rolls": rolls,
+                        "operation": operation,
+                        "signed_total": signed_total,
+                        "damage_type": pending_attack.get("damage_type"),
+                        "doubled_on_critical": bool(pending_attack.get("is_critical")),
+                        "minimum_total_damage": min_total,
+                    })
 
         turn_resources = cls._get_turn_resources(attacker)
         is_weapon_attack = pending_attack.get("is_weapon_attack") is True
+        
         hunters_mark_effect = cls._get_hunters_mark_effect_for_target(attacker, target_participant_id=target_participant.get("id", "") if target_participant else "") if is_weapon_attack else None
         if hunters_mark_effect is not None:
-            hm_rolls, hm_damage = cls._resolve_damage_roll("1d6", roll_source="system")
-            extra_damage += hm_damage
-            extra_damage_rolls.extend(hm_rolls)
-            extra_damage_label += " Hunter's Mark: +1d6."
+            hm_rolls, hm_damage = cls._resolve_damage_roll("1d6", critical=bool(pending_attack.get("is_critical")), roll_source="system")
+            components.append({
+                "id": str(uuid.uuid4()),
+                "kind": "extra_damage",
+                "source_key": "hunters_mark",
+                "source_label": "Hunter's Mark",
+                "dice": "1d6",
+                "rolls": hm_rolls,
+                "operation": "add",
+                "signed_total": hm_damage,
+                "damage_type": pending_attack.get("damage_type"),
+                "doubled_on_critical": bool(pending_attack.get("is_critical")),
+                "minimum_total_damage": None,
+            })
+
         can_use_colossus_slayer = cls._player_has_colossus_slayer(attacker_data) and target_current_hp is not None and target_max_hp is not None and target_current_hp < target_max_hp and not turn_resources.get("colossus_slayer_used")
         if can_use_colossus_slayer:
-            slayer_rolls, slayer_damage = cls._resolve_damage_roll("1d8", roll_source="system")
-            extra_damage_rolls.extend(slayer_rolls)
-            extra_damage += slayer_damage
+            slayer_rolls, slayer_damage = cls._resolve_damage_roll("1d8", critical=bool(pending_attack.get("is_critical")), roll_source="system")
+            components.append({
+                "id": str(uuid.uuid4()),
+                "kind": "extra_damage",
+                "source_key": "colossus_slayer",
+                "source_label": "Assassino de Colossos",
+                "dice": "1d8",
+                "rolls": slayer_rolls,
+                "operation": "add",
+                "signed_total": slayer_damage,
+                "damage_type": pending_attack.get("damage_type"),
+                "doubled_on_critical": bool(pending_attack.get("is_critical")),
+                "minimum_total_damage": None,
+            })
             turn_resources["colossus_slayer_used"] = True
             attacker["turn_resources"] = turn_resources
-            extra_damage_label += " Assassino de Colossos: +1d8."
+
+        total_before_minimum = sum(c["signed_total"] for c in components)
+        minimum_applied = min_damage if total_before_minimum < min_damage else None
+        final_damage = max(min_damage, total_before_minimum)
+
+        damage_breakdown = {
+            "total_before_minimum": total_before_minimum,
+            "minimum_applied": minimum_applied,
+            "total": final_damage,
+            "components": components,
+        }
+
+        extra_damage_rolls = []
+        extra_damage_label = ""
+        for c in components:
+            if c["kind"] in ("extra_damage", "weapon_damage_modifier", "flat_modifier"):
+                extra_damage_rolls.extend(c["rolls"])
+                op_sign = "+" if c["signed_total"] >= 0 else "-"
+                extra_damage_label += f" {c['source_label']}: {op_sign}{abs(c['signed_total'])}."
         new_hp = effect_msg = previous_hp = concentration_check = None
         effect_msg = ""
-        if damage > 0:
+        if final_damage > 0:
             new_hp, effect_msg, previous_hp, concentration_check = cls._apply_damage_to_target(
                 db,
                 target_ref_id,
                 target_kind,
-                damage + extra_damage,
+                final_damage,
                 damage_type=pending_attack.get("damage_type"),
                 is_crit=bool(pending_attack.get("is_critical")),
                 state=state,
@@ -107,14 +189,14 @@ class WeaponAttackDamageMixin:
         db.add(state)
         db.commit()
         db.refresh(state)
-        if damage > 0 and target_kind == "player":
+        if final_damage > 0 and target_kind == "player":
             target_state, *_ = cls._get_stats(db, target_ref_id, target_kind, session_id)
             await cls._emit_player_state_update(db, session_id, target_ref_id, target_state)
-        elif damage > 0 and previous_hp != new_hp:
+        elif final_damage > 0 and previous_hp != new_hp:
             await cls._emit_entity_hp_update(db, session_id, target_ref_id, previous_hp)
         await cls._emit_state(session_id, state)
         concentration_summary = f" {concentration_check['summary_text']}" if isinstance(concentration_check, dict) and isinstance(concentration_check.get("summary_text"), str) else ""
-        await cls._emit_and_persist_log(db, session_id, actor_user_id, attacker["display_name"], {"message": f"{attacker['display_name']} rolled damage with {pending_attack.get('weapon_name') or 'Attack'} against {target_display_name}: {damage + extra_damage} damage.{extra_damage_label}{effect_msg}{concentration_summary}", "actorUserId": actor_user_id, "source": "gm_override" if is_gm else "player_turn"})
+        await cls._emit_and_persist_log(db, session_id, actor_user_id, attacker["display_name"], {"message": f"{attacker['display_name']} rolled damage with {pending_attack.get('weapon_name') or 'Attack'} against {target_display_name}: {final_damage} damage.{extra_damage_label}{effect_msg}{concentration_summary}", "actorUserId": actor_user_id, "source": "gm_override" if is_gm else "player_turn"})
         return {
             "roll": cls._safe_int(pending_attack.get("roll"), 0),
             "is_hit": True,
@@ -122,15 +204,16 @@ class WeaponAttackDamageMixin:
             "target_ac": cls._safe_int(pending_attack.get("target_ac"), 10),
             "target_kind": "session_entity" if target_kind == "entity" else target_kind,
             "weapon_name": pending_attack.get("weapon_name") or "Attack",
-            "damage": damage + extra_damage,
+            "damage": final_damage,
             "new_hp": new_hp,
             "damage_dice": pending_attack.get("damage_dice") or "",
             "damage_rolls": damage_rolls,
             "extra_damage_rolls": extra_damage_rolls,
+            "extra_damage_label": extra_damage_label,
+            "damage_breakdown": damage_breakdown,
             "base_damage": base_damage,
             "damage_bonus": damage_bonus,
             "attack_bonus": cls._safe_int(pending_attack.get("attack_bonus"), 0),
-            "extra_damage": extra_damage,
             "roll_result": roll_result,
             "target_display_name": target_display_name,
             "damage_type": pending_attack.get("damage_type"),

--- a/apps/control-server/tests/_combat_test_shared.py
+++ b/apps/control-server/tests/_combat_test_shared.py
@@ -53,11 +53,11 @@ class TestResolutionTypeMapping(unittest.TestCase):
 
 class TestCombatDiceParser(unittest.TestCase):
     def test_parse_dice(self):
-        self.assertEqual(_parse_dice("1d8"), (1, 8, 0))
-        self.assertEqual(_parse_dice("2d6+3"), (2, 6, 3))
-        self.assertEqual(_parse_dice("1d10 - 1"), (1, 10, -1))
-        self.assertEqual(_parse_dice(""), (0, 0, 0))
-        self.assertEqual(_parse_dice("invalid"), (0, 0, 0))
+        self.assertEqual(_parse_dice("1d8"), (1, 1, 8, 0))
+        self.assertEqual(_parse_dice("2d6+3"), (1, 2, 6, 3))
+        self.assertEqual(_parse_dice("1d10 - 1"), (1, 1, 10, -1))
+        self.assertEqual(_parse_dice(""), (1, 0, 0, 0))
+        self.assertEqual(_parse_dice("invalid"), (1, 0, 0, 0))
 
     @patch("random.randint", return_value=5)
     def test_roll_dice_expression(self, mock_randint):

--- a/apps/control-server/tests/test_weapon_damage_breakdown.py
+++ b/apps/control-server/tests/test_weapon_damage_breakdown.py
@@ -1,0 +1,495 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.models.combat import CombatPhase, CombatState
+from app.schemas.combat import CombatResolveDamageRequest
+from app.services.combat import CombatService
+
+
+class TestWeaponDamageBreakdown(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.db = MagicMock()
+        self.state = CombatState(
+            id="combat-123",
+            session_id="session-123",
+            phase=CombatPhase.active,
+            round=1,
+            current_turn_index=0,
+            participants=[
+                {
+                    "id": "p1",
+                    "ref_id": "player-123",
+                    "kind": "player",
+                    "display_name": "Hero",
+                    "initiative": 15,
+                    "status": "active",
+                    "team": "players",
+                    "visible": True,
+                    "actor_user_id": "user-1",
+                    "turn_resources": {"action_used": False},
+                    "active_effects": [],
+                },
+                {
+                    "id": "e1",
+                    "ref_id": "enemy-123",
+                    "kind": "session_entity",
+                    "display_name": "Goblin",
+                    "initiative": 10,
+                    "status": "active",
+                    "team": "enemies",
+                    "visible": True,
+                    "actor_user_id": None,
+                    "active_effects": [],
+                },
+            ],
+        )
+
+    def _make_pending_attack(self, *, damage_dice="1d8", damage_bonus=3,
+                              weapon_name="Longsword", is_critical=False,
+                              damage_type="slashing"):
+        return {
+            "id": "attack-123",
+            "type": "player_attack",
+            "weapon_name": weapon_name,
+            "weapon_item_id": "item-ls",
+            "damage_dice": damage_dice,
+            "damage_bonus": damage_bonus,
+            "attack_bonus": 5,
+            "damage_type": damage_type,
+            "target_ref_id": "enemy-123",
+            "target_kind": "session_entity",
+            "target_display_name": "Goblin",
+            "is_weapon_attack": True,
+            "is_critical": is_critical,
+            "roll": 18,
+            "target_ac": 15,
+        }
+
+    def _make_req(self):
+        return CombatResolveDamageRequest(pending_attack_id="attack-123")
+
+    # ------------------------------------------------------------------
+    # 1. base_weapon component
+    # ------------------------------------------------------------------
+    @patch("app.services.combat.CombatService._emit_and_persist_log")
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_player_state_update")
+    @patch("app.services.combat.CombatService._emit_entity_hp_update")
+    async def test_breakdown_includes_base_weapon(self, *_mocks):
+        self.state.participants[0]["pending_attack"] = self._make_pending_attack()
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat.CombatService._get_stats", side_effect=[
+                (MagicMock(state_json={}), 10, 10, 10, 2, 0),
+                (MagicMock(), 15, 10, 10, 2, 0),
+            ]),
+            patch("app.services.combat.CombatService._get_target_hp_snapshot", return_value=(20, 20)),
+            patch("app.services.combat.CombatService._apply_damage_to_target", return_value=(12, "", 20, None)),
+            patch("app.services.combat.CombatService._resolve_damage_roll", return_value=([5], 5)),
+        ):
+            res = await CombatService.attack_damage(self.db, "session-123", self._make_req(), "user-1", True)
+
+        breakdown = res["damage_breakdown"]
+        base = next(c for c in breakdown["components"] if c["kind"] == "base_weapon")
+        self.assertEqual(base["signed_total"], 5)
+        self.assertEqual(base["dice"], "1d8")
+        self.assertEqual(base["rolls"], [5])
+        self.assertEqual(base["operation"], "add")
+        self.assertEqual(base["damage_type"], "slashing")
+
+    # ------------------------------------------------------------------
+    # 2. ability_modifier component
+    # ------------------------------------------------------------------
+    @patch("app.services.combat.CombatService._emit_and_persist_log")
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_player_state_update")
+    @patch("app.services.combat.CombatService._emit_entity_hp_update")
+    async def test_breakdown_includes_ability_modifier(self, *_mocks):
+        self.state.participants[0]["pending_attack"] = self._make_pending_attack(damage_bonus=3)
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat.CombatService._get_stats", side_effect=[
+                (MagicMock(state_json={}), 10, 10, 10, 2, 0),
+                (MagicMock(), 15, 10, 10, 2, 0),
+            ]),
+            patch("app.services.combat.CombatService._get_target_hp_snapshot", return_value=(20, 20)),
+            patch("app.services.combat.CombatService._apply_damage_to_target", return_value=(12, "", 20, None)),
+            patch("app.services.combat.CombatService._resolve_damage_roll", return_value=([6], 6)),
+        ):
+            res = await CombatService.attack_damage(self.db, "session-123", self._make_req(), "user-1", True)
+
+        breakdown = res["damage_breakdown"]
+        ability = next(c for c in breakdown["components"] if c["kind"] == "ability_modifier")
+        self.assertEqual(ability["signed_total"], 3)
+        self.assertEqual(ability["operation"], "add")
+        self.assertIsNone(ability["dice"])
+
+    # ------------------------------------------------------------------
+    # 3. ability_modifier omitted when zero
+    # ------------------------------------------------------------------
+    @patch("app.services.combat.CombatService._emit_and_persist_log")
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_player_state_update")
+    @patch("app.services.combat.CombatService._emit_entity_hp_update")
+    async def test_breakdown_omits_ability_modifier_when_zero(self, *_mocks):
+        self.state.participants[0]["pending_attack"] = self._make_pending_attack(damage_bonus=0)
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat.CombatService._get_stats", side_effect=[
+                (MagicMock(state_json={}), 10, 10, 10, 2, 0),
+                (MagicMock(), 15, 10, 10, 2, 0),
+            ]),
+            patch("app.services.combat.CombatService._get_target_hp_snapshot", return_value=(20, 20)),
+            patch("app.services.combat.CombatService._apply_damage_to_target", return_value=(15, "", 20, None)),
+            patch("app.services.combat.CombatService._resolve_damage_roll", return_value=([5], 5)),
+        ):
+            res = await CombatService.attack_damage(self.db, "session-123", self._make_req(), "user-1", True)
+
+        kinds = [c["kind"] for c in res["damage_breakdown"]["components"]]
+        self.assertNotIn("ability_modifier", kinds)
+
+    # ------------------------------------------------------------------
+    # 4. flat_modifier from damage_bonus effect
+    # ------------------------------------------------------------------
+    @patch("app.services.combat.CombatService._emit_and_persist_log")
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_player_state_update")
+    @patch("app.services.combat.CombatService._emit_entity_hp_update")
+    async def test_breakdown_includes_flat_modifier(self, *_mocks):
+        self.state.participants[0]["pending_attack"] = self._make_pending_attack()
+        self.state.participants[0]["active_effects"] = [
+            {"id": "eff-df", "kind": "damage_bonus", "display_label": "Divine Favor", "numeric_value": 2},
+        ]
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat.CombatService._get_stats", side_effect=[
+                (MagicMock(state_json={}), 10, 10, 10, 2, 0),
+                (MagicMock(), 15, 10, 10, 2, 0),
+            ]),
+            patch("app.services.combat.CombatService._get_target_hp_snapshot", return_value=(20, 20)),
+            patch("app.services.combat.CombatService._apply_damage_to_target", return_value=(10, "", 20, None)),
+            patch("app.services.combat.CombatService._resolve_damage_roll", return_value=([5], 5)),
+        ):
+            res = await CombatService.attack_damage(self.db, "session-123", self._make_req(), "user-1", True)
+
+        flat = next(c for c in res["damage_breakdown"]["components"] if c["kind"] == "flat_modifier")
+        self.assertEqual(flat["signed_total"], 2)
+        self.assertEqual(flat["source_label"], "Divine Favor")
+
+    # ------------------------------------------------------------------
+    # 5. modify_weapon_damage add
+    # ------------------------------------------------------------------
+    @patch("app.services.combat.CombatService._emit_and_persist_log")
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_player_state_update")
+    @patch("app.services.combat.CombatService._emit_entity_hp_update")
+    async def test_breakdown_includes_weapon_damage_modifier_add(self, *_mocks):
+        self.state.participants[0]["pending_attack"] = self._make_pending_attack()
+        self.state.participants[0]["active_effects"] = [
+            {
+                "id": "eff-enlarge",
+                "kind": "modify_weapon_damage",
+                "display_label": "Enlarge",
+                "metadata": {"declarative_effect": {"params": {"dice": "1d4", "operation": "add"}}},
+            },
+        ]
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat.CombatService._get_stats", side_effect=[
+                (MagicMock(state_json={}), 10, 10, 10, 2, 0),
+                (MagicMock(), 15, 10, 10, 2, 0),
+            ]),
+            patch("app.services.combat.CombatService._get_target_hp_snapshot", return_value=(20, 20)),
+            patch("app.services.combat.CombatService._apply_damage_to_target", return_value=(5, "", 20, None)),
+            patch("app.services.combat.CombatService._resolve_damage_roll", side_effect=[
+                ([6], 6),   # base 1d8
+                ([3], 3),   # enlarge 1d4
+            ]),
+        ):
+            res = await CombatService.attack_damage(self.db, "session-123", self._make_req(), "user-1", True)
+
+        mod = next(c for c in res["damage_breakdown"]["components"] if c["kind"] == "weapon_damage_modifier")
+        self.assertEqual(mod["signed_total"], 3)
+        self.assertEqual(mod["operation"], "add")
+
+    # ------------------------------------------------------------------
+    # 6. modify_weapon_damage subtract
+    # ------------------------------------------------------------------
+    @patch("app.services.combat.CombatService._emit_and_persist_log")
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_player_state_update")
+    @patch("app.services.combat.CombatService._emit_entity_hp_update")
+    async def test_breakdown_includes_weapon_damage_modifier_subtract(self, *_mocks):
+        self.state.participants[0]["pending_attack"] = self._make_pending_attack()
+        self.state.participants[0]["active_effects"] = [
+            {
+                "id": "eff-reduce",
+                "kind": "modify_weapon_damage",
+                "display_label": "Reduce",
+                "metadata": {"declarative_effect": {"params": {"dice": "1d4", "operation": "subtract"}}},
+            },
+        ]
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat.CombatService._get_stats", side_effect=[
+                (MagicMock(state_json={}), 10, 10, 10, 2, 0),
+                (MagicMock(), 15, 10, 10, 2, 0),
+            ]),
+            patch("app.services.combat.CombatService._get_target_hp_snapshot", return_value=(20, 20)),
+            patch("app.services.combat.CombatService._apply_damage_to_target", return_value=(5, "", 20, None)),
+            patch("app.services.combat.CombatService._resolve_damage_roll", side_effect=[
+                ([6], 6),   # base 1d8
+                ([2], 2),   # reduce 1d4
+            ]),
+        ):
+            res = await CombatService.attack_damage(self.db, "session-123", self._make_req(), "user-1", True)
+
+        mod = next(c for c in res["damage_breakdown"]["components"] if c["kind"] == "weapon_damage_modifier")
+        self.assertEqual(mod["signed_total"], -2)
+        self.assertEqual(mod["operation"], "subtract")
+
+    # ------------------------------------------------------------------
+    # 7. total, total_before_minimum, minimum_applied consistency
+    # ------------------------------------------------------------------
+    @patch("app.services.combat.CombatService._emit_and_persist_log")
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_player_state_update")
+    @patch("app.services.combat.CombatService._emit_entity_hp_update")
+    async def test_breakdown_totals_match_applied_damage(self, *_mocks):
+        self.state.participants[0]["pending_attack"] = self._make_pending_attack()
+        self.state.participants[0]["active_effects"] = [
+            {
+                "id": "eff-reduce",
+                "kind": "modify_weapon_damage",
+                "display_label": "Reduce",
+                "metadata": {"declarative_effect": {"params": {"dice": "1d4", "operation": "subtract"}}},
+            },
+        ]
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat.CombatService._get_stats", side_effect=[
+                (MagicMock(state_json={}), 10, 10, 10, 2, 0),
+                (MagicMock(), 15, 10, 10, 2, 0),
+            ]),
+            patch("app.services.combat.CombatService._get_target_hp_snapshot", return_value=(20, 20)),
+            patch("app.services.combat.CombatService._apply_damage_to_target", return_value=(16, "", 20, None)),
+            patch("app.services.combat.CombatService._resolve_damage_roll", side_effect=[
+                ([4], 4),   # base 1d8
+                ([1], 1),   # reduce 1d4
+            ]),
+        ):
+            res = await CombatService.attack_damage(self.db, "session-123", self._make_req(), "user-1", True)
+
+        bd = res["damage_breakdown"]
+        # 4 (base) + 3 (ability) - 1 (reduce) = 6
+        self.assertEqual(bd["total_before_minimum"], 6)
+        self.assertIsNone(bd["minimum_applied"])
+        self.assertEqual(bd["total"], 6)
+        self.assertEqual(res["damage"], 6)
+
+    # ------------------------------------------------------------------
+    # 8. minimum_applied floor (dano minimo 1)
+    # ------------------------------------------------------------------
+    @patch("app.services.combat.CombatService._emit_and_persist_log")
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_player_state_update")
+    @patch("app.services.combat.CombatService._emit_entity_hp_update")
+    async def test_breakdown_minimum_floor(self, *_mocks):
+        self.state.participants[0]["pending_attack"] = self._make_pending_attack(
+            damage_dice="1d4", damage_bonus=-1, weapon_name="Dagger"
+        )
+        self.state.participants[0]["active_effects"] = [
+            {
+                "id": "eff-reduce",
+                "kind": "modify_weapon_damage",
+                "display_label": "Reduce",
+                "metadata": {"declarative_effect": {"params": {
+                    "dice": "1d4", "operation": "subtract", "minimum_total_damage": 1,
+                }}},
+            },
+        ]
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat.CombatService._get_stats", side_effect=[
+                (MagicMock(state_json={}), 10, 10, 10, 2, 0),
+                (MagicMock(), 15, 10, 10, 2, 0),
+            ]),
+            patch("app.services.combat.CombatService._get_target_hp_snapshot", return_value=(20, 20)),
+            patch("app.services.combat.CombatService._apply_damage_to_target", return_value=(19, "", 20, None)),
+            patch("app.services.combat.CombatService._resolve_damage_roll", side_effect=[
+                ([1], 1),   # base 1d4 = 1
+                ([4], 4),   # reduce 1d4 = 4
+            ]),
+        ):
+            res = await CombatService.attack_damage(self.db, "session-123", self._make_req(), "user-1", True)
+
+        bd = res["damage_breakdown"]
+        # 1 (base) - 1 (ability) - 4 (reduce) = -4
+        self.assertEqual(bd["total_before_minimum"], -4)
+        self.assertEqual(bd["minimum_applied"], 1)
+        self.assertEqual(bd["total"], 1)
+        self.assertEqual(res["damage"], 1)
+
+    # ------------------------------------------------------------------
+    # 9. extra_damage_rolls and extra_damage_label legacy fields
+    # ------------------------------------------------------------------
+    @patch("app.services.combat.CombatService._emit_and_persist_log")
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_player_state_update")
+    @patch("app.services.combat.CombatService._emit_entity_hp_update")
+    async def test_legacy_extra_damage_fields_populated(self, *_mocks):
+        self.state.participants[0]["pending_attack"] = self._make_pending_attack()
+        self.state.participants[0]["active_effects"] = [
+            {"id": "eff-df", "kind": "damage_bonus", "display_label": "Divine Favor", "numeric_value": 2},
+            {
+                "id": "eff-reduce",
+                "kind": "modify_weapon_damage",
+                "display_label": "Reduce",
+                "metadata": {"declarative_effect": {"params": {"dice": "1d4", "operation": "subtract"}}},
+            },
+        ]
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat.CombatService._get_stats", side_effect=[
+                (MagicMock(state_json={}), 10, 10, 10, 2, 0),
+                (MagicMock(), 15, 10, 10, 2, 0),
+            ]),
+            patch("app.services.combat.CombatService._get_target_hp_snapshot", return_value=(20, 20)),
+            patch("app.services.combat.CombatService._apply_damage_to_target", return_value=(10, "", 20, None)),
+            patch("app.services.combat.CombatService._resolve_damage_roll", side_effect=[
+                ([5], 5),   # base
+                ([3], 3),   # reduce
+            ]),
+        ):
+            res = await CombatService.attack_damage(self.db, "session-123", self._make_req(), "user-1", True)
+
+        self.assertIn("extra_damage_rolls", res)
+        self.assertIn("extra_damage_label", res)
+        self.assertIn("Divine Favor", res["extra_damage_label"])
+        self.assertIn("Reduce", res["extra_damage_label"])
+
+    # ------------------------------------------------------------------
+    # 10. Schema serialization round-trip
+    # ------------------------------------------------------------------
+    def test_combat_attack_result_serializes_breakdown(self):
+        from app.schemas.combat import CombatAttackResult
+        from app.schemas.roll import RollResult
+        from datetime import datetime, timezone
+
+        roll_result = RollResult(
+            event_id="ev-1", roll_type="attack", actor_kind="player",
+            actor_ref_id="p1", actor_display_name="Hero",
+            rolls=[15, 8], selected_roll=15, advantage_mode="normal",
+            modifier_used=5, override_used=False, formula="1d20+5",
+            total=20, roll_source="system", timestamp=datetime.now(timezone.utc),
+        )
+        result = CombatAttackResult(
+            roll=20, is_hit=True, damage=8, is_critical=False,
+            roll_result=roll_result, target_ac=15,
+            target_display_name="Goblin", target_kind="session_entity",
+            weapon_name="Longsword", damage_dice="1d8", damage_bonus=3,
+            attack_bonus=5, damage_rolls=[5],
+            damage_breakdown={
+                "total_before_minimum": 8,
+                "minimum_applied": None,
+                "total": 8,
+                "components": [
+                    {
+                        "id": "c1", "kind": "base_weapon", "source_key": None,
+                        "source_label": "Longsword", "dice": "1d8", "rolls": [5],
+                        "operation": "add", "signed_total": 5,
+                        "damage_type": "slashing", "doubled_on_critical": False,
+                        "minimum_total_damage": None,
+                    },
+                    {
+                        "id": "c2", "kind": "ability_modifier", "source_key": None,
+                        "source_label": "Modificador", "dice": None, "rolls": [],
+                        "operation": "add", "signed_total": 3,
+                        "damage_type": "slashing", "doubled_on_critical": False,
+                        "minimum_total_damage": None,
+                    },
+                ],
+            },
+            extra_damage_rolls=[],
+            extra_damage_label=None,
+        )
+
+        data = result.model_dump()
+        self.assertIn("damage_breakdown", data)
+        self.assertEqual(data["damage_breakdown"]["total"], 8)
+        self.assertEqual(len(data["damage_breakdown"]["components"]), 2)
+        self.assertEqual(data["extra_damage_rolls"], [])
+        self.assertIsNone(data["extra_damage_label"])
+
+    # ------------------------------------------------------------------
+    # 11. Hunter's Mark generates extra_damage component
+    # ------------------------------------------------------------------
+    @patch("app.services.combat.CombatService._emit_and_persist_log")
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_player_state_update")
+    @patch("app.services.combat.CombatService._emit_entity_hp_update")
+    async def test_breakdown_includes_hunters_mark(self, *_mocks):
+        self.state.participants[0]["pending_attack"] = self._make_pending_attack()
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat.CombatService._get_stats", side_effect=[
+                (MagicMock(state_json={}), 10, 10, 10, 2, 0),
+                (MagicMock(), 15, 10, 10, 2, 0),
+            ]),
+            patch("app.services.combat.CombatService._get_target_hp_snapshot", return_value=(20, 20)),
+            patch("app.services.combat.CombatService._apply_damage_to_target", return_value=(6, "", 20, None)),
+            patch("app.services.combat.CombatService._resolve_damage_roll", side_effect=[
+                ([5], 5),  # base
+                ([4], 4),  # Hunter's Mark
+            ]),
+            patch("app.services.combat.CombatService._get_hunters_mark_effect_for_target", return_value={"id": "hm-1"}),
+        ):
+            res = await CombatService.attack_damage(self.db, "session-123", self._make_req(), "user-1", True)
+
+        hm = next(c for c in res["damage_breakdown"]["components"] if c["source_key"] == "hunters_mark")
+        self.assertEqual(hm["kind"], "extra_damage")
+        self.assertEqual(hm["signed_total"], 4)
+        self.assertEqual(hm["dice"], "1d6")
+
+    # ------------------------------------------------------------------
+    # 12. Colossus Slayer generates extra_damage component
+    # ------------------------------------------------------------------
+    @patch("app.services.combat.CombatService._emit_and_persist_log")
+    @patch("app.services.combat.CombatService._emit_state")
+    @patch("app.services.combat.CombatService._emit_player_state_update")
+    @patch("app.services.combat.CombatService._emit_entity_hp_update")
+    async def test_breakdown_includes_colossus_slayer(self, *_mocks):
+        self.state.participants[0]["pending_attack"] = self._make_pending_attack()
+        self.state.participants[0]["turn_resources"] = {"action_used": False, "colossus_slayer_used": False}
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=self.state),
+            patch("app.services.combat.CombatService._get_stats", side_effect=[
+                (MagicMock(state_json={"class": "ranger", "features": ["colossus_slayer"]}), 10, 10, 10, 2, 0),
+                (MagicMock(), 15, 10, 10, 2, 0),
+            ]),
+            patch("app.services.combat.CombatService._get_target_hp_snapshot", return_value=(18, 20)),
+            patch("app.services.combat.CombatService._apply_damage_to_target", return_value=(2, "", 18, None)),
+            patch("app.services.combat.CombatService._resolve_damage_roll", side_effect=[
+                ([5], 5),  # base
+                ([7], 7),  # Colossus Slayer
+            ]),
+            patch("app.services.combat.CombatService._get_hunters_mark_effect_for_target", return_value=None),
+            patch("app.services.combat.CombatService._player_has_colossus_slayer", return_value=True),
+        ):
+            res = await CombatService.attack_damage(self.db, "session-123", self._make_req(), "user-1", True)
+
+        cs = next(c for c in res["damage_breakdown"]["components"] if c["source_key"] == "colossus_slayer")
+        self.assertEqual(cs["kind"], "extra_damage")
+        self.assertEqual(cs["signed_total"], 7)
+        self.assertEqual(cs["dice"], "1d8")

--- a/apps/control-web/src/pages/GmDashboardPage/GmActionResultPanel.tsx
+++ b/apps/control-web/src/pages/GmDashboardPage/GmActionResultPanel.tsx
@@ -74,7 +74,7 @@ export const GmActionResultPanel = ({
           </p>
         ) : null}
         {result.is_hit && !pendingDamage ? (
-          <p className="mt-1 text-xs text-slate-400">{formatDamageBreakdown(result)}</p>
+          <p className="mt-1 text-xs text-slate-400" style={{ whiteSpace: "pre-line" }}>{formatDamageBreakdown(result)}</p>
         ) : null}
         {result.is_hit && !pendingDamage ? (
           <p className="mt-1 text-xs text-slate-400">Perfil de dano: {damageProfile}</p>

--- a/apps/control-web/src/pages/GmDashboardPage/GmEntityActionRollDialog.tsx
+++ b/apps/control-web/src/pages/GmDashboardPage/GmEntityActionRollDialog.tsx
@@ -223,7 +223,7 @@ export const GmEntityActionRollDialog = ({
                 </p>
               ) : null}
               {result.is_hit && !pendingDamage ? (
-                <p className="mt-1 text-xs text-slate-400">
+                <p className="mt-1 text-xs text-slate-400" style={{ whiteSpace: "pre-line" }}>
                   {formatDamageBreakdown(result)}
                 </p>
               ) : null}

--- a/apps/control-web/src/pages/GmDashboardPage/formatDamageBreakdown.test.ts
+++ b/apps/control-web/src/pages/GmDashboardPage/formatDamageBreakdown.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vitest";
+import { formatDamageBreakdown } from "./gmEntityActionRollDialog.helpers";
+import type { CombatEntityActionResult, WeaponDamageBreakdown } from "../../shared/api/combatRepo";
+
+const makeResult = (overrides: Partial<CombatEntityActionResult> = {}): CombatEntityActionResult => ({
+  action_name: "Longsword",
+  action_kind: "weapon_attack",
+  damage: 8,
+  healing: 0,
+  ...overrides,
+});
+
+const makeBreakdown = (overrides: Partial<WeaponDamageBreakdown> = {}): WeaponDamageBreakdown => ({
+  total_before_minimum: 8,
+  minimum_applied: null,
+  total: 8,
+  components: [
+    {
+      id: "c1",
+      kind: "base_weapon",
+      source_key: null,
+      source_label: "Longsword",
+      dice: "1d8",
+      rolls: [5],
+      operation: "add",
+      signed_total: 5,
+      damage_type: "slashing",
+      doubled_on_critical: false,
+      minimum_total_damage: null,
+    },
+    {
+      id: "c2",
+      kind: "ability_modifier",
+      source_key: null,
+      source_label: "Modificador",
+      dice: null,
+      rolls: [],
+      operation: "add",
+      signed_total: 3,
+      damage_type: "slashing",
+      doubled_on_critical: false,
+      minimum_total_damage: null,
+    },
+  ],
+  ...overrides,
+});
+
+describe("formatDamageBreakdown", () => {
+  // ------------------------------------------------------------------
+  // Structured breakdown rendering
+  // ------------------------------------------------------------------
+  it("renders structured breakdown with base_weapon and ability_modifier", () => {
+    const result = makeResult({ damage_breakdown: makeBreakdown() });
+    const output = formatDamageBreakdown(result);
+
+    expect(output).toContain("Longsword (1d8): 5");
+    expect(output).toContain("Modificador: +3");
+    expect(output).toContain("Total: 8");
+  });
+
+  it("renders negative component correctly", () => {
+    const result = makeResult({
+      damage_breakdown: makeBreakdown({
+        total_before_minimum: 4,
+        total: 4,
+        components: [
+          {
+            id: "c1",
+            kind: "base_weapon",
+            source_key: null,
+            source_label: "Longsword",
+            dice: "1d8",
+            rolls: [6],
+            operation: "add",
+            signed_total: 6,
+            damage_type: "slashing",
+            doubled_on_critical: false,
+            minimum_total_damage: null,
+          },
+          {
+            id: "c2",
+            kind: "ability_modifier",
+            source_key: null,
+            source_label: "Modificador",
+            dice: null,
+            rolls: [],
+            operation: "add",
+            signed_total: 1,
+            damage_type: "slashing",
+            doubled_on_critical: false,
+            minimum_total_damage: null,
+          },
+          {
+            id: "c3",
+            kind: "weapon_damage_modifier",
+            source_key: "eff-reduce",
+            source_label: "Aumentar/Reduzir — Reduzir",
+            dice: "1d4",
+            rolls: [3],
+            operation: "subtract",
+            signed_total: -3,
+            damage_type: "slashing",
+            doubled_on_critical: false,
+            minimum_total_damage: 1,
+          },
+        ],
+      }),
+    });
+
+    const output = formatDamageBreakdown(result);
+
+    expect(output).toContain("Longsword (1d8): 6");
+    expect(output).toContain("Modificador: +1");
+    expect(output).toContain("Aumentar/Reduzir — Reduzir (1d4): -3");
+    expect(output).toContain("Total: 4");
+    expect(output).not.toContain("mínimo");
+  });
+
+  it("renders minimum_applied when floor is triggered", () => {
+    const result = makeResult({
+      damage_breakdown: makeBreakdown({
+        total_before_minimum: -2,
+        minimum_applied: 1,
+        total: 1,
+        components: [
+          {
+            id: "c1",
+            kind: "base_weapon",
+            source_key: null,
+            source_label: "Dagger",
+            dice: "1d4",
+            rolls: [1],
+            operation: "add",
+            signed_total: 1,
+            damage_type: "piercing",
+            doubled_on_critical: false,
+            minimum_total_damage: null,
+          },
+          {
+            id: "c2",
+            kind: "weapon_damage_modifier",
+            source_key: "eff-reduce",
+            source_label: "Reduce",
+            dice: "1d4",
+            rolls: [3],
+            operation: "subtract",
+            signed_total: -3,
+            damage_type: "piercing",
+            doubled_on_critical: false,
+            minimum_total_damage: 1,
+          },
+        ],
+      }),
+    });
+
+    const output = formatDamageBreakdown(result);
+
+    expect(output).toContain("Dano mínimo aplicado: 1");
+    expect(output).toContain("Total: 1");
+  });
+
+  // ------------------------------------------------------------------
+  // Legacy fallback when damage_breakdown is null/undefined
+  // ------------------------------------------------------------------
+  it("falls back to legacy format when damage_breakdown is null", () => {
+    const result = makeResult({
+      damage_breakdown: null,
+      damage_dice: "1d8",
+      damage_rolls: [5],
+      damage_bonus: 3,
+      damage: 8,
+      base_damage: 5,
+    });
+
+    const output = formatDamageBreakdown(result);
+
+    // Should use the legacy format (no component lines)
+    expect(output).not.toContain("Total:");
+    expect(output).toContain("[5]");
+    expect(output).toContain("= 8");
+  });
+
+  it("falls back to legacy format when damage_breakdown is undefined", () => {
+    const result = makeResult({
+      damage_dice: "1d8",
+      damage_rolls: [5],
+      damage_bonus: 3,
+      damage: 8,
+      base_damage: 5,
+    });
+
+    const output = formatDamageBreakdown(result);
+
+    expect(output).not.toContain("Total:");
+    expect(output).toContain("[5]");
+  });
+
+  // ------------------------------------------------------------------
+  // Extra damage components
+  // ------------------------------------------------------------------
+  it("renders Hunter's Mark and Colossus Slayer components", () => {
+    const result = makeResult({
+      damage_breakdown: makeBreakdown({
+        total_before_minimum: 19,
+        total: 19,
+        components: [
+          {
+            id: "c1",
+            kind: "base_weapon",
+            source_key: null,
+            source_label: "Longsword",
+            dice: "1d8",
+            rolls: [6],
+            operation: "add",
+            signed_total: 6,
+            damage_type: "slashing",
+            doubled_on_critical: false,
+            minimum_total_damage: null,
+          },
+          {
+            id: "c2",
+            kind: "ability_modifier",
+            source_key: null,
+            source_label: "Modificador",
+            dice: null,
+            rolls: [],
+            operation: "add",
+            signed_total: 3,
+            damage_type: "slashing",
+            doubled_on_critical: false,
+            minimum_total_damage: null,
+          },
+          {
+            id: "c3",
+            kind: "extra_damage",
+            source_key: "hunters_mark",
+            source_label: "Hunter's Mark",
+            dice: "1d6",
+            rolls: [4],
+            operation: "add",
+            signed_total: 4,
+            damage_type: "slashing",
+            doubled_on_critical: true,
+            minimum_total_damage: null,
+          },
+          {
+            id: "c4",
+            kind: "extra_damage",
+            source_key: "colossus_slayer",
+            source_label: "Assassino de Colossos",
+            dice: "1d8",
+            rolls: [6],
+            operation: "add",
+            signed_total: 6,
+            damage_type: "slashing",
+            doubled_on_critical: true,
+            minimum_total_damage: null,
+          },
+        ],
+      }),
+    });
+
+    const output = formatDamageBreakdown(result);
+
+    expect(output).toContain("Hunter's Mark (1d6): +4");
+    expect(output).toContain("Assassino de Colossos (1d8): +6");
+    expect(output).toContain("Total: 19");
+  });
+});

--- a/apps/control-web/src/pages/GmDashboardPage/gmEntityActionRollDialog.helpers.ts
+++ b/apps/control-web/src/pages/GmDashboardPage/gmEntityActionRollDialog.helpers.ts
@@ -6,6 +6,25 @@ export const D20_VALUES = Array.from({ length: 20 }, (_, i) => i + 1);
 export const formatSigned = (value: number) => `${value >= 0 ? "+" : ""}${value}`;
 
 export const formatDamageBreakdown = (result: CombatEntityActionResult) => {
+  // Structured breakdown (canonical source)
+  if (result.damage_breakdown) {
+    const bd = result.damage_breakdown;
+    const lines = bd.components.map((c) => {
+      const sign = c.signed_total >= 0 ? "+" : "-";
+      const abs = Math.abs(c.signed_total);
+      const diceHint = c.dice ? ` (${c.dice})` : "";
+      if (c.kind === "base_weapon") {
+        return `${c.source_label}${diceHint}: ${c.signed_total}`;
+      }
+      return `${c.source_label}${diceHint}: ${sign}${abs}`;
+    });
+    if (bd.minimum_applied != null) {
+      lines.push(`Dano mínimo aplicado: ${bd.minimum_applied}`);
+    }
+    lines.push(`Total: ${bd.total}`);
+    return lines.join("\n");
+  }
+  // Legacy fallback
   const rolls = result.damage_rolls ?? [];
   const damageDiceLabel =
     formatDamageDiceExpression(result.damage_dice, Boolean(result.is_critical)) ??

--- a/apps/control-web/src/pages/GmDashboardPage/gmEntityActionRollHelpers.ts
+++ b/apps/control-web/src/pages/GmDashboardPage/gmEntityActionRollHelpers.ts
@@ -6,6 +6,25 @@ export const D20_VALUES = Array.from({ length: 20 }, (_, i) => i + 1);
 export const formatSigned = (value: number) => `${value >= 0 ? "+" : ""}${value}`;
 
 export const formatDamageBreakdown = (result: CombatEntityActionResult) => {
+  // Structured breakdown (canonical source)
+  if (result.damage_breakdown) {
+    const bd = result.damage_breakdown;
+    const lines = bd.components.map((c) => {
+      const sign = c.signed_total >= 0 ? "+" : "-";
+      const abs = Math.abs(c.signed_total);
+      const diceHint = c.dice ? ` (${c.dice})` : "";
+      if (c.kind === "base_weapon") {
+        return `${c.source_label}${diceHint}: ${c.signed_total}`;
+      }
+      return `${c.source_label}${diceHint}: ${sign}${abs}`;
+    });
+    if (bd.minimum_applied != null) {
+      lines.push(`Dano mínimo aplicado: ${bd.minimum_applied}`);
+    }
+    lines.push(`Total: ${bd.total}`);
+    return lines.join("\n");
+  }
+  // Legacy fallback
   const rolls = result.damage_rolls ?? [];
   const damageDiceLabel =
     formatDamageDiceExpression(result.damage_dice, Boolean(result.is_critical)) ??

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerAttackRollDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerAttackRollDialog.tsx
@@ -34,6 +34,25 @@ const D20_VALUES = Array.from({ length: 20 }, (_, i) => i + 1);
 const formatSigned = (value: number) => `${value >= 0 ? "+" : ""}${value}`;
 
 const formatDamageBreakdown = (result: CombatAttackResult) => {
+  // Structured breakdown (canonical source)
+  if (result.damage_breakdown) {
+    const bd = result.damage_breakdown;
+    const lines = bd.components.map((c) => {
+      const sign = c.signed_total >= 0 ? "+" : "-";
+      const abs = Math.abs(c.signed_total);
+      const diceHint = c.dice ? ` (${c.dice})` : "";
+      if (c.kind === "base_weapon") {
+        return `${c.source_label}${diceHint}: ${c.signed_total}`;
+      }
+      return `${c.source_label}${diceHint}: ${sign}${abs}`;
+    });
+    if (bd.minimum_applied != null) {
+      lines.push(`Dano mínimo aplicado: ${bd.minimum_applied}`);
+    }
+    lines.push(`Total: ${bd.total}`);
+    return lines.join("\n");
+  }
+  // Legacy fallback
   const rolls = result.damage_rolls ?? [];
   const damageDiceLabel =
     formatDamageDiceExpression(result.damage_dice, Boolean(result.is_critical)) ??
@@ -204,7 +223,7 @@ export const PlayerAttackRollDialog = ({
                   : `${result.weapon_name} nao acertou ${result.target_display_name}.`}
               </p>
               {result.is_hit && !pendingDamage ? (
-                <p className="mt-2 text-xs text-slate-300">{formatDamageBreakdown(result)}</p>
+                <p className="mt-2 text-xs text-slate-300" style={{ whiteSpace: "pre-line" }}>{formatDamageBreakdown(result)}</p>
               ) : null}
               {result.is_hit && !pendingDamage && result.concentration_check?.summary_text ? (
                 <p className="mt-2 text-xs text-amber-100">

--- a/apps/control-web/src/shared/api/combatRepo.ts
+++ b/apps/control-web/src/shared/api/combatRepo.ts
@@ -262,6 +262,35 @@ export type CombatAttackRequest = {
   override_resource_limit?: boolean;
 };
 
+export type WeaponDamageOperation = "add" | "subtract";
+export type WeaponDamageComponentKind =
+  | "base_weapon"
+  | "ability_modifier"
+  | "flat_modifier"
+  | "extra_damage"
+  | "weapon_damage_modifier";
+
+export type WeaponDamageComponent = {
+  id: string;
+  kind: WeaponDamageComponentKind;
+  source_key: string | null;
+  source_label: string;
+  dice: string | null;
+  rolls: number[];
+  operation: WeaponDamageOperation;
+  signed_total: number;
+  damage_type: string | null;
+  doubled_on_critical: boolean;
+  minimum_total_damage: number | null;
+};
+
+export type WeaponDamageBreakdown = {
+  total_before_minimum: number;
+  minimum_applied: number | null;
+  total: number;
+  components: WeaponDamageComponent[];
+};
+
 export type CombatAttackResult = {
   roll: number;
   is_hit: boolean;
@@ -283,6 +312,9 @@ export type CombatAttackResult = {
   base_damage?: number | null;
   damage_roll_source?: RollSource | null;
   concentration_check?: CombatConcentrationCheckResult | null;
+  damage_breakdown?: WeaponDamageBreakdown | null;
+  extra_damage_rolls?: number[];
+  extra_damage_label?: string | null;
 };
 
 export type CombatCastSpellRequest = {
@@ -713,6 +745,9 @@ export type CombatEntityActionResult = {
   base_damage?: number | null;
   damage_roll_source?: RollSource | null;
   concentration_check?: CombatConcentrationCheckResult | null;
+  damage_breakdown?: WeaponDamageBreakdown | null;
+  extra_damage_rolls?: number[];
+  extra_damage_label?: string | null;
 };
 
 export type CombatConcentrationCheckResult = {


### PR DESCRIPTION
# PR: feat(combat) structured weapon damage breakdown (#283)

## Description

Este PR implementa a reestruturação completa do sistema de cálculo e exibição de dano de armas. A principal mudança é a transição de um valor escalar simples para um modelo de `WeaponDamageBreakdown` estruturado. Agora, o `final_damage` é derivado exclusivamente do breakdown, garantindo que o log de combate (VTT) exiba cada componente da rolagem (arma base, modificadores de atributo, bônus mágicos e efeitos extras) de forma transparente.

## Changes

### Backend & Core Engine
- **Data Models (`roll.py`):** Introduzidos `WeaponDamageComponent` e `WeaponDamageBreakdown`, suportando tipagem de dano por componente e regras de teto mínimo (`minimum_total_damage`).
- **Schema Updates:** Adicionados campos `damage_breakdown`, `extra_damage_rolls` e `extra_damage_label` aos tipos de resultado em `combat_spells.py` e `combat_actions.py`.
- **Refatoração da Engine (`weapon_attack_damage.py`):** A lógica foi centralizada para que o cálculo de dano final seja uma derivação direta da soma dos componentes do breakdown, eliminando cálculos paralelos e inconsistências.
- **Refatoração de Testes:** Atualizada a assinatura do `_parse_dice` em `_combat_test_shared.py` para manter compatibilidade com as mudanças de infraestrutura recentes.

### Frontend & UI
- **Type Safety:** Tipos TypeScript em `combatRepo.ts` atualizados para espelhar a estrutura do backend.
- **Enhanced Formatting:** Implementada a função `formatDamageBreakdown` (versões Player e GM) que prioriza a exibição estruturada, mantendo fallback para o modelo legado.
- **VTT Display:** Ajustados 4 pontos de renderização para suportar `white-space: pre-line`, permitindo logs multilinhas detalhados e legíveis.

## Summary of Changes

| Component | Change |
| :--- | :--- |
| **`roll.py`** | New structured breakdown and component schemas |
| **`weapon_attack_damage.py`** | Refactored engine for authoritative breakdown calculation |
| **`combatRepo.ts`** | TS interfaces reflecting the new structured damage payload |
| **`VTT UI`** | Multiline support and granular damage breakdown rendering |

## Validation

- **Focada (`test_weapon_damage_breakdown.py`):** 12 testes cobrindo:
    - Base weapon e modificadores de atributo.
    - `Hunter's Mark` e `Colossus Slayer`.
    - Operações de soma/subtração de modificadores de dano.
    - Validação de floor mínimo (teto de dano).
    - Serialização e fallbacks para efeitos legados.
- **Regressão:** Todas as suítes de combate e testes de regressão de parser de dados estão passando.
- **TypeScript:** Compilação limpa, sem novos erros nas áreas modificadas.

## Documentation
- O arquivo `walkthrough.md` foi incluído no repositório com o diff detalhado de cada arquivo para revisão técnica aprofundada.

> [!CHECK]
> O motor agora é 100% determinístico: o que o usuário vê no breakdown é exatamente o que compõe o dano final no banco de dados.