### PR TITLE
feat(spells) Guidance automation and consumable roll modifiers (#346)

### DIFF
--- a/Base/base_spells.seed.json
+++ b/Base/base_spells.seed.json
@@ -1588,7 +1588,7 @@
       ],
       "castingTime": "1 action",
       "castingTimeType": "action",
-      "rangeMeters": 0,
+      "rangeMeters": 1.5,
       "rangeText": "Touch",
       "duration": "Concentration, up to 1 minute",
       "componentsJson": [
@@ -1611,7 +1611,28 @@
       "targetAnchor": "selected_target",
       "attackType": "none",
       "rangeKind": "touch",
-      "effectTiming": "persistent"
+      "effectTiming": "persistent",
+      "effects": [
+        {
+          "type": "roll_dice_modifier",
+          "target": "selected_target",
+          "duration": {
+            "type": "rounds",
+            "rounds": 10,
+            "anchor": "caster"
+          },
+          "params": {
+            "mode": "bonus",
+            "roll_types": [
+              "ability",
+              "skill"
+            ],
+            "dice": "1d4",
+            "consume_on_apply": true
+          },
+          "stacking": "replace"
+        }
+      ]
     },
     {
       "system": "DND5E",

--- a/apps/control-server/app/api/routes/sessions/rolls_resolution.py
+++ b/apps/control-server/app/api/routes/sessions/rolls_resolution.py
@@ -177,8 +177,11 @@ def _attach_check_modifier_sources(
     result: RollResult,
     sources: list[dict],
 ) -> RollResult:
+    existing = list(result.check_modifier_sources or [])
     if sources:
-        result.check_modifier_sources = sources
+        existing.extend(sources)
+    if existing:
+        result.check_modifier_sources = existing
     return result
 
 
@@ -250,6 +253,14 @@ async def roll_ability(
     result = resolve_ability_check(
         stats, body.ability, effective_advantage_mode, body.bonus_override, body.dc,
         body.roll_source, body.manual_roll, body.manual_rolls,
+    )
+    CombatService._apply_roll_dice_modifiers_for_actor(
+        db,
+        session_id,
+        actor_kind=body.actor_kind,
+        actor_ref_id=body.actor_ref_id,
+        roll_result=result,
+        roll_type="ability",
     )
     modifier_sources = CombatService._explain_check_modifier_sources_for_actor(
         db,
@@ -336,6 +347,14 @@ async def roll_skill(
     result = resolve_skill_check(
         stats, body.skill, effective_advantage_mode, body.bonus_override, body.dc,
         body.roll_source, body.manual_roll, body.manual_rolls,
+    )
+    CombatService._apply_roll_dice_modifiers_for_actor(
+        db,
+        session_id,
+        actor_kind=body.actor_kind,
+        actor_ref_id=body.actor_ref_id,
+        roll_result=result,
+        roll_type="skill",
     )
     modifier_sources = CombatService._explain_check_modifier_sources_for_actor(
         db,

--- a/apps/control-server/app/schemas/base_spell_effects.py
+++ b/apps/control-server/app/schemas/base_spell_effects.py
@@ -187,6 +187,7 @@ class RollDiceModifierParams(BaseModel):
     mode: Literal["bonus", "penalty"]
     roll_types: list[Literal["attack", "save", "ability", "skill"]]
     dice: str
+    consume_on_apply: bool = False
 
 
 class ArmorClassFormulaParams(BaseModel):

--- a/apps/control-server/app/services/combat_service/condition_effects_predicates.py
+++ b/apps/control-server/app/services/combat_service/condition_effects_predicates.py
@@ -517,21 +517,30 @@ def _normalize_roll_dice_modifier_declarative(declarative: dict) -> dict | None:
         mode = params.get("mode")
         roll_types = params.get("roll_types")
         dice = params.get("dice")
+        consume_on_apply = params.get("consume_on_apply") is True
     else:
         return None
+    if raw_type == "roll_bonus_dice":
+        consume_on_apply = False
     if mode not in {"bonus", "penalty"}:
         return None
     if not isinstance(roll_types, list) or not all(isinstance(rt, str) for rt in roll_types):
         return None
     if not isinstance(dice, str) or not dice.strip():
         return None
-    return {"type": "roll_dice_modifier", "mode": mode, "roll_types": roll_types, "dice": dice.strip()}
+    return {
+        "type": "roll_dice_modifier",
+        "mode": mode,
+        "roll_types": roll_types,
+        "dice": dice.strip(),
+        "consume_on_apply": consume_on_apply,
+    }
 
 
 def get_roll_bonus_dice_sources(
     participant: dict,
     *,
-    roll_type: Literal["attack", "save"],
+    roll_type: Literal["attack", "save", "ability", "skill"],
 ) -> list[dict]:
     sources: list[dict] = []
     seen_keys: set[str] = set()
@@ -550,6 +559,7 @@ def get_roll_bonus_dice_sources(
         roll_types = normalized.get("roll_types")
         dice = normalized.get("dice")
         mode = normalized.get("mode")
+        consume_on_apply = normalized.get("consume_on_apply") is True
         if not isinstance(roll_types, list) or roll_type not in roll_types:
             continue
         if not isinstance(dice, str) or not dice.strip():
@@ -572,6 +582,9 @@ def get_roll_bonus_dice_sources(
                 "rolls": rolls,
                 "signed_total": signed_total,
                 "display_label": f"{source_label}: {sign_label}{dice.strip()}",
+                "effect_id": effect.get("id") if isinstance(effect.get("id"), str) else None,
+                "concentration_group": metadata.get("concentration_group") if isinstance(metadata.get("concentration_group"), str) else None,
+                "consume_on_apply": consume_on_apply,
                 "applied": True,
                 "skip_reason": None,
             }

--- a/apps/control-server/app/services/combat_service/spell_declarative_effects.py
+++ b/apps/control-server/app/services/combat_service/spell_declarative_effects.py
@@ -5,7 +5,8 @@ from copy import deepcopy
 from typing import Literal
 from uuid import uuid4
 
-from app.models.combat import CombatPhase
+from sqlalchemy.orm.attributes import flag_modified
+from app.models.combat import CombatPhase, CombatState
 from app.models.session_state import SessionState
 from app.schemas.base_spell import SpellDeclarativeEffect
 from app.services.game_time import get_game_time_seconds
@@ -30,11 +31,12 @@ class CombatSpellDeclarativeEffectsMixin:
         *,
         participant: dict,
         roll_result,
-        roll_type: Literal["attack", "save"],
-    ) -> None:
+        roll_type: Literal["attack", "save", "ability", "skill"],
+        state: CombatState | None = None,
+    ) -> list[str]:
         sources = get_roll_bonus_dice_sources(participant, roll_type=roll_type)
         if not sources:
-            return
+            return []
         extra_total = sum(int(s.get("signed_total") or 0) for s in sources)
         roll_result.total = int(roll_result.total) + extra_total
         merged = list(roll_result.check_modifier_sources or [])
@@ -49,6 +51,55 @@ class CombatSpellDeclarativeEffectsMixin:
                 roll_result.success = roll_result.total >= roll_result.target_ac
         elif roll_type == "save" and roll_result.dc is not None:
             roll_result.success = roll_result.total >= roll_result.dc
+        elif roll_type in {"ability", "skill"} and roll_result.dc is not None:
+            roll_result.success = roll_result.total >= roll_result.dc
+
+        consumed_effect_ids: list[str] = []
+        for source in sources:
+            if source.get("consume_on_apply") is not True:
+                continue
+            effect_id = source.get("effect_id")
+            if isinstance(effect_id, str) and effect_id and effect_id not in consumed_effect_ids:
+                consumed_effect_ids.append(effect_id)
+        if not consumed_effect_ids:
+            return []
+
+        effects = cls._get_participant_effects(participant)
+        if effects:
+            kept = [e for e in effects if e.get("id") not in set(consumed_effect_ids)]
+            cls._set_participant_effects(participant, kept)
+            if state is not None:
+                flag_modified(state, "participants")
+        return consumed_effect_ids
+
+    @classmethod
+    def _apply_roll_dice_modifiers_for_actor(
+        cls,
+        db,
+        session_id: str,
+        *,
+        actor_kind: str,
+        actor_ref_id: str,
+        roll_result,
+        roll_type: Literal["attack", "save", "ability", "skill"],
+    ) -> list[str]:
+        state = cls.get_state(db, session_id)
+        if state is None or state.phase == CombatPhase.ended:
+            return []
+        participant = resolve_actor_participant(state, actor_ref_id)
+        if not isinstance(participant, dict) or participant.get("kind") != actor_kind:
+            return []
+        consumed_effect_ids = cls._apply_roll_bonus_dice_to_roll_result(
+            participant=participant,
+            roll_result=roll_result,
+            roll_type=roll_type,
+            state=state,
+        )
+        if consumed_effect_ids:
+            db.add(state)
+            db.commit()
+            db.refresh(state)
+        return consumed_effect_ids
 
     @classmethod
     def _build_temp_hp_observability_from_metadata(

--- a/apps/control-server/tests/test_guidance_declarative.py
+++ b/apps/control-server/tests/test_guidance_declarative.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+from app.models.combat import CombatPhase, CombatState
+from app.schemas.roll import RollResult
+from app.services.combat import CombatService
+from app.services.combat_service.condition_effects_predicates import get_roll_bonus_dice_sources
+
+
+def _guidance_effect(effect_id: str = "eff-guid") -> dict:
+    return {
+        "id": effect_id,
+        "kind": "spell_effect",
+        "metadata": {
+            "declarative_effect_group_id": "grp-guid",
+            "source_spell_key": "guidance",
+            "source_spell_name": "Orientação",
+            "concentration": True,
+            "concentration_group": "grp-guid",
+            "declarative_effect": {
+                "type": "roll_dice_modifier",
+                "params": {
+                    "mode": "bonus",
+                    "roll_types": ["ability", "skill"],
+                    "dice": "1d4",
+                    "consume_on_apply": True,
+                },
+            },
+        },
+    }
+
+
+class GuidanceSeedTests(unittest.TestCase):
+    def test_seed_has_guidance_roll_dice_modifier_consumable(self):
+        path = os.path.join(os.path.dirname(__file__), "..", "..", "..", "Base", "base_spells.seed.json")
+        with open(os.path.abspath(path), encoding="utf-8") as f:
+            data = json.load(f)
+        spells = {s["canonicalKey"]: s for s in data.get("spells", [])}
+        self.assertIn("guidance", spells)
+        s = spells["guidance"]
+        self.assertEqual(s["level"], 0)
+        eff = s.get("effects", [])[0]
+        self.assertEqual(eff.get("type"), "roll_dice_modifier")
+        self.assertEqual(eff.get("params", {}).get("roll_types"), ["ability", "skill"])
+        self.assertTrue(eff.get("params", {}).get("consume_on_apply"))
+
+
+class GuidanceRuntimeTests(unittest.TestCase):
+    @patch("app.services.combat_service.condition_effects_predicates._roll_dice_expression", return_value=([3], 3))
+    def test_applies_to_ability_and_consumes_effect_id_only(self, _mock_roll):
+        participant = {"id": "p1", "kind": "player", "active_effects": [_guidance_effect(), {"id": "other", "kind": "spell_effect", "metadata": {"source_spell_key": "bless", "declarative_effect": {"type": "roll_dice_modifier", "params": {"mode": "bonus", "roll_types": ["attack", "save"], "dice": "1d4"}}}}]}
+        state = CombatState(id="c1", session_id="s1", phase=CombatPhase.active, round=1, current_turn_index=0, participants=[participant], use_map=False)
+        result = RollResult(event_id="e1", roll_type="ability", actor_kind="player", actor_ref_id="p1", actor_display_name="Lia", rolls=[10, 10], selected_roll=10, advantage_mode="normal", modifier_used=2, override_used=False, formula="1d20 + 2", total=12, ability="wisdom", dc=12, success=True, roll_source="system", timestamp="2026-01-01T00:00:00Z")
+        consumed = CombatService._apply_roll_bonus_dice_to_roll_result(participant=participant, roll_result=result, roll_type="ability", state=state)
+        self.assertEqual(result.total, 15)
+        self.assertEqual(consumed, ["eff-guid"])
+        self.assertEqual(len(participant.get("active_effects", [])), 1)
+        self.assertEqual(participant["active_effects"][0]["id"], "other")
+        self.assertEqual(result.check_modifier_sources[0]["display_label"], "Orientação: +1d4")
+
+    @patch("app.services.combat_service.condition_effects_predicates._roll_dice_expression", return_value=([4], 4))
+    def test_not_applied_to_attack_and_not_consumed(self, _mock_roll):
+        participant = {"id": "p1", "kind": "player", "active_effects": [_guidance_effect()]}
+        result = RollResult(event_id="e2", roll_type="attack", actor_kind="player", actor_ref_id="p1", actor_display_name="Lia", rolls=[10, 10], selected_roll=10, advantage_mode="normal", modifier_used=4, override_used=False, formula="1d20 + 4", total=14, target_ac=15, success=False, roll_source="system", timestamp="2026-01-01T00:00:00Z")
+        consumed = CombatService._apply_roll_bonus_dice_to_roll_result(participant=participant, roll_result=result, roll_type="attack")
+        self.assertEqual(consumed, [])
+        self.assertEqual(result.total, 14)
+        self.assertEqual(len(participant.get("active_effects", [])), 1)
+
+    @patch("app.services.combat_service.condition_effects_predicates._roll_dice_expression", return_value=([2], 2))
+    def test_invalid_then_valid_roll_consumes_only_on_valid(self, _mock_roll):
+        participant = {"id": "p1", "kind": "player", "active_effects": [_guidance_effect()]}
+        atk_sources = get_roll_bonus_dice_sources(participant, roll_type="attack")
+        self.assertEqual(atk_sources, [])
+        self.assertEqual(len(participant.get("active_effects", [])), 1)
+
+        result = RollResult(event_id="e3", roll_type="skill", actor_kind="player", actor_ref_id="p1", actor_display_name="Lia", rolls=[9, 9], selected_roll=9, advantage_mode="normal", modifier_used=1, override_used=False, formula="1d20 + 1", total=10, skill="perception", dc=11, success=False, roll_source="system", timestamp="2026-01-01T00:00:00Z")
+        consumed = CombatService._apply_roll_bonus_dice_to_roll_result(participant=participant, roll_result=result, roll_type="skill")
+        self.assertEqual(result.total, 12)
+        self.assertTrue(result.success)
+        self.assertEqual(consumed, ["eff-guid"])
+        self.assertEqual(len(participant.get("active_effects", [])), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/control-web/src/features/rolls/components/AuthoritativeRollDialog.test.tsx
+++ b/apps/control-web/src/features/rolls/components/AuthoritativeRollDialog.test.tsx
@@ -233,4 +233,55 @@ describe("AuthoritativeRollDialog", () => {
     );
     expect(markup).toContain("Perdição: -1d4");
   });
+
+  it("exibe bônus de Orientação +1d4 em teste de atributo", () => {
+    useRollResolutionMock.mockReturnValue({
+      result: {
+        event_id: "roll-4",
+        roll_type: "ability",
+        actor_kind: "player",
+        actor_ref_id: "player-1",
+        actor_display_name: "Hero",
+        rolls: [12, 12],
+        selected_roll: 12,
+        advantage_mode: "normal",
+        modifier_used: 1,
+        override_used: false,
+        formula: "1d20 + 1",
+        total: 16,
+        check_modifier_sources: [
+          {
+            source_label: "Orientação",
+            modifier_type: "roll_dice_modifier",
+            mode: "bonus",
+            roll_type: "ability",
+            dice: "1d4",
+            rolls: [3],
+            signed_total: 3,
+            display_label: "Orientação: +1d4",
+            applied: true,
+            skip_reason: null,
+          },
+        ],
+        is_gm_roll: false,
+        roll_source: "system",
+        timestamp: "2026-05-01T00:00:00Z",
+      },
+      loading: false,
+      error: null,
+      submitRoll: vi.fn(),
+      clearResult: vi.fn(),
+    });
+
+    const markup = renderToStaticMarkup(
+      <AuthoritativeRollDialog
+        request={{ rollType: "ability", advantageMode: "normal", reason: "Ability check" }}
+        sessionId="session-1"
+        actorKind="player"
+        actorRefId="player-1"
+        onClose={() => undefined}
+      />,
+    );
+    expect(markup).toContain("Orientação: +1d4");
+  });
 });

--- a/apps/control-web/src/features/sessions/components/sessionActivityRowUtils.test.ts
+++ b/apps/control-web/src/features/sessions/components/sessionActivityRowUtils.test.ts
@@ -126,4 +126,21 @@ describe("sessionActivityRowUtils", () => {
       }),
     ).toBe("Perdição: -1d4");
   });
