### PR TITLE
feat: add healing preview support in spell cast UI

### DIFF
--- a/apps/control-server/app/api/routes/sessions/state.py
+++ b/apps/control-server/app/api/routes/sessions/state.py
@@ -33,6 +33,7 @@ from app.services.goodberry_inventory import grant_catalog_item_to_player_invent
 from app.services.healing_consumables_types import _extract_hp_snapshot, _safe_int
 from app.services.out_of_combat_cast import (
     build_concentration_marker,
+    build_healing_preview,
     build_persisted_effects,
     check_out_of_combat_cast_eligibility,
     collect_create_consumable_effects,
@@ -205,6 +206,10 @@ def _list_out_of_combat_castable_spells_for_player(
         campaign_spell = next((c for c in campaign_spells if c.canonical_key == spell_key), None)
         if not campaign_spell:
             continue
+        healing_preview = build_healing_preview(
+            campaign_spell,
+            state.state_json if isinstance(state.state_json, dict) else {},
+        )
         result.append({
             "id": player_spell.get("id"),
             "canonicalKey": campaign_spell.canonical_key,
@@ -216,6 +221,7 @@ def _list_out_of_combat_castable_spells_for_player(
             "variants": campaign_spell.variants_json or [],
             "effects": campaign_spell.effects_json or [],
             "outOfCombatTarget": campaign_spell.out_of_combat_target,
+            "healingPreview": healing_preview,
         })
     return result
 

--- a/apps/control-server/app/services/out_of_combat_cast.py
+++ b/apps/control-server/app/services/out_of_combat_cast.py
@@ -284,6 +284,62 @@ def has_castable_effects(spell) -> bool:
 _SKIP_EFFECT_TYPES = {"grant_temp_hp", "create_consumable", "heal"}
 
 
+def build_healing_preview(
+    spell,
+    caster_state_json: dict,
+) -> dict | None:
+    """Return a structured healing preview for spells with heal effects, or None.
+
+    The dict contains enough data for the frontend to compute the upcast formula
+    without re-implementing the upcast algorithm.
+    """
+    heal_effects = collect_heal_effects(spell, None)
+    if not heal_effects:
+        return None
+
+    params = (heal_effects[0].get("params") or {})
+    base_dice: str = params.get("dice") or ""
+    modifier = (
+        resolve_spellcasting_modifier(caster_state_json)
+        if params.get("ability_modifier") == "spellcasting"
+        else 0
+    )
+
+    base_count = 1
+    die_sides = 8
+    if "d" in base_dice:
+        parts = base_dice.split("d", 1)
+        try:
+            base_count = int(parts[0])
+            die_sides = int(parts[1])
+        except (ValueError, IndexError):
+            pass
+
+    upcast = getattr(spell, "upcast_json", None) or {}
+    upcast_per_level = 0
+    if upcast.get("mode") == "extra_heal_dice":
+        raw_per = upcast.get("perLevel")
+        if isinstance(raw_per, (int, float)):
+            upcast_per_level = int(raw_per)
+
+    def _formula(count: int) -> str:
+        dice_str = f"{count}d{die_sides}"
+        if modifier > 0:
+            return f"{dice_str} + {modifier}"
+        if modifier < 0:
+            return f"{dice_str} - {abs(modifier)}"
+        return dice_str
+
+    return {
+        "base_formula": _formula(base_count),
+        "base_dice": base_dice,
+        "base_count": base_count,
+        "die_sides": die_sides,
+        "modifier": modifier,
+        "upcast_per_level": upcast_per_level,
+    }
+
+
 def collect_create_consumable_effects(
     spell,
     variant_key: str | None,

--- a/apps/control-server/tests/test_cure_wounds_cast.py
+++ b/apps/control-server/tests/test_cure_wounds_cast.py
@@ -362,3 +362,76 @@ class ApplyHealToStateDictTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# build_healing_preview tests
+# ---------------------------------------------------------------------------
+
+class BuildHealingPreviewTests(unittest.TestCase):
+    from unittest.mock import MagicMock
+
+    def _spell(self, *, dice="1d8", upcast_json=None):
+        from unittest.mock import MagicMock
+        spell = MagicMock()
+        spell.level = 1
+        spell.effects_json = [{"type": "heal", "target": "selected_target",
+                                "params": {"dice": dice, "ability_modifier": "spellcasting"}}]
+        spell.variants_json = []
+        spell.upcast_json = upcast_json if upcast_json is not None else {
+            "mode": "extra_heal_dice", "dice": dice, "perLevel": 1
+        }
+        return spell
+
+    def test_returns_none_for_non_heal_spell(self):
+        from unittest.mock import MagicMock
+        from app.services.out_of_combat_cast import build_healing_preview
+        spell = MagicMock()
+        spell.effects_json = []
+        spell.variants_json = []
+        self.assertIsNone(build_healing_preview(spell, {}))
+
+    def test_cure_wounds_base_formula(self):
+        from app.services.out_of_combat_cast import build_healing_preview
+        spell = self._spell(dice="1d8")
+        state = {"spellcasting": {"ability": "wisdom"}, "abilities": {"wisdom": 16}}
+        result = build_healing_preview(spell, state)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["base_formula"], "1d8 + 3")
+        self.assertEqual(result["base_count"], 1)
+        self.assertEqual(result["die_sides"], 8)
+        self.assertEqual(result["modifier"], 3)
+        self.assertEqual(result["upcast_per_level"], 1)
+
+    def test_healing_word_base_formula(self):
+        from app.services.out_of_combat_cast import build_healing_preview
+        spell = self._spell(dice="1d4")
+        state = {"spellcasting": {"ability": "wisdom"}, "abilities": {"wisdom": 16}}
+        result = build_healing_preview(spell, state)
+        self.assertEqual(result["base_formula"], "1d4 + 3")
+        self.assertEqual(result["die_sides"], 4)
+
+    def test_zero_modifier_omits_sign(self):
+        from app.services.out_of_combat_cast import build_healing_preview
+        spell = self._spell(dice="1d8")
+        state = {"spellcasting": {"ability": "wisdom"}, "abilities": {"wisdom": 10}}
+        result = build_healing_preview(spell, state)
+        self.assertEqual(result["base_formula"], "1d8")
+        self.assertEqual(result["modifier"], 0)
+
+    def test_negative_modifier(self):
+        from app.services.out_of_combat_cast import build_healing_preview
+        spell = self._spell(dice="1d8")
+        state = {"spellcasting": {"ability": "wisdom"}, "abilities": {"wisdom": 8}}
+        result = build_healing_preview(spell, state)
+        self.assertEqual(result["base_formula"], "1d8 - 1")
+        self.assertEqual(result["modifier"], -1)
+
+    def test_goodberry_returns_none(self):
+        from unittest.mock import MagicMock
+        from app.services.out_of_combat_cast import build_healing_preview
+        goodberry = MagicMock()
+        goodberry.effects_json = [{"type": "create_consumable", "target": "caster",
+                                    "params": {"canonical_key": "goodberry", "quantity": 10, "expires_in_seconds": 86400}}]
+        goodberry.variants_json = []
+        self.assertIsNone(build_healing_preview(goodberry, {}))

--- a/apps/control-web/src/entities/character/character.types.ts
+++ b/apps/control-web/src/entities/character/character.types.ts
@@ -61,6 +61,15 @@ export type OutOfCombatSpellVariant = {
   effects?: unknown[] | null;
 };
 
+export type SpellHealingPreview = {
+  baseFormula: string;
+  baseDice: string;
+  baseCount: number;
+  dieSides: number;
+  modifier: number;
+  upcastPerLevel: number;
+};
+
 export type OutOfCombatCastableSpell = {
   id: string | null;
   canonicalKey: string;
@@ -72,4 +81,5 @@ export type OutOfCombatCastableSpell = {
   variants: OutOfCombatSpellVariant[];
   effects: unknown[];
   outOfCombatTarget?: "self" | "ally" | "self_or_ally";
+  healingPreview?: SpellHealingPreview | null;
 };

--- a/apps/control-web/src/entities/character/index.ts
+++ b/apps/control-web/src/entities/character/index.ts
@@ -6,4 +6,5 @@ export type {
   OutOfCombatSpellVariant,
   PartyCharacterSheetDraftRecord,
   SessionStateRecord,
+  SpellHealingPreview,
 } from "./character.types";

--- a/apps/control-web/src/features/sessions/components/SessionActivityRowEventsB.tsx
+++ b/apps/control-web/src/features/sessions/components/SessionActivityRowEventsB.tsx
@@ -326,6 +326,21 @@ export const SessionActivityOutOfCombatSpellCastRow = ({ event, actor }: Props) 
             .
           </p>
         )}
+        {event.healingApplied != null && event.healingApplied > 0 && (
+          <p className="mt-0.5 text-xs text-emerald-400">
+            <span className="font-semibold">+{event.healingApplied}</span>
+            {" "}
+            {t("sessionActivity.healedHp")}
+            {event.healingRolls && event.healingRolls.length > 0 && (
+              <span className="ml-1 text-slate-400">
+                ({event.healingRolls[0].dice}
+                {event.healingRolls[0].modifier !== 0
+                  ? ` + ${event.healingRolls[0].modifier}`
+                  : ""})
+              </span>
+            )}
+          </p>
+        )}
       </div>
       <span className="shrink-0 text-xs font-mono text-slate-500">
         {formatSessionActivityOffset(event.sessionOffsetSeconds)}

--- a/apps/control-web/src/pages/PlayerBoardPage/OutOfCombatSpellCastCard.test.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/OutOfCombatSpellCastCard.test.tsx
@@ -33,6 +33,7 @@ vi.mock("../../shared/hooks/useLocale", () => ({
         "playerBoard.targetSelf": "Você mesmo",
         "playerBoard.castSpellLoading": "Conjurando...",
         "playerBoard.castSpellConfirm": "Conjurar",
+        "playerBoard.healingPreview": "Cura prevista",
       }[key] ?? key),
   }),
 }));
