### PR TITLE
 PR: feat(combat) size-based melee reach bonus (#297)

### DIFF
--- a/apps/control-server/app/services/combat_service/actions/weapon_attack_roll.py
+++ b/apps/control-server/app/services/combat_service/actions/weapon_attack_roll.py
@@ -46,6 +46,7 @@ class WeaponAttackRollMixin:
             range_long_meters=attack_context.get("range_long_meters"),
             weapon_range_type=attack_context.get("weapon_range_type"),
             has_reach=bool(attack_context.get("has_reach")),
+            actor_effective_size=attacker.get("effective_size"),
             requires_sight=resolve_weapon_targeting_requirements().requires_target_sight,
             requires_effect=resolve_weapon_targeting_requirements().requires_target_effect,
         )
@@ -77,6 +78,7 @@ class WeaponAttackRollMixin:
             range_meters=attack_context.get("range_meters"),
             range_long_meters=attack_context.get("range_long_meters"),
             has_reach=bool(attack_context.get("has_reach")),
+            effective_size=attacker.get("effective_size"),
             distance_meters=targeting_result.spatial_metadata.distance_meters,
         )
         adv_ctx = resolve_attack_advantage(attacker, target, attack_kind)

--- a/apps/control-server/app/services/combat_service/actions/wild_shape.py
+++ b/apps/control-server/app/services/combat_service/actions/wild_shape.py
@@ -135,6 +135,7 @@ class WildShapeMixin:
             is_wild_shape=True,
             weapon_range_type=BaseItemWeaponRangeType.MELEE.value,
             has_reach=natural_attack.has_reach,
+            actor_effective_size=attacker.get("effective_size") or attacker.get("base_size"),
             requires_sight=weapon_targeting.requires_target_sight,
             requires_effect=weapon_targeting.requires_target_effect,
         )

--- a/apps/control-server/app/services/combat_service/combat_targeting.py
+++ b/apps/control-server/app/services/combat_service/combat_targeting.py
@@ -106,6 +106,7 @@ def _build_map_spatial_metadata(
         range_long_meters=intent.range_long_meters,
         weapon_range_type=intent.weapon_range_type,
         has_reach=intent.has_reach,
+        effective_size=getattr(intent, "actor_effective_size", None),
     )
     if weapon_profile.normal_range is None:
         return spatial_metadata
@@ -209,6 +210,7 @@ def _derive_range_cells(intent: ActionIntent) -> int | None:
         range_long_meters=intent.range_long_meters,
         weapon_range_type=intent.weapon_range_type,
         has_reach=intent.has_reach,
+        effective_size=getattr(intent, "actor_effective_size", None),
     )
     if profile.max_range is not None:
         return meters_to_cells(profile.max_range)

--- a/apps/control-server/app/services/combat_service/combat_targeting_local.py
+++ b/apps/control-server/app/services/combat_service/combat_targeting_local.py
@@ -188,6 +188,7 @@ class LocalCombatTargetingService(CombatTargetingService):
                 range_long_meters=getattr(intent, "range_long_meters", None),
                 weapon_range_type=getattr(intent, "weapon_range_type", None),
                 has_reach=getattr(intent, "has_reach", False),
+                effective_size=getattr(intent, "actor_effective_size", None),
             )
             max_range = weapon_profile.max_range
             range_failure = weapon_profile.failure_reason

--- a/apps/control-server/app/services/combat_service/combat_targeting_map.py
+++ b/apps/control-server/app/services/combat_service/combat_targeting_map.py
@@ -85,6 +85,7 @@ class LimiarMapTargetingService(CombatTargetingService):
                 range_long_meters=intent.range_long_meters,
                 weapon_range_type=intent.weapon_range_type,
                 has_reach=intent.has_reach,
+                effective_size=getattr(intent, "actor_effective_size", None),
             )
             if weapon_profile.failure_reason is not None:
                 diag.set_check(CHECK_IN_RANGE, False)

--- a/apps/control-server/app/services/combat_service/condition_effects_attacks.py
+++ b/apps/control-server/app/services/combat_service/condition_effects_attacks.py
@@ -83,7 +83,9 @@ def resolve_spell_attack_kind(spell_or_action: dict | None = None) -> str:  # no
     return "ranged"
 
 