+
+  it("formats Guidance roll bonus source", () => {
+    expect(
+      formatCheckModifierSource({
+        source_label: "Orientação",
+        modifier_type: "roll_dice_modifier",
+        mode: "bonus",
+        roll_type: "ability",
+        dice: "1d4",
+        rolls: [3],
+        signed_total: 3,
+        display_label: "Orientação: +1d4",
+        applied: true,
+        skip_reason: null,
+      }),
+    ).toBe("Orientação: +1d4");
+  });
 });


### PR DESCRIPTION
# PR: feat(spells) Guidance automation and consumable roll modifiers (#346)

## Description

Este PR implementa a automação da magia *Guidance* e introduz a funcionalidade de modificadores consumíveis no motor de regras. Agora, efeitos declarativos podem ser marcados com `consume_on_apply: true`, garantindo que o bônus seja aplicado a uma rolagem e o efeito removido imediatamente após o uso. O sistema foi expandido para suportar rolagens de atributos (`ability`) e perícias (`skill`) de forma autoritativa.

## Changes

### Engine de Modificadores e Consumo (`apps/control-server`)
- **Consumable Logic:** O schema `roll_dice_modifier` agora suporta a flag `consume_on_apply`. No momento da resolução da rolagem, o backend identifica o efeito, aplica o bônus e remove a instância específica do `active_effect` do participante.
- **Expanded Scopes:** O pipeline de modificadores foi generalizado para aceitar `ability` e `skill`, permitindo que magias influenciem testes fora do combate (como Atletismo, Percepção, etc.).
- **Atomic Removal:** A remoção é feita por `effect_id`, garantindo que se o jogador tiver múltiplos efeitos distintos, apenas o utilizado seja consumido.