@@ -350,6 +351,106 @@ describe("OutOfCombatSpellCastCard", () => {
 
       expect(onCast).toHaveBeenCalledTimes(1);
       expect(onCast).toHaveBeenCalledWith("spell-1", 1, null, "ally-1");
+    });
+  });
+
+  describe("healing preview", () => {
+    const basePreview = {
+      baseFormula: "1d8 + 3",
+      baseDice: "1d8",
+      baseCount: 1,
+      dieSides: 8,
+      modifier: 3,
+      upcastPerLevel: 1,
+    };
+
+    it("shows healing preview when healingPreview is provided and spell is expanded", () => {
+      mockState.overrides = ["spell-1", {}, {}, {}];
+      const markup = renderToStaticMarkup(
+        <OutOfCombatSpellCastCard
+          spells={[makeSpell({ healingPreview: basePreview })]}
+          casting={false}
+          onCast={() => undefined}
+        />,
+      );
+      expect(markup).toContain("Cura prevista");
+      expect(markup).toContain("1d8 + 3");
+    });
+
+    it("does not show healing preview section when healingPreview is null", () => {
+      mockState.overrides = ["spell-1", {}, {}, {}];
+      const markup = renderToStaticMarkup(
+        <OutOfCombatSpellCastCard
+          spells={[makeSpell({ healingPreview: null })]}
+          casting={false}
+          onCast={() => undefined}
+        />,
+      );
+      expect(markup).not.toContain("Cura prevista");
+    });
+
+    it("does not show healing preview section when healingPreview is absent", () => {
+      mockState.overrides = ["spell-1", {}, {}, {}];
+      const markup = renderToStaticMarkup(
+        <OutOfCombatSpellCastCard
+          spells={[makeSpell()]}
+          casting={false}
+          onCast={() => undefined}
+        />,
+      );
+      expect(markup).not.toContain("Cura prevista");
+    });
+
+    it("shows upcast formula when slot level 2 is selected", () => {
+      // expandedId="spell-1", variants={}, levels={"spell-1": 2}, targets={}
+      mockState.overrides = ["spell-1", {}, { "spell-1": 2 }, {}];
+      const markup = renderToStaticMarkup(
+        <OutOfCombatSpellCastCard
+          spells={[makeSpell({ healingPreview: basePreview })]}
+          casting={false}
+          onCast={() => undefined}
+        />,
+      );
+      expect(markup).toContain("2d8 + 3");
+    });
+
+    it("shows upcast formula when slot level 3 is selected", () => {
+      mockState.overrides = ["spell-1", {}, { "spell-1": 3 }, {}];
+      const markup = renderToStaticMarkup(
+        <OutOfCombatSpellCastCard
+          spells={[makeSpell({ healingPreview: basePreview })]}
+          casting={false}
+          onCast={() => undefined}
+        />,
+      );
+      expect(markup).toContain("3d8 + 3");
+    });
+
+    it("shows base formula for 1d4 spell (Healing Word style)", () => {
+      const hwPreview = { baseFormula: "1d4 + 4", baseDice: "1d4", baseCount: 1, dieSides: 4, modifier: 4, upcastPerLevel: 1 };
+      mockState.overrides = ["spell-1", {}, {}, {}];
+      const markup = renderToStaticMarkup(
+        <OutOfCombatSpellCastCard
+          spells={[makeSpell({ healingPreview: hwPreview })]}
+          casting={false}
+          onCast={() => undefined}
+        />,
+      );
+      expect(markup).toContain("1d4 + 4");
+    });
+
+    it("shows dice without modifier when modifier is zero", () => {
+      const zeroModPreview = { baseFormula: "1d8", baseDice: "1d8", baseCount: 1, dieSides: 8, modifier: 0, upcastPerLevel: 1 };
+      mockState.overrides = ["spell-1", {}, {}, {}];
+      const markup = renderToStaticMarkup(
+        <OutOfCombatSpellCastCard
+          spells={[makeSpell({ healingPreview: zeroModPreview })]}
+          casting={false}
+          onCast={() => undefined}
+        />,
+      );
+      expect(markup).toContain("1d8");
+      expect(markup).not.toContain("+ 0");
     });
   });
 });

