### PR TITLE
feat(encumbrance) dynamic carrying capacity multiplier

### DIFF
--- a/apps/control-server/app/services/combat_service/condition_effects_predicates.py
+++ b/apps/control-server/app/services/combat_service/condition_effects_predicates.py
@@ -176,12 +176,18 @@ def is_lightly_obscured(participant: dict) -> bool:
     return has_condition(participant, "lightly_obscured")
 
 
-def compute_encumbrance_tier_from_lb(strength_score: float, weight_lb: float) -> str:
-    if weight_lb > strength_score * 15:
+def compute_encumbrance_tier_from_lb(
+    strength_score: float,
+    weight_lb: float,
+    *,
+    capacity_multiplier: float = 1.0,
+) -> str:
+    effective = strength_score * capacity_multiplier
+    if weight_lb > effective * 15:
         return "overloaded"
-    if weight_lb > strength_score * 10:
+    if weight_lb > effective * 10:
         return "heavily_encumbered"
-    if weight_lb > strength_score * 5:
+    if weight_lb > effective * 5:
         return "encumbered"
     return "normal"
 
@@ -205,7 +211,8 @@ def _get_encumbrance_tier_for_participant(participant: dict) -> str:
     weight_kg = participant.get("total_weight_kg")
     if isinstance(strength, (int, float)) and isinstance(weight_kg, (int, float)) and strength > 0:
         weight_lb = weight_kg / _LB_TO_KG
-        return compute_encumbrance_tier_from_lb(strength, weight_lb)
+        multiplier = get_carrying_capacity_multiplier(participant)
+        return compute_encumbrance_tier_from_lb(strength, weight_lb, capacity_multiplier=multiplier)
 
     return "normal"
 

--- a/apps/control-server/app/services/combat_service/lifecycle_initiative.py
+++ b/apps/control-server/app/services/combat_service/lifecycle_initiative.py
@@ -8,7 +8,7 @@ from app.models.session import Session as CampaignSession
 from app.schemas.campaign import decode_blocked_cells, decode_edge_obstacles, decode_obstacles
 from app.schemas.combat import CombatMapSelection
 