-def get_effective_reach(base_reach_cells: int) -> int:
+def get_effective_reach(base_reach_cells: int, *, effective_size: str | None = None) -> int:
     from .reach import get_effective_reach as _reach
+    from .entity_size import normalize_size_category
 
-    return _reach(base_reach_cells)
+    size_cat = normalize_size_category(effective_size) if effective_size is not None else None
+    return _reach(base_reach_cells, effective_size=size_cat)

--- a/apps/control-server/app/services/combat_service/entity_size.py
+++ b/apps/control-server/app/services/combat_service/entity_size.py
@@ -71,9 +71,27 @@ _CARRYING_CAPACITY_MULTIPLIER: dict[SizeCategory, float] = {
     SizeCategory.GARGANTUAN: 8.0,
 }
 
+_MELEE_REACH_BONUS_CELLS: dict[SizeCategory, int] = {
+    SizeCategory.TINY: 0,
+    SizeCategory.SMALL: 0,
+    SizeCategory.MEDIUM: 0,
+    SizeCategory.LARGE: 1,
+    SizeCategory.HUGE: 2,
+    SizeCategory.GARGANTUAN: 3,
+}
+
 
 def size_carrying_capacity_multiplier(size: SizeCategory) -> float:
     return _CARRYING_CAPACITY_MULTIPLIER[size]
+
+
+def size_melee_reach_bonus_cells(size: SizeCategory) -> int:
+    """Return the melee reach bonus in grid cells for a given creature size.
+
+    Tiny/Small/Medium get 0 bonus (standard 1-cell reach).
+    Large gets +1 cell, Huge gets +2 cells, Gargantuan gets +3 cells.
+    """
+    return _MELEE_REACH_BONUS_CELLS[size]
 
 
 def size_footprint_cells(size_category: SizeCategory) -> int:

--- a/apps/control-server/app/services/combat_service/npc_action_steps.py
+++ b/apps/control-server/app/services/combat_service/npc_action_steps.py
@@ -126,6 +126,7 @@ class CombatNpcActionStepsMixin:
                 range_long_meters=cls._safe_int(resolved_action.get("rangeLongMeters"), None),
                 weapon_range_type=resolved_action.get("rangeType"),
                 has_reach=bool(resolved_action.get("hasReach")),
+                actor_effective_size=attacker.get("effective_size") or attacker.get("base_size"),
                 requires_sight=weapon_targeting.requires_target_sight,
                 requires_effect=weapon_targeting.requires_target_effect,
             )

--- a/apps/control-server/app/services/combat_service/reach.py
+++ b/apps/control-server/app/services/combat_service/reach.py
@@ -16,6 +16,14 @@ uses the minimum Chebyshev distance between any pair of cells — one
 from the attacker's footprint, one from the target's footprint.
 
 For 1×1 entities the two functions are equivalent.
+
+Phase #297 — size-based melee reach
+--------------------------------------
+Creatures larger than Medium gain a melee reach bonus based on their
+effective size: Large +1 cell, Huge +2 cells, Gargantuan +3 cells.
+This composes with the weapon *reach* property and any condition-based
+modifiers.  ``resolve_melee_reach_cells`` now accepts ``effective_size``
+to add the size bonus.
 """
 
 from __future__ import annotations
@@ -23,6 +31,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
+from .entity_size import SizeCategory, normalize_size_category, size_melee_reach_bonus_cells
 from .unit_conversion import METERS_PER_CELL
 
 DEFAULT_MELEE_REACH_CELLS: int = 1
@@ -51,32 +60,47 @@ class WeaponAttackRangeClassification:
     is_in_long_range: bool
 
 
-def get_effective_reach(base_reach_cells: int) -> int:
+def get_effective_reach(base_reach_cells: int, *, effective_size: SizeCategory | None = None) -> int:
     """Return effective reach in grid cells.
 
-    Currently a passthrough — creature-size and condition modifiers will be
-    resolved here once the combat model carries that data.
+    Applies creature-size modifiers on top of the weapon/form's native
+    reach.  When *effective_size* is provided, a size-based bonus is
+    added (Large +1, Huge +2, Gargantuan +3 cells).
 
     Args:
         base_reach_cells: The weapon/form's native reach in cells.
