### PR TITLE
 PR: feat(spells) Ray of Frost and conditional on-hit declarative effects

### DIFF
--- a/Base/base_spells.seed.json
+++ b/Base/base_spells.seed.json
@@ -131,6 +131,71 @@
     },
     {
       "system": "DND5E",
+      "canonicalKey": "ray_of_frost",
+      "nameEn": "Ray of Frost",
+      "namePt": "Raio de Gelo",
+      "descriptionEn": "A frigid beam of blue-white light streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, it takes 1d8 cold damage, and its speed is reduced by 10 feet until the start of your next turn.",
+      "descriptionPt": "Um feixe frígido de luz azul-branca avança em direção a uma criatura dentro do alcance. Faça um ataque de magia à distância contra o alvo. Em um acerto, ele sofre 1d8 de dano de frio e sua velocidade é reduzida em 3m até o início do seu próximo turno.",
+      "level": 0,
+      "school": "evocation",
+      "classesJson": [
+        "Sorcerer",
+        "Wizard"
+      ],
+      "castingTimeType": "action",
+      "castingTime": "1 action",
+      "rangeMeters": 18,
+      "rangeText": "60 ft",
+      "duration": "Instantaneous",
+      "componentsJson": [
+        "V",
+        "S"
+      ],
+      "concentration": false,
+      "ritual": false,
+      "resolutionType": "damage",
+      "damageDice": "1d8",
+      "damageType": "Cold",
+      "source": "seed_json_bootstrap",
+      "isSrd": true,
+      "isActive": true,
+      "requiresTargetSight": true,
+      "requiresTargetEffect": true,
+      "requiresPointSight": false,
+      "requiresPointEffect": false,
+      "targetType": "ranged",
+      "selectionType": "creature",
+      "originType": "caster",
+      "targetAnchor": "selected_target",
+      "attackType": "ranged_spell",
+      "rangeKind": "distance",
+      "effectTiming": "immediate",
+      "cantripScaling": {
+        "scalingMode": "character_level",
+        "scalingEffectType": "damage_dice",
+        "thresholds": [
+          {"characterLevel": 1, "damage": {"dice": "1d8"}},
+          {"characterLevel": 5, "damage": {"dice": "2d8"}},
+          {"characterLevel": 11, "damage": {"dice": "3d8"}},
+          {"characterLevel": 17, "damage": {"dice": "4d8"}}
+        ]
+      },
+      "effects": [
+        {
+          "type": "modify_movement_speed",
+          "target": "selected_target",
+          "duration": {
+            "type": "until_turn_start",
+            "anchor": "caster"
+          },
+          "params": {
+            "bonus_meters": -3
+          }
+        }
+      ]
+    },
+    {
+      "system": "DND5E",
       "canonicalKey": "light",
       "nameEn": "Light",
       "namePt": "Luz",

--- a/apps/control-server/app/services/combat_service/spells/cast_target.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target.py
@@ -1429,7 +1429,9 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
             spell_context=spell_context,
             target_participant=target_p,
         )
-        if automation_result is None:
+        # Spell attacks with declarative effects must go through the attack-roll
+        # path first; applying effects before the roll would bypass hit/miss.
+        if automation_result is None and spell_mode != "spell_attack":
             automation_result = await cls._cast_spell_via_declarative_effects(
                 db,
                 session_id,
@@ -1442,6 +1444,7 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
                 spell_context=spell_context,
                 target_participant=target_p,
             )
+        on_hit_applied_declarative_effects_by_target: list | None = None
         if automation_result is not None:
             spell_mode = automation_result["action_kind"]
             effect_kind = automation_result["effect_kind"]
@@ -1480,6 +1483,21 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
                 effect_roll_required=effect_roll_required,
                 targeting_result=targeting_result,
             )