--- a/apps/control-web/src/pages/PlayerBoardPage/OutOfCombatSpellCastCard.tsx
+++ b/apps/control-web/src/pages/PlayerBoardPage/OutOfCombatSpellCastCard.tsx
@@ -1,6 +1,15 @@
 import { useState } from "react";
-import type { OutOfCombatCastableSpell } from "../../entities/character";
+import type { OutOfCombatCastableSpell, SpellHealingPreview } from "../../entities/character";
 import { useLocale } from "../../shared/hooks/useLocale";
+
+function buildHealFormula(preview: SpellHealingPreview, spellLevel: number, slotLevel: number): string {
+  const extra = (slotLevel - spellLevel) * preview.upcastPerLevel;
+  const count = preview.baseCount + extra;
+  const diceStr = `${count}d${preview.dieSides}`;
+  if (preview.modifier > 0) return `${diceStr} + ${preview.modifier}`;
+  if (preview.modifier < 0) return `${diceStr} - ${Math.abs(preview.modifier)}`;
+  return diceStr;
+}
 
 type TargetOption = { playerUserId: string; label: string };
 
@@ -150,6 +159,21 @@ export const OutOfCombatSpellCastCard = ({ spells, casting, onCast, targetOption
                           </option>
                         ))}
                       </select>