+        effective_size:   The attacker's effective size category.  When
+                          *None* no size bonus is applied (backward
+                          compatible).
 
     Returns:
         Effective reach, clamped to a minimum of 1 cell.
     """
-    return max(1, base_reach_cells)
+    size_bonus = size_melee_reach_bonus_cells(effective_size) if effective_size is not None else 0
+    return max(1, base_reach_cells + size_bonus)
 
 
-def resolve_melee_reach_cells(*, has_reach: bool = False) -> int:
+def resolve_melee_reach_cells(*, has_reach: bool = False, effective_size: str | None = None) -> int:
     """Resolve melee reach in grid cells for a weapon or natural attack.
 
+    Combines:
+      1. Base melee reach (1 cell) or extended reach (2 cells for
+         weapons with the *reach* property).
+      2. Size-based bonus derived from *effective_size* (Large +1,
+         Huge +2, Gargantuan +3 cells).
+
     Args:
-        has_reach: True when the weapon carries the *reach* property.
+        has_reach:      True when the weapon carries the *reach* property.
+        effective_size: The attacker's effective size as a raw string.
+                        Normalised via ``normalize_size_category``;
+                        defaults to *Medium* when *None*.
 
     Returns:
         Effective reach in cells.
     """
     base = EXTENDED_REACH_CELLS if has_reach else DEFAULT_MELEE_REACH_CELLS
-    return get_effective_reach(base)
+    size_cat = normalize_size_category(effective_size) if effective_size is not None else None
+    return get_effective_reach(base, effective_size=size_cat)
 
 
 def normalize_weapon_long_range(
@@ -111,22 +135,23 @@ def resolve_weapon_attack_range_profile(
     range_long_meters: int | float | None = None,
     weapon_range_type: str | None = None,
     has_reach: bool = False,
+    effective_size: str | None = None,
 ) -> WeaponAttackRangeProfile:
     """Resolve the authoritative weapon range profile for a targeting intent."""
-    normal_range, long_range = normalize_weapon_long_range(
+    normalized_range, long_range = normalize_weapon_long_range(
         range_meters=range_meters,
         range_long_meters=range_long_meters,
     )
-    if normal_range is not None:
+    if normalized_range is not None:
         return WeaponAttackRangeProfile(
-            normal_range=normal_range,
+            normal_range=normalized_range,
             long_range=long_range,
-            max_range=long_range if long_range is not None else normal_range,
+            max_range=long_range if long_range is not None else normalized_range,
         )
 
     rng_type = (weapon_range_type or "").strip().lower()
     if rng_type == "melee":
-        melee_reach = resolve_melee_reach_cells(has_reach=has_reach) * METERS_PER_CELL
+        melee_reach = resolve_melee_reach_cells(has_reach=has_reach, effective_size=effective_size) * METERS_PER_CELL
         return WeaponAttackRangeProfile(
             normal_range=melee_reach,
             long_range=None,
@@ -194,6 +219,7 @@ def resolve_weapon_attack_kind(
     range_meters: int | float | None = None,
     range_long_meters: int | float | None = None,
     has_reach: bool = False,
+    effective_size: str | None = None,
     distance_meters: int | float | None = None,
 ) -> Literal["melee", "ranged"]:
     """Resolve the effective attack kind for a weapon strike.
@@ -214,8 +240,9 @@ def resolve_weapon_attack_kind(
             range_long_meters=range_long_meters,
             weapon_range_type=weapon_range_type,
             has_reach=has_reach,
+            effective_size=effective_size,
         )
-        melee_reach = resolve_melee_reach_cells(has_reach=has_reach) * METERS_PER_CELL
+        melee_reach = resolve_melee_reach_cells(has_reach=has_reach, effective_size=effective_size) * METERS_PER_CELL
         if profile.normal_range is not None and float(distance_meters) > melee_reach:
             return "ranged"
 
@@ -292,6 +319,7 @@ def derive_max_range_meters(
     range_long_meters: int | float | None = None,
     weapon_range_type: str | None = None,
     has_reach: bool = False,
+    effective_size: str | None = None,
     target_type: str | None = None,
     range_kind: str | None = None,
 ) -> tuple[float | None, str | None]:
