### PR TITLE
feat(spells) reactive Shield and Magic Missile interception (#321)

### DIFF
--- a/apps/control-server/app/services/combat_service/spells/cast_target.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target.py
@@ -49,6 +49,38 @@ def _resolve_instance_spatial_error_phrase(result: TargetingResult) -> str:
 
 class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
     @classmethod
+    def _upsert_shield_temp_ac_effect(cls, participant: dict, *, source_participant_id: str | None) -> None:
+        effects = cls._get_participant_effects(participant)
+        kept = []
+        for effect in effects:
+            metadata = cls._as_dict(effect.get("metadata"))
+            if effect.get("kind") == "temp_ac_bonus" and metadata.get("source_spell_key") == "shield":
+                continue
+            kept.append(effect)
+        cls._set_participant_effects(participant, kept)
+        cls._append_effect_to_participant(
+            participant,
+            cls._build_active_effect(
+                kind="temp_ac_bonus",
+                source_participant_id=source_participant_id,
+                numeric_value=5,
+                duration_type="until_turn_start",
+                expires_at_participant_id=participant.get("id"),
+                metadata={"source_spell_key": "shield"},
+                display_label="Shield",
+            ),
+        )
+
+    @classmethod
+    def _is_shielded_for_magic_missile(cls, participant: dict | None) -> bool:
+        if not isinstance(participant, dict):
+            return False
+        for effect in cls._get_participant_effects(participant):
+            metadata = cls._as_dict(effect.get("metadata"))
+            if effect.get("kind") == "temp_ac_bonus" and metadata.get("source_spell_key") == "shield":
+                return True
+        return False
+    @classmethod
     async def _resolve_teleport_spell(
         cls, db, session_id, req, state, attacker, attacker_model, spell_context, actor_user_id, is_gm
     ):
@@ -936,6 +968,10 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
                 outcome = cls._resolve_instance_direct(
                     db, state, attacker, target_p, spell_context, req,
                 )
+                is_magic_missile = cls._normalize_lookup(spell_context.get("spell_canonical_key")) == "magic missile"
+                if is_magic_missile and cls._is_shielded_for_magic_missile(target_p):
+                    outcome["damage"] = 0
+                    outcome["new_hp"] = None
 
             outcome["instance_index"] = vt["instance_index"]
             outcomes.append(outcome)
@@ -1669,6 +1705,27 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
         spell_context, actor_user_id, is_gm,
     ):
         slot_spent = False
+        is_shield = cls._normalize_lookup(spell_context.get("spell_canonical_key")) == "shield"
+        shield_pending_attacker = None
+        shield_pending_payload = None
+        if is_shield:
+            for participant in state.participants:
+                pending = participant.get("pending_attack")
+                if not isinstance(pending, dict):
+                    continue
+                if pending.get("target_ref_id") != attacker.get("ref_id"):
+                    continue
+                if pending.get("type") != "player_attack":
+                    continue
+                attack_roll = cls._safe_int(pending.get("roll"), 0)
+                target_ac = cls._safe_int(pending.get("target_ac"), 10)
+                if attack_roll < target_ac:
+                    continue
+                shield_pending_attacker = participant
+                shield_pending_payload = pending
+                break
+            if shield_pending_payload is None:
+                raise CombatServiceError("Shield requires an incoming hit trigger.", 400)
         if spell_context.get("source_kind") == "magic_item":
             inventory_item = spell_context.get("inventory_item")
             source_item = spell_context.get("source_item")
@@ -1700,6 +1757,23 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
             cls._consume_player_spell_slot(attacker_model, spell_context["slot_level"])
             db.add(attacker_model)
             slot_spent = True