-from .condition_effects_predicates import compute_encumbrance_tier_from_lb
+from .condition_effects_predicates import compute_encumbrance_tier_from_lb, get_carrying_capacity_multiplier
 from .exceptions import CombatServiceError
 from .limiar_map_projection import (
     maybe_project_combat_start_to_limiar_map as _project_combat_start_to_limiar_map,
@@ -64,7 +64,7 @@ def get_player_total_inventory_weight_lb(db, session_id: str, player_user_id: st
     return float(result or 0.0)
 
 
-def _encumbrance_tier_for_player(db, session_id: str, player_user_id: str) -> str:
+def _encumbrance_tier_for_player(db, session_id: str, player_user_id: str, *, active_effects: list | None = None) -> str:
     from app.models.session_state import SessionState
 
     entry = db.exec(
@@ -78,7 +78,12 @@ def _encumbrance_tier_for_player(db, session_id: str, player_user_id: str) -> st
     sj = entry.state_json or {}
     strength = float((sj.get("abilities") or {}).get("strength") or 10)
     total_lb = get_player_total_inventory_weight_lb(db, session_id, player_user_id)
-    return compute_encumbrance_tier_from_lb(strength, total_lb)
+    capacity_multiplier = (
+        get_carrying_capacity_multiplier({"active_effects": active_effects})
+        if active_effects
+        else 1.0
+    )
+    return compute_encumbrance_tier_from_lb(strength, total_lb, capacity_multiplier=capacity_multiplier)
 
 
 class CombatLifecycleInitiativeMixin:
@@ -163,6 +168,9 @@ class CombatLifecycleInitiativeMixin:
                 entry["encumbrance_tier"] = _encumbrance_tier_for_player(db, session_id, p.ref_id)
                 from .persistent_effects import restore_persisted_effects
                 restore_persisted_effects(db, session_id, entry)
+                entry["encumbrance_tier"] = _encumbrance_tier_for_player(
+                    db, session_id, p.ref_id, active_effects=entry.get("active_effects"),
+                )
             built_participants.append(entry)
 
         new_state = CombatState(
@@ -204,7 +212,8 @@ class CombatLifecycleInitiativeMixin:
         participant = cls._get_participant_by_ref(state, player_user_id)
         if not participant:
             return False
-        new_tier = _encumbrance_tier_for_player(db, session_id, player_user_id)
+        active_effects = participant.get("active_effects")
+        new_tier = _encumbrance_tier_for_player(db, session_id, player_user_id, active_effects=active_effects)
         old_tier = participant.get("encumbrance_tier", "normal")
         if new_tier == old_tier:
             return False

--- a/apps/control-server/tests/test_encumbrance_capacity_multiplier.py
+++ b/apps/control-server/tests/test_encumbrance_capacity_multiplier.py
@@ -1,0 +1,342 @@
+"""Test: carrying capacity multiplier applied to encumbrance tier recomputation.
+
+Validates that:
+- compute_encumbrance_tier_from_lb accepts capacity_multiplier and scales thresholds
+- _encumbrance_tier_for_player reads active_effects and passes the multiplier
+- _get_encumbrance_tier_for_participant uses get_carrying_capacity_multiplier
+- recompute_participant_encumbrance_tier passes participant active_effects
+- removing the effect reverts the tier
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from app.models.combat import CombatPhase
+from app.services.combat_service.condition_effects_predicates import (
+    compute_encumbrance_tier_from_lb,
+    _get_encumbrance_tier_for_participant,
+)
+from app.services.combat_service.lifecycle_initiative import (
+    CombatLifecycleInitiativeMixin,
+    _encumbrance_tier_for_player,
+)
+
+_LB_TO_KG = 0.45359237
+
+
+def _kg_to_lb(kg: float) -> float:
+    return kg / _LB_TO_KG
+
+
+def _carry_effect(multiplier: float, group_id: str | None = None) -> dict:
+    metadata: dict = {
+        "source_spell_name": "Enhance Ability",
+        "declarative_effect_group_id": group_id or "enhance_ability|bulls_strength|carrying_capacity_multiplier|2",
+        "declarative_effect": {
+            "type": "carrying_capacity_multiplier",
+            "params": {"multiplier": multiplier},
+        },
+    }
+    return {
+        "id": f"eff-carry-{multiplier}",
+        "kind": "spell_effect",
+        "metadata": metadata,
+    }
+
+
+def _make_db(strength: int = 10, weight_lb: float = 0.0) -> MagicMock:
+    db = MagicMock()
+    session_state = MagicMock()
+    session_state.state_json = {"abilities": {"strength": strength}}
+    campaign_session = MagicMock()
+    campaign_session.campaign_id = "camp-1"
+    member = MagicMock()
+    member.id = "member-1"
+    db.exec.side_effect = [
+        MagicMock(first=MagicMock(return_value=session_state)),
+        MagicMock(first=MagicMock(return_value=campaign_session)),
+        MagicMock(first=MagicMock(return_value=member)),
+        MagicMock(scalar=MagicMock(return_value=weight_lb)),
+    ]
+    return db
+
+
+class TestComputeEncumbranceTierWithMultiplier(unittest.TestCase):
+
+    def test_default_multiplier_preserves_existing_behavior(self):
+        self.assertEqual(compute_encumbrance_tier_from_lb(10, 30), "normal")
+        self.assertEqual(compute_encumbrance_tier_from_lb(10, 50), "normal")
+        self.assertEqual(compute_encumbrance_tier_from_lb(10, 50.1), "encumbered")
+        self.assertEqual(compute_encumbrance_tier_from_lb(10, 100), "encumbered")
+        self.assertEqual(compute_encumbrance_tier_from_lb(10, 100.1), "heavily_encumbered")
+        self.assertEqual(compute_encumbrance_tier_from_lb(10, 150), "heavily_encumbered")
+        self.assertEqual(compute_encumbrance_tier_from_lb(10, 150.1), "overloaded")
+
+    def test_x2_multiplier_doubles_effective_strength(self):
+        self.assertEqual(
+            compute_encumbrance_tier_from_lb(10, 100, capacity_multiplier=2.0),
+            "normal",
+        )
+        self.assertEqual(
+            compute_encumbrance_tier_from_lb(10, 100.1, capacity_multiplier=2.0),
+            "encumbered",
+        )
+        self.assertEqual(
+            compute_encumbrance_tier_from_lb(10, 200, capacity_multiplier=2.0),
+            "encumbered",
+        )
+        self.assertEqual(
+            compute_encumbrance_tier_from_lb(10, 200.1, capacity_multiplier=2.0),
+            "heavily_encumbered",
+        )
+        self.assertEqual(
+            compute_encumbrance_tier_from_lb(10, 300, capacity_multiplier=2.0),
+            "heavily_encumbered",
+        )
+        self.assertEqual(
+            compute_encumbrance_tier_from_lb(10, 300.1, capacity_multiplier=2.0),
+            "overloaded",
+        )
+
+    def test_x2_heavy_weight_becomes_encumbered_not_heavily(self):
+        self.assertEqual(
+            compute_encumbrance_tier_from_lb(10, 120, capacity_multiplier=2.0),
+            "encumbered",
+        )
+
+    def test_x2_light_weight_stays_normal(self):
+        self.assertEqual(
+            compute_encumbrance_tier_from_lb(10, 80, capacity_multiplier=2.0),
+            "normal",
+        )
+
+    def test_x3_multiplier_triples_effective_strength(self):
+        self.assertEqual(
+            compute_encumbrance_tier_from_lb(10, 150, capacity_multiplier=3.0),
+            "normal",
+        )
+        self.assertEqual(
+            compute_encumbrance_tier_from_lb(10, 150.1, capacity_multiplier=3.0),
+            "encumbered",
+        )
+        self.assertEqual(
+            compute_encumbrance_tier_from_lb(10, 450.1, capacity_multiplier=3.0),
+            "overloaded",
+        )
+
+    def test_boundary_exact_threshold_with_x2(self):
+        self.assertEqual(
+            compute_encumbrance_tier_from_lb(10, 50.0, capacity_multiplier=2.0),
+            "normal",
+        )
+        self.assertEqual(
+            compute_encumbrance_tier_from_lb(10, 100.0, capacity_multiplier=2.0),
+            "normal",
+        )
+
+
+class TestEncumbranceTierForPlayerWithMultiplier(unittest.TestCase):
+
+    def test_no_effects_uses_default_multiplier(self):
+        db = _make_db(strength=10, weight_lb=120.0)
+        self.assertEqual(
+            _encumbrance_tier_for_player(db, "s1", "u1", active_effects=[]),
+            "heavily_encumbered",
+        )
+
+    def test_x2_effect_downgrades_from_heavily_to_encumbered(self):
+        db = _make_db(strength=10, weight_lb=120.0)
+        effects = [_carry_effect(2.0)]
+        self.assertEqual(
+            _encumbrance_tier_for_player(db, "s1", "u1", active_effects=effects),
+            "encumbered",
+        )
+
+    def test_x2_effect_light_weight_normal(self):
+        db = _make_db(strength=10, weight_lb=80.0)
+        effects = [_carry_effect(2.0)]
+        self.assertEqual(
+            _encumbrance_tier_for_player(db, "s1", "u1", active_effects=effects),
+            "normal",
+        )
+
+    def test_x2_effect_on_boundary(self):
+        db = _make_db(strength=10, weight_lb=100.1)
+        effects = [_carry_effect(2.0)]
+        self.assertEqual(
+            _encumbrance_tier_for_player(db, "s1", "u1", active_effects=effects),
+            "encumbered",
+        )
+
+    def test_x2_effect_heavy_weight_heavily_encumbered(self):
+        db = _make_db(strength=10, weight_lb=250.0)
+        effects = [_carry_effect(2.0)]
+        self.assertEqual(
+            _encumbrance_tier_for_player(db, "s1", "u1", active_effects=effects),
+            "heavily_encumbered",
+        )
+
+    def test_x2_effect_overloaded_still_overloaded(self):
+        db = _make_db(strength=10, weight_lb=350.0)
+        effects = [_carry_effect(2.0)]
+        self.assertEqual(
+            _encumbrance_tier_for_player(db, "s1", "u1", active_effects=effects),
+            "overloaded",
+        )
+
+    def test_none_active_effects_uses_default_multiplier(self):
+        db = _make_db(strength=10, weight_lb=120.0)
+        self.assertEqual(
+            _encumbrance_tier_for_player(db, "s1", "u1", active_effects=None),
+            "heavily_encumbered",
+        )
+
+    def test_without_active_effects_kwarg_preserves_behavior(self):
+        db = _make_db(strength=10, weight_lb=120.0)
+        self.assertEqual(
+            _encumbrance_tier_for_player(db, "s1", "u1"),
+            "heavily_encumbered",
+        )
+
+
+class TestGetEncumbranceTierForParticipantWithMultiplier(unittest.TestCase):
+
+    def test_with_x2_effect_and_fallback_computation(self):
+        participant = {
+            "id": "p1",
+            "strength_score": 10,
+            "total_weight_kg": 45.0,
+            "active_effects": [_carry_effect(2.0)],
+        }
+        self.assertEqual(
+            _get_encumbrance_tier_for_participant(participant),
+            "normal",
+        )
+
+    def test_without_effect_uses_default(self):
+        participant = {
+            "id": "p1",
+            "strength_score": 10,
+            "total_weight_kg": 45.0,
+            "active_effects": [],
+        }
+        self.assertEqual(
+            _get_encumbrance_tier_for_participant(participant),
+            "encumbered",
+        )
+
+    def test_with_x2_effect_medium_weight_encumbered(self):
+        participant = {
+            "id": "p1",
+            "strength_score": 10,
+            "total_weight_kg": 55.0,
+            "active_effects": [_carry_effect(2.0)],
+        }
+        self.assertEqual(
+            _get_encumbrance_tier_for_participant(participant),
+            "encumbered",
+        )
+
+
+def _state_with_effects(
+    encumbrance_tier: str = "normal",
+    phase=CombatPhase.active,
+    active_effects: list | None = None,
+) -> MagicMock:
+    s = MagicMock()
+    s.phase = phase
+    s.participants = [
+        {
+            "id": "p1",
+            "ref_id": "user-1",
+            "kind": "player",
+            "encumbrance_tier": encumbrance_tier,
+            "active_effects": active_effects or [],
+        }
+    ]
+    return s
+
+
+class _CombatMixin(CombatLifecycleInitiativeMixin):
+    @classmethod
+    def _get_participant_by_ref(cls, state, ref_id):
+        return next(
+            (p for p in state.participants if p.get("ref_id") == ref_id), None
+        )
+
+
+def _recompute(db, state, player_user_id="user-1") -> bool:
+    return _CombatMixin.recompute_participant_encumbrance_tier(db, "s1", state, player_user_id)
+
+
+class TestRecomputeWithMultiplier(unittest.TestCase):
+
+    def test_x2_effect_changes_tier_from_heavily_to_encumbered(self):
+        db = _make_db(strength=10, weight_lb=120.0)
+        state = _state_with_effects(
+            encumbrance_tier="heavily_encumbered",
+            active_effects=[_carry_effect(2.0)],
+        )
+        changed = _recompute(db, state)
+        self.assertTrue(changed)
+        self.assertEqual(state.participants[0]["encumbrance_tier"], "encumbered")
+
+    def test_x2_effect_keeps_normal_when_weight_within_doubled_threshold(self):
+        db = _make_db(strength=10, weight_lb=80.0)
+        state = _state_with_effects(
+            encumbrance_tier="normal",
+            active_effects=[_carry_effect(2.0)],
+        )
+        changed = _recompute(db, state)
+        self.assertFalse(changed)
+        self.assertEqual(state.participants[0]["encumbrance_tier"], "normal")
+
+    def test_no_effect_preserves_existing_tier(self):
+        db = _make_db(strength=10, weight_lb=120.0)
+        state = _state_with_effects(
+            encumbrance_tier="heavily_encumbered",
+            active_effects=[],
+        )
+        changed = _recompute(db, state)
+        self.assertFalse(changed)
+        self.assertEqual(state.participants[0]["encumbrance_tier"], "heavily_encumbered")
+
+    def test_removing_effect_reverts_tier(self):
+        db = _make_db(strength=10, weight_lb=120.0)
+        state = _state_with_effects(
+            encumbrance_tier="encumbered",
+            active_effects=[],
+        )
+        changed = _recompute(db, state)
+        self.assertTrue(changed)
+        self.assertEqual(state.participants[0]["encumbrance_tier"], "heavily_encumbered")
+
+    def test_x2_effect_heavy_weight_still_overloaded(self):
+        db = _make_db(strength=10, weight_lb=350.0)
+        state = _state_with_effects(
+            encumbrance_tier="overloaded",
+            active_effects=[_carry_effect(2.0)],
+        )
+        changed = _recompute(db, state)
+        self.assertFalse(changed)
+        self.assertEqual(state.participants[0]["encumbrance_tier"], "overloaded")
+
+    def test_x2_effect_medium_weight_becomes_encumbered(self):
+        db = _make_db(strength=10, weight_lb=150.0)
+        state = _state_with_effects(
+            encumbrance_tier="overloaded",
+            active_effects=[_carry_effect(2.0)],
+        )
+        changed = _recompute(db, state)
+        self.assertTrue(changed)
+        self.assertEqual(state.participants[0]["encumbrance_tier"], "encumbered")
+
+    def test_phase_ignored_during_initiative(self):
+        db = _make_db(strength=10, weight_lb=120.0)
+        state = _state_with_effects(
+            encumbrance_tier="heavily_encumbered",
+            phase=CombatPhase.initiative,
+            active_effects=[_carry_effect(2.0)],
+        )
+        changed = _recompute(db, state)
+        self.assertFalse(changed)


### PR DESCRIPTION
# PR: feat(encumbrance) dynamic carrying capacity multiplier

## Description

Este PR implementa o suporte para modificadores dinâmicos de capacidade de carga. Agora, o sistema de encumbramento respeita o multiplicador de capacidade vindo de efeitos ativos (`carrying_capacity_multiplier`), garantindo que magias como *Bull's Strength* ou habilidades de classe reflitam corretamente no peso que um personagem pode carregar sem penalidades, tanto em combate quanto em exploração.

## Changes

### Predicates & Logic (`condition_effects_predicates.py`)
- **`compute_encumbrance_tier_from_lb`**: Atualizado para aceitar `capacity_multiplier`. O cálculo de força efetiva agora utiliza esse multiplicador para escalar todos os thresholds (Light, Medium, Heavy, Overburdened). O valor padrão `1.0` garante compatibilidade total com o comportamento legado.
- **`_get_encumbrance_tier_for_participant`**: Agora busca o multiplicador atual do participante antes de calcular o tier de encumbramento, garantindo que efeitos de capacidade sejam considerados na leitura de estado.

### Combat Lifecycle (`lifecycle_initiative.py`)
- **`_encumbrance_tier_for_player`**: Adicionado suporte para injetar `active_effects` no cálculo, permitindo a resolução do multiplicador via metadados de efeitos ativos.
- **`recompute_participant_encumbrance_tier`**: Atualizado para propagar os efeitos ativos do participante durante o re-cálculo de carga.
- **`start_combat`**: O início do combate agora força um re-cálculo de encumbramento logo após a restauração de efeitos persistidos. Isso garante que um personagem com *Bull's Strength* ativo antes da iniciativa comece a luta com o peso e movimentação corrigidos.

## Summary of Changes

| Component | Change |
| :--- | :--- |
| **`Encumbrance Engine`** | Scale thresholds based on dynamic capacity multiplier |
| **`Active Effects`** | Bull's Strength (x2) now affects movement penalties in real-time |
| **`Combat Start`** | Correctly accounts for persisted OOC capacity buffs |
| **`Test Suite`** | 24 new specialized tests for capacity and boundaries |

## Validation

A implementação foi validada através de uma nova suíte de testes robusta e pela suíte de regressão do sistema:

- **`test_encumbrance_capacity_multiplier.py`**: 24 novos testes cobrindo:
    - Escalonamento de thresholds (x2, x3) e limites de fronteira.
    - Comportamento com efeitos ausentes ou nulos.
    - Re-cálculo atômico após remoção ou adição de buffs.
- **Regressão:** 2303+ testes passando (as falhas pré-existentes permanecem isoladas e não foram afetadas por estas mudanças).

> [!TIP]
> Com esta mudança, o peso de itens pesados no inventário deixará de aplicar penalidades de movimentação automaticamente se o personagem estiver sob efeito de magias de aumento de força, tornando o gerenciamento de carga muito mais fluido no VTT.