@@ -337,6 +365,7 @@ def derive_max_range_meters(
         range_long_meters=range_long_meters,
         weapon_range_type=weapon_range_type,
         has_reach=has_reach,
+        effective_size=effective_size,
     )
     if profile.failure_reason is not None:
         return (None, profile.failure_reason)

--- a/apps/control-server/app/services/combat_service/targeting_intent.py
+++ b/apps/control-server/app/services/combat_service/targeting_intent.py
@@ -42,6 +42,7 @@ class WeaponAttackIntent:
     range_long_meters: int | float | None = None
     weapon_range_type: str | None = None
     has_reach: bool = False
+    actor_effective_size: str | None = None
     # Final target-facing requirements resolved before validation.
     requires_sight: bool | None = None
     requires_effect: bool | None = None

--- a/apps/control-server/tests/test_local_targeting_range.py
+++ b/apps/control-server/tests/test_local_targeting_range.py
@@ -456,3 +456,206 @@ class TestLocalSymmetricDistanceLookup(unittest.TestCase):
         intent = _weapon_intent(weapon_range_type="melee")
         result = svc.validate(intent, state)
         self.assertTrue(result.is_valid)
+
+
+# ── Size-based melee reach integration tests (#297) ────────────────────────
+
+
+class TestSizeMeleeReachIntegration(unittest.TestCase):
+    """Integration: actor_effective_size flows through the targeting pipeline.
+
+    These tests prove that the size-based reach bonus is not just computed
+    by the helper but is actually used by the targeting service to accept
+    or reject attacks.
+    """
+
+    def test_medium_melee_out_of_range_at_2_cells(self):
+        state = _make_state(
+            _make_participant("player-1", "player"),
+            _make_participant("enemy-1", "session_entity"),
+            local_distances={"player-1": {"enemy-1": 3.0}},
+        )
+        intent = WeaponAttackIntent(
+            session_id="sess",
+            action_id="act",
+            actor_ref_id="player-1",
+            actor_kind="player",
+            requested_target_ref_id="enemy-1",
+            weapon_range_type="melee",
+            has_reach=False,
+            actor_effective_size="medium",
+        )
+        result = svc.validate(intent, state)
+        self.assertFalse(result.is_valid)
+        self.assertIn(TARGET_OUT_OF_REACH, result.diagnostics.failure_reasons)
+
+    def test_large_melee_in_range_at_2_cells(self):
+        state = _make_state(
+            _make_participant("player-1", "player"),
+            _make_participant("enemy-1", "session_entity"),
+            local_distances={"player-1": {"enemy-1": 3.0}},
+        )
+        intent = WeaponAttackIntent(
+            session_id="sess",
+            action_id="act",
+            actor_ref_id="player-1",
+            actor_kind="player",
+            requested_target_ref_id="enemy-1",
+            weapon_range_type="melee",
+            has_reach=False,
+            actor_effective_size="large",
+        )
+        result = svc.validate(intent, state)
+        self.assertTrue(result.is_valid)
+        self.assertTrue(result.diagnostics.checks.get(CHECK_IN_RANGE))
+
+    def test_large_melee_out_of_range_at_3_cells(self):
+        state = _make_state(
+            _make_participant("player-1", "player"),
+            _make_participant("enemy-1", "session_entity"),
+            local_distances={"player-1": {"enemy-1": 4.5}},
+        )
+        intent = WeaponAttackIntent(
+            session_id="sess",
+            action_id="act",
+            actor_ref_id="player-1",
+            actor_kind="player",
+            requested_target_ref_id="enemy-1",
+            weapon_range_type="melee",
+            has_reach=False,
+            actor_effective_size="large",
+        )
+        result = svc.validate(intent, state)
+        self.assertFalse(result.is_valid)
+        self.assertIn(TARGET_OUT_OF_REACH, result.diagnostics.failure_reasons)
+
+    def test_huge_melee_in_range_at_3_cells(self):
+        state = _make_state(
+            _make_participant("player-1", "player"),
+            _make_participant("enemy-1", "session_entity"),
+            local_distances={"player-1": {"enemy-1": 4.5}},
+        )
+        intent = WeaponAttackIntent(
+            session_id="sess",
+            action_id="act",
+            actor_ref_id="player-1",
+            actor_kind="player",
+            requested_target_ref_id="enemy-1",
+            weapon_range_type="melee",
+            has_reach=False,
+            actor_effective_size="huge",
+        )
+        result = svc.validate(intent, state)
+        self.assertTrue(result.is_valid)
+
+    def test_gargantuan_melee_in_range_at_4_cells(self):
+        state = _make_state(
+            _make_participant("player-1", "player"),
+            _make_participant("enemy-1", "session_entity"),
+            local_distances={"player-1": {"enemy-1": 6.0}},
+        )
+        intent = WeaponAttackIntent(
+            session_id="sess",
+            action_id="act",
+            actor_ref_id="player-1",
+            actor_kind="player",
+            requested_target_ref_id="enemy-1",
+            weapon_range_type="melee",
+            has_reach=False,
+            actor_effective_size="gargantuan",
+        )
+        result = svc.validate(intent, state)
+        self.assertTrue(result.is_valid)
+
+    def test_large_plus_reach_weapon_in_range_at_3_cells(self):
+        state = _make_state(
+            _make_participant("player-1", "player"),
+            _make_participant("enemy-1", "session_entity"),
+            local_distances={"player-1": {"enemy-1": 4.5}},
+        )
+        intent = WeaponAttackIntent(
+            session_id="sess",
+            action_id="act",
+            actor_ref_id="player-1",
+            actor_kind="player",
+            requested_target_ref_id="enemy-1",
+            weapon_range_type="melee",
+            has_reach=True,
+            actor_effective_size="large",
+        )
+        result = svc.validate(intent, state)
+        self.assertTrue(result.is_valid)
+
+    def test_tiny_and_small_melee_still_only_1_cell(self):
+        for size in ("tiny", "small"):
+            state = _make_state(
+                _make_participant("player-1", "player"),
+                _make_participant("enemy-1", "session_entity"),
+                local_distances={"player-1": {"enemy-1": 3.0}},
+            )
+            intent = WeaponAttackIntent(
+                session_id="sess",
+                action_id="act",
+                actor_ref_id="player-1",
+                actor_kind="player",
+                requested_target_ref_id="enemy-1",
+                weapon_range_type="melee",
+                has_reach=False,
+                actor_effective_size=size,
+            )
+            result = svc.validate(intent, state)
+            self.assertFalse(result.is_valid, f"{size} should not have extended reach")
+
+    def test_no_effective_size_defaults_to_medium(self):
+        state = _make_state(
+            _make_participant("player-1", "player"),
+            _make_participant("enemy-1", "session_entity"),
+            local_distances={"player-1": {"enemy-1": 3.0}},
+        )
+        intent = WeaponAttackIntent(
+            session_id="sess",
+            action_id="act",
+            actor_ref_id="player-1",
+            actor_kind="player",
+            requested_target_ref_id="enemy-1",
+            weapon_range_type="melee",
+            has_reach=False,
+        )
+        result = svc.validate(intent, state)
+        self.assertFalse(result.is_valid)
+
+    def test_derive_max_range_meters_large_melee_reach(self):
+        r, fail = derive_max_range_meters(
+            weapon_range_type="melee",
+            has_reach=False,
+            effective_size="large",
+        )
+        self.assertAlmostEqual(r, 3.0)
+        self.assertIsNone(fail)
+
+    def test_derive_max_range_meters_huge_melee_reach(self):
+        r, fail = derive_max_range_meters(
+            weapon_range_type="melee",
+            has_reach=False,
+            effective_size="huge",
+        )
+        self.assertAlmostEqual(r, 4.5)
+        self.assertIsNone(fail)
+
+    def test_derive_max_range_meters_large_plus_reach_weapon(self):
+        r, fail = derive_max_range_meters(
+            weapon_range_type="melee",
+            has_reach=True,
+            effective_size="large",
+        )
+        self.assertAlmostEqual(r, 4.5)
+        self.assertIsNone(fail)
+
+    def test_derive_max_range_meters_ranged_unaffected_by_size(self):
+        r, fail = derive_max_range_meters(
+            range_meters=18,
+            weapon_range_type="ranged",
+            effective_size="large",
+        )
+        self.assertEqual(r, 18.0)
+        self.assertIsNone(fail)