+                    </div>
+                  )}
+
+                  {spell.healingPreview && (
+                    <div className="rounded-lg bg-slate-700/50 px-3 py-2">
+                      <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
+                        {t("playerBoard.healingPreview")}
+                      </p>
+                      <p className="mt-0.5 text-sm font-medium text-emerald-300">
+                        {buildHealFormula(
+                          spell.healingPreview,
+                          spell.level,
+                          selectedLevels[id] ?? spell.level,
+                        )}
+                      </p>
                     </div>
                   )}
 

--- a/apps/control-web/src/shared/api/sessionsRepo.ts
+++ b/apps/control-web/src/shared/api/sessionsRepo.ts
@@ -356,6 +356,13 @@ export type OutOfCombatSpellCastActivityEvent = {
   previousSpellName?: string | null;
   previousVariantLabel?: string | null;
   castByGm?: boolean;
+  healingApplied?: number | null;
+  healingRolls?: Array<{
+    dice: string;
+    rolls: number[];
+    modifier: number;
+    total: number;
+  }> | null;
   timestamp: string;
   sessionOffsetSeconds: number;
 };

--- a/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/enUS/playerBoard.ts
@@ -234,4 +234,5 @@ export const playerBoardEnUSDictionary = {
   "playerBoard.castSpellLoading": "Casting...",
   "playerBoard.selectTarget": "Target",
   "playerBoard.targetSelf": "Self",
+  "playerBoard.healingPreview": "Healing preview",
 } as const;

