### PR TITLE
feat(saves) declarative advantage/disadvantage on saving throws (#285)

### DIFF
--- a/apps/control-server/app/api/routes/sessions/rolls_resolution.py
+++ b/apps/control-server/app/api/routes/sessions/rolls_resolution.py
@@ -280,10 +280,27 @@ async def roll_save(
     is_gm = _authorize_roll(member, body.actor_kind, body.actor_ref_id, user.id)
     stats = _build_actor_stats(db, session_id, body.actor_kind, body.actor_ref_id)
 
+    effective_advantage_mode = CombatService._resolve_save_advantage_mode_for_actor(
+        db,
+        session_id,
+        actor_kind=body.actor_kind,
+        actor_ref_id=body.actor_ref_id,
+        ability=body.ability,
+        manual_mode=body.advantage_mode,
+    )
+
     result = resolve_saving_throw(
-        stats, body.ability, body.advantage_mode, body.bonus_override, body.dc,
+        stats, body.ability, effective_advantage_mode, body.bonus_override, body.dc,
         body.roll_source, body.manual_roll, body.manual_rolls,
     )
+    modifier_sources = CombatService._explain_save_modifier_sources_for_actor(
+        db,
+        session_id,
+        actor_kind=body.actor_kind,
+        actor_ref_id=body.actor_ref_id,
+        ability=body.ability,
+    )
+    _attach_check_modifier_sources(result, modifier_sources)
     result.is_gm_roll = is_gm
     result.roll_source = body.roll_source
 

--- a/apps/control-server/app/schemas/base_spell_effects.py
+++ b/apps/control-server/app/schemas/base_spell_effects.py
@@ -14,6 +14,8 @@ SpellDeclarativeEffectType = Literal[
     "armor_class_formula",
     "advantage_on_checks",
     "disadvantage_on_checks",
+    "advantage_on_saves",
+    "disadvantage_on_saves",
     "restrict_action",
     "grant_temp_hp",
     "passive_skill_bonus",
@@ -115,6 +117,10 @@ class CheckModifierParams(BaseModel):
     against: SpellDeclarativeAgainst | None = None
 
 
+class SaveModifierParams(BaseModel):
+    abilities: list[AbilityName]
+
+
 class RestrictActionParams(BaseModel):
     action: SpellDeclarativeRestrictActionKind
 
@@ -168,6 +174,7 @@ class SpellDeclarativeEffect(BaseModel):
         | ModifyWeaponDamageParams
         | ArmorClassFormulaParams
         | CheckModifierParams
+        | SaveModifierParams
         | RestrictActionParams
         | GrantTempHpParams
         | PassiveSkillBonusParams
@@ -191,6 +198,10 @@ class SpellDeclarativeEffect(BaseModel):
             self.params, CheckModifierParams
         ):
             raise ValueError(f"{self.type} effects require CheckModifierParams")
+        if self.type in {"advantage_on_saves", "disadvantage_on_saves"} and not isinstance(
+            self.params, SaveModifierParams
+        ):
+            raise ValueError(f"{self.type} effects require SaveModifierParams")
         if self.type == "restrict_action" and not isinstance(self.params, RestrictActionParams):
             raise ValueError("restrict_action effects require RestrictActionParams")
         if self.type == "grant_temp_hp" and not isinstance(self.params, GrantTempHpParams):

--- a/apps/control-server/app/services/combat_service/condition_effects_predicates.py
+++ b/apps/control-server/app/services/combat_service/condition_effects_predicates.py
@@ -385,6 +385,73 @@ def explain_check_modifier_sources(
     return explanations
 
 
+def _get_save_declarative_context(
+    participant: dict,
+    ability: AbilityName,
+) -> tuple[str, list[str], list[str], list[dict]]:
+    """Extract declared save-modifier effects for the given ability.
+
+    Returns (automatic_mode, advantage_source_strs, disadvantage_source_strs, source_details).
+    """
+    automatic_mode = "normal"
+    adv_strs: list[str] = []
+    dis_strs: list[str] = []
+    details: list[dict] = []
+    seen_keys: set[str] = set()
+
+    for effect in participant.get("active_effects") or []:
+        if effect.get("kind") != "spell_effect":
+            continue
+        metadata = effect.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        declarative = metadata.get("declarative_effect")
+        if not isinstance(declarative, dict):
+            continue
+
+        effect_type = declarative.get("type")
+        if effect_type not in {"advantage_on_saves", "disadvantage_on_saves"}:
+            continue
+
+        params = declarative.get("params")
+        if not isinstance(params, dict):
+            continue
+        abilities = params.get("abilities")
+        if not isinstance(abilities, list) or ability not in abilities:
+            continue
+
+        dedup_key = f"{_declarative_effect_group_key(metadata, effect, effect_type, ability)}|{effect_type}"
+        if dedup_key in seen_keys:
+            continue
+        seen_keys.add(dedup_key)
+
+        source_label = metadata.get("source_spell_name") or effect.get("display_label") or "Spell effect"
+        if effect_type == "advantage_on_saves":
+            automatic_mode = combine_advantage_modes(automatic_mode, "advantage")
+            adv_strs.append(source_label)
+            details.append({
+                "source_label": source_label,
+                "modifier_type": "advantage",
+                "roll_type": "save",
+                "ability": ability,
+                "applied": True,
+                "skip_reason": None,
+            })
+        elif effect_type == "disadvantage_on_saves":
+            automatic_mode = combine_advantage_modes(automatic_mode, "disadvantage")
+            dis_strs.append(source_label)
+            details.append({
+                "source_label": source_label,
+                "modifier_type": "disadvantage",
+                "roll_type": "save",
+                "ability": ability,
+                "applied": True,
+                "skip_reason": None,
+            })
+
+    return automatic_mode, adv_strs, dis_strs, details
+
+
 def _declarative_effect_group_key(
     metadata: dict, effect: dict, effect_type: str, params_key: str
 ) -> str:

--- a/apps/control-server/app/services/combat_service/condition_effects_saves.py
+++ b/apps/control-server/app/services/combat_service/condition_effects_saves.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
-from .condition_effects_predicates import has_condition
+from .condition_effects_predicates import (
+    _get_save_declarative_context,
+    combine_advantage_modes,
+    has_condition,
+)
 
 _AUTO_FAIL_SAVE_CONDITIONS = frozenset({"paralyzed", "stunned", "unconscious"})
 _AUTO_FAIL_SAVE_ABILITIES = frozenset({"strength", "dexterity"})
@@ -15,17 +19,44 @@ class SaveModifierContext:
     auto_fail_source: str = ""
     advantage_sources: list[str] = field(default_factory=list)
     disadvantage_sources: list[str] = field(default_factory=list)
+    advantage_source_details: list[dict] = field(default_factory=list)
+    disadvantage_source_details: list[dict] = field(default_factory=list)
     result: Literal["advantage", "normal", "disadvantage"] = "normal"
 
 
-def modify_saving_throw(actor: dict, ability: str) -> SaveModifierContext:
+def modify_saving_throw(
+    actor: dict,
+    ability: str,
+    manual_mode: Literal["advantage", "normal", "disadvantage"] = "normal",
+) -> SaveModifierContext:
     normalized = ability.lower()
     if normalized in _AUTO_FAIL_SAVE_ABILITIES:
         for cond in _AUTO_FAIL_SAVE_CONDITIONS:
             if has_condition(actor, cond):
                 return SaveModifierContext(auto_fail=True, auto_fail_source=f"actor_{cond}")
+
     dis: list[str] = []
     if normalized == "dexterity" and has_condition(actor, "restrained"):
         dis.append("actor_restrained")
-    result: Literal["advantage", "normal", "disadvantage"] = "disadvantage" if dis else "normal"
-    return SaveModifierContext(disadvantage_sources=dis, result=result)
+
+    # Declarative active effects
+    auto_mode, decl_adv_strs, decl_dis_strs, decl_details = _get_save_declarative_context(
+        actor, normalized
+    )
+
+    # Merge hardcoded + declarative automatic sources
+    automatic_mode = combine_advantage_modes(
+        "disadvantage" if dis else "normal",
+        auto_mode,
+    )
+
+    # Merge with manual mode
+    result = combine_advantage_modes(automatic_mode, manual_mode)
+
+    return SaveModifierContext(
+        advantage_sources=decl_adv_strs,
+        disadvantage_sources=[*dis, *decl_dis_strs],
+        advantage_source_details=[d for d in decl_details if d.get("modifier_type") == "advantage"],
+        disadvantage_source_details=[d for d in decl_details if d.get("modifier_type") == "disadvantage"],
+        result=result,
+    )

--- a/apps/control-server/app/services/combat_service/npc_action_resolution.py
+++ b/apps/control-server/app/services/combat_service/npc_action_resolution.py
@@ -251,6 +251,10 @@ class CombatNpcActionResolutionMixin:
                 roll_source=req.roll_source,
                 manual_roll=req.manual_roll,
             )
+            roll_result.check_modifier_sources = [
+                *save_mod.advantage_source_details,
+                *save_mod.disadvantage_source_details,
+            ]
             roll_result.is_gm_roll = is_gm
             is_saved = False if save_mod.auto_fail else bool(roll_result.success)
             damage_rolls: list[int] = []

--- a/apps/control-server/app/services/combat_service/save_resolve.py
+++ b/apps/control-server/app/services/combat_service/save_resolve.py
@@ -51,6 +51,10 @@ class CombatSaveResolveMixin:
             manual_roll=req.manual_roll,
             manual_rolls=req.manual_rolls,
         )
+        roll_result.check_modifier_sources = [
+            *save_mod.advantage_source_details,
+            *save_mod.disadvantage_source_details,
+        ]
         roll_result.is_gm_roll = True
         is_saved = False if save_mod.auto_fail else bool(roll_result.success)
 

--- a/apps/control-server/app/services/combat_service/spell_declarative_effects.py
+++ b/apps/control-server/app/services/combat_service/spell_declarative_effects.py
@@ -17,6 +17,7 @@ from .condition_effects_predicates import (
     resolve_actor_participant,
     resolve_check_advantage_mode,
 )
+from .condition_effects_saves import modify_saving_throw
 from .exceptions import CombatServiceError, _roll_dice_expression
 
 
@@ -680,3 +681,64 @@ class CombatSpellDeclarativeEffectsMixin:
             skill=skill,
             target_participant_id=target_participant_id,
         )
