### PR TITLE
ui(combat) human-friendly feedback for size modifiers and declarative effects (#291)

### DIFF
--- a/apps/control-web/src/features/active-effects/activeEffectDisplay.test.ts
+++ b/apps/control-web/src/features/active-effects/activeEffectDisplay.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { formatActiveEffectLabel, getActiveEffectLifecycleBadges } from "./activeEffectDisplay";
+import {
+  buildActiveEffectGroupTitle,
+  formatActiveEffectLabel,
+  formatCreatureSize,
+  formatEffectiveCreatureSize,
+  getActiveEffectLifecycleBadges,
+  groupActiveEffectsForDisplay,
+} from "./activeEffectDisplay";
 
 describe("formatActiveEffectLabel", () => {
   it("returns spellName + variantLabel when both exist", () => {
@@ -198,5 +205,62 @@ describe("getActiveEffectLifecycleBadges", () => {
     };
     const badges = getActiveEffectLifecycleBadges(effect);
     expect(badges.map((b) => b.key)).toEqual(["manual", "long-rest"]);
+  });
+});
+
+describe("groupActiveEffectsForDisplay", () => {
+  const makeEffect = (id: string, groupId: string, type: string, params: Record<string, unknown>) => ({
+    id,
+    kind: type === "size_modifier" ? "size_modifier" : "spell_effect",
+    duration_type: "timed",
+    created_at: "2026-05-01T00:00:00Z",
+    metadata: {
+      source_spell_name: "Aumentar/Reduzir",
+      selected_variant_label: "Aumentar",
+      declarative_effect_group_id: groupId,
+      declarative_effect: { type, params },
+    },
+  });
+
+  it("groups declarative effects by group id and summarizes children", () => {
+    const groups = groupActiveEffectsForDisplay([
+      makeEffect("size", "group-a", "size_modifier", { value: 1 }),
+      makeEffect("save", "group-a", "advantage_on_saves", { abilities: ["strength"] }),
+      makeEffect("damage", "group-a", "modify_weapon_damage", { dice: "1d4", operation: "add" }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].title).toBe("Aumentar/Reduzir — Aumentar");
+    expect(groups[0].summaryLines).toEqual([
+      "Tamanho aumentado",
+      "Vantagem em salvaguardas de Força",
+      "Dano de arma +1d4",
+    ]);
+  });
+
+  it("does not merge distinct groups from the same spell and variant", () => {
+    const groups = groupActiveEffectsForDisplay([
+      makeEffect("size-a", "group-a", "size_modifier", { value: 1 }),
+      makeEffect("size-b", "group-b", "size_modifier", { value: 1 }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups.map((group) => group.groupKey)).toEqual(["declarative:group-a", "declarative:group-b"]);
+  });
+
+  it("builds group title with graceful fallbacks", () => {
+    expect(buildActiveEffectGroupTitle({ effects: [{ metadata: { source_spell_name: "Bless" } }] })).toBe("Bless");
+    expect(buildActiveEffectGroupTitle({ effects: [{ metadata: { selected_variant_label: "Aumentar" } }] })).toBe("Aumentar");
+    expect(buildActiveEffectGroupTitle({ effects: [{ display_label: "Legacy" }] })).toBe("Legacy");
+  });
+});
+
+describe("formatCreatureSize", () => {
+  it("localizes creature sizes and hides unchanged effective size", () => {
+    expect(formatCreatureSize("large", "pt")).toBe("Grande");
+    expect(formatEffectiveCreatureSize({ base_size: "medium", effective_size: "large" }, "pt")).toBe(
+      "Tamanho atual: Grande (base Médio)",
+    );
+    expect(formatEffectiveCreatureSize({ base_size: "medium", effective_size: "medium" }, "pt")).toBeNull();
   });
 });

--- a/apps/control-web/src/features/active-effects/activeEffectDisplay.ts
+++ b/apps/control-web/src/features/active-effects/activeEffectDisplay.ts
@@ -1,9 +1,67 @@
-import type { LocaleKey } from "../../shared/i18n";
+import { formatDeclarativeEffectSummaryLine } from "../combat-ui/spellVariantUi";
+import type { Locale, LocaleKey } from "../../shared/i18n";
 
 export type ActiveEffectLifecycleBadge = {
   key: string;
   i18nKey: LocaleKey;
   params?: Record<string, string | number>;
+};
+
+export type ActiveEffectDisplayGroup = {
+  effects: Record<string, unknown>[];
+  groupKey: string | null;
+  title: string | null;
+  summaryLines: string[];
+};
+
+const CREATURE_SIZE_LABELS: Record<Locale, Record<string, string>> = {
+  en: {
+    tiny: "Tiny",
+    small: "Small",
+    medium: "Medium",
+    large: "Large",
+    huge: "Huge",
+    gargantuan: "Gargantuan",
+  },
+  pt: {
+    tiny: "Minúsculo",
+    small: "Pequeno",
+    medium: "Médio",
+    large: "Grande",
+    huge: "Enorme",
+    gargantuan: "Colossal",
+  },
+};
+
+const normalizeSize = (size: unknown) =>
+  typeof size === "string" && size.trim() ? size.trim().toLowerCase() : null;
+
+export const formatCreatureSize = (size: unknown, locale: Locale = "pt") => {
+  const normalized = normalizeSize(size);
+  if (!normalized) {
+    return null;
+  }
+  return CREATURE_SIZE_LABELS[locale][normalized] ?? normalized;
+};
+
+export const formatEffectiveCreatureSize = (
+  participant: {
+    base_size?: string | null;
+    effective_size?: string | null;
+  },
+  locale: Locale = "pt",
+) => {
+  const baseSize = normalizeSize(participant.base_size) ?? "medium";
+  const effectiveSize = normalizeSize(participant.effective_size);
+  if (!effectiveSize || effectiveSize === baseSize) {
+    return null;
+  }
+  const effectiveLabel = formatCreatureSize(effectiveSize, locale);
+  const baseLabel = formatCreatureSize(baseSize, locale);
+  if (!effectiveLabel || !baseLabel) {
+    return null;
+  }
+  return `Tamanho atual: ${effectiveLabel} (base ${baseLabel})`;
 };
 
 export const formatActiveEffectLabel = (
@@ -21,6 +79,95 @@ export const formatActiveEffectLabel = (
   if (spellName) return spellName;
   if (spellKey) return spellKey;
   return null;
+};
+
+const getGroupKey = (effect: Record<string, unknown>) => {
+  const metadata = ((effect.metadata ?? {}) as Record<string, unknown>) || {};
+  const declarativeGroup = metadata.declarative_effect_group_id;
+  if (typeof declarativeGroup === "string" && declarativeGroup.trim()) {
+    return `declarative:${declarativeGroup.trim()}`;
+  }
+  const concentrationGroup = metadata.concentration_group;
+  if (typeof concentrationGroup === "string" && concentrationGroup.trim()) {
+    return `concentration:${concentrationGroup.trim()}`;
+  }
+  return null;
+};
+
+export const buildActiveEffectGroupTitle = (
+  group: Pick<ActiveEffectDisplayGroup, "effects">,
+) => {
+  const first = group.effects[0];
+  if (!first) {
+    return null;
+  }
+  const metadata = ((first.metadata ?? {}) as Record<string, unknown>) || {};
+  const spellName = typeof metadata.source_spell_name === "string" ? metadata.source_spell_name.trim() : "";
+  const variantLabel = typeof metadata.selected_variant_label === "string" ? metadata.selected_variant_label.trim() : "";
+  if (spellName && variantLabel) {
+    return `${spellName} \u2014 ${variantLabel}`;
+  }
+  if (spellName) {
+    return spellName;
+  }
+  if (variantLabel) {
+    return variantLabel;
+  }
+  return formatActiveEffectLabel(first);
+};
+
+const buildSummaryLines = (effects: Record<string, unknown>[]) =>
+  effects
+    .map((effect) => {
+      const metadata = ((effect.metadata ?? {}) as Record<string, unknown>) || {};
+      const declarative = metadata.declarative_effect;
+      if (!declarative || typeof declarative !== "object") {
+        return null;
+      }
+      return formatDeclarativeEffectSummaryLine(
+        declarative as { type?: unknown; params?: Record<string, unknown> | null },
+        metadata,
+      );
+    })
+    .filter((line): line is string => Boolean(line));
+
+export const groupActiveEffectsForDisplay = (
+  effects: Record<string, unknown>[] | null | undefined,
+): ActiveEffectDisplayGroup[] => {
+  if (!effects?.length) {
+    return [];
+  }
+  const grouped = new Map<string, Record<string, unknown>[]>();
+  const output: ActiveEffectDisplayGroup[] = [];
+
+  effects.forEach((effect) => {
+    const groupKey = getGroupKey(effect);
+    if (!groupKey) {
+      output.push({
+        effects: [effect],
+        groupKey: null,
+        title: formatActiveEffectLabel(effect),
+        summaryLines: buildSummaryLines([effect]),
+      });
+      return;
+    }
+    grouped.set(groupKey, [...(grouped.get(groupKey) ?? []), effect]);
+  });
+
+  grouped.forEach((groupEffects, groupKey) => {
+    const group = {
+      effects: groupEffects,
+      groupKey,
+      title: null,
+      summaryLines: buildSummaryLines(groupEffects),
+    };
+    output.push({
+      ...group,
+      title: buildActiveEffectGroupTitle(group),
+    });
+  });
+
+  return output;
 };
 
 export const getActiveEffectLifecycleBadges = (

--- a/apps/control-web/src/features/active-effects/index.ts
+++ b/apps/control-web/src/features/active-effects/index.ts
@@ -1,2 +1,9 @@
-export { formatActiveEffectLabel, getActiveEffectLifecycleBadges } from "./activeEffectDisplay";
-export type { ActiveEffectLifecycleBadge } from "./activeEffectDisplay";
+export {
+  buildActiveEffectGroupTitle,
+  formatActiveEffectLabel,
+  formatCreatureSize,
+  formatEffectiveCreatureSize,
+  getActiveEffectLifecycleBadges,
+  groupActiveEffectsForDisplay,
+} from "./activeEffectDisplay";
+export type { ActiveEffectDisplayGroup, ActiveEffectLifecycleBadge } from "./activeEffectDisplay";

--- a/apps/control-web/src/features/combat-ui/combatErrors.test.ts
+++ b/apps/control-web/src/features/combat-ui/combatErrors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isMissingDistanceError, toPlayerFriendlyError } from "./combatErrors";
+import { isInvalidEffectiveFootprintError, isMissingDistanceError, toPlayerFriendlyError } from "./combatErrors";
 
 describe("isMissingDistanceError", () => {
   it("detects the exact backend phrase", () => {
@@ -38,5 +38,24 @@ describe("toPlayerFriendlyError", () => {
 
   it("passes through empty string unchanged", () => {
     expect(toPlayerFriendlyError("")).toBe("");
+  });
+
+  it("returns a human-readable message for invalid footprint errors", () => {
+    expect(toPlayerFriendlyError({ code: "invalid_effective_footprint" })).toBe(
+      "Não há espaço suficiente para Aumentar este alvo.",
+    );
+    expect(toPlayerFriendlyError("invalid_effective_footprint:target-1")).toBe(
+      "Não há espaço suficiente para Aumentar este alvo.",
+    );
+  });
+
+  it("extracts structured non-spatial error messages", () => {
+    expect(toPlayerFriendlyError({ detail: "Resource limit exceeded" })).toBe("Resource limit exceeded");
+  });
+});
+
+describe("isInvalidEffectiveFootprintError", () => {
+  it("prefers structured codes and supports nested detail", () => {
+    expect(isInvalidEffectiveFootprintError({ detail: { code: "invalid_effective_footprint" } })).toBe(true);
   });
 });

--- a/apps/control-web/src/features/combat-ui/combatErrors.ts
+++ b/apps/control-web/src/features/combat-ui/combatErrors.ts
@@ -1,12 +1,66 @@
 export const MISSING_DISTANCE_MARKER = "distance not configured";
+export const INVALID_EFFECTIVE_FOOTPRINT_CODE = "invalid_effective_footprint";
 
 export function isMissingDistanceError(msg: string): boolean {
   return msg.toLowerCase().includes(MISSING_DISTANCE_MARKER);
 }
 
-export function toPlayerFriendlyError(rawMsg: string): string {
-  if (isMissingDistanceError(rawMsg)) {
+export function isInvalidEffectiveFootprintError(value: unknown): boolean {
+  if (!value) {
+    return false;
+  }
+  if (typeof value === "string") {
+    return value.toLowerCase().includes(INVALID_EFFECTIVE_FOOTPRINT_CODE);
+  }
+  if (typeof value !== "object") {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if (record.code === INVALID_EFFECTIVE_FOOTPRINT_CODE) {
+    return true;
+  }
+  if (record.error === INVALID_EFFECTIVE_FOOTPRINT_CODE) {
+    return true;
+  }
+  if (record.reason === INVALID_EFFECTIVE_FOOTPRINT_CODE) {
+    return true;
+  }
+  if (record.detail && record.detail !== value) {
+    return isInvalidEffectiveFootprintError(record.detail);
+  }
+  if (record.message && record.message !== value) {
+    return isInvalidEffectiveFootprintError(record.message);
+  }
+  return false;
+}
+
+function extractErrorMessage(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (!value || typeof value !== "object") {
+    return "";
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.detail === "string") {
+    return record.detail;
+  }
+  if (typeof record.message === "string") {
+    return record.message;
+  }
+  if (typeof record.error === "string") {
+    return record.error;
+  }
+  return "";
+}
+
+export function toPlayerFriendlyError(rawMsg: unknown): string {
+  if (isInvalidEffectiveFootprintError(rawMsg)) {
+    return "Não há espaço suficiente para Aumentar este alvo.";
+  }
+  const message = extractErrorMessage(rawMsg);
+  if (isMissingDistanceError(message)) {
     return "Distância não configurada — aguarde o GM definir as distâncias antes de agir.";
   }
-  return rawMsg;
+  return message;
 }

--- a/apps/control-web/src/features/combat-ui/components/ActiveEffectDebugPanel.test.tsx
+++ b/apps/control-web/src/features/combat-ui/components/ActiveEffectDebugPanel.test.tsx
@@ -37,10 +37,8 @@ describe("ActiveEffectDebugPanel", () => {
       />,
     );
 
-    expect(markup).toContain("Source: Friends");
-    expect(markup).toContain("Selected target: Guard Captain");
-    expect(markup).toContain("Against: selected target");
-    expect(markup).toContain("Advantage: charisma checks");
+    expect(markup).toContain("Friends");
+    expect(markup).toContain("Vantagem em testes de Carisma");
   });
 
   it("exibe PV temporários concedidos com valor final e aviso de não expiração", () => {

--- a/apps/control-web/src/features/combat-ui/components/ActiveEffectDebugPanel.tsx
+++ b/apps/control-web/src/features/combat-ui/components/ActiveEffectDebugPanel.tsx
@@ -2,6 +2,7 @@ import { formatEffectContextDebug } from "../spellVariantUi";
 import { getCombatEffectLabel } from "../combatUi.helpers";
 import type { ActiveEffect } from "../../../shared/api/combatRepo";
 import { useLocale } from "../../../shared/hooks/useLocale";
+import { groupActiveEffectsForDisplay } from "../../active-effects";
 
 type Props = {
   effects: ActiveEffect[];
@@ -13,10 +14,12 @@ export const ActiveEffectDebugPanel = ({
   targetDisplayName = null,
 }: Props) => {
   const { t } = useLocale();
-  const debugEntries = effects
-    .map((effect) => ({
-      effect,
-      lines: formatEffectContextDebug(effect, { targetDisplayName }),
+  const debugEntries = groupActiveEffectsForDisplay(effects)
+    .map((group) => ({
+      group,
+      lines: group.summaryLines.length
+        ? group.summaryLines
+        : group.effects.flatMap((effect) => formatEffectContextDebug(effect as ActiveEffect, { targetDisplayName })),
     }))
     .filter((entry) => entry.lines.length > 0);
 
@@ -26,21 +29,24 @@ export const ActiveEffectDebugPanel = ({
 
   return (
     <div className="mt-3 space-y-2">
-      {debugEntries.map(({ effect, lines }) => (
+      {debugEntries.map(({ group, lines }, index) => {
+        const firstEffect = group.effects[0] as ActiveEffect;
+        return (
         <details
-          key={effect.id}
+          key={group.groupKey ?? firstEffect.id ?? index}
           className="rounded-2xl border border-sky-500/20 bg-sky-500/8 px-3 py-2"
         >
           <summary className="cursor-pointer text-xs font-semibold uppercase tracking-[0.16em] text-sky-100">
-            {getCombatEffectLabel(t, effect)}
+            {group.title ?? getCombatEffectLabel(t, firstEffect)}
           </summary>
           <div className="mt-2 space-y-1 text-xs text-slate-200">
             {lines.map((line, index) => (
-              <p key={`${effect.id}:${index}`}>{line}</p>
+              <p key={`${group.groupKey ?? firstEffect.id}:${index}`}>{line}</p>
             ))}
           </div>
         </details>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/apps/control-web/src/features/combat-ui/components/CombatParticipantRoster.tsx
+++ b/apps/control-web/src/features/combat-ui/components/CombatParticipantRoster.tsx
@@ -1,4 +1,5 @@
 import { useLocale } from "../../../shared/hooks/useLocale";
+import { formatEffectiveCreatureSize, groupActiveEffectsForDisplay } from "../../active-effects";
 import { getCombatEffectLabel, getCombatStatusLabel, getTurnResourceLabel } from "../combatUi.helpers";
 import type { CombatParticipantView } from "../types";
 import { ActiveEffectDebugPanel } from "./ActiveEffectDebugPanel";
@@ -29,15 +30,18 @@ export const CombatParticipantRoster = ({
       </div>
 
       <div className="mt-4 space-y-2">
-        {participants.map((participant, index) => (
-          <article
-            key={participant.id}
-            className={`rounded-3xl border px-4 py-3 transition-colors ${
-              participant.isCurrentTurn
-                ? "border-amber-400/35 bg-amber-500/12"
-                : "border-white/6 bg-white/4"
-            }`}
-          >
+        {participants.map((participant, index) => {
+          const effectiveSizeLabel = formatEffectiveCreatureSize(participant, "pt");
+          const activeEffectGroups = groupActiveEffectsForDisplay(participant.activeEffects);
+          return (
+            <article
+              key={participant.id}
+              className={`rounded-3xl border px-4 py-3 transition-colors ${
+                participant.isCurrentTurn
+                  ? "border-amber-400/35 bg-amber-500/12"
+                  : "border-white/6 bg-white/4"
+              }`}
+            >
             <div className="flex items-start justify-between gap-3">
               <div className="min-w-0 flex-1">
                 <div className="flex flex-wrap items-center gap-2">
@@ -62,6 +66,7 @@ export const CombatParticipantRoster = ({
                       {t("combatUi.hp")}: {participant.maxHp != null ? `${participant.currentHp}/${participant.maxHp}` : participant.currentHp}
                     </span>
                   ) : null}
+                  {effectiveSizeLabel ? <span>{effectiveSizeLabel}</span> : null}
                 </div>
               </div>
 
@@ -77,23 +82,26 @@ export const CombatParticipantRoster = ({
             {participant.activeEffects.length > 0 ? (
               <>
                 <div className="mt-3 flex flex-wrap gap-2">
-                  {participant.activeEffects.map((effect) => (
+                  {activeEffectGroups.map((group, groupIndex) => (
                     <span
-                      key={effect.id}
+                      key={group.groupKey ?? String(groupIndex)}
                       className="inline-flex items-center gap-1 rounded-full border border-fuchsia-500/25 bg-fuchsia-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-fuchsia-100"
                     >
-                      {getCombatEffectLabel(t, effect)}
+                      {group.title ?? getCombatEffectLabel(t, group.effects[0] as any)}
                       {onRemoveEffect ? (
-                        <button
-                          type="button"
-                          onClick={() => {
-                            void onRemoveEffect(participant.id, effect.id);
-                          }}
-                          className="text-fuchsia-200 transition-colors hover:text-white"
-                          aria-label={t("combatUi.removeEffect")}
-                        >
-                          x
-                        </button>
+                        (group.effects as typeof participant.activeEffects).map((effect) => (
+                          <button
+                            key={effect.id}
+                            type="button"
+                            onClick={() => {
+                              void onRemoveEffect(participant.id, effect.id);
+                            }}
+                            className="text-fuchsia-200 transition-colors hover:text-white"
+                            aria-label={t("combatUi.removeEffect")}
+                          >
+                            x
+                          </button>
+                        ))
                       ) : null}
                     </span>
                   ))}
@@ -104,8 +112,9 @@ export const CombatParticipantRoster = ({
                 />
               </>
             ) : null}
-          </article>
-        ))}
+            </article>
+          );
+        })}
       </div>
     </section>
   );

--- a/apps/control-web/src/features/combat-ui/spellVariantUi.test.ts
+++ b/apps/control-web/src/features/combat-ui/spellVariantUi.test.ts
@@ -125,7 +125,34 @@ describe("spellVariantUi", () => {
     expect(lines).toContain("Selected target: Guard Captain");
     expect(lines).toContain("Against: selected target");
     expect(lines).toContain("Concentration: group-1");
-    expect(lines).toContain("Advantage: charisma checks");
+    expect(lines).toContain("Vantagem em testes de Carisma");
+  });
+
+  it("formata Aumentar/Reduzir em PT-BR a partir dos efeitos declarativos", () => {
+    expect(
+      formatDeclarativeEffectSummaryLine({
+        type: "size_modifier",
+        params: { value: 1 },
+      }),
+    ).toBe("Tamanho aumentado");
+    expect(
+      formatDeclarativeEffectSummaryLine({
+        type: "size_modifier",
+        params: { value: -1 },
+      }),
+    ).toBe("Tamanho reduzido");
+    expect(
+      formatDeclarativeEffectSummaryLine({
+        type: "advantage_on_saves",
+        params: { abilities: ["strength"] },
+      }),
+    ).toBe("Vantagem em salvaguardas de Força");
+    expect(
+      formatDeclarativeEffectSummaryLine({
+        type: "modify_weapon_damage",
+        params: { dice: "1d4", operation: "subtract" },
+      }),
+    ).toBe("Dano de arma -1d4");
   });
 
   it("formata efeitos declarativos aplicados por alvo e remove notas duplicadas", () => {

--- a/apps/control-web/src/features/combat-ui/spellVariantUi.ts
+++ b/apps/control-web/src/features/combat-ui/spellVariantUi.ts
@@ -1,4 +1,4 @@
-import type { SpellVariantManualNote } from "../../entities/base-spell";
+import type { SpellDeclarativeEffect, SpellVariant, SpellVariantManualNote } from "../../entities/base-spell";
 import type {
   ActiveEffect,
   AppliedDeclarativeEffectsByTargetEntry,
@@ -196,6 +196,21 @@ const humanizeAgainst = (value: unknown) => {
   return null;
 };
 
+const ABILITY_LABELS_PT: Record<string, string> = {
+  strength: "Força",
+  dexterity: "Destreza",
+  constitution: "Constituição",
+  intelligence: "Inteligência",
+  wisdom: "Sabedoria",
+  charisma: "Carisma",
+};
+
+const formatAbilityList = (abilities: unknown[]) =>
+  abilities
+    .filter((ability): ability is string => typeof ability === "string")
+    .map((ability) => ABILITY_LABELS_PT[ability] ?? ability)
+    .join(", ");
+
 export const formatDeclarativeEffectSummaryLine = (
   declarative: DeclarativeEffectSummaryLike | null | undefined,
   metadata?: Record<string, unknown> | null,
@@ -208,23 +223,29 @@ export const formatDeclarativeEffectSummaryLine = (
     (declarative.type === "advantage_on_checks" || declarative.type === "disadvantage_on_checks")
     && typeof p.ability === "string"
   ) {
-    return `${declarative.type === "advantage_on_checks" ? "Advantage" : "Disadvantage"}: ${p.ability} checks`;
+    return `${declarative.type === "advantage_on_checks" ? "Vantagem" : "Desvantagem"} em testes de ${ABILITY_LABELS_PT[p.ability] ?? p.ability}`;
   }
   if (declarative.type === "modify_stat" && typeof p.stat === "string") {
     return `Effect: ${p.stat}`;
   }
   if (declarative.type === "modify_weapon_damage" && typeof p.dice === "string") {
     const operation = p.operation === "subtract" ? "-" : "+";
-    return `Weapon damage: ${operation}${p.dice}`;
+    return `Dano de arma ${operation}${p.dice}`;
   }
   if (
     (declarative.type === "advantage_on_saves" || declarative.type === "disadvantage_on_saves")
     && Array.isArray(p.abilities)
   ) {
-    return `${declarative.type === "advantage_on_saves" ? "Advantage" : "Disadvantage"}: ${p.abilities.join(", ")} saves`;
+    return `${declarative.type === "advantage_on_saves" ? "Vantagem" : "Desvantagem"} em salvaguardas de ${formatAbilityList(p.abilities)}`;
   }
   if (declarative.type === "size_modifier" && typeof p.value === "number") {
-    return `Size: ${p.value > 0 ? "+" : ""}${p.value}`;
+    if (p.value > 0) {
+      return "Tamanho aumentado";
+    }
+    if (p.value < 0) {
+      return "Tamanho reduzido";
+    }
+    return "Tamanho inalterado";
   }
   if (declarative.type === "apply_condition" && typeof p.condition === "string") {
     return `Condition: ${p.condition}`;
@@ -263,6 +284,16 @@ export const formatDeclarativeEffectSummaryLine = (
     return `Imunidade a queda: até ${p.max_distance_meters}m`;
   }
   return null;
+};
+
+export const formatSpellVariantSummaryLines = (
+  variant: Pick<SpellVariant, "effects" | "manualNotes"> | null | undefined,
+) => {
+  const effectLines = (variant?.effects ?? [])
+    .map((effect: SpellDeclarativeEffect) => formatDeclarativeEffectSummaryLine(effect))
+    .filter((line): line is string => Boolean(line));
+  const manualLines = (variant?.manualNotes ?? []).map((note) => `${note.label} - ${note.description}`);
+  return [...effectLines, ...manualLines];
 };
 
 export const filterManualNotesByAppliedEffects = (

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardPage.tsx
@@ -468,6 +468,7 @@ export const PlayerBoardPage = () => {
             onClearConcentration={handleClearConcentration}
             onRemoveEffect={handleRemoveEffect}
             pendingRoll={pendingRoll}
+            participant={combatBarState.myParticipant ?? null}
             playerSheet={playerSheet}
             playerStatus={playerStatus}
             removingEffectId={removingEffectId}

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.test.tsx
@@ -364,6 +364,37 @@ describe("PlayerBoardStatusPanel", () => {
     expect(markup).toContain("Encerrando...");
   });
 
+  it("mostra tamanho efetivo traduzido quando difere do tamanho base", () => {
+    const markup = renderToStaticMarkup(
+      <PlayerBoardStatusPanel
+        combatActive={false}
+        participant={{ base_size: "medium", effective_size: "large" } as any}
+        pendingRoll={null}
+        playerStatus={{
+          level: 3,
+          currentHp: 20,
+          maxHp: 20,
+          hpPercent: 100,
+          tempHp: 0,
+          xpPercent: 10,
+          nextLevelThreshold: 900,
+          experiencePoints: 100,
+          ac: 12,
+          initiative: 1,
+          passivePerception: 13,
+        } as any}
+        restState="exploration"
+        usingHitDie={false}
+        onUseHitDie={() => undefined}
+        onClearConcentration={() => undefined}
+        onRemoveEffect={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Tamanho");
+    expect(markup).toContain("Grande (base Médio)");
+  });
+
   it("não renderiza card de concentração quando activeConcentration é nulo", () => {
     const markup = renderToStaticMarkup(
       <PlayerBoardStatusPanel

--- a/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/PlayerBoardStatusPanel.tsx
@@ -1,12 +1,16 @@
 import type { ActiveConcentration, OutOfCombatCastableSpell } from "../../entities/character";
-import type { ActiveEffect } from "../../shared/api/combatRepo";
+import type { ActiveEffect, CombatParticipant } from "../../shared/api/combatRepo";
 import type { CharacterSheet } from "../../features/character-sheet/model/characterSheet.types";
 import { OutOfCombatSpellCastCard } from "./OutOfCombatSpellCastCard";
 import { useLocale } from "../../shared/hooks/useLocale";
 import { SpellSlotSummary } from "../../shared/ui/SpellSlotSummary";
 import { formatPassiveBonusBreakdown } from "../../features/character-sheet/utils/passiveSkillBonusDisplay";
 import { formatActiveConcentrationLabel } from "./concentrationLabel";
-import { formatActiveEffectLabel, getActiveEffectLifecycleBadges } from "../../features/active-effects";
+import {
+  formatEffectiveCreatureSize,
+  getActiveEffectLifecycleBadges,
+  groupActiveEffectsForDisplay,
+} from "../../features/active-effects";
 import type { PendingRoll, PlayerBoardStatusSummary } from "./playerBoard.types";
 import {
   DeathSaveCard,
@@ -39,6 +43,7 @@ type Props = {
   pendingRoll: PendingRoll | null;
   playerSheet?: CharacterSheet | null;
   playerStatus: PlayerBoardStatusSummary | null;
+  participant?: Pick<CombatParticipant, "base_size" | "effective_size"> | null;
   removingEffectId?: string | null;
   restState: "exploration" | "short_rest" | "long_rest";
   targetOptions?: Array<{ playerUserId: string; label: string }>;
@@ -59,6 +64,7 @@ export const PlayerBoardStatusPanel = ({
   pendingRoll,
   playerSheet,
   playerStatus,
+  participant = null,
   removingEffectId,
   restState,
   targetOptions,
@@ -66,6 +72,8 @@ export const PlayerBoardStatusPanel = ({
   onUseHitDie,
 }: Props) => {
   const { t } = useLocale();
+  const activeEffectGroups = groupActiveEffectsForDisplay(activeSpellEffects ?? []);
+  const effectiveSizeLabel = participant ? formatEffectiveCreatureSize(participant, "pt") : null;
 
   return (
     <section className="rounded-4xl border border-white/8 bg-[linear-gradient(180deg,rgba(15,23,42,0.82),rgba(2,6,23,0.94))] p-6 shadow-[0_18px_60px_rgba(2,6,23,0.2)]">
@@ -174,6 +182,14 @@ export const PlayerBoardStatusPanel = ({
                   : null
               }
             />
+            {effectiveSizeLabel ? (
+              <StatCard
+                label={t("playerBoard.creatureSizeLabel")}
+                mobileLabel={t("playerBoard.creatureSizeLabel")}
+                value={effectiveSizeLabel.replace(/^Tamanho atual: /, "")}
+                accent="text-fuchsia-200"
+              />
+            ) : null}
           </div>
 
           <div className="mt-3">
@@ -241,14 +257,21 @@ export const PlayerBoardStatusPanel = ({
                 {t("playerBoard.activeEffectsLabel")}
               </p>
               <ul className="mt-3 space-y-2">
-                {activeSpellEffects.map((effect) => {
-                  const label = formatActiveEffectLabel(effect) ?? t("playerBoard.activeEffectFallback");
-                  const lifecycleBadges = getActiveEffectLifecycleBadges(effect);
-                  const isRemoving = removingEffectId === effect.id;
+                {activeEffectGroups.map((group, groupIndex) => {
+                  const primaryEffect = group.effects[0] as ActiveEffect | undefined;
+                  const lifecycleBadges = primaryEffect ? getActiveEffectLifecycleBadges(primaryEffect) : [];
+                  const title = group.title ?? t("playerBoard.activeEffectFallback");
                   return (
-                    <li key={effect.id} className="flex items-center justify-between gap-3">
+                    <li key={group.groupKey ?? primaryEffect?.id ?? groupIndex} className="flex items-start justify-between gap-3">
                       <div className="min-w-0">
-                        <p className="truncate text-sm font-medium text-white">{label}</p>
+                        <p className="truncate text-sm font-medium text-white">{title}</p>
+                        {group.summaryLines.length > 0 ? (
+                          <div className="mt-1 space-y-0.5 text-xs text-slate-300">
+                            {group.summaryLines.map((line, index) => (
+                              <p key={`${line}:${index}`}>{line}</p>
+                            ))}
+                          </div>
+                        ) : null}
                         {lifecycleBadges.length > 0 ? (
                           <p className="mt-0.5 flex flex-wrap gap-x-1.5 gap-y-0.5">
                             {lifecycleBadges.map((badge, index) => (
@@ -266,14 +289,22 @@ export const PlayerBoardStatusPanel = ({
                           </p>
                         ) : null}
                       </div>
-                      <button
-                        type="button"
-                        onClick={() => onRemoveEffect(effect.id)}
-                        disabled={isRemoving}
-                        className="shrink-0 rounded-full bg-white/8 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.22em] text-slate-300 transition hover:bg-red-500/20 hover:text-red-300 disabled:cursor-not-allowed disabled:opacity-50"
-                      >
-                        {isRemoving ? t("playerBoard.removingEffect") : t("playerBoard.removeEffect")}
-                      </button>
+                      <div className="flex shrink-0 flex-wrap justify-end gap-1">
+                        {(group.effects as ActiveEffect[]).map((effect) => {
+                          const isRemoving = removingEffectId === effect.id;
+                          return (
+                            <button
+                              key={effect.id}
+                              type="button"
+                              onClick={() => onRemoveEffect(effect.id)}
+                              disabled={isRemoving}
+                              className="rounded-full bg-white/8 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.22em] text-slate-300 transition hover:bg-red-500/20 hover:text-red-300 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                              {isRemoving ? t("playerBoard.removingEffect") : t("playerBoard.removeEffect")}
+                            </button>
+                          );
+                        })}
+                      </div>
                     </li>
                   );
                 })}

--- a/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/player-combat-debug/PlayerSpellCastDialog.tsx
@@ -11,6 +11,7 @@ import type {
 } from "../../../shared/api/combatRepo";
 import { combatRepo } from "../../../shared/api/combatRepo";
 import { toPlayerFriendlyError } from "../../../features/combat-ui/combatErrors";
+import { formatSpellVariantSummaryLines } from "../../../features/combat-ui/spellVariantUi";
 import { useTargetingPreview } from "../../../features/combat-ui/hooks/useTargetingPreview";
 import {
   getDamageRollCount,
@@ -700,7 +701,7 @@ export const PlayerSpellCastDialog = ({
         await onResolved?.(resolved);
       }
     } catch (err: any) {
-      setError(toPlayerFriendlyError(err?.data?.detail || err?.message || "Falha ao conjurar magia"));
+      setError(toPlayerFriendlyError(err?.data?.detail ?? err?.data ?? err?.message ?? "Falha ao conjurar magia"));
       setTargetingMode(isAreaSpell ? "area_target_select" : "single_target_select");
       setAttackMode("choose");
     } finally {
@@ -790,12 +791,22 @@ export const PlayerSpellCastDialog = ({
             {selectedVariantKey
               ? spellVariants
                   .filter((variant) => variant.key === selectedVariantKey)
-                  .flatMap((variant) => variant.manualNotes ?? [])
-                  .map((note) => (
-                    <p key={note.key} className="text-xs text-amber-100">
-                      Automação parcial: {note.label} - {note.description}
-                    </p>
-                  ))
+                  .map((variant) => {
+                    const summaryLines = formatSpellVariantSummaryLines(variant);
+                    const label = variant.labelPt ?? variant.labelEn ?? variant.key;
+                    return (
+                      <div key={variant.key} className="rounded-2xl border border-fuchsia-500/15 bg-fuchsia-500/8 px-3 py-2">
+                        <p className="text-sm font-semibold text-fuchsia-100">{label}</p>
+                        {summaryLines.length ? (
+                          <ul className="mt-2 space-y-1 text-xs text-slate-300">
+                            {summaryLines.map((line, index) => (
+                              <li key={`${variant.key}:${index}`}>{line}</li>
+                            ))}
+                          </ul>
+                        ) : null}
+                      </div>
+                    );
+                  })
               : null}
           </div>
         ) : null}

--- a/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
@@ -48,6 +48,7 @@ export const playerBoardEnUSDictionary = {
   "playerBoard.hpTrackLabel": "Hit points",
   "playerBoard.xpTrackLabel": "XP progress",
   "playerBoard.initiativeLabel": "Initiative",
+  "playerBoard.creatureSizeLabel": "Size",
   "playerBoard.rollBaseLabel": "Roll base",
   "playerBoard.rollBaseFallback": "AC ready for combat",
   "playerBoard.waitingSheetState": "Waiting for the live sheet to build the combat panel.",

--- a/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
@@ -48,6 +48,7 @@ export const playerBoardPtBRDictionary = {
   "playerBoard.hpTrackLabel": "Pontos de vida",
   "playerBoard.xpTrackLabel": "Progresso de XP",
   "playerBoard.initiativeLabel": "Iniciativa",
+  "playerBoard.creatureSizeLabel": "Tamanho",
   "playerBoard.rollBaseLabel": "Base de rolagem",
   "playerBoard.rollBaseFallback": "AC pronta para combate",
   "playerBoard.waitingSheetState": "Aguardando a ficha em tempo real para montar o painel de combate.",


### PR DESCRIPTION
# PR: ui(combat) human-friendly feedback for size modifiers and declarative effects (#291)

## Description

Este PR implementa o refinamento da interface de usuário para o sistema de efeitos declarativos, com foco especial na magia *Aumentar/Reduzir*. As mudanças incluem tradução de erros técnicos para mensagens amigáveis, agrupamento inteligente de efeitos ativos e exibição dinâmica do tamanho efetivo das criaturas.

## Changes

### Erros e Feedback (`combatErrors.ts`)
- **Human-friendly Errors:** Implementada a detecção do erro `invalid_effective_footprint`. O sistema agora reconhece esse erro tanto em formatos estruturados quanto em strings brutas.
- **PT-BR Localization:** O erro é mapeado para a mensagem amigável: **"Não há espaço suficiente para Aumentar este alvo."**, informando claramente ao jogador por que a magia falhou no grid.

### Resumos de Variantes (`spellVariantUi.ts`)
- **Declarative Summary:** Nova lógica de formatação para transformar metadados em texto legível:
    - `size_modifier +1/-1` → "Tamanho aumentado" / "Tamanho reduzido".
    - `advantage_on_checks/saves` → "Vantagem em testes/salvaguardas de {Atributo}".
    - `modify_weapon_damage` → "Dano de arma ±1d4".
- **Label Resolution:** Melhoria na identificação da variante selecionada (`selected_variant_label`) com fallbacks inteligentes para anotações manuais ou chaves humanizadas.

### Agrupamento de Efeitos Ativos (`activeEffectDisplay.ts`)
- **Smart Grouping:** Efeitos são agrupados por `declarative_effect_group_id` ou `concentration_group`. Isso limpa a interface, mostrando uma única "caixa" para magias complexas com múltiplos sub-efeitos.
- **Dynamic Titles:** Títulos de grupos agora seguem a hierarquia: `Nome da Magia — Variante` -> `Nome da Magia` -> `Label Técnico`.
- **Size Display:** Adicionada a função `formatEffectiveCreatureSize()`. O tamanho da criatura agora é exibido apenas quando difere da base (ex: **"Grande (base Médio)"**).

### Componentes de UI
- **Cast Dialog:** O seletor de variante agora exibe um resumo compacto dos efeitos antes da confirmação, ajudando na decisão tática.
- **Status Panel:** O painel de status do jogador agora reflete as mudanças de tamanho em tempo real com labels em PT-BR (Minúsculo a Colossal).

## Summary of Changes

| Component | Change |
| :--- | :--- |
| **`combatErrors`** | Translation of spatial conflicts into human-readable warnings |
| **`spellVariantUi`** | Rich PT-BR formatting for complex declarative effects |
| **`activeEffectDisplay`** | Effect grouping logic and dynamic size labels |
| **`UI Components`** | Integration of summaries in Cast Dialog and Result Panel |

## Validation

A suíte de testes foi expandida para garantir que a tradução e o agrupamento não omitam informações críticas:

- **`combatErrors.test.ts`:** Validação da detecção de erro em múltiplos formatos de payload.
- **`spellVariantUi.test.ts`:** 232 linhas de teste cobrindo todas as novas strings de resumo em PT-BR.
- **`activeEffectDisplay.test.ts`:** Testes de agrupamento, títulos e lógica de exibição de tamanho condicional.
- **E2E Integration:** Testes de renderização nos componentes `PlayerSpellCastDialog`, `SpellCastResultPanel` e `PlayerBoardStatusPanel`.

> [!TIP]
> Com esta atualização, o VTT deixa de exibir "ActiveEffect #123" e passa a exibir "Armadura Arcana: +3 AC", elevando drasticamente a clareza para mestres e jogadores.