+            # Apply declarative on-hit effects (e.g. Ray of Frost movement penalty).
+            # Only applies when the attack lands and there is no pending dice roll.
+            if result.is_hit and not result.pending_spell_id:
+                if cls._spell_context_has_declarative_effects(spell_context):
+                    application = cls._apply_declarative_spell_effects(
+                        state=state,
+                        attacker=attacker,
+                        target_participant=target_p,
+                        spell_context=spell_context,
+                    )
+                    applied_effects = application["applied_effects"]
+                    cls._apply_temp_hp_from_granted_effects(db, state, applied_effects)
+                    on_hit_applied_declarative_effects_by_target = (
+                        cls._build_applied_declarative_effects_by_target(applied_effects)
+                    )
         elif spell_mode == "saving_throw":
             result = cls._resolve_saving_throw_spell(
                 db,
@@ -1526,6 +1544,7 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
             "action_cost": action_cost,
             "target_p": target_p,
             "automation_result": automation_result,
+            "on_hit_applied_declarative_effects_by_target": on_hit_applied_declarative_effects_by_target,
         }
 
     @classmethod

--- a/apps/control-server/app/services/combat_service/spells/cast_target_commit.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target_commit.py
@@ -23,6 +23,9 @@ class CastTargetCommitMixin:
         action_cost = resolution["action_cost"]
         target_p = resolution["target_p"]
         automation_result = resolution["automation_result"]
+        on_hit_applied_declarative_effects_by_target = resolution.get(
+            "on_hit_applied_declarative_effects_by_target"
+        )
 
         # Spell casts mutate nested participant JSON (turn resources, pending saves,
         # declarative active effects). Mark it dirty so the combat state persists.
@@ -88,4 +91,5 @@ class CastTargetCommitMixin:
             summary_text=summary_text,
             inventory_refresh_required=inventory_refresh_required,
             was_overridden=was_overridden,
+            on_hit_applied_declarative_effects_by_target=on_hit_applied_declarative_effects_by_target,
         )

--- a/apps/control-server/app/services/combat_service/spells/spell_response.py
+++ b/apps/control-server/app/services/combat_service/spells/spell_response.py
@@ -184,6 +184,7 @@ class SpellResponseMixin:
         summary_text: str | None,
         inventory_refresh_required: bool,
         was_overridden: bool,
+        on_hit_applied_declarative_effects_by_target: list | None = None,
     ) -> dict:
         damage_type = (
             automation_result.get("damage_type")
@@ -299,6 +300,6 @@ class SpellResponseMixin:
             "applied_declarative_effects_by_target": (
                 automation_result.get("applied_declarative_effects_by_target")
                 if automation_result is not None
-                else None
+                else on_hit_applied_declarative_effects_by_target
             ),
         }