+
+    @classmethod
+    def _resolve_save_advantage_mode_for_actor(
+        cls,
+        db,
+        session_id: str,
+        *,
+        actor_kind: str,
+        actor_ref_id: str,
+        ability: AbilityName,
+        manual_mode: Literal["advantage", "normal", "disadvantage"] = "normal",
+    ) -> str:
+        state = cls.get_state(db, session_id)
+        if state is None:
+            logger.info("[_resolve_save_advantage_mode_for_actor] no combat state session_id=%s", session_id)
+            return "normal"
+        if state.phase == CombatPhase.ended:
+            logger.info("[_resolve_save_advantage_mode_for_actor] combat ended session_id=%s", session_id)
+            return "normal"
+        participant = resolve_actor_participant(state, actor_ref_id)
+        if not isinstance(participant, dict):
+            logger.info("[_resolve_save_advantage_mode_for_actor] no participant session_id=%s actor_ref_id=%s", session_id, actor_ref_id)
+            return "normal"
+        if participant.get("kind") != actor_kind:
+            logger.info(
+                "[_resolve_save_advantage_mode_for_actor] kind mismatch session_id=%s actor_ref_id=%s expected=%s got=%s",
+                session_id, actor_ref_id, actor_kind, participant.get("kind"),
+            )
+            return "normal"
+        ctx = modify_saving_throw(participant, ability, manual_mode=manual_mode)
+        return ctx.result
+
+    @classmethod
+    def _explain_save_modifier_sources_for_actor(
+        cls,
+        db,
+        session_id: str,
+        *,
+        actor_kind: str,
+        actor_ref_id: str,
+        ability: AbilityName,
+    ) -> list[dict]:
+        state = cls.get_state(db, session_id)
+        if state is None:
+            logger.info("[_explain_save_modifier_sources_for_actor] no combat state session_id=%s", session_id)
+            return []
+        if state.phase == CombatPhase.ended:
+            logger.info("[_explain_save_modifier_sources_for_actor] combat ended session_id=%s", session_id)
+            return []
+        participant = resolve_actor_participant(state, actor_ref_id)
+        if not isinstance(participant, dict):
+            logger.info("[_explain_save_modifier_sources_for_actor] no participant session_id=%s actor_ref_id=%s", session_id, actor_ref_id)
+            return []
+        if participant.get("kind") != actor_kind:
+            logger.info(
+                "[_explain_save_modifier_sources_for_actor] kind mismatch session_id=%s actor_ref_id=%s expected=%s got=%s",
+                session_id, actor_ref_id, actor_kind, participant.get("kind"),
+            )
+            return []
+        ctx = modify_saving_throw(participant, ability, manual_mode="normal")
+        return [*ctx.advantage_source_details, *ctx.disadvantage_source_details]