### Resolução de Rolagens (`rolls_resolution.py`)
- **Authoritative Injection:** O endpoint de rolagens de perícias e atributos agora processa modificadores declarativos antes da publicação do resultado, garantindo que o bônus de $1d4$ seja somado e logado corretamente com a label **"Orientação: +1d4"**.

### Data & Content (`base_spells.seed.json`)
- **Guidance Seed:** Configurada como Truque (Level 0), toque, duração de 1 minuto (concentração) e configurada para ser consumida ao aplicar o bônus em testes de perícia ou atributo.

## Summary of Changes

| Component | Change |
| :--- | :--- |
| **`base_spell_effects`** | Added `consume_on_apply` flag to roll modifiers |
| **`Guidance Spell`** | Full automation: 1d4 bonus to Ability/Skill with auto-consume |
| **`Roll Pipeline`** | Integration of declarative bonuses into out-of-combat checks |
| **`UI Consistency`** | Displays "Orientação: +1d4" in the authoritative roll results |

## Validation

A implementação foi validada com foco no ciclo de vida do efeito e precisão de consumo:

- **Backend (`test_guidance_declarative.py`)**: 128 testes passando, cobrindo:
    - Aplicação do bônus em testes de Perícia (ex: *Stealth*).
    - Remoção automática do efeito após a rolagem.
    - Persistência do efeito se a rolagem for de um tipo não coberto (ex: Ataque).
- **Frontend (`Vitest`)**: 13 testes passando, garantindo que o diálogo de rolagem e as labels de atividade exibem o bônus consumível corretamente.
- **Regressão**: Estabilidade mantida para *Bless* e *Bane* (que permanecem persistentes) e magias de instância única como *Magic Missile*.

> [!TIP]
> Esta arquitetura de consumo será fundamental para futuras implementações como *Bardic Inspiration* ou a manobra *Precision Attack*, onde o recurso deve ser subtraído no exato momento do sucesso ou uso.