### PR TITLE
feat(spells) declarative healing and Cure Wounds automation

### DIFF
--- a/Base/base_spells.seed.json
+++ b/Base/base_spells.seed.json
@@ -253,7 +253,19 @@
       "targetAnchor": "selected_target",
       "attackType": "none",
       "rangeKind": "touch",
-      "effectTiming": "immediate"
+      "effectTiming": "immediate",
+      "outOfCombatCastable": true,
+      "outOfCombatTarget": "self_or_ally",
+      "effects": [
+        {
+          "type": "heal",
+          "target": "selected_target",
+          "params": {
+            "dice": "1d8",
+            "ability_modifier": "spellcasting"
+          }
+        }
+      ]
     },
     {
       "system": "DND5E",

--- a/apps/control-server/app/api/routes/sessions/state.py
+++ b/apps/control-server/app/api/routes/sessions/state.py
@@ -30,14 +30,20 @@ from app.services.combat_service.persistent_effects import (
 )
 from app.services.game_time import get_game_time_seconds
 from app.services.goodberry_inventory import grant_catalog_item_to_player_inventory
+from app.services.healing_consumables_types import _extract_hp_snapshot, _safe_int
 from app.services.out_of_combat_cast import (
     build_concentration_marker,
     build_persisted_effects,
     check_out_of_combat_cast_eligibility,
     collect_create_consumable_effects,
+    collect_heal_effects,
     consume_spell_slot,
     has_castable_effects,
+    roll_spell_heal_effects,
 )
+from app.services.wild_shape_catalog import get_form
+from app.services.wild_shape_service import apply_healing_to_form
+from app.services.wild_shape_service import is_active as is_wild_shape_active
 from app.services.declarative_effect_lifecycle import remove_armor_don_effects_from_combat_participant
 from app.services.session_rest import ensure_rest_state
 from app.services.session_state_finalize import finalize_session_state_data
@@ -62,6 +68,18 @@ OUT_OF_COMBAT_ACTIVITY_EVENT_TYPES = (
     "out_of_combat_effect_removed",
 )
 OUT_OF_COMBAT_ACTIVITY_CAP = 50
+
+
+def _apply_heal_to_state_dict(data: dict, amount: int) -> dict:
+    """Apply immediate healing to a state dict in place. Handles wild shape."""
+    if is_wild_shape_active(data):
+        form_key = (data.get("wildShape") or {}).get("formKey")
+        form = get_form(form_key) if isinstance(form_key, str) else None
+        if form is not None:
+            return apply_healing_to_form(data, amount, form)
+    current, max_hp = _extract_hp_snapshot(data)
+    new_hp = min(max_hp, current + max(0, amount))
+    return {**data, "currentHP": new_hp}
 
 
 def _find_effect_by_id(state_json: dict | None, effect_id: str) -> dict | None:
@@ -385,7 +403,15 @@ async def _cast_spell_out_of_combat_for_player(
             )
             consumables_granted_count += quantity
 
-    if not new_target_effects and not consumables_granted_count:
+    # --- Precompute immediate healing (heal effects) ---
+    heal_effects = collect_heal_effects(campaign_spell, req.variantKey)
+    heal_rolled = (
+        roll_spell_heal_effects(heal_effects, campaign_spell, req.slotLevel, state_json)
+        if heal_effects
+        else []
+    )
+
+    if not new_target_effects and not consumables_granted_count and not heal_rolled:
         raise HTTPException(status_code=400, detail="No persistable effects could be created for this spell")
 
     group_id: str | None = (
@@ -441,6 +467,12 @@ async def _cast_spell_out_of_combat_for_player(
         target_effects = list(target_json.get("active_spell_effects") or [])
         target_effects.extend(new_target_effects)
         target_json["active_spell_effects"] = target_effects
+        # Immediate healing on ally target
+        for hr in heal_rolled:
+            if hr.get("target") == "caster":
+                updated_caster_json = _apply_heal_to_state_dict(updated_caster_json, hr["amount"])
+            else:
+                target_json = _apply_heal_to_state_dict(target_json, hr["amount"])
         target_state.state_json = finalize_session_state_data(  # type: ignore[union-attr]
             target_json,
             game_time_seconds=current_game_time_seconds,
@@ -453,6 +485,9 @@ async def _cast_spell_out_of_combat_for_player(
         existing_effects.extend(new_target_effects)
         updated_caster_json["active_spell_effects"] = existing_effects
         marker_effect_id = None
+        # Immediate healing on self (target == caster)
+        for hr in heal_rolled:
+            updated_caster_json = _apply_heal_to_state_dict(updated_caster_json, hr["amount"])
 
     # --- Persist caster state ---
     caster_state.state_json = finalize_session_state_data(
@@ -515,6 +550,13 @@ async def _cast_spell_out_of_combat_for_player(
         if consumables_granted_count:
             activity_payload["consumables_granted_count"] = consumables_granted_count
             activity_payload["inventory_refresh_required"] = True
+        if heal_rolled:
+            total_healed = sum(hr["amount"] for hr in heal_rolled)
+            activity_payload["healing_applied"] = total_healed
+            activity_payload["healing_rolls"] = [
+                {"dice": hr["effective_dice"], "rolls": hr["rolls"], "modifier": hr["modifier"], "total": hr["amount"]}
+                for hr in heal_rolled
+            ]
         record_session_activity(
             entry,
             "out_of_combat_spell_cast",

--- a/apps/control-server/app/schemas/base_spell_effects.py
+++ b/apps/control-server/app/schemas/base_spell_effects.py
@@ -24,6 +24,7 @@ SpellDeclarativeEffectType = Literal[
     "modify_movement_speed",
     "fall_damage_immunity_threshold",
     "create_consumable",
+    "heal",
 ]
 
 SpellDeclarativeEffectTarget = Literal["selected_target", "caster"]
@@ -164,6 +165,15 @@ class CreateConsumableParams(BaseModel):
     expires_in_seconds: int | None = Field(default=None, ge=1)
 
 
+class HealParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    dice: str
+    # Required (no default) so {"dice": "..."} alone matches GrantTempHpParams, not HealParams.
+    # Pass None explicitly for heals without an ability modifier.
+    ability_modifier: Literal["spellcasting"] | None
+
+
 class ArmorClassFormulaParams(BaseModel):
     base_value: int = Field(ge=0)
     ability: AbilityName
@@ -201,6 +211,7 @@ class SpellDeclarativeEffect(BaseModel):
         | ModifyMovementSpeedParams
         | FallDamageImmunityThresholdParams
         | CreateConsumableParams
+        | HealParams
     )
     stacking: SpellDeclarativeEffectStacking | None = None
 
@@ -238,4 +249,6 @@ class SpellDeclarativeEffect(BaseModel):
             raise ValueError("modify_movement_speed effects require ModifyMovementSpeedParams")
         if self.type == "create_consumable" and not isinstance(self.params, CreateConsumableParams):
             raise ValueError("create_consumable effects require CreateConsumableParams")
+        if self.type == "heal" and not isinstance(self.params, HealParams):
+            raise ValueError("heal effects require HealParams")
         return self

--- a/apps/control-server/app/services/out_of_combat_cast.py
+++ b/apps/control-server/app/services/out_of_combat_cast.py
@@ -8,7 +8,9 @@ correctly.
 
 from __future__ import annotations
 
+import random
 from datetime import datetime, timezone
+from math import floor
 from uuid import uuid4
 
 
@@ -279,7 +281,7 @@ def has_castable_effects(spell) -> bool:
     return any(v.get("effects") for v in variants)
 
 
-_SKIP_EFFECT_TYPES = {"grant_temp_hp", "create_consumable"}
+_SKIP_EFFECT_TYPES = {"grant_temp_hp", "create_consumable", "heal"}
 
 
 def collect_create_consumable_effects(
@@ -291,6 +293,96 @@ def collect_create_consumable_effects(
         e for e in _resolve_effects(spell, variant_key)
         if isinstance(e, dict) and e.get("type") == "create_consumable"
     ]
+
+
+def collect_heal_effects(
+    spell,
+    variant_key: str | None,
+) -> list[dict]:
+    """Return only heal effect dicts from the spell's effective effects list."""
+    return [
+        e for e in _resolve_effects(spell, variant_key)
+        if isinstance(e, dict) and e.get("type") == "heal"
+    ]
+
+
+def compute_heal_dice_with_upcast(
+    base_dice: str,
+    spell,
+    slot_level: int | None,
+) -> str:
+    """Scale base heal dice by upcast level using the spell's upcast_json config."""
+    effective_slot = slot_level if isinstance(slot_level, int) else getattr(spell, "level", 1)
+    spell_level = getattr(spell, "level", 1) or 1
+    upcast = getattr(spell, "upcast_json", None) or {}
+    mode = upcast.get("mode", "")
+    per_level = int(upcast.get("perLevel", 0)) if isinstance(upcast.get("perLevel"), (int, float)) else 0
+
+    if mode == "extra_heal_dice" and per_level > 0 and effective_slot > spell_level:
+        extra_levels = effective_slot - spell_level
+        extra_dice = extra_levels * per_level
+        if "d" in base_dice:
+            count_str, sides_str = base_dice.split("d", 1)
+            try:
+                total = int(count_str) + extra_dice
+                return f"{total}d{sides_str}"
+            except ValueError:
+                pass
+    return base_dice
+
+
+def resolve_spellcasting_modifier(state_json: dict) -> int:
+    """Return the caster's spellcasting ability modifier from state_json."""
+    spellcasting = (state_json or {}).get("spellcasting") or {}
+    precomputed = spellcasting.get("modifier")
+    if isinstance(precomputed, int):
+        return precomputed
+    ability = spellcasting.get("ability")
+    if isinstance(ability, str):
+        abilities = (state_json or {}).get("abilities") or {}
+        score = abilities.get(ability, 10)
+        if isinstance(score, (int, float)):
+            return floor((int(score) - 10) / 2)
+    return 0
+
+
+def roll_spell_heal_effects(
+    heal_effects: list[dict],
+    spell,
+    slot_level: int | None,
+    caster_state_json: dict,
+) -> list[dict]:
+    """Roll healing for each heal effect.
+
+    Returns a list of dicts with keys: amount, target, effective_dice, rolls, modifier.
+    """
+    from app.services.healing_consumables_types import _parse_heal_dice
+
+    results = []
+    for he in heal_effects:
+        params = he.get("params") or {}
+        base_dice = params.get("dice") or ""
+        effective_dice = compute_heal_dice_with_upcast(base_dice, spell, slot_level)
+        spell_mod = (
+            resolve_spellcasting_modifier(caster_state_json)
+            if params.get("ability_modifier") == "spellcasting"
+            else 0
+        )
+        count, sides, expr_mod = _parse_heal_dice(effective_dice)
+        rolls = (
+            [random.randint(1, sides) for _ in range(count)]
+            if count > 0 and sides > 0
+            else []
+        )
+        healing_amount = max(0, sum(rolls) + expr_mod + spell_mod)
+        results.append({
+            "amount": healing_amount,
+            "target": he.get("target", "selected_target"),
+            "effective_dice": effective_dice,
+            "rolls": rolls,
+            "modifier": spell_mod,
+        })
+    return results
 
 
 def _resolve_kind_and_value(effect_type: str, params: dict) -> tuple[str | None, int | None]:

--- a/apps/control-server/tests/test_cure_wounds_cast.py
+++ b/apps/control-server/tests/test_cure_wounds_cast.py
@@ -1,0 +1,364 @@
+"""Tests for Cure Wounds (Curar Ferimentos) out-of-combat automation (issue #303).
+
+Covers:
+- HealParams schema validation
+- heal effect type correctly registered and rejected for wrong params
+- build_persisted_effects returns [] for heal (no active_spell_effects created)
+- collect_heal_effects extracts params
+- compute_heal_dice_with_upcast scales correctly
+- resolve_spellcasting_modifier reads from state_json
+- roll_spell_heal_effects rolls and sums correctly
+- HP application: heals, caps at max, handles wild shape pass-through
+- Upcast: 1→2→3 slot levels produce correct dice counts
+- Goodberry regression: still creates consumable, not immediate heal
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pydantic import ValidationError
+
+from app.schemas.base_spell_effects import HealParams, SpellDeclarativeEffect
+from app.services.out_of_combat_cast import (
+    build_persisted_effects,
+    check_out_of_combat_cast_eligibility,
+    collect_heal_effects,
+    compute_heal_dice_with_upcast,
+    resolve_spellcasting_modifier,
+    roll_spell_heal_effects,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _heal_effect(
+    *,
+    dice: str = "1d8",
+    ability_modifier: str | None = "spellcasting",
+    target: str = "selected_target",
+) -> dict:
+    return {"type": "heal", "target": target, "params": {"dice": dice, "ability_modifier": ability_modifier}}
+
+
+def _make_spell(
+    *,
+    canonical_key: str = "cure_wounds",
+    level: int = 1,
+    effects_json: list | None = None,
+    upcast_json: dict | None = None,
+    out_of_combat_castable: bool = True,
+    out_of_combat_target: str = "self_or_ally",
+):
+    spell = MagicMock()
+    spell.canonical_key = canonical_key
+    spell.level = level
+    spell.concentration = False
+    spell.out_of_combat_castable = out_of_combat_castable
+    spell.out_of_combat_target = out_of_combat_target
+    spell.effects_json = effects_json if effects_json is not None else [_heal_effect()]
+    spell.variants_json = []
+    spell.upcast_json = upcast_json if upcast_json is not None else {
+        "mode": "extra_heal_dice",
+        "dice": "1d8",
+        "perLevel": 1,
+    }
+    spell.name_pt = "Curar Ferimentos"
+    spell.name_en = "Cure Wounds"
+    return spell
+
+
+def _slot_state(*, slot_level: int = 1, used: int = 0, max_slots: int = 4) -> dict:
+    return {"spellcasting": {"slots": {str(slot_level): {"used": used, "max": max_slots}}}}
+
+
+def _caster_state(
+    *,
+    current_hp: int = 8,
+    max_hp: int = 14,
+    spellcasting_ability: str = "wisdom",
+    wisdom: int = 16,
+) -> dict:
+    return {
+        "currentHP": current_hp,
+        "maxHP": max_hp,
+        "abilities": {
+            "strength": 10, "dexterity": 10, "constitution": 10,
+            "intelligence": 10, "wisdom": wisdom, "charisma": 10,
+        },
+        "spellcasting": {
+            "ability": spellcasting_ability,
+            "slots": {"1": {"used": 0, "max": 4}},
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+class HealParamsSchemaTests(unittest.TestCase):
+    def test_heal_effect_validates_with_dice_and_modifier(self):
+        effect = SpellDeclarativeEffect(**_heal_effect())
+        self.assertEqual(effect.type, "heal")
+        self.assertIsInstance(effect.params, HealParams)
+        self.assertEqual(effect.params.dice, "1d8")
+        self.assertEqual(effect.params.ability_modifier, "spellcasting")
+
+    def test_heal_effect_validates_without_ability_modifier(self):
+        # ability_modifier must be explicitly null (not omitted) to distinguish from GrantTempHpParams
+        effect = SpellDeclarativeEffect(**{
+            "type": "heal",
+            "target": "selected_target",
+            "params": {"dice": "1d8", "ability_modifier": None},
+        })
+        self.assertIsNone(effect.params.ability_modifier)
+
+    def test_heal_params_rejects_extra_fields(self):
+        with self.assertRaises(ValidationError):
+            HealParams(dice="1d8", ability_modifier="spellcasting", unknown=True)
+
+    def test_heal_effect_rejects_wrong_params(self):
+        with self.assertRaises(ValidationError):
+            SpellDeclarativeEffect(**{
+                "type": "heal",
+                "target": "selected_target",
+                "params": {"condition": "blinded"},
+            })
+
+
+# ---------------------------------------------------------------------------
+# Eligibility tests
+# ---------------------------------------------------------------------------
+
+class CureWoundsEligibilityTests(unittest.TestCase):
+    def test_eligibility_passes_with_heal_effect(self):
+        spell = _make_spell()
+        state = _slot_state()
+        ok, reason = check_out_of_combat_cast_eligibility(
+            spell=spell,
+            state_json=state,
+            slot_level=1,
+            variant_key=None,
+        )
+        self.assertTrue(ok)
+        self.assertIsNone(reason)
+
+    def test_eligibility_fails_when_no_slot(self):
+        spell = _make_spell()
+        state = _slot_state(used=4, max_slots=4)
+        ok, reason = check_out_of_combat_cast_eligibility(
+            spell=spell,
+            state_json=state,
+            slot_level=1,
+            variant_key=None,
+        )
+        self.assertFalse(ok)
+
+
+# ---------------------------------------------------------------------------
+# build_persisted_effects / collect helpers
+# ---------------------------------------------------------------------------
+
+class CureWoundsBuildEffectsTests(unittest.TestCase):
+    def test_build_persisted_effects_returns_empty_for_heal(self):
+        spell = _make_spell()
+        effects = build_persisted_effects(
+            spell=spell,
+            caster_user_id="user-1",
+            target_user_id="user-1",
+            variant_key=None,
+            game_time_seconds=0,
+        )
+        self.assertEqual(effects, [])
+
+    def test_no_active_spell_effects_created_for_cure_wounds(self):
+        spell = _make_spell()
+        effects = build_persisted_effects(
+            spell=spell,
+            caster_user_id="user-1",
+            target_user_id="user-2",
+            variant_key=None,
+            game_time_seconds=0,
+        )
+        self.assertEqual(len(effects), 0, "heal must not produce active_spell_effects")
+
+    def test_collect_heal_effects_extracts_correct_params(self):
+        spell = _make_spell()
+        collected = collect_heal_effects(spell, variant_key=None)
+        self.assertEqual(len(collected), 1)
+        params = collected[0]["params"]
+        self.assertEqual(params["dice"], "1d8")
+        self.assertEqual(params["ability_modifier"], "spellcasting")
+
+    def test_collect_heal_effects_empty_for_non_heal_spell(self):
+        spell = _make_spell(effects_json=[
+            {"type": "modify_stat", "target": "caster", "params": {"stat": "attack_bonus", "value": 1}},
+        ])
+        collected = collect_heal_effects(spell, variant_key=None)
+        self.assertEqual(collected, [])
+
+    def test_goodberry_has_no_heal_effects_regression(self):
+        """Goodberry must stay as create_consumable — no heal_effects."""
+        goodberry = MagicMock()
+        goodberry.effects_json = [
+            {"type": "create_consumable", "target": "caster",
+             "params": {"canonical_key": "goodberry", "quantity": 10, "expires_in_seconds": 86400}}
+        ]
+        goodberry.variants_json = []
+        self.assertEqual(collect_heal_effects(goodberry, variant_key=None), [])
+
+
+# ---------------------------------------------------------------------------
+# Upcast tests
+# ---------------------------------------------------------------------------
+
+class CureWoundsUpcastTests(unittest.TestCase):
+    def _spell_with_upcast(self, upcast_json=None):
+        return _make_spell(upcast_json=upcast_json or {"mode": "extra_heal_dice", "dice": "1d8", "perLevel": 1})
+
+    def test_base_cast_uses_1d8(self):
+        spell = self._spell_with_upcast()
+        result = compute_heal_dice_with_upcast("1d8", spell, slot_level=1)
+        self.assertEqual(result, "1d8")
+
+    def test_upcast_level_2_gives_2d8(self):
+        spell = self._spell_with_upcast()
+        result = compute_heal_dice_with_upcast("1d8", spell, slot_level=2)
+        self.assertEqual(result, "2d8")
+
+    def test_upcast_level_3_gives_3d8(self):
+        spell = self._spell_with_upcast()
+        result = compute_heal_dice_with_upcast("1d8", spell, slot_level=3)
+        self.assertEqual(result, "3d8")
+
+    def test_upcast_level_5_gives_5d8(self):
+        spell = self._spell_with_upcast()
+        result = compute_heal_dice_with_upcast("1d8", spell, slot_level=5)
+        self.assertEqual(result, "5d8")
+
+    def test_no_upcast_config_returns_base_dice(self):
+        spell = _make_spell(upcast_json={})
+        result = compute_heal_dice_with_upcast("1d8", spell, slot_level=3)
+        self.assertEqual(result, "1d8")
+
+    def test_slot_level_none_returns_base_dice(self):
+        spell = self._spell_with_upcast()
+        result = compute_heal_dice_with_upcast("1d8", spell, slot_level=None)
+        self.assertEqual(result, "1d8")
+
+
+# ---------------------------------------------------------------------------
+# Spellcasting modifier tests
+# ---------------------------------------------------------------------------
+
+class SpellcastingModifierTests(unittest.TestCase):
+    def test_reads_precomputed_modifier(self):
+        state = {"spellcasting": {"ability": "wisdom", "modifier": 5}}
+        self.assertEqual(resolve_spellcasting_modifier(state), 5)
+
+    def test_computes_from_ability_score(self):
+        # wisdom=16 → modifier = (16-10)//2 = 3
+        state = _caster_state(wisdom=16)
+        self.assertEqual(resolve_spellcasting_modifier(state), 3)
+
+    def test_defaults_to_zero_when_no_spellcasting(self):
+        self.assertEqual(resolve_spellcasting_modifier({}), 0)
+
+    def test_negative_modifier(self):
+        # wisdom=8 → (8-10)//2 = -1
+        state = _caster_state(wisdom=8)
+        self.assertEqual(resolve_spellcasting_modifier(state), -1)
+
+
+# ---------------------------------------------------------------------------
+# Roll heal effects tests
+# ---------------------------------------------------------------------------
+
+class RollSpellHealEffectsTests(unittest.TestCase):
+    def test_total_is_at_least_modifier(self):
+        spell = _make_spell()
+        state = _caster_state(wisdom=16)  # mod=3
+        heal_effects = collect_heal_effects(spell, variant_key=None)
+        with patch("app.services.out_of_combat_cast.random.randint", return_value=4):
+            results = roll_spell_heal_effects(heal_effects, spell, slot_level=1, caster_state_json=state)
+        self.assertEqual(len(results), 1)
+        # 4 (roll) + 3 (mod) = 7
+        self.assertEqual(results[0]["amount"], 7)
+        self.assertEqual(results[0]["rolls"], [4])
+        self.assertEqual(results[0]["modifier"], 3)
+        self.assertEqual(results[0]["effective_dice"], "1d8")
+
+    def test_upcast_rolls_more_dice(self):
+        spell = _make_spell()
+        state = _caster_state(wisdom=16)  # mod=3
+        heal_effects = collect_heal_effects(spell, variant_key=None)
+        with patch("app.services.out_of_combat_cast.random.randint", return_value=5):
+            results = roll_spell_heal_effects(heal_effects, spell, slot_level=2, caster_state_json=state)
+        # 2d8: 5+5=10, mod=3 → total=13
+        self.assertEqual(results[0]["amount"], 13)
+        self.assertEqual(len(results[0]["rolls"]), 2)
+        self.assertEqual(results[0]["effective_dice"], "2d8")
+
+    def test_zero_healing_when_amount_would_be_negative(self):
+        spell = _make_spell(effects_json=[{"type": "heal", "target": "selected_target", "params": {"dice": "1d8"}}])
+        state = {}
+        heal_effects = collect_heal_effects(spell, variant_key=None)
+        with patch("app.services.out_of_combat_cast.random.randint", return_value=0):
+            results = roll_spell_heal_effects(heal_effects, spell, slot_level=1, caster_state_json=state)
+        self.assertGreaterEqual(results[0]["amount"], 0)
+
+
+# ---------------------------------------------------------------------------
+# HP application helper tests
+# ---------------------------------------------------------------------------
+
+class ApplyHealToStateDictTests(unittest.TestCase):
+    def setUp(self):
+        # Import the private helper from routes (testing internal logic)
+        from app.api.routes.sessions.state import _apply_heal_to_state_dict
+        self._apply = _apply_heal_to_state_dict
+
+    def test_heals_hp_correctly(self):
+        state = {"currentHP": 5, "maxHP": 14}
+        result = self._apply(state, 4)
+        self.assertEqual(result["currentHP"], 9)
+
+    def test_caps_at_max_hp(self):
+        state = {"currentHP": 12, "maxHP": 14}
+        result = self._apply(state, 10)
+        self.assertEqual(result["currentHP"], 14)
+
+    def test_already_at_max_stays_at_max(self):
+        state = {"currentHP": 14, "maxHP": 14}
+        result = self._apply(state, 5)
+        self.assertEqual(result["currentHP"], 14)
+
+    def test_zero_healing_unchanged(self):
+        state = {"currentHP": 7, "maxHP": 14}
+        result = self._apply(state, 0)
+        self.assertEqual(result["currentHP"], 7)
+
+    def test_wild_shape_delegates_to_form_healing(self):
+        state = {
+            "currentHP": 20,
+            "maxHP": 20,
+            "wildShape": {"formKey": "brown_bear", "formCurrentHP": 5, "formMaxHP": 34},
+        }
+        mock_form = MagicMock()
+        mock_form.max_hp = 34
+        healed_state = {**state, "wildShape": {**state["wildShape"], "formCurrentHP": 9}}
+
+        with patch("app.api.routes.sessions.state.is_wild_shape_active", return_value=True, create=True), \
+             patch("app.api.routes.sessions.state.get_form", return_value=mock_form), \
+             patch("app.api.routes.sessions.state.apply_healing_to_form", return_value=healed_state):
+            result = self._apply(state, 4)
+
+        self.assertEqual(result["wildShape"]["formCurrentHP"], 9)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PR: feat(spells) declarative healing and Cure Wounds automation

## Description

Este PR implementa o suporte para efeitos declarativos de cura (`heal`). O sistema permite que magias como *Cure Wounds* (Curar Ferimentos) sejam conjuradas fora de combate, resolvendo a rolagem de dados e aplicando a cura diretamente no HP do alvo (ou da forma de Wild Shape, se ativa), com suporte total a escalonamento por nível de slot (Upcast).

## Changes

### Schema & Metadata (`base_spell_effects.py`)
- **New Effect Type:** Adicionado `heal` ao `SpellDeclarativeEffectType`.
- **HealParams:** Criado o modelo `HealParams` com `dice` e `ability_modifier`. O modificador de atributo é obrigatório (podendo ser `null`) para diferenciar a estrutura técnica de efeitos de PV Temporário.

### Out-of-Combat Logic (`out_of_combat_cast.py`)
- **Instant Resolution:** Adicionado `heal` ao `_SKIP_EFFECT_TYPES` para garantir que a cura seja aplicada e descartada, sem gerar efeitos persistentes.
- **Healing Helpers:**
    - `collect_heal_effects()`: Extrai os parâmetros de cura da magia.
    - `compute_heal_dice_with_upcast()`: Calcula o bônus de dados baseado no `upcast_json`.
    - `resolve_spellcasting_modifier()`: Identifica dinamicamente o modificador de conjuração do personagem (`state_json.spellcasting.ability`).
    - `roll_spell_heal_effects()`: Executa a rolagem física dos dados e soma os modificadores.

### Session State (`sessions/state.py`)
- **HP Application:** O handler agora aplica a cura diretamente no `target_json` (aliado) ou `updated_caster_json` (self).
- **Wild Shape Support:** Implementada lógica para detectar se o alvo está transformado (`is_active`), aplicando a cura na forma atual via `apply_healing_to_form`.
- **Activity Enrichment:** O payload de atividade agora inclui `healing_applied` e `healing_rolls` para transparência no log do chat.

### Data & Content
- **Cure Wounds Seed:** Atualizada para permitir cast fora de combate em si mesmo ou aliados, utilizando a nova estrutura declarativa (`1d8 + spellcasting`).

## Summary of Changes

| Component | Change |
| :--- | :--- |
| **`base_spell_effects.py`** | Declarative support for instant healing effects |
| **`Healing Engine`** | Automated dice rolling with upcast and ability modifier integration |
| **`Wild Shape Logic`** | Direct healing application to active forms |
| **`Activity Payload`** | Rich metadata for chat logging (rolls and totals) |

## Validation

A implementação foi validada com uma suíte de testes exaustiva:

- **`test_cure_wounds_cast.py`**: 29 novos testes cobrindo:
    - Validação de schema e elegibilidade.
    - Escalonamento de Upcast (níveis 1, 2, 3 e 5).
    - Aplicação de HP: cura normal, estouro de teto (cap), cura zero e cura em Wild Shape.
    - Verificação de que `active_spell_effects` permanece limpo.
    - **Regressão:** Garantia de que a funcionalidade de *Goodberry* permanece intacta.

> [!TIP]
> Com esta base, magias como *Healing Word*, *Mass Healing Word* e *Prayer of Healing* podem ser automatizadas apenas via JSON de semente, sem necessidade de novo código Python.