--- a/apps/control-server/tests/test_condition_effects.py
+++ b/apps/control-server/tests/test_condition_effects.py
@@ -660,6 +660,175 @@ class TestModifySavingThrow(unittest.TestCase):
         ctx_upper = modify_saving_throw(_participant(["paralyzed"]), "STRENGTH")
         self.assertEqual(ctx_lower.auto_fail, ctx_upper.auto_fail)
 
+    # ── declared save effects ────────────────────────────────────────────────
+    def _mod_with_effects(self, extra_effects=None, ability="strength", manual_mode="normal"):
+        return modify_saving_throw(_participant(extra_effects=extra_effects), ability, manual_mode=manual_mode)
+
+    def test_declared_advantage_on_save_matching_ability(self):
+        ctx = self._mod_with_effects(
+            extra_effects=[
+                {
+                    "kind": "spell_effect",
+                    "metadata": {
+                        "declarative_effect": {
+                            "type": "advantage_on_saves",
+                            "params": {"abilities": ["strength"]},
+                        },
+                        "source_spell_name": "Aumentar",
+                    },
+                }
+            ],
+            ability="strength",
+        )
+        self.assertEqual(ctx.result, "advantage")
+        self.assertEqual(ctx.advantage_sources, ["Aumentar"])
+        self.assertEqual(len(ctx.advantage_source_details), 1)
+        self.assertEqual(ctx.advantage_source_details[0]["modifier_type"], "advantage")
+
+    def test_declared_disadvantage_on_save_matching_ability(self):
+        ctx = self._mod_with_effects(
+            extra_effects=[
+                {
+                    "kind": "spell_effect",
+                    "metadata": {
+                        "declarative_effect": {
+                            "type": "disadvantage_on_saves",
+                            "params": {"abilities": ["dexterity"]},
+                        },
+                        "source_spell_name": "Reduzir",
+                    },
+                }
+            ],
+            ability="dexterity",
+        )
+        self.assertEqual(ctx.result, "disadvantage")
+        self.assertIn("Reduzir", ctx.disadvantage_sources)
+        self.assertEqual(len(ctx.disadvantage_source_details), 1)
+        self.assertEqual(ctx.disadvantage_source_details[0]["modifier_type"], "disadvantage")
+
+    def test_declared_save_modifier_ignores_unrelated_ability(self):
+        ctx = self._mod_with_effects(
+            extra_effects=[
+                {
+                    "kind": "spell_effect",
+                    "metadata": {
+                        "declarative_effect": {
+                            "type": "advantage_on_saves",
+                            "params": {"abilities": ["strength"]},
+                        },
+                    },
+                }
+            ],
+            ability="dexterity",
+        )
+        self.assertEqual(ctx.result, "normal")
+        self.assertEqual(ctx.advantage_sources, [])
+
+    def test_declared_advantage_and_disadvantage_cancel(self):
+        ctx = self._mod_with_effects(
+            extra_effects=[
+                {
+                    "kind": "spell_effect",
+                    "metadata": {
+                        "declarative_effect": {
+                            "type": "advantage_on_saves",
+                            "params": {"abilities": ["strength"]},
+                        },
+                        "source_spell_name": "Aumentar",
+                    },
+                },
+                {
+                    "kind": "spell_effect",
+                    "metadata": {
+                        "declarative_effect": {
+                            "type": "disadvantage_on_saves",
+                            "params": {"abilities": ["strength"]},
+                        },
+                        "source_spell_name": "Reduzir",
+                    },
+                },
+            ],
+            ability="strength",
+        )
+        self.assertEqual(ctx.result, "normal")
+
+    def test_manual_advantage_plus_declared_disadvantage_is_normal(self):
+        ctx = self._mod_with_effects(
+            extra_effects=[
+                {
+                    "kind": "spell_effect",
+                    "metadata": {
+                        "declarative_effect": {
+                            "type": "disadvantage_on_saves",
+                            "params": {"abilities": ["strength"]},
+                        },
+                    },
+                }
+            ],
+            ability="strength",
+            manual_mode="advantage",
+        )
+        self.assertEqual(ctx.result, "normal")
+
+    def test_manual_disadvantage_plus_declared_advantage_is_normal(self):
+        ctx = self._mod_with_effects(
+            extra_effects=[
+                {
+                    "kind": "spell_effect",
+                    "metadata": {
+                        "declarative_effect": {
+                            "type": "advantage_on_saves",
+                            "params": {"abilities": ["strength"]},
+                        },
+                    },
+                }
+            ],
+            ability="strength",
+            manual_mode="disadvantage",
+        )
+        self.assertEqual(ctx.result, "normal")
+
+    def test_restrained_plus_declared_advantage_cancels(self):
+        ctx = modify_saving_throw(
+            _participant(
+                conditions=["restrained"],
+                extra_effects=[
+                    {
+                        "kind": "spell_effect",
+                        "metadata": {
+                            "declarative_effect": {
+                                "type": "advantage_on_saves",
+                                "params": {"abilities": ["dexterity"]},
+                            },
+                        },
+                    }
+                ],
+            ),
+            "dexterity",
+        )
+        self.assertEqual(ctx.result, "normal")
+
+    def test_paralyzed_still_auto_fails_despite_declared_advantage(self):
+        ctx = modify_saving_throw(
+            _participant(
+                conditions=["paralyzed"],
+                extra_effects=[
+                    {
+                        "kind": "spell_effect",
+                        "metadata": {
+                            "declarative_effect": {
+                                "type": "advantage_on_saves",
+                                "params": {"abilities": ["strength"]},
+                            },
+                        },
+                    }
+                ],
+            ),
+            "strength",
+        )
+        self.assertTrue(ctx.auto_fail)
+        self.assertEqual(ctx.result, "normal")
+
 
 # ─── resolve_spell_attack_kind ───────────────────────────────────────────────
 