--- a/apps/control-server/tests/test_reach.py
+++ b/apps/control-server/tests/test_reach.py
@@ -360,5 +360,166 @@ class TestIsWithinMeleeReachMulti(unittest.TestCase):
         self.assertFalse(is_within_melee_reach_multi([_pos(0, 0)], [_pos(3, 0)], 2))
 
 
+# ─── size-based melee reach (#297) ───────────────────────────────────────────
+
+class TestSizeMeleeReachBonus(unittest.TestCase):
+    def test_tiny_no_bonus(self):
+        self.assertEqual(resolve_melee_reach_cells(effective_size="tiny"), 1)
+
+    def test_small_no_bonus(self):
+        self.assertEqual(resolve_melee_reach_cells(effective_size="small"), 1)
+
+    def test_medium_no_bonus(self):
+        self.assertEqual(resolve_melee_reach_cells(effective_size="medium"), 1)
+
+    def test_large_plus_one(self):
+        self.assertEqual(resolve_melee_reach_cells(effective_size="large"), 2)
+
+    def test_huge_plus_two(self):
+        self.assertEqual(resolve_melee_reach_cells(effective_size="huge"), 3)
+
+    def test_gargantuan_plus_three(self):
+        self.assertEqual(resolve_melee_reach_cells(effective_size="gargantuan"), 4)
+
+    def test_none_defaults_to_medium(self):
+        self.assertEqual(resolve_melee_reach_cells(effective_size=None), 1)
+
+    def test_invalid_defaults_to_medium(self):
+        self.assertEqual(resolve_melee_reach_cells(effective_size="colossal"), 1)
+
+    def test_large_plus_reach_weapon(self):
+        self.assertEqual(resolve_melee_reach_cells(has_reach=True, effective_size="large"), 3)
+
+    def test_huge_plus_reach_weapon(self):
+        self.assertEqual(resolve_melee_reach_cells(has_reach=True, effective_size="huge"), 4)
+
+    def test_gargantuan_plus_reach_weapon(self):
+        self.assertEqual(resolve_melee_reach_cells(has_reach=True, effective_size="gargantuan"), 5)
+
+    def test_tiny_plus_reach_weapon(self):
+        self.assertEqual(resolve_melee_reach_cells(has_reach=True, effective_size="tiny"), 2)
+
+    def test_case_insensitive(self):
+        self.assertEqual(resolve_melee_reach_cells(effective_size="Large"), 2)
+        self.assertEqual(resolve_melee_reach_cells(effective_size="LARGE"), 2)
+
+
+class TestGetEffectiveReachWithSize(unittest.TestCase):
+    def test_base_1_medium_no_bonus(self):
+        self.assertEqual(get_effective_reach(1, effective_size=None), 1)
+
+    def test_base_1_large_plus_one(self):
+        from app.services.combat_service.entity_size import SizeCategory
+        self.assertEqual(get_effective_reach(1, effective_size=SizeCategory.LARGE), 2)
+
+    def test_base_2_large_plus_one(self):
+        from app.services.combat_service.entity_size import SizeCategory
+        self.assertEqual(get_effective_reach(2, effective_size=SizeCategory.LARGE), 3)
+
+    def test_base_1_huge_plus_two(self):
+        from app.services.combat_service.entity_size import SizeCategory
+        self.assertEqual(get_effective_reach(1, effective_size=SizeCategory.HUGE), 3)
+
+    def test_base_1_tiny_no_bonus(self):
+        from app.services.combat_service.entity_size import SizeCategory
+        self.assertEqual(get_effective_reach(1, effective_size=SizeCategory.TINY), 1)
+
+
+class TestSizeReachWithDistance(unittest.TestCase):
+    """Integration: size-adjusted reach used with is_within_melee_reach."""
+
+    def test_large_reach_two_cells_away(self):
+        reach = resolve_melee_reach_cells(effective_size="large")
+        self.assertTrue(is_within_melee_reach(_pos(0, 0), _pos(2, 0), reach))
+
+    def test_large_reach_three_cells_away(self):
+        reach = resolve_melee_reach_cells(effective_size="large")
+        self.assertFalse(is_within_melee_reach(_pos(0, 0), _pos(3, 0), reach))
+
+    def test_huge_reach_three_cells_away(self):
+        reach = resolve_melee_reach_cells(effective_size="huge")
+        self.assertTrue(is_within_melee_reach(_pos(0, 0), _pos(3, 0), reach))
+
+    def test_gargantuan_reach_four_cells_away(self):
+        reach = resolve_melee_reach_cells(effective_size="gargantuan")
+        self.assertTrue(is_within_melee_reach(_pos(0, 0), _pos(4, 0), reach))
+
+    def test_gargantuan_reach_five_cells_away(self):
+        reach = resolve_melee_reach_cells(effective_size="gargantuan")
+        self.assertFalse(is_within_melee_reach(_pos(0, 0), _pos(5, 0), reach))
+
+    def test_large_plus_reach_weapon_three_cells(self):
+        reach = resolve_melee_reach_cells(has_reach=True, effective_size="large")
+        self.assertTrue(is_within_melee_reach(_pos(0, 0), _pos(3, 0), reach))
+
+    def test_medium_default_one_cell(self):
+        reach = resolve_melee_reach_cells(effective_size="medium")
+        self.assertTrue(is_within_melee_reach(_pos(0, 0), _pos(1, 0), reach))
+        self.assertFalse(is_within_melee_reach(_pos(0, 0), _pos(2, 0), reach))
+
+
+class TestSizeReachWithMultiCell(unittest.TestCase):
+    """Integration: size-adjusted reach with multi-cell footprints."""
+
+    def test_large_attacker_with_size_reach(self):
+        large_cells = [_pos(0, 0), _pos(1, 0), _pos(0, 1), _pos(1, 1)]
+        target_at_3 = [_pos(4, 0)]
+        reach = resolve_melee_reach_cells(effective_size="large")
+        min_dist = min(max(abs(a["x"] - b["x"]), abs(a["y"] - b["y"])) for a in large_cells for b in target_at_3)
+        self.assertEqual(min_dist, 3)
+        self.assertFalse(is_within_melee_reach_multi(large_cells, target_at_3, reach))
+
+    def test_large_attacker_adjacent_target(self):
+        large_cells = [_pos(0, 0), _pos(1, 0), _pos(0, 1), _pos(1, 1)]
+        target_adjacent = [_pos(2, 0)]
+        reach = resolve_melee_reach_cells(effective_size="large")
+        self.assertTrue(is_within_melee_reach_multi(large_cells, target_adjacent, reach))
+
+
+class TestResolveWeaponAttackKindWithSize(unittest.TestCase):
+    def test_large_melee_within_extended_reach(self):
+        result = resolve_weapon_attack_kind(
+            weapon_range_type="melee",
+            distance_meters=3.0,
+            effective_size="large",
+        )
+        self.assertEqual(result, "melee")
+
+    def test_large_melee_beyond_reach_becomes_ranged(self):
+        result = resolve_weapon_attack_kind(
+            weapon_range_type="melee",
+            distance_meters=4.5,
+            effective_size="large",
+        )
+        self.assertEqual(result, "ranged")
+
+    def test_large_melee_at_max_reach_is_melee(self):
+        result = resolve_weapon_attack_kind(
+            weapon_range_type="melee",
+            distance_meters=3.0,
+            effective_size="large",
+        )
+        self.assertEqual(result, "melee")
+
+    def test_medium_melee_beyond_normal_reach(self):
+        result = resolve_weapon_attack_kind(
+            weapon_range_type="melee",
+            range_meters=6,
+            range_long_meters=18,
+            distance_meters=3.0,
+        )
+        self.assertEqual(result, "ranged")
+
+    def test_large_melee_stays_melee_at_3m(self):
+        result = resolve_weapon_attack_kind(
+            weapon_range_type="melee",
+            range_meters=6,
+            range_long_meters=18,
+            distance_meters=3.0,
+            effective_size="large",
+        )
+        self.assertEqual(result, "melee")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/packages/shared-contracts/src/domain.ts
+++ b/packages/shared-contracts/src/domain.ts
@@ -175,6 +175,19 @@ export function getSizeCarryingCapacityMultiplier(size: CreatureSize): number {
   return sizeCarryingCapacityMultiplier[size];
 }
 