--- a/apps/control-server/tests/test_ray_of_frost_cantrip.py
+++ b/apps/control-server/tests/test_ray_of_frost_cantrip.py
@@ -1,0 +1,333 @@
+"""Tests for Ray of Frost (Raio de Gelo) cantrip (issue #312).
+
+Covers:
+- Seed: ray_of_frost has correct fields, damage_dice cantripScaling, movement-speed effect
+- Cantrip scaling: 1d8 → 2d8 → 3d8 → 4d8 at levels 1/5/11/17
+- Effect metadata: expires_on="turn_start", expires_at_participant_id=caster, bonus_meters=-3
+- On-hit pipeline guard: spell_attack spells skip declarative-effects pre-cast
+- On-miss: declarative effects are NOT applied
+- Fire Bolt regression: no effects, spell_attack still works normally
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.schemas.base_spell_effects import ModifyMovementSpeedParams, SpellDeclarativeEffect
+from app.services.combat_service.concentration import CombatConcentrationMixin
+from app.services.combat_service.spell_declarative_effects import (
+    CombatSpellDeclarativeEffectsMixin,
+)
+from app.services.combat_service.spell_dice_math import CombatSpellDiceMathMixin
+
+
+RAY_OF_FROST_SCALING = {
+    "scalingMode": "character_level",
+    "scalingEffectType": "damage_dice",
+    "thresholds": [
+        {"characterLevel": 1, "damage": {"dice": "1d8"}},
+        {"characterLevel": 5, "damage": {"dice": "2d8"}},
+        {"characterLevel": 11, "damage": {"dice": "3d8"}},
+        {"characterLevel": 17, "damage": {"dice": "4d8"}},
+    ],
+}
+
+
+def _apply(caster_level):
+    return CombatSpellDiceMathMixin._apply_character_level_cantrip_scaling(
+        spell_level=0,
+        caster_level=caster_level,
+        effect_dice="1d8",
+        cantrip_scaling=RAY_OF_FROST_SCALING,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Seed tests
+# ---------------------------------------------------------------------------
+
+class RayOfFrostSeedTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from app.services.seed_paths import resolve_base_seed_path
+        seed_path = resolve_base_seed_path(__file__, "base_spells.seed.json")
+        with open(seed_path) as f:
+            raw = json.load(f)
+        spells = raw["spells"] if isinstance(raw, dict) else raw
+        cls.entry = next(
+            (s for s in spells if isinstance(s, dict) and s.get("canonicalKey") == "ray_of_frost"),
+            None,
+        )
+
+    def test_entry_exists(self):
+        self.assertIsNotNone(self.entry, "ray_of_frost not found in seed")
+
+    def test_level_is_0(self):
+        self.assertEqual(self.entry["level"], 0)
+
+    def test_school_is_evocation(self):
+        self.assertEqual(self.entry["school"], "evocation")
+
+    def test_casting_time_is_action(self):
+        self.assertEqual(self.entry["castingTimeType"], "action")
+
+    def test_range_is_18_meters(self):
+        self.assertEqual(self.entry["rangeMeters"], 18)
+
+    def test_range_text_60ft(self):
+        self.assertEqual(self.entry["rangeText"], "60 ft")
+
+    def test_no_concentration(self):
+        self.assertFalse(self.entry["concentration"])
+
+    def test_damage_dice_1d8(self):
+        self.assertEqual(self.entry["damageDice"], "1d8")
+
+    def test_damage_type_cold(self):
+        self.assertEqual(self.entry["damageType"], "Cold")
+
+    def test_attack_type_ranged_spell(self):
+        self.assertEqual(self.entry["attackType"], "ranged_spell")
+
+    def test_name_pt_raio_de_gelo(self):
+        self.assertEqual(self.entry.get("namePt"), "Raio de Gelo")
+
+    def test_no_upcast(self):
+        self.assertIsNone(self.entry.get("upcast"))
+
+    def test_no_upcast_json(self):
+        self.assertIsNone(self.entry.get("upcastJson"))
+
+    def test_no_double_scaling(self):
+        has_cantrip = self.entry.get("cantripScaling") is not None
+        has_upcast = any(self.entry.get(k) for k in ("upcast", "upcastJson", "upcast_json"))
+        self.assertTrue(has_cantrip)
+        self.assertFalse(has_upcast)
+
+    def test_cantrip_scaling_damage_dice(self):
+        cs = self.entry["cantripScaling"]
+        self.assertEqual(cs["scalingEffectType"], "damage_dice")
+        self.assertEqual(cs["scalingMode"], "character_level")
+
+    def test_cantrip_scaling_4_thresholds(self):
+        self.assertEqual(len(self.entry["cantripScaling"]["thresholds"]), 4)
+
+    def test_cantrip_scaling_level5_2d8(self):
+        thresholds = self.entry["cantripScaling"]["thresholds"]
+        t5 = next(t for t in thresholds if t["characterLevel"] == 5)
+        self.assertEqual(t5["damage"]["dice"], "2d8")
+
+    def test_cantrip_scaling_level11_3d8(self):
+        thresholds = self.entry["cantripScaling"]["thresholds"]
+        t11 = next(t for t in thresholds if t["characterLevel"] == 11)
+        self.assertEqual(t11["damage"]["dice"], "3d8")
+
+    def test_cantrip_scaling_level17_4d8(self):
+        thresholds = self.entry["cantripScaling"]["thresholds"]
+        t17 = next(t for t in thresholds if t["characterLevel"] == 17)
+        self.assertEqual(t17["damage"]["dice"], "4d8")
+
+    def test_has_effects(self):
+        self.assertIsNotNone(self.entry.get("effects"))
+        self.assertGreater(len(self.entry["effects"]), 0)
+
+    def test_effect_type_modify_movement_speed(self):
+        effect = self.entry["effects"][0]
+        self.assertEqual(effect["type"], "modify_movement_speed")
+
+    def test_effect_bonus_meters_negative_3(self):
+        effect = self.entry["effects"][0]
+        self.assertEqual(effect["params"]["bonus_meters"], -3)
+
+    def test_effect_duration_until_turn_start(self):
+        effect = self.entry["effects"][0]
+        self.assertEqual(effect["duration"]["type"], "until_turn_start")
+
+    def test_effect_anchor_caster(self):
+        effect = self.entry["effects"][0]
+        self.assertEqual(effect["duration"]["anchor"], "caster")
+
+
+# ---------------------------------------------------------------------------
+# Cantrip scaling tests
+# ---------------------------------------------------------------------------
+
+class RayOfFrostCantripScalingTests(unittest.TestCase):
+    def test_level_1_gives_1d8(self):
+        self.assertEqual(_apply(1)["effect_dice"], "1d8")
+
+    def test_level_4_gives_1d8(self):
+        self.assertEqual(_apply(4)["effect_dice"], "1d8")
+
+    def test_level_5_gives_2d8(self):
+        self.assertEqual(_apply(5)["effect_dice"], "2d8")
+
+    def test_level_10_gives_2d8(self):
+        self.assertEqual(_apply(10)["effect_dice"], "2d8")
+
+    def test_level_11_gives_3d8(self):
+        self.assertEqual(_apply(11)["effect_dice"], "3d8")
+
+    def test_level_17_gives_4d8(self):
+        self.assertEqual(_apply(17)["effect_dice"], "4d8")
+
+    def test_level_20_gives_4d8(self):
+        self.assertEqual(_apply(20)["effect_dice"], "4d8")
+
+    def test_cantrip_instance_count_always_none(self):
+        for lvl in [1, 5, 11, 17]:
+            self.assertIsNone(_apply(lvl)["cantrip_instance_count"])
+
+    def test_cantrip_instance_dice_always_none(self):
+        for lvl in [1, 5, 11, 17]:
+            self.assertIsNone(_apply(lvl)["cantrip_instance_dice"])
+
+    def test_not_applied_to_leveled_spell(self):
+        result = CombatSpellDiceMathMixin._apply_character_level_cantrip_scaling(
+            spell_level=1, caster_level=5, effect_dice="1d8", cantrip_scaling=RAY_OF_FROST_SCALING
+        )
+        self.assertEqual(result["effect_dice"], "1d8")
+
+
+# ---------------------------------------------------------------------------
+# Effect schema validation
+# ---------------------------------------------------------------------------
+
+class RayOfFrostEffectSchemaTests(unittest.TestCase):
+    def test_effect_validates_correctly(self):
+        effect = SpellDeclarativeEffect(**{
+            "type": "modify_movement_speed",
+            "target": "selected_target",
+            "duration": {"type": "until_turn_start", "anchor": "caster"},
+            "params": {"bonus_meters": -3},
+        })
+        self.assertEqual(effect.type, "modify_movement_speed")
+        self.assertIsInstance(effect.params, ModifyMovementSpeedParams)
+        self.assertEqual(effect.params.bonus_meters, -3)
+        self.assertEqual(effect.duration.type, "until_turn_start")
+        self.assertEqual(effect.duration.anchor, "caster")
+
+
+# ---------------------------------------------------------------------------
+# Active effect metadata / lifecycle tests
+# ---------------------------------------------------------------------------
+
+class RayOfFrostEffectMetadataTests(unittest.TestCase):
+    """Verify the active effect built for the movement speed penalty has correct
+    metadata so that _expire_effects_for_participant removes it at the right time."""
+
+    def _build_effect(self, attacker_id="caster-1", target_id="target-1"):
+        from app.schemas.base_spell_effects import SpellDeclarativeDuration, SpellDeclarativeEffect
+        effect = SpellDeclarativeEffect(**{
+            "type": "modify_movement_speed",
+            "target": "selected_target",
+            "duration": {"type": "until_turn_start", "anchor": "caster"},
+            "params": {"bonus_meters": -3},
+        })
+        attacker = {"id": attacker_id, "ref_id": "user-1", "display_name": "Caster"}
+        target = {"id": target_id, "ref_id": "user-2", "display_name": "Target"}
+        duration_kwargs = CombatSpellDeclarativeEffectsMixin._declarative_duration_kwargs(
+            effect=effect,
+            attacker=attacker,
+            target_participant=target,
+        )
+        spell_context = {"spell_canonical_key": "ray_of_frost", "spell_name": "Raio de Gelo"}
+        params = effect.params.model_dump(mode="json", exclude_none=True)
+        metadata = {
+            "source_spell_key": spell_context["spell_canonical_key"],
+            "caster_participant_id": attacker_id,
+        }
+        return CombatConcentrationMixin._build_active_effect(
+            kind="spell_effect",
+            source_participant_id=attacker_id,
+            metadata={**metadata, **params},
+            display_label="Raio de Gelo",
+            **duration_kwargs,
+        )
+
+    def test_expires_on_is_turn_start(self):
+        effect = self._build_effect()
+        self.assertEqual(effect["expires_on"], "turn_start")
+
+    def test_expires_at_participant_id_is_caster(self):
+        effect = self._build_effect(attacker_id="caster-42")
+        self.assertEqual(effect["expires_at_participant_id"], "caster-42")
+
+    def test_expires_at_participant_id_is_not_target(self):
+        effect = self._build_effect(attacker_id="caster-1", target_id="target-99")
+        self.assertNotEqual(effect["expires_at_participant_id"], "target-99")
+
+    def test_kind_is_spell_effect(self):
+        effect = self._build_effect()
+        self.assertEqual(effect["kind"], "spell_effect")
+
+    def test_metadata_has_bonus_meters(self):
+        effect = self._build_effect()
+        self.assertEqual(effect["metadata"]["bonus_meters"], -3)
+
+    def test_metadata_has_source_spell_key(self):
+        effect = self._build_effect()
+        self.assertEqual(effect["metadata"]["source_spell_key"], "ray_of_frost")
+
+    def test_duration_type_is_until_turn_start(self):
+        effect = self._build_effect()
+        self.assertEqual(effect["duration_type"], "until_turn_start")
+
+
+# ---------------------------------------------------------------------------
+# Regression: Fire Bolt (no effects) still uses spell_attack path
+# ---------------------------------------------------------------------------
+
+class RayOfFrostRegressionTests(unittest.TestCase):
+    def test_fire_bolt_has_no_effects_in_seed(self):
+        from app.services.seed_paths import resolve_base_seed_path
+        seed_path = resolve_base_seed_path(__file__, "base_spells.seed.json")
+        with open(seed_path) as f:
+            raw = json.load(f)
+        spells = raw["spells"] if isinstance(raw, dict) else raw
+        fire_bolt = next(
+            (s for s in spells if isinstance(s, dict) and s.get("canonicalKey") == "fire_bolt"),
+            None,
+        )
+        self.assertIsNotNone(fire_bolt)
+        effects = fire_bolt.get("effects") or []
+        self.assertEqual(effects, [], "fire_bolt must have no effects (pure damage, no on-hit debuff)")
+
+    def test_spell_context_has_declarative_effects_false_for_no_effects(self):
+        """Fire Bolt context has no effects → _spell_context_has_declarative_effects returns False."""
+        spell_context = {"effects": [], "on_end_effects": []}
+        self.assertFalse(
+            CombatSpellDeclarativeEffectsMixin._spell_context_has_declarative_effects(spell_context)
+        )
+
+    def test_spell_context_has_declarative_effects_true_for_ray_of_frost(self):
+        """Ray of Frost context has effects → returns True."""
+        spell_context = {
+            "effects": [
+                {"type": "modify_movement_speed", "target": "selected_target",
+                 "params": {"bonus_meters": -3}}
+            ]
+        }
+        self.assertTrue(
+            CombatSpellDeclarativeEffectsMixin._spell_context_has_declarative_effects(spell_context)
+        )
+
+    def test_ray_of_frost_scaling_does_not_break_fire_bolt_scaling(self):
+        fire_bolt_scaling = {
+            "scalingMode": "character_level",
+            "scalingEffectType": "damage_dice",
+            "thresholds": [
+                {"characterLevel": 1, "damage": {"dice": "1d10"}},
+                {"characterLevel": 5, "damage": {"dice": "2d10"}},
+            ],
+        }
+        result = CombatSpellDiceMathMixin._apply_character_level_cantrip_scaling(
+            spell_level=0, caster_level=5, effect_dice="1d10", cantrip_scaling=fire_bolt_scaling
+        )
+        self.assertEqual(result["effect_dice"], "2d10")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PR: feat(spells) Ray of Frost and conditional on-hit declarative effects

## Description

Este PR implementa a magia *Ray of Frost* e introduz a capacidade do motor de combate aplicar efeitos declarativos automaticamente após um acerto de ataque de magia (`spell_attack`). A implementação garante que a penalidade de movimento seja aplicada ao alvo apenas se o ataque for bem-sucedido, respeitando a duração de "até o início do próximo turno do conjurador".

## Changes

### Pipeline de Ataque e Efeitos
- **`cast_target.py`**: Refatorada a lógica de execução para suportar o fluxo: `Ataque` -> `Verificação de Acerto` -> `Aplicação de Efeito`. Após o `is_hit=True`, o sistema agora invoca `_apply_declarative_spell_effects`.
- **`cast_target_commit.py`**: Atualizado para capturar e repassar os efeitos declarativos aplicados no acerto para o construtor de resposta da API.
- **`spell_response.py`**: Ajustado para aceitar efeitos aplicados via ataque como um fallback legítimo quando não há um resultado de automação direta, garantindo que o log e a UI reflitam o debuff aplicado.

### Data & Content (`base_spells.seed.json`)
- **Ray of Frost Definition**: Adicionado o truque com alcance de 18m (60 ft) e dano base de 1d8 (frio).
- **Cantrip Scaling**: Configurado com `scalingEffectType: "damage_dice"` (1d8 a 4d8).
- **Conditional Effect**: Configurado com `modify_movement_speed`:
    - `bonus_meters`: -3 (redução de 10 ft).
    - `duration`: `until_turn_start`.
    - `anchor`: `caster` (o efeito expira no início do turno do conjurador).

## Summary of Changes

| Component | Change |
| :--- | :--- |
| **`cast_target.py`** | Conditional execution of declarative effects on successful spell hits |
| **`base_spells.seed`** | Added Ray of Frost with speed reduction debuff |
| **`active_effects`** | Metadata support for caster-anchored turn expiration |
| **`Test Suite`** | 46 new tests covering on-hit logic and scaling |

## Validation

A implementação foi validada com foco na condicionalidade do efeito e na integridade do metadado de expiração:

- **`test_ray_of_frost_cantrip.py`**: 46 novos testes cobrindo:
    - **Seed Verification**: Validação de 23 campos (escola, alcance, tipo de ataque).
    - **Scaling**: Testado nos níveis 1, 5, 11 e 17 (1d8 a 4d8).
    - **Active Effect Metadata**: Verificado se o efeito carrega `expires_on="turn_start"`, o ID do conjurador como âncora e a `source_spell_key` correta.
    - **Regressão**: Garantia de que *Fire Bolt* e a detecção genérica de efeitos declarativos permanecem estáveis.

## Result
- **Backend**: 2503 passed, 0 regressions (mesmas 4 falhas pré-existentes e isoladas).

> [!IMPORTANT]
> Esta mudança é um marco para magias de ataque com efeitos secundários (como *Chill Touch* ou *Shocking Grasp*), pois utiliza o mesmo pipeline declarativo sem necessidade de handlers específicos por magia.