--- a/apps/control-server/tests/test_roll_resolution_endpoints.py
+++ b/apps/control-server/tests/test_roll_resolution_endpoints.py
@@ -597,5 +597,173 @@ class TestSessionActivityRollResolvedEvent(unittest.TestCase):
         self.assertTrue(event.check_modifier_sources[0]["applied"])
 
 
+
+
+class TestSaveRollEndToEnd(unittest.IsolatedAsyncioTestCase):
+    @patch("app.services.roll_resolution.roll_d20_pair", return_value=(15, 8))
+    async def test_save_roll_applies_declared_advantage(self, _mock_d20):
+        from app.api.routes.sessions.rolls_resolution import roll_save
+        from app.schemas.roll import RollActorStats, SaveRollRequest
+
+        user = MagicMock()
+        user.id = "user-1"
+
+        session_entry = MagicMock()
+        session_entry.id = "session-1"
+        session_entry.campaign_id = "campaign-1"
+        session_entry.party_id = "party-1"
+        session_entry.status = "ACTIVE"
+
+        member = _make_member(RoleMode.PLAYER, user_id="user-1")
+
+        db = MagicMock()
+
+        body = SaveRollRequest(
+            actor_kind="player",
+            actor_ref_id="user-1",
+            ability="strength",
+            advantage_mode="normal",
+            dc=15,
+        )
+
+        with (
+            patch(
+                "app.api.routes.sessions.rolls_resolution._get_session_and_member",
+                return_value=(session_entry, member),
+            ),
+            patch(
+                "app.api.routes.sessions.rolls_resolution._build_actor_stats",
+            ) as mock_build,
+            patch(
+                "app.api.routes.sessions.rolls_resolution._publish_and_log",
+                new_callable=AsyncMock,
+            ) as mock_publish,
+            patch(
+                "app.services.combat_service.service.CombatService.get_state",
+            ) as mock_get_state,
+        ):
+            mock_build.return_value = RollActorStats(
+                display_name="Hero",
+                abilities={"strength": 16},
+                actor_kind="player",
+                actor_ref_id="user-1",
+            )
+            mock_get_state.return_value = MagicMock(
+                phase="active",
+                participants=[
+                    {
+                        "id": "participant-1",
+                        "ref_id": "user-1",
+                        "kind": "player",
+                        "active_effects": [
+                            {
+                                "kind": "spell_effect",
+                                "metadata": {
+                                    "source_spell_name": "Aumentar",
+                                    "declarative_effect": {
+                                        "type": "advantage_on_saves",
+                                        "params": {"abilities": ["strength"]},
+                                    },
+                                },
+                            }
+                        ],
+                    }
+                ],
+            )
+
+            result = await roll_save(
+                session_id="session-1", body=body, user=user, db=db
+            )
+
+            self.assertEqual(result.roll_type, "save")
+            self.assertEqual(result.advantage_mode, "advantage")
+            self.assertEqual(result.total, 18)  # 15 + 3 (STR mod)
+            self.assertIsNotNone(result.check_modifier_sources)
+            self.assertEqual(len(result.check_modifier_sources), 1)
+            self.assertEqual(
+                result.check_modifier_sources[0]["source_label"], "Aumentar"
+            )
+            self.assertTrue(result.check_modifier_sources[0]["applied"])
+            mock_publish.assert_called_once()
+
+    @patch("app.services.roll_resolution.roll_d20_pair", return_value=(15, 8))
+    async def test_save_roll_manual_disadvantage_cancels_declared_advantage(self, _mock_d20):
+        from app.api.routes.sessions.rolls_resolution import roll_save
+        from app.schemas.roll import RollActorStats, SaveRollRequest
+
+        user = MagicMock()
+        user.id = "user-1"
+
+        session_entry = MagicMock()
+        session_entry.id = "session-1"
+        session_entry.campaign_id = "campaign-1"
+        session_entry.party_id = "party-1"
+        session_entry.status = "ACTIVE"
+
+        member = _make_member(RoleMode.PLAYER, user_id="user-1")
+
+        db = MagicMock()
+
+        body = SaveRollRequest(
+            actor_kind="player",
+            actor_ref_id="user-1",
+            ability="strength",
+            advantage_mode="disadvantage",
+            dc=15,
+        )
+
+        with (
+            patch(
+                "app.api.routes.sessions.rolls_resolution._get_session_and_member",
+                return_value=(session_entry, member),
+            ),
+            patch(
+                "app.api.routes.sessions.rolls_resolution._build_actor_stats",
+            ) as mock_build,
+            patch(
+                "app.api.routes.sessions.rolls_resolution._publish_and_log",
+                new_callable=AsyncMock,
+            ) as mock_publish,
+            patch(
+                "app.services.combat_service.service.CombatService.get_state",
+            ) as mock_get_state,
+        ):
+            mock_build.return_value = RollActorStats(
+                display_name="Hero",
+                abilities={"strength": 16},
+                actor_kind="player",
+                actor_ref_id="user-1",
+            )
+            mock_get_state.return_value = MagicMock(
+                phase="active",
+                participants=[
+                    {
+                        "id": "participant-1",
+                        "ref_id": "user-1",
+                        "kind": "player",
+                        "active_effects": [
+                            {
+                                "kind": "spell_effect",
+                                "metadata": {
+                                    "source_spell_name": "Aumentar",
+                                    "declarative_effect": {
+                                        "type": "advantage_on_saves",
+                                        "params": {"abilities": ["strength"]},
+                                    },
+                                },
+                            }
+                        ],
+                    }
+                ],
+            )
+
+            result = await roll_save(
+                session_id="session-1", body=body, user=user, db=db
+            )
+
+            self.assertEqual(result.advantage_mode, "normal")
+            mock_publish.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/apps/control-server/tests/test_save_declarative_effects.py
+++ b/apps/control-server/tests/test_save_declarative_effects.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.models.combat import CombatPhase, CombatState
+from app.services.combat import CombatService
+from app.services.combat_service.condition_effects_predicates import (
+    _get_save_declarative_context,
+    combine_advantage_modes,
+)
+
+
+def _participant_with_save_effects(effects: list[dict]) -> dict:
+    return {"id": "p1", "kind": "player", "ref_id": "user-1", "active_effects": effects}
+
+
+def _save_effect(effect_type: str, abilities: list[str], source_name: str = "Test Spell") -> dict:
+    return {
+        "id": f"eff-{effect_type}",
+        "kind": "spell_effect",
+        "metadata": {
+            "declarative_effect": {
+                "type": effect_type,
+                "params": {"abilities": abilities},
+            },
+            "source_spell_name": source_name,
+        },
+    }
+
+
+class TestGetSaveDeclarativeContext(unittest.TestCase):
+    def test_no_effects_returns_normal(self):
+        mode, adv_strs, dis_strs, details = _get_save_declarative_context(
+            _participant_with_save_effects([]), "strength"
+        )
+        self.assertEqual(mode, "normal")
+        self.assertEqual(adv_strs, [])
+        self.assertEqual(dis_strs, [])
+        self.assertEqual(details, [])
+
+    def test_matching_advantage(self):
+        p = _participant_with_save_effects([_save_effect("advantage_on_saves", ["strength"])])
+        mode, adv_strs, dis_strs, details = _get_save_declarative_context(p, "strength")
+        self.assertEqual(mode, "advantage")
+        self.assertEqual(adv_strs, ["Test Spell"])
+        self.assertEqual(dis_strs, [])
+        self.assertEqual(len(details), 1)
+        self.assertEqual(details[0]["modifier_type"], "advantage")
+
+    def test_matching_disadvantage(self):
+        p = _participant_with_save_effects([_save_effect("disadvantage_on_saves", ["dexterity"])])
+        mode, adv_strs, dis_strs, details = _get_save_declarative_context(p, "dexterity")
+        self.assertEqual(mode, "disadvantage")
+        self.assertEqual(adv_strs, [])
+        self.assertEqual(dis_strs, ["Test Spell"])
+        self.assertEqual(len(details), 1)
+        self.assertEqual(details[0]["modifier_type"], "disadvantage")
+
+    def test_unrelated_ability_ignored(self):
+        p = _participant_with_save_effects([_save_effect("advantage_on_saves", ["strength"])])
+        mode, adv_strs, dis_strs, details = _get_save_declarative_context(p, "dexterity")
+        self.assertEqual(mode, "normal")
+        self.assertEqual(adv_strs, [])
+        self.assertEqual(details, [])
+
+    def test_advantage_and_disadvantage_cancel(self):
+        p = _participant_with_save_effects(
+            [
+                _save_effect("advantage_on_saves", ["strength"], "Buff"),
+                _save_effect("disadvantage_on_saves", ["strength"], "Debuff"),
+            ]
+        )
+        mode, adv_strs, dis_strs, details = _get_save_declarative_context(p, "strength")
+        self.assertEqual(mode, "normal")
+        self.assertEqual(len(adv_strs), 1)
+        self.assertEqual(len(dis_strs), 1)
+        self.assertEqual(len(details), 2)
+
+    def test_deduplication_by_group_key(self):
+        p = _participant_with_save_effects(
+            [
+                _save_effect("advantage_on_saves", ["strength"], "Same"),
+                _save_effect("advantage_on_saves", ["strength"], "Same"),
+            ]
+        )
+        mode, adv_strs, dis_strs, details = _get_save_declarative_context(p, "strength")
+        self.assertEqual(mode, "advantage")
+        self.assertEqual(len(adv_strs), 1)
+        self.assertEqual(len(details), 1)
+
+    def test_empty_abilities_list_ignored(self):
+        p = _participant_with_save_effects(
+            [
+                {
+                    "id": "eff-1",
+                    "kind": "spell_effect",
+                    "metadata": {
+                        "declarative_effect": {
+                            "type": "advantage_on_saves",
+                            "params": {"abilities": []},
+                        },
+                    },
+                }
+            ]
+        )
+        mode, adv_strs, dis_strs, details = _get_save_declarative_context(p, "strength")
+        self.assertEqual(mode, "normal")
+        self.assertEqual(details, [])
+
+    def test_non_spell_effect_ignored(self):
+        p = _participant_with_save_effects(
+            [
+                {
+                    "id": "eff-1",
+                    "kind": "condition",
+                    "condition_type": "blinded",
+                    "metadata": {
+                        "declarative_effect": {
+                            "type": "advantage_on_saves",
+                            "params": {"abilities": ["strength"]},
+                        },
+                    },
+                }
+            ]
+        )
+        mode, adv_strs, dis_strs, details = _get_save_declarative_context(p, "strength")
+        self.assertEqual(mode, "normal")
+        self.assertEqual(details, [])
+
+
+class TestResolveSaveAdvantageModeForActor(unittest.TestCase):
+    @patch("app.services.combat.CombatService.get_state")
+    def test_no_combat_state_returns_normal(self, mock_get_state):
+        mock_get_state.return_value = None
+        result = CombatService._resolve_save_advantage_mode_for_actor(
+            MagicMock(),
+            "session-1",
+            actor_kind="player",
+            actor_ref_id="user-1",
+            ability="strength",
+            manual_mode="normal",
+        )
+        self.assertEqual(result, "normal")
+
+    @patch("app.services.combat.CombatService.get_state")
+    def test_ended_combat_returns_normal(self, mock_get_state):
+        mock_get_state.return_value = CombatState(
+            id="cs-1",
+            session_id="session-1",
+            phase=CombatPhase.ended,
+            round=1,
+            current_turn_index=0,
+            participants=[],
+        )
+        result = CombatService._resolve_save_advantage_mode_for_actor(
+            MagicMock(),
+            "session-1",
+            actor_kind="player",
+            actor_ref_id="user-1",
+            ability="strength",
+            manual_mode="normal",
+        )
+        self.assertEqual(result, "normal")
+
+    @patch("app.services.combat.CombatService.get_state")
+    def test_valid_participant_with_declared_advantage(self, mock_get_state):
+        state = CombatState(
+            id="cs-1",
+            session_id="session-1",
+            phase=CombatPhase.active,
+            round=1,
+            current_turn_index=0,
+            participants=[
+                {
+                    "id": "p1",
+                    "kind": "player",
+                    "ref_id": "user-1",
+                    "active_effects": [
+                        _save_effect("advantage_on_saves", ["strength"], "Aumentar"),
+                    ],
+                }
+            ],
+        )
+        mock_get_state.return_value = state
+        result = CombatService._resolve_save_advantage_mode_for_actor(
+            MagicMock(),
+            "session-1",
+            actor_kind="player",
+            actor_ref_id="user-1",
+            ability="strength",
+            manual_mode="normal",
+        )
+        self.assertEqual(result, "advantage")
+
+    @patch("app.services.combat.CombatService.get_state")
+    def test_kind_mismatch_returns_normal(self, mock_get_state):
+        state = CombatState(
+            id="cs-1",
+            session_id="session-1",
+            phase=CombatPhase.active,
+            round=1,
+            current_turn_index=0,
+            participants=[
+                {
+                    "id": "p1",
+                    "kind": "session_entity",
+                    "ref_id": "user-1",
+                    "active_effects": [],
+                }
+            ],
+        )
+        mock_get_state.return_value = state
+        result = CombatService._resolve_save_advantage_mode_for_actor(
+            MagicMock(),
+            "session-1",
+            actor_kind="player",
+            actor_ref_id="user-1",
+            ability="strength",
+            manual_mode="normal",
+        )
+        self.assertEqual(result, "normal")
+
+
+class TestExplainSaveModifierSourcesForActor(unittest.TestCase):
+    @patch("app.services.combat.CombatService.get_state")
+    def test_no_combat_state_returns_empty(self, mock_get_state):
+        mock_get_state.return_value = None
+        result = CombatService._explain_save_modifier_sources_for_actor(
+            MagicMock(),
+            "session-1",
+            actor_kind="player",
+            actor_ref_id="user-1",
+            ability="strength",
+        )
+        self.assertEqual(result, [])
+
+    @patch("app.services.combat.CombatService.get_state")
+    def test_valid_participant_returns_sources(self, mock_get_state):
+        state = CombatState(
+            id="cs-1",
+            session_id="session-1",
+            phase=CombatPhase.active,
+            round=1,
+            current_turn_index=0,
+            participants=[
+                {
+                    "id": "p1",
+                    "kind": "player",
+                    "ref_id": "user-1",
+                    "active_effects": [
+                        _save_effect("advantage_on_saves", ["strength"], "Aumentar"),
+                    ],
+                }
+            ],
+        )
+        mock_get_state.return_value = state
+        result = CombatService._explain_save_modifier_sources_for_actor(
+            MagicMock(),
+            "session-1",
+            actor_kind="player",
+            actor_ref_id="user-1",
+            ability="strength",
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["source_label"], "Aumentar")
+        self.assertEqual(result[0]["modifier_type"], "advantage")
+        self.assertTrue(result[0]["applied"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/control-server/tests/test_save_resolve.py
+++ b/apps/control-server/tests/test_save_resolve.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.models.combat import CombatPhase, CombatState
+from app.schemas.combat import CombatResolveSaveRequest
+from app.schemas.roll import RollResult
+from app.services.combat import CombatService
+
+
+def _build_state_with_participant_effects(effects: list[dict]) -> CombatState:
+    return CombatState(
+        id="combat-save-resolve",
+        session_id="session-save-resolve",
+        phase=CombatPhase.active,
+        round=1,
+        current_turn_index=0,
+        participants=[
+            {
+                "id": "p1",
+                "ref_id": "player-1",
+                "kind": "player",
+                "display_name": "Mage",
+                "initiative": 15,
+                "status": "active",
+                "team": "players",
+                "visible": True,
+                "actor_user_id": "user-1",
+                "active_effects": [],
+            },
+            {
+                "id": "e1",
+                "ref_id": "enemy-1",
+                "kind": "session_entity",
+                "display_name": "Target",
+                "initiative": 10,
+                "status": "active",
+                "team": "enemies",
+                "visible": True,
+                "actor_user_id": None,
+                "active_effects": effects,
+            },
+        ],
+    )
+
+
+class TestPendingSaveModifierSources(unittest.IsolatedAsyncioTestCase):
+    async def test_pending_save_includes_declared_disadvantage_sources(self):
+        state = _build_state_with_participant_effects(
+            [
+                {
+                    "kind": "spell_effect",
+                    "metadata": {
+                        "source_spell_name": "Reduzir",
+                        "declarative_effect": {
+                            "type": "disadvantage_on_saves",
+                            "params": {"abilities": ["strength"]},
+                        },
+                    },
+                }
+            ]
+        )
+        target = state.participants[1]
+        target["pending_save"] = {
+            "id": "pending-save-1",
+            "status": "pending",
+            "spell_name": "Test Spell",
+            "spell_canonical_key": "test_spell",
+            "action_kind": "saving_throw",
+            "save_ability": "strength",
+            "save_dc": 15,
+            "effect_kind": "damage",
+            "effect_bonus": 0,
+            "effect_dice": None,
+            "effect_roll_required": False,
+            "save_success_outcome": "none",
+            "damage_type": None,
+            "attacker_ref_id": "player-1",
+            "attacker_participant_id": "p1",
+            "attacker_display_name": "Mage",
+        }
+
+        db = MagicMock()
+        db.add = MagicMock()
+        db.commit = MagicMock()
+        db.refresh = MagicMock()
+
+        save_roll = RollResult(
+            event_id="save-roll-1",
+            roll_type="save",
+            actor_kind="session_entity",
+            actor_ref_id="enemy-1",
+            actor_display_name="Target",
+            rolls=[5],
+            selected_roll=5,
+            advantage_mode="disadvantage",
+            modifier_used=0,
+            override_used=False,
+            formula="1d20 + 0",
+            total=5,
+            ability="strength",
+            dc=15,
+            success=False,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=state),
+            patch(
+                "app.services.combat.CombatService._build_roll_actor_stats_for_save",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "app.services.combat_service.save_resolve.resolve_saving_throw",
+                return_value=save_roll,
+            ),
+            patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock),
+            patch("app.services.combat.CombatService._emit_and_persist_log", new_callable=AsyncMock),
+            patch("app.services.combat.CombatService._apply_spell_effect", return_value=(None, "", None, None)),
+        ):
+            result = await CombatService.resolve_pending_save(
+                db,
+                "session-save-resolve",
+                CombatResolveSaveRequest(
+                    target_participant_id="e1",
+                    pending_save_id="pending-save-1",
+                ),
+                "user-1",
+                True,
+            )
+
+        self.assertIn("roll_result", result)
+        roll_result = result["roll_result"]
+        self.assertIsNotNone(roll_result.check_modifier_sources)
+        self.assertEqual(len(roll_result.check_modifier_sources), 1)
+        self.assertEqual(roll_result.check_modifier_sources[0]["source_label"], "Reduzir")
+        self.assertEqual(roll_result.check_modifier_sources[0]["modifier_type"], "disadvantage")
+        self.assertTrue(roll_result.check_modifier_sources[0]["applied"])
+
+    async def test_pending_save_preserves_restrained_behavior(self):
+        state = _build_state_with_participant_effects(
+            [
+                {
+                    "kind": "condition",
+                    "condition_type": "restrained",
+                }
+            ]
+        )
+        target = state.participants[1]
+        target["pending_save"] = {
+            "id": "pending-save-1",
+            "status": "pending",
+            "spell_name": "Test Spell",
+            "spell_canonical_key": "test_spell",
+            "action_kind": "saving_throw",
+            "save_ability": "dexterity",
+            "save_dc": 15,
+            "effect_kind": "damage",
+            "effect_bonus": 0,
+            "effect_dice": None,
+            "effect_roll_required": False,
+            "save_success_outcome": "none",
+            "damage_type": None,
+            "attacker_ref_id": "player-1",
+            "attacker_participant_id": "p1",
+            "attacker_display_name": "Mage",
+        }
+
+        db = MagicMock()
+        db.add = MagicMock()
+        db.commit = MagicMock()
+        db.refresh = MagicMock()
+
+        save_roll = RollResult(
+            event_id="save-roll-1",
+            roll_type="save",
+            actor_kind="session_entity",
+            actor_ref_id="enemy-1",
+            actor_display_name="Target",
+            rolls=[5],
+            selected_roll=5,
+            advantage_mode="disadvantage",
+            modifier_used=0,
+            override_used=False,
+            formula="1d20 + 0",
+            total=5,
+            ability="dexterity",
+            dc=15,
+            success=False,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=state),
+            patch(
+                "app.services.combat.CombatService._build_roll_actor_stats_for_save",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "app.services.combat_service.save_resolve.resolve_saving_throw",
+                return_value=save_roll,
+            ),
+            patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock),
+            patch("app.services.combat.CombatService._emit_and_persist_log", new_callable=AsyncMock),
+            patch("app.services.combat.CombatService._apply_spell_effect", return_value=(None, "", None, None)),
+        ):
+            result = await CombatService.resolve_pending_save(
+                db,
+                "session-save-resolve",
+                CombatResolveSaveRequest(
+                    target_participant_id="e1",
+                    pending_save_id="pending-save-1",
+                ),
+                "user-1",
+                True,
+            )
+
+        self.assertIn("roll_result", result)
+        roll_result = result["roll_result"]
+        self.assertIsNotNone(roll_result.check_modifier_sources)
+        # restrained does not produce source_details today; verify it doesn't break
+        self.assertEqual(roll_result.advantage_mode, "disadvantage")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/control-server/tests/test_spell_declarative_effects.py
+++ b/apps/control-server/tests/test_spell_declarative_effects.py
@@ -1483,3 +1483,83 @@ class TestPassiveSkillBonusDedup(unittest.TestCase):
         ]
         participant = self._make_participant(effects)
         self.assertEqual(get_passive_skill_bonus(participant, "perception"), 8)