+export const sizeMeleeReachBonusCells: Record<CreatureSize, number> = {
+  Tiny: 0,
+  Small: 0,
+  Medium: 0,
+  Large: 1,
+  Huge: 2,
+  Gargantuan: 3,
+} as const satisfies Record<CreatureSize, number>;
+
+export function getSizeMeleeReachBonusCells(size: CreatureSize): number {
+  return sizeMeleeReachBonusCells[size];
+}
+
 export const sizeTierToFootprint = {
   Tiny: { width: 1, height: 1 },
   Small: { width: 1, height: 1 },


### PR DESCRIPTION
# PR: feat(combat) size-based melee reach bonus (#297)

## Description

Este PR implementa o bônus de alcance corpo a corpo (*melee reach*) derivado do tamanho efetivo da criatura, conforme a Issue #297. A implementação garante que criaturas de tamanho Grande ou maior recebam um incremento automático em seu alcance de ataque, refletindo sua envergadura no grid tático. 

A lógica foi integrada em todo o pipeline de ataque (Weapon Attacks, NPC Actions, Wild Shape), garantindo que a validação de distância no mapa respeite o alcance estendido.

## Changes

### Shared Contracts & Metadata
- **Canonical Mapping:** Implementado `sizeMeleeReachBonusCells` e o helper `getSizeMeleeReachBonusCells()` em `packages/shared-contracts`.
- **Reach Rules:**
    - Tiny, Small, Medium: +0 células (1.5m base).
    - **Large:** +1 célula (3.0m total).
    - **Huge:** +2 células (4.5m total).
    - **Gargantuan:** +3 células (6.0m total).

### Backend Engine (`reach.py` & `entity_size.py`)
- **Effective Reach Resolution:** `get_effective_reach()` agora é o ponto autoritativo que combina o alcance da arma com o bônus de tamanho do `effective_size`.
- **Range Profiles:** Atualizada a resolução de perfis de ataque e tipos de ataque (Melee vs Ranged) para considerar o tamanho do atacante na definição do alcance máximo.

### Targeting Pipeline
- **Intent Enrichment:** `WeaponAttackIntent` agora carrega o `actor_effective_size`.
- **Cross-Service Integration:** A propagação do tamanho efetivo foi aplicada em:
    - `weapon_attack_roll.py` (Ataques de jogadores).
    - `npc_action_steps.py` (Ações de NPCs).
    - `wild_shape.py` (Formas selvagens).
- **Spatial Validation:** Os serviços de targeting (`local`, `map` e `combat_targeting`) agora utilizam o tamanho do atacante para validar se o alvo está "dentro do alcance".

## Summary of Changes

| Component | Change |
| :--- | :--- |
| **`Shared Contracts`** | Mapping of size-to-reach bonus (Large: +1, Huge: +2, etc.) |
| **`reach.py`** | Centralized reach logic with `effective_size` support |
| **`Targeting`** | Full propagation of attacker size through the attack pipeline |
| **`Tests`** | 31 new unit tests for reach and spatial distance |

## Validation

A implementação foi validada com foco em geometria tática e integridade de regras:

- **Backend Tests:** 31 novos testes em `test_reach.py` cobrindo:
    - Bônus por categoria de tamanho.
    - Alcance efetivo com armas de haste (*Reach weapons*).
    - Validação de distância em criaturas multi-célula.
- **Regressão:** Todos os 95 testes de alcance e a suíte geral do backend (2303+ testes) estão passando.

## Out of Scope (Tratado separadamente)

> [!IMPORTANT]
> A exibição visual deste alcance na interface de combate (UI) e os indicadores de feedback no mapa serão tratados em um esforço separado. Esta PR foca exclusivamente na **correção da engine e validação de regras no servidor**.

## Next Steps
- Implementação de indicadores visuais de alcance no Frontend quando o tamanho for Grande+.
- Testes de integração end-to-end com o Map Server para visualização do footprint de ataque.