--- a/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
+++ b/apps/control-web/src/shared/i18n/ptBR/playerBoard.ts
@@ -234,4 +234,5 @@ export const playerBoardPtBRDictionary = {
   "playerBoard.castSpellLoading": "Lançando...",
   "playerBoard.selectTarget": "Alvo",
   "playerBoard.targetSelf": "Você mesmo",
+  "playerBoard.healingPreview": "Cura prevista",
 } as const;


### PR DESCRIPTION
# PR: feat(spells) healing preview and rich activity logging for OOC cast

## Description

Este PR implementa um sistema de "Healing Preview" para magias de conjuração fora de combate (OOC). Agora, ao selecionar uma magia de cura, o jogador vê exatamente a fórmula que será rolada (ex: `1d8 + 3`), e essa fórmula se atualiza dinamicamente conforme o nível do slot (Upcast) é alterado. Além disso, o log de atividades foi enriquecido para exibir o resultado final da cura e os detalhes dos dados rolados.

## Changes

### Backend Logic
- **`out_of_combat_cast.py`**: Implementada a função `build_healing_preview()`. Ela extrai metadados do efeito de cura, resolve o modificador de conjuração atual e calcula o escalonamento por nível de slot.
- **`sessions/state.py`**: A listagem de magias conjuráveis agora injeta o objeto `healingPreview` em tempo real, permitindo que o frontend receba a fórmula calculada especificamente para os atributos daquele personagem.

### Frontend & UI
- **Type Safety**: Adicionado o tipo `SpellHealingPreview` aos contratos de API e schemas de personagem.
- **Dynamic Preview**: O componente `OutOfCombatSpellCastCard.tsx` agora exibe a "Cura prevista". Utiliza o helper `buildHealFormula()` para atualizar a string da fórmula (ex: `1d8` -> `2d8`) conforme o jogador troca o slot no diálogo.
- **Activity Feed**: Atualizado o `SessionActivityRowEventsB.tsx` para mostrar o feedback visual da cura realizada (ex: **"+7 PV curados: (1d8 + 3)"**).
- **i18n**: Adicionadas chaves de tradução para "Cura prevista" / "Healing preview".

## Summary of Changes

| Component | Change |
| :--- | :--- |
| **`out_of_combat_cast.py`** | Metadata extractor for healing formulas and upcast math |
| **`OutOfCombatSpellCastCard`** | Real-time formula preview based on selected slot level |
| **`Session Activity`** | Detailed healing results (total + rolls) in the activity feed |
| **`Contracts`** | New `healingPreview` field in the OOC spell payload |

## Validation

A implementação foi validada com testes de integração que cobrem desde o cálculo matemático até a renderização visual:

- **Backend (BuildHealingPreviewTests)**: 6 novos testes validando a extração de fórmulas, suporte a modificadores nulos e exclusão de magias sem cura direta (como *Goodberry*).
- **Frontend (OutOfCombatSpellCastCard.test.tsx)**: 8 novos testes cobrindo:
    - Exibição da fórmula base (1d8 + 3).
    - Atualização dinâmica da fórmula em Upcast (Slots 2 e 3).
    - Comportamento com *Healing Word* (1d4).
    - Tratamento de modificadores zero.
- **Regressão**: Sistema estável com 2456 testes passando (mesmas 4 falhas pré-existentes e isoladas).

> [!TIP]
> Com esta mudança, o sistema de conjuração OOC agora fornece o mesmo nível de feedback visual que o sistema de combate, garantindo consistência em toda a plataforma.