+
+
+class TestSaveDeclarativeEffectSchema(unittest.TestCase):
+    def test_advantage_on_saves_accepts_valid_params(self):
+        spell = BaseSpellCreate(
+            canonicalKey="enlarge_reduce",
+            nameEn="Enlarge/Reduce",
+            descriptionEn="Test spell.",
+            level=2,
+            school="transmutation",
+            resolutionType="buff",
+            effects=[
+                {
+                    "type": "advantage_on_saves",
+                    "target": "selected_target",
+                    "duration": {"type": "rounds", "rounds": 10, "anchor": "target"},
+                    "params": {"abilities": ["strength"]},
+                    "stacking": "replace",
+                }
+            ],
+        )
+        self.assertEqual(spell.effects[0].type, "advantage_on_saves")
+        self.assertEqual(spell.effects[0].params.abilities, ["strength"])
+
+    def test_disadvantage_on_saves_accepts_valid_params(self):
+        spell = BaseSpellCreate(
+            canonicalKey="enlarge_reduce",
+            nameEn="Enlarge/Reduce",
+            descriptionEn="Test spell.",
+            level=2,
+            school="transmutation",
+            resolutionType="buff",
+            effects=[
+                {
+                    "type": "disadvantage_on_saves",
+                    "target": "selected_target",
+                    "duration": {"type": "rounds", "rounds": 10, "anchor": "target"},
+                    "params": {"abilities": ["strength"]},
+                    "stacking": "replace",
+                }
+            ],
+        )
+        self.assertEqual(spell.effects[0].type, "disadvantage_on_saves")
+        self.assertEqual(spell.effects[0].params.abilities, ["strength"])
+
+    def test_save_modifier_rejects_missing_abilities(self):
+        with self.assertRaises(ValueError):
+            BaseSpellCreate(
+                canonicalKey="enlarge_reduce",
+                nameEn="Enlarge/Reduce",
+                descriptionEn="Test spell.",
+                level=2,
+                school="transmutation",
+                resolutionType="buff",
+                effects=[
+                    {
+                        "type": "advantage_on_saves",
+                        "target": "selected_target",
+                        "params": {},
+                    }
+                ],
+            )
+
+    def test_save_modifier_rejects_invalid_ability(self):
+        with self.assertRaises(ValueError):
+            BaseSpellCreate(
+                canonicalKey="enlarge_reduce",
+                nameEn="Enlarge/Reduce",
+                descriptionEn="Test spell.",
+                level=2,
+                school="transmutation",
+                resolutionType="buff",
+                effects=[
+                    {
+                        "type": "advantage_on_saves",
+                        "target": "selected_target",
+                        "params": {"abilities": ["luck"]},
+                    }
+                ],
+            )