+        if is_shield:
+            cls._upsert_shield_temp_ac_effect(
+                attacker,
+                source_participant_id=attacker.get("id"),
+            )
+            pending_roll = cls._safe_int(shield_pending_payload.get("roll"), 0)
+            _, recalculated_ac, *_ = cls._get_stats(
+                db,
+                attacker["ref_id"],
+                attacker["kind"],
+                session_id,
+                combat_state=state,
+            )
+            recalculated_ac = recalculated_ac or 10
+            if pending_roll < recalculated_ac:
+                cls._clear_participant_pending_attack(shield_pending_attacker)
+                flag_modified(state, "participants")
 
         automation_result = await cls._cast_spell_via_automation(
             db,

--- a/apps/control-server/tests/test_shield_reaction_hardening.py
+++ b/apps/control-server/tests/test_shield_reaction_hardening.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.models.combat import CombatPhase, CombatState
+from app.services.combat import CombatService, CombatServiceError
+from app.schemas.combat import CombatCastSpellRequest
+
+
+class ShieldHelpersTests(unittest.TestCase):
+    def test_upsert_shield_effect_replaces_existing(self):
+        participant = {
+            "id": "p1",
+            "active_effects": [
+                {"id": "a", "kind": "temp_ac_bonus", "numeric_value": 5, "metadata": {"source_spell_key": "shield"}},
+                {"id": "b", "kind": "temp_ac_bonus", "numeric_value": 2, "metadata": {"source_spell_key": "other"}},
+            ],
+        }
+        CombatService._upsert_shield_temp_ac_effect(participant, source_participant_id="p1")
+        effects = participant["active_effects"]
+        shield = [e for e in effects if e.get("kind") == "temp_ac_bonus" and (e.get("metadata") or {}).get("source_spell_key") == "shield"]
+        self.assertEqual(len(shield), 1)
+        self.assertEqual(shield[0]["numeric_value"], 5)
+        self.assertEqual(shield[0]["expires_on"], "turn_start")
+
+    def test_is_shielded_for_magic_missile(self):
+        participant = {
+            "active_effects": [
+                {"kind": "temp_ac_bonus", "numeric_value": 5, "metadata": {"source_spell_key": "shield"}}
+            ]
+        }
+        self.assertTrue(CombatService._is_shielded_for_magic_missile(participant))
+
+
+class ShieldTriggerTests(unittest.IsolatedAsyncioTestCase):
+    async def test_shield_requires_incoming_hit_trigger(self):
+        state = CombatState(
+            id="c1",
+            session_id="s1",
+            phase=CombatPhase.active,
+            round=1,
+            current_turn_index=0,
+            participants=[
+                {"id": "p1", "ref_id": "player-1", "kind": "player", "display_name": "Lia", "status": "active", "team": "players", "turn_resources": {"reaction_used": False}},
+                {"id": "e1", "ref_id": "enemy-1", "kind": "session_entity", "display_name": "Goblin", "status": "active", "team": "enemies"},
+            ],
+        )
+        req = MagicMock(override_resource_limit=False)
+        spell_context = {"spell_canonical_key": "shield", "source_kind": "spell", "slot_level": 1}
+        with self.assertRaises(CombatServiceError):
+            await CombatService._resolve_no_external_target_cast(
+                db=MagicMock(),
+                session_id="s1",
+                req=req,
+                state=state,
+                attacker=state.participants[0],
+                attacker_model=MagicMock(),
+                spell_context=spell_context,
+                actor_user_id="u1",
+                is_gm=False,
+            )
+
+
+class ShieldCastE2ETests(unittest.IsolatedAsyncioTestCase):
+    async def test_cast_spell_consumes_reaction_and_slot_and_clears_pending_when_shield_turns_hit_into_miss(self):
+        state = CombatState(
+            id="c1",
+            session_id="s1",
+            phase=CombatPhase.active,
+            round=1,
+            current_turn_index=0,
+            participants=[
+                {
+                    "id": "p1",
+                    "ref_id": "lia",
+                    "kind": "player",
+                    "display_name": "Lia",
+                    "status": "active",
+                    "team": "players",
+                    "actor_user_id": "u1",
+                    "turn_resources": {"reaction_used": False},
+                },
+                {
+                    "id": "e1",
+                    "ref_id": "goblin",
+                    "kind": "session_entity",
+                    "display_name": "Goblin",
+                    "status": "active",
+                    "team": "enemies",
+                    "pending_attack": {
+                        "id": "pa-1",
+                        "type": "player_attack",
+                        "target_ref_id": "lia",
+                        "roll": 17,
+                        "target_ac": 15,
+                    },
+                },
+            ],
+        )
+        attacker_state = MagicMock()
+        attacker_state.state_json = {
+            "spellcasting": {
+                "slots": {"1": {"used": 0, "max": 2}},
+                "spells": [{"canonicalKey": "shield", "name": "Shield", "prepared": True, "level": 1}],
+            }
+        }
+        req = CombatCastSpellRequest(actor_participant_id="p1", spell_canonical_key="shield")
+        spell_context = {
+            "spell_name": "Shield",
+            "spell_canonical_key": "shield",
+            "spell_mode": "utility",
+            "selection_type": "none",
+            "slot_level": 1,
+            "action_cost": "reaction",
+            "source_kind": "spell",
+            "effect_kind": None,
+        }
+
+        def _mock_get_stats(*args, **kwargs):
+            if kwargs.get("combat_state") is not None:
+                return (attacker_state, 20, None, None, 2, 3)
+            return (attacker_state, 15, None, None, 2, 3)
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=state),
+            patch("app.services.combat.CombatService._resolve_player_spell_context", return_value=spell_context),
+            patch("app.services.combat.CombatService._get_stats", side_effect=_mock_get_stats),
+            patch.object(CombatService, "_emit_and_persist_log", new_callable=AsyncMock) as emit_log,
+            patch.object(CombatService, "_emit_state", new_callable=AsyncMock),
+        ):
+            db = MagicMock()
+            result = await CombatService.cast_spell(db, "s1", req, "u1", False)
+
+        self.assertEqual(result["spell_canonical_key"], "shield")
+        self.assertNotIn("pending_attack", state.participants[1])
+        self.assertEqual(attacker_state.state_json["spellcasting"]["slots"]["1"]["used"], 1)
+        self.assertTrue(state.participants[0]["turn_resources"]["reaction_used"])
+        shield_effects = [
+            e for e in state.participants[0].get("active_effects", [])
+            if e.get("kind") == "temp_ac_bonus" and (e.get("metadata") or {}).get("source_spell_key") == "shield"
+        ]
+        self.assertEqual(len(shield_effects), 1)
+        emit_log.assert_awaited()
+
+
+class MagicMissileInterceptTests(unittest.IsolatedAsyncioTestCase):
+    async def test_shielded_target_instances_are_zeroed(self):
+        state = CombatState(
+            id="c1",
+            session_id="s1",
+            phase=CombatPhase.active,
+            round=1,
+            current_turn_index=0,
+            participants=[
+                {"id": "p1", "ref_id": "caster", "kind": "player", "display_name": "Mage", "status": "active", "team": "players", "turn_resources": {}},
+                {"id": "p2", "ref_id": "lia", "kind": "player", "display_name": "Lia", "status": "active", "team": "players", "turn_resources": {}, "active_effects": [{"kind": "temp_ac_bonus", "numeric_value": 5, "metadata": {"source_spell_key": "shield"}}]},
+                {"id": "p3", "ref_id": "theo", "kind": "player", "display_name": "Theo", "status": "active", "team": "players", "turn_resources": {}},
+            ],
+        )
+        validated_targets = [
+            {"instance_index": 1, "target_ref_id": "lia", "participant": state.participants[1]},
+            {"instance_index": 2, "target_ref_id": "lia", "participant": state.participants[1]},
+            {"instance_index": 3, "target_ref_id": "theo", "participant": state.participants[2]},
+        ]
+        spell_context = {"spell_canonical_key": "magic_missile", "spell_mode": "direct_damage", "action_cost": "action", "effect_kind": "damage", "source_kind": "spell", "slot_level": 1, "spell_name": "Magic Missile"}
+        req = MagicMock(override_resource_limit=False)
+
+        with patch.object(CombatService, "_consume_turn_resource", return_value=False), \
+             patch.object(CombatService, "_consume_player_spell_slot"), \
+             patch.object(CombatService, "_resolve_instance_direct", side_effect=[
+                 {"target_ref_id": "lia", "target_display_name": "Lia", "target_kind": "player", "damage": 4, "healing": 0, "new_hp": 10, "previous_hp": 14},
+                 {"target_ref_id": "lia", "target_display_name": "Lia", "target_kind": "player", "damage": 3, "healing": 0, "new_hp": 7, "previous_hp": 10},
+                 {"target_ref_id": "theo", "target_display_name": "Theo", "target_kind": "player", "damage": 5, "healing": 0, "new_hp": 8, "previous_hp": 13},
+             ]), \
+             patch.object(CombatService, "_emit_player_state_update"), \
+             patch.object(CombatService, "_emit_state"), \
+             patch.object(CombatService, "_emit_and_persist_log"), \
+             patch.object(CombatService, "_get_stats", return_value=(MagicMock(), 10, None, None, None, None)):
+            db = MagicMock()
+            result = await CombatService._resolve_multi_instance_cast(
+                db=db,
+                session_id="s1",
+                req=req,
+                state=state,
+                attacker=state.participants[0],
+                attacker_model=MagicMock(),
+                spell_context=spell_context,
+                actor_user_id="u1",
+                is_gm=False,
+                validated_targets=validated_targets,
+            )
+
+        outcomes = result["effect_instance_outcomes"]
+        self.assertEqual(outcomes[0]["damage"], 0)
+        self.assertEqual(outcomes[1]["damage"], 0)
+        self.assertEqual(outcomes[2]["damage"], 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PR: feat(spells) reactive Shield and Magic Missile interception (#321)

## Description

Este PR implementa a automação da magia `shield` como uma reação tática. A implementação introduz a lógica de interceptação de ataques pendentes, substituição de efeitos de CA temporários e a imunidade específica contra `magic_missile` para alvos protegidos. O sistema garante que a reação só seja consumida se houver um gatilho válido, evitando desperdício de recursos por erro do jogador.

## Changes

### Engine de Reação e Gatilhos (`cast_target.py`)
- **Triggered Buff:** A magia agora exige a presença de um `pending_attack` válido que resultaria em acerto (*hit*).
- **Atomic AC Recalculation:** Ao conjurar `shield`, o sistema aplica o bônus de +5 na CA e recalcula imediatamente o ataque gatilho. Se o novo total for menor que a nova CA, o ataque é convertido em erro (*miss*) e o estado de `pending_attack` é limpo.
- **Resource Integrity:** Slot e Reação são consumidos **apenas** no sucesso da aplicação do buff reativo.

### Interceptação de Magic Missile
- **Innate Immunity:** Atualizado o pipeline de multi-instância para detectar o efeito de `shield` ativo no alvo. 
- **Partial Interception:** Em conjurações de `magic_missile` contra múltiplos alvos, dardos direcionados a alguém protegido por `shield` causam `0` de dano, enquanto dardos em outros alvos desprotegidos resolvem normalmente.

### Gestão de Efeitos
- **Renewal Policy:** Implementada política de substituição para o efeito de `shield`. Conjurar a magia enquanto uma versão anterior ainda está ativa renova a duração (até o início do próximo turno) sem acumular o bônus de CA.

## Summary of Changes

| Component | Change |
| :--- | :--- |
| **`cast_target.py`** | Reactive trigger resolution and AC recalculation logic |
| **`magic_missile`** | Direct interception by Shield effect (0 damage per instance) |
| **`Active Effects`** | Non-stacking renewal policy for temporary AC bonuses |
| **`Test Suite`** | E2E validation of reactions, slot consumption, and partial interception |

## Validation

A implementação foi validada através de testes rigorosos de estado e fluxo:

- **`test_shield_reaction_hardening.py`**: 5 testes passando, incluindo:
    - **Trigger Guard:** Bloqueio de consumo de recurso sem gatilho de ataque.
    - **E2E Reaction:** Consumo de 1 reação + 1 slot com limpeza de ataque pendente.
    - **MM Interception:** Validação de dano zero em alvos protegidos (Cenário: Lia protegida vs Theo atingido).
- **Regressões:** 51 testes de integridade de instâncias e validação espacial passando.

> [!IMPORTANT]
> O Escudo Arcano agora funciona como uma "negação de estado": ele altera o resultado de um dado já rolado, removendo a necessidade de intervenção manual do mestre para ajustar o HP após um acerto que deveria ter sido bloqueado.