### PR DESCRIPTION
# PR: feat(saves) declarative advantage/disadvantage on saving throws (#285)

## Description

Este PR implementa o suporte declarativo para vantagem e desvantagem em testes de resistência (*Saving Throws*) via `active_spell_effects`. A implementação centraliza a lógica de modificadores em um único ponto canônico (`modify_saving_throw`), permitindo que efeitos ativos (como magias e condições) sejam explicados detalhadamente no resultado da rolagem, mantendo a compatibilidade com o sistema legado de condições hardcoded.

## Changes

### Backend & Core Engine
- **Schema Update (`base_spell_effects.py`):** Adicionados os campos `advantage_on_saves` e `disadvantage_on_saves` utilizando `SaveModifierParams(abilities: list[AbilityName])`.
- **Predicate Logic (`condition_effects_predicates.py`):** Implementado o helper `_get_save_declarative_context` para iterar sobre efeitos ativos, realizando a deduplicação de fontes via `_declarative_effect_group_key`.
- **Canonical Resolver (`condition_effects_saves.py`):** Refatoração do `modify_saving_throw` para:
    - Aceitar `manual_mode`.
    - Combinar condições hardcoded (ex: *Restrained*) com efeitos declarativos.
    - Utilizar `combine_advantage_modes` para determinar o estado final da rolagem.
    - Preencher `advantage_source_details` e `disadvantage_source_details` sem alterar campos legados.

### Integration & API
- **Façade Methods:** Adicionados `_resolve_save_advantage_mode_for_actor` e `_explain_save_modifier_sources_for_actor` em `spell_declarative_effects.py`, seguindo o padrão de design já utilizado para Perícias e Atributos.
- **Roll Endpoints:** O endpoint `roll_save` em `rolls_resolution.py` agora resolve o modo efetivo e expõe a origem dos modificadores.
- **Combat Resolution:** Atualizados `save_resolve.py` e `npc_action_resolution.py` para popular `check_modifier_sources` no resultado final da rolagem durante o combate.

## Summary of Changes

| Component | Change |
| :--- | :--- |
| **`base_spell_effects.py`** | Suporte declarativo para modificadores de Save por habilidade |
| **`modify_saving_throw`** | Unificação da lógica de condições, manual mode e efeitos ativos |
| **`RollResult`** | Inclusão de metadados ricos sobre a origem da vantagem/desvantagem |
| **`Combat Pipeline`** | Sincronização de fontes de modificadores em saves pendentes e reações |

## Validation

A implementação foi validada através de uma suíte abrangente de testes:
- **Schema:** Validação de tipos e garantia de que dicionários vazios de `abilities` são ignorados com segurança.
- **Predicates:** Verificação da extração e deduplicação de contextos declarativos.
- **Saves Pipeline:** Testes de composição (Advantage + Disadvantage = Neutral) e persistência de `auto_fail`.
- **Endpoints:** Verificação do contrato da API em rolagens livres.
- **Combat Flow:** Testes de integração em Saves pendentes originados por ações de NPCs.

## Technical Notes

> [!NOTE]
> A implementação mantém o campo legado de strings intocado para evitar quebras em sistemas externos, mas injeta o objeto rico `check_modifier_sources` para consumo da nova UI de VTT, permitindo que o jogador veja exatamente qual magia ou condição está afetando seu Save.