### PR TITLE
feat(spells) Charm Person automation and hostile context logic (#359)

### DIFF
--- a/Base/base_spells.seed.json
+++ b/Base/base_spells.seed.json
@@ -1584,6 +1584,7 @@
       "resolutionType": "control",
       "savingThrow": "WIS",
       "saveSuccessOutcome": "none",
+      "maxTargets": 1,
       "upcast": {
         "mode": "additional_targets",
         "perLevel": 1

--- a/apps/control-server/app/services/combat_service/spell_automation.py
+++ b/apps/control-server/app/services/combat_service/spell_automation.py
@@ -81,6 +81,12 @@ class CombatSpellAutomationMixin:
             requires_effect_payload=False,
             handler_name="_cast_animal_friendship_automation",
         ),
+        "charm_person": SpellAutomationSpec(
+            canonical_key="charm_person",
+            default_mode="saving_throw",
+            requires_effect_payload=False,
+            handler_name="_cast_charm_person_automation",
+        ),
         "hunters_mark": SpellAutomationSpec(
             canonical_key="hunters_mark",
             default_mode="utility",
@@ -175,6 +181,16 @@ class CombatSpellAutomationMixin:
         )
         if creature_type != "beast":
             raise CombatServiceError("Animal Friendship can only target beasts.", 400)
+
+    @classmethod
+    def _is_hostile_team_context(cls, attacker: dict, target_participant: dict) -> bool:
+        attacker_team = str(attacker.get("team") or "").strip().lower()
+        target_team = str(target_participant.get("team") or "").strip().lower()
+        if attacker_team in {"players", "allies"}:
+            return target_team == "enemies"
+        if attacker_team == "enemies":
+            return target_team in {"players", "allies"}
+        return False
 
     @staticmethod
     def _base_spell_result(
@@ -348,6 +364,90 @@ class CombatSpellAutomationMixin:
                         "source_spell_key": "animal_friendship",
                         "caster_participant_id": attacker["id"],
                         "charmer_participant_id": attacker["id"],
+                        "termination_conditions": [
+                            {"type": "target_takes_damage_from_caster_or_allies"},
+                        ],
+                    },
+                ),
+            )
+            flag_modified(state, "participants")
+
+        spell_name = spell_context["spell_name"]
+        if is_saved:
+            summary_text = f"{target_participant['display_name']} passou na salvaguarda contra {spell_name}."
+        else:
+            summary_text = f"{target_participant['display_name']} falhou na salvaguarda e ficou enfeitiçado."
+
+        return cls._base_spell_result(
+            spell_name=spell_name,
+            spell_context=spell_context,
+            target_display_name=target_participant["display_name"],
+            target_kind=target_participant["kind"],
+            action_kind="saving_throw",
+            summary_text=summary_text,
+            log_message=(
+                f"{attacker['display_name']} lançou {spell_name} em {target_participant['display_name']}: "
+                f"{'o alvo passou na salvaguarda' if is_saved else 'o alvo falhou e ficou enfeitiçado'}."
+            ),
+            extra={
+                "is_saved": is_saved,
+                "roll": roll_total,
+                "roll_result": roll_result,
+                "save_ability": spell_context.get("save_ability"),
+                "save_dc": spell_context.get("save_dc"),
+                "save_success_outcome": spell_context.get("save_success_outcome"),
+            },
+        )
+
+    @classmethod
+    async def _cast_charm_person_automation(
+        cls,
+        db: Session,
+        session_id: str,
+        *,
+        attacker: dict,
+        attacker_model,
+        actor_user_id: str,
+        is_gm: bool,
+        req,
+        state: CombatState,
+        spell_context: dict,
+        target_participant: dict,
+    ) -> dict:
+        is_hostile = cls._is_hostile_team_context(attacker, target_participant)
+        advantage_mode = "advantage" if is_hostile else "normal"
+        roll_result = resolve_saving_throw(
+            cls._build_roll_actor_stats_for_save(
+                db,
+                session_id,
+                target_participant["ref_id"],
+                target_participant["kind"],
+                target_participant["display_name"],
+            ),
+            ability=spell_context["save_ability"],
+            dc=cls._safe_int(spell_context.get("save_dc"), 0),
+            advantage_mode=advantage_mode,
+        )
+        roll_result.is_gm_roll = is_gm
+        roll_total = roll_result.total
+        is_saved = bool(roll_result.success)
+
+        game_time = get_game_time_seconds(session_id, db)
+        if not is_saved:
+            cls._append_effect_to_participant(
+                target_participant,
+                cls._build_active_effect(
+                    kind="condition",
+                    condition_type="charmed",
+                    source_participant_id=attacker["id"],
+                    duration_type="timed",
+                    created_at_game_time_seconds=game_time,
+                    expires_at_game_time_seconds=game_time + 3600,
+                    metadata={
+                        "source_spell_key": "charm_person",
+                        "caster_participant_id": attacker["id"],
+                        "charmer_participant_id": attacker["id"],
+                        "target_knows_charmed_by_caster": True,
                         "termination_conditions": [
                             {"type": "target_takes_damage_from_caster_or_allies"},
                         ],

--- a/apps/control-server/app/services/combat_service/spells/cast_target.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_target.py
@@ -58,7 +58,7 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
         target_participant: dict,
     ) -> None:
         spell_key = cls._normalize_lookup(spell_canonical_key).replace(" ", "_")
-        if spell_key != "hold_person":
+        if spell_key not in {"hold_person", "charm_person"}:
             return
         creature_type = cls.resolve_effective_creature_type(
             db,
@@ -66,7 +66,8 @@ class CastTargetMixin(CastTargetCommitMixin, CastTargetEffectMixin):
             target_participant,
         )
         if creature_type is not None and creature_type != "humanoid":
-            raise CombatServiceError("Hold Person can only target humanoids.", 400)
+            spell_name = "Hold Person" if spell_key == "hold_person" else "Charm Person"
+            raise CombatServiceError(f"{spell_name} can only target humanoids.", 400)
 
     @classmethod
     def _upsert_shield_temp_ac_effect(cls, participant: dict, *, source_participant_id: str | None) -> None:

--- a/apps/control-server/tests/test_charm_person.py
+++ b/apps/control-server/tests/test_charm_person.py
@@ -1,0 +1,561 @@
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.models.combat import CombatPhase, CombatState
+from app.models.session_state import SessionState
+from app.schemas.base_spell import BaseSpellCreate
+from app.schemas.combat import CombatCastSpellRequest
+from app.schemas.combat_spells import CombatResolveSpellContextRequest
+from app.schemas.roll import RollResult
+from app.services.combat import CombatService, CombatServiceError
+from app.services.declarative_effect_lifecycle import remove_damage_terminated_effects_from_participant
+
+
+def _make_player() -> dict:
+    return {
+        "id": "p1",
+        "ref_id": "caster",
+        "kind": "player",
+        "display_name": "Lia",
+        "initiative": 10,
+        "status": "active",
+        "team": "players",
+        "visible": True,
+        "actor_user_id": "u1",
+        "active_effects": [],
+        "turn_resources": {"action_used": False, "bonus_action_used": False, "reaction_used": False},
+    }
+
+
+def _make_target(pid: str, ref_id: str, team: str = "enemies") -> dict:
+    return {
+        "id": pid,
+        "ref_id": ref_id,
+        "kind": "session_entity",
+        "display_name": f"Target {pid}",
+        "initiative": 5,
+        "status": "active",
+        "team": team,
+        "visible": True,
+        "actor_user_id": None,
+        "active_effects": [],
+        "turn_resources": {"action_used": False, "bonus_action_used": False, "reaction_used": False},
+    }
+
+
+def _make_state(participants: list[dict]) -> CombatState:
+    return CombatState(
+        id="c1",
+        session_id="s1",
+        phase=CombatPhase.active,
+        round=1,
+        current_turn_index=0,
+        participants=participants,
+        use_map=False,
+    )
+
+
+def _make_charm_catalog_spell(max_targets: int = 1):
+    return SimpleNamespace(
+        canonical_key="charm_person",
+        name_en="Charm Person",
+        name_pt="Enfeitiçar Pessoa",
+        level=1,
+        resolution_type="control",
+        damage_dice=None,
+        heal_dice=None,
+        damage_type=None,
+        saving_throw="wisdom",
+        save_success_outcome="none",
+        upcast_json={"mode": "additional_targets", "perLevel": 1},
+        cantrip_scaling_json=None,
+        casting_time_type="action",
+        target_type="ranged",
+        selection_type="creature",
+        origin_type="caster",
+        target_anchor="selected_target",
+        attack_type="none",
+        range_kind="distance",
+        effect_timing="immediate",
+        area_shape=None,
+        range_meters=9,
+        duration="1 hour",
+        concentration=False,
+        cover_applies_to_save="none",
+        max_targets=max_targets,
+        requires_target_sight=True,
+        requires_target_effect=True,
+        requires_point_sight=False,
+        requires_point_effect=False,
+        effects_json=None,
+    )
+
+
+class CharmPersonSeedTests(unittest.TestCase):
+    def test_charm_person_seed_contract(self):
+        payload = json.loads(open("Base/base_spells.seed.json", encoding="utf-8").read())
+        raw_spell = next(entry for entry in payload["spells"] if entry["canonicalKey"] == "charm_person")
+        spell = BaseSpellCreate.model_validate(raw_spell)
+
+        self.assertEqual(spell.level, 1)
+        self.assertEqual(spell.school, "enchantment")
+        self.assertEqual(spell.savingThrow, "WIS")
+        self.assertEqual(raw_spell.get("saveSuccessOutcome"), "none")
+        self.assertFalse(spell.concentration)
+        self.assertEqual(spell.rangeMeters, 9)
+        self.assertEqual(raw_spell.get("maxTargets"), 1)
+        upcast = raw_spell.get("upcast") or {}
+        self.assertEqual(upcast.get("mode"), "additional_targets")
+        self.assertEqual(upcast.get("perLevel"), 1)
+
+
+class CharmPersonUpcastContextTests(unittest.TestCase):
+    def _resolve_context(self, slot_level: int) -> dict:
+        state = _make_state([_make_player()])
+        attacker_state = SessionState(
+            id="ss-1",
+            session_id="s1",
+            player_user_id="u1",
+            state_json={
+                "spellcasting": {
+                    "spells": [{"canonicalKey": "charm_person", "level": 1, "prepared": True}],
+                    "slots": {str(slot_level): {"used": 0, "max": 3}},
+                }
+            },
+        )
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=state),
+            patch("app.services.combat.CombatService._get_spell_catalog_entry_for_session", return_value=_make_charm_catalog_spell(1)),
+            patch("app.services.combat.CombatService._get_stats", return_value=(attacker_state, 12, 10, 10, 3, 4)),
+        ):
+            return CombatService.resolve_spell_context(
+                MagicMock(),
+                "s1",
+                CombatResolveSpellContextRequest(
+                    actor_participant_id="p1",
+                    spell_canonical_key="charm_person",
+                    spell_mode="saving_throw",
+                    slot_level=slot_level,
+                ),
+                "u1",
+                False,
+            )
+
+    def test_upcast_max_targets_progression(self):
+        self.assertEqual(self._resolve_context(1)["max_targets"], 1)
+        self.assertEqual(self._resolve_context(2)["max_targets"], 2)
+        self.assertEqual(self._resolve_context(3)["max_targets"], 3)
+        self.assertEqual(self._resolve_context(4)["max_targets"], 4)
+
+
+class CharmPersonCastFlowTests(unittest.IsolatedAsyncioTestCase):
+    async def test_known_non_humanoid_is_rejected_without_slot_spend(self):
+        state = _make_state([_make_player(), _make_target("e1", "enemy-a")])
+        attacker_state = MagicMock()
+        attacker_state.state_json = {
+            "spellcasting": {
+                "slots": {"1": {"used": 0, "max": 2}},
+                "spells": [{"canonicalKey": "charm_person", "name": "Charm Person", "prepared": True, "level": 1}],
+            }
+        }
+        req = CombatCastSpellRequest(actor_participant_id="p1", spell_canonical_key="charm_person", target_ref_id="enemy-a")
+        spell_context = {
+            "spell_name": "Charm Person",
+            "spell_canonical_key": "charm_person",
+            "spell_mode": "saving_throw",
+            "selection_type": "creature",
+            "slot_level": 1,
+            "action_cost": "action",
+            "source_kind": "spell",
+            "effect_kind": "damage",
+            "effect_dice": None,
+            "effect_bonus": 0,
+            "save_ability": "wisdom",
+            "save_dc": 14,
+            "save_success_outcome": "none",
+            "target_type": "ranged",
+            "range_kind": "distance",
+            "attack_type": "none",
+            "requires_target_sight": True,
+            "requires_target_effect": True,
+            "concentration": False,
+        }
+        targeting_result = MagicMock(is_valid=True, validated_primary_target_ref_id="enemy-a", spatial_metadata=MagicMock(cover=None))
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=state),
+            patch("app.services.combat.CombatService._get_stats", return_value=(attacker_state, 10, 10, 10, 2, 3)),
+            patch("app.services.combat.CombatService._resolve_player_spell_context", return_value=spell_context),
+            patch("app.services.combat.CombatService.resolve_effective_creature_type", return_value="undead"),
+            patch("app.services.combat_service.spells.cast_target.get_combat_targeting_service", return_value=MagicMock(validate=MagicMock(return_value=targeting_result))),
+            patch.object(CombatService, "_emit_and_persist_log", new_callable=AsyncMock) as emit_log,
+        ):
+            with self.assertRaises(CombatServiceError):
+                await CombatService.cast_spell(MagicMock(), "s1", req, "u1", False)
+
+        self.assertEqual(attacker_state.state_json["spellcasting"]["slots"]["1"]["used"], 0)
+        self.assertEqual(state.participants[1].get("active_effects") or [], [])
+        success_logs = [
+            c for c in emit_log.await_args_list
+            if "conjurou Charm Person" in ((c.args[4] or {}).get("message", "") if len(c.args) > 4 else "")
+        ]
+        self.assertEqual(success_logs, [])
+
+    async def test_unknown_type_follows_hold_person_policy_and_allows_cast(self):
+        state = _make_state([_make_player(), _make_target("e1", "enemy-a")])
+        attacker_state = MagicMock()
+        attacker_state.state_json = {
+            "spellcasting": {
+                "slots": {"1": {"used": 0, "max": 2}},
+                "spells": [{"canonicalKey": "charm_person", "name": "Charm Person", "prepared": True, "level": 1}],
+            }
+        }
+        req = CombatCastSpellRequest(actor_participant_id="p1", spell_canonical_key="charm_person", target_ref_id="enemy-a")
+        spell_context = {
+            "spell_name": "Charm Person",
+            "spell_canonical_key": "charm_person",
+            "spell_mode": "saving_throw",
+            "selection_type": "creature",
+            "slot_level": 1,
+            "action_cost": "action",
+            "source_kind": "spell",
+            "effect_kind": "damage",
+            "effect_dice": None,
+            "effect_bonus": 0,
+            "save_ability": "wisdom",
+            "save_dc": 14,
+            "save_success_outcome": "none",
+            "target_type": "ranged",
+            "range_kind": "distance",
+            "attack_type": "none",
+            "requires_target_sight": True,
+            "requires_target_effect": True,
+            "concentration": False,
+        }
+        roll_fail = RollResult(
+            event_id="r1",
+            roll_type="save",
+            actor_kind="session_entity",
+            actor_ref_id="enemy-a",
+            actor_display_name="Target e1",
+            rolls=[2],
+            selected_roll=2,
+            advantage_mode="normal",
+            modifier_used=0,
+            override_used=False,
+            formula="1d20",
+            total=2,
+            ability="wisdom",
+            dc=14,
+            success=False,
+            timestamp=datetime.now(timezone.utc),
+        )
+        targeting_result = MagicMock(is_valid=True, validated_primary_target_ref_id="enemy-a", spatial_metadata=MagicMock(cover=None))
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=state),
+            patch("app.services.combat.CombatService._get_stats", return_value=(attacker_state, 10, 10, 10, 2, 3)),
+            patch("app.services.combat.CombatService._resolve_player_spell_context", return_value=spell_context),
+            patch("app.services.combat.CombatService.resolve_effective_creature_type", return_value=None),
+            patch("app.services.combat_service.spells.cast_target.get_combat_targeting_service", return_value=MagicMock(validate=MagicMock(return_value=targeting_result))),
+            patch("app.services.combat_service.spell_automation.resolve_saving_throw", return_value=roll_fail),
+            patch.object(CombatService, "_emit_state", new_callable=AsyncMock),
+            patch.object(CombatService, "_emit_and_persist_log", new_callable=AsyncMock),
+        ):
+            result = await CombatService.cast_spell(MagicMock(), "s1", req, "u1", False)
+
+        self.assertEqual(attacker_state.state_json["spellcasting"]["slots"]["1"]["used"], 1)
+        self.assertFalse(result["is_saved"])
+        self.assertEqual(len(state.participants[1].get("active_effects") or []), 1)
+
+    async def test_hostile_teams_apply_initial_save_advantage(self):
+        state = _make_state([_make_player(), _make_target("e1", "enemy-a", team="enemies")])
+        roll_pass = RollResult(
+            event_id="r1",
+            roll_type="save",
+            actor_kind="session_entity",
+            actor_ref_id="enemy-a",
+            actor_display_name="Target e1",
+            rolls=[7, 17],
+            selected_roll=17,
+            advantage_mode="advantage",
+            modifier_used=0,
+            override_used=False,
+            formula="2d20kh1",
+            total=17,
+            ability="wisdom",
+            dc=14,
+            success=True,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        with patch("app.services.combat_service.spell_automation.resolve_saving_throw", return_value=roll_pass) as save_mock:
+            await CombatService._cast_charm_person_automation(
+                MagicMock(),
+                "s1",
+                attacker=state.participants[0],
+                attacker_model=MagicMock(),
+                actor_user_id="u1",
+                is_gm=False,
+                req=MagicMock(),
+                state=state,
+                spell_context={"spell_name": "Charm Person", "spell_canonical_key": "charm_person", "save_ability": "wisdom", "save_dc": 14, "save_success_outcome": "none"},
+                target_participant=state.participants[1],
+            )
+
+        self.assertEqual(save_mock.call_args.kwargs.get("advantage_mode"), "advantage")
+
+    async def test_non_hostile_teams_do_not_apply_initial_save_advantage(self):
+        state = _make_state([_make_player(), _make_target("e1", "enemy-a", team="neutral")])
+        roll_pass = RollResult(
+            event_id="r1",
+            roll_type="save",
+            actor_kind="session_entity",
+            actor_ref_id="enemy-a",
+            actor_display_name="Target e1",
+            rolls=[12],
+            selected_roll=12,
+            advantage_mode="normal",
+            modifier_used=0,
+            override_used=False,
+            formula="1d20",
+            total=12,
+            ability="wisdom",
+            dc=14,
+            success=False,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        with patch("app.services.combat_service.spell_automation.resolve_saving_throw", return_value=roll_pass) as save_mock:
+            await CombatService._cast_charm_person_automation(
+                MagicMock(),
+                "s1",
+                attacker=state.participants[0],
+                attacker_model=MagicMock(),
+                actor_user_id="u1",
+                is_gm=False,
+                req=MagicMock(),
+                state=state,
+                spell_context={"spell_name": "Charm Person", "spell_canonical_key": "charm_person", "save_ability": "wisdom", "save_dc": 14, "save_success_outcome": "none"},
+                target_participant=state.participants[1],
+            )
+
+        self.assertEqual(save_mock.call_args.kwargs.get("advantage_mode"), "normal")
+
+    async def test_multi_target_atomic_failure_before_slot_consumption(self):
+        state = _make_state([_make_player(), _make_target("e1", "enemy-a"), _make_target("e2", "enemy-b")])
+        attacker_state = MagicMock()
+        attacker_state.state_json = {
+            "spellcasting": {
+                "slots": {"3": {"used": 0, "max": 2}},
+                "spells": [{"canonicalKey": "charm_person", "name": "Charm Person", "prepared": True, "level": 1}],
+            }
+        }
+        req = CombatCastSpellRequest(actor_participant_id="p1", spell_canonical_key="charm_person", target_ref_ids=["enemy-a", "enemy-b"], slot_level=3)
+        spell_context = {
+            "spell_name": "Charm Person",
+            "spell_canonical_key": "charm_person",
+            "spell_mode": "saving_throw",
+            "selection_type": "creature",
+            "slot_level": 3,
+            "action_cost": "action",
+            "source_kind": "spell",
+            "effect_kind": "damage",
+            "effect_dice": None,
+            "effect_bonus": 0,
+            "save_ability": "wisdom",
+            "save_dc": 14,
+            "save_success_outcome": "none",
+            "target_type": "ranged",
+            "range_kind": "distance",
+            "attack_type": "none",
+            "requires_target_sight": True,
+            "requires_target_effect": True,
+            "concentration": False,
+            "max_targets": 3,
+        }
+        targeting_result = MagicMock(is_valid=True, validated_primary_target_ref_id="enemy-a", spatial_metadata=MagicMock(cover=None))
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=state),
+            patch("app.services.combat.CombatService._get_stats", return_value=(attacker_state, 10, 10, 10, 2, 3)),
+            patch("app.services.combat.CombatService._resolve_player_spell_context", return_value=spell_context),
+            patch("app.services.combat.CombatService.resolve_effective_creature_type", side_effect=["humanoid", "dragon"]),
+            patch("app.services.combat_service.spells.cast_target.get_combat_targeting_service", return_value=MagicMock(validate=MagicMock(return_value=targeting_result))),
+            patch.object(CombatService, "_emit_and_persist_log", new_callable=AsyncMock) as emit_log,
+        ):
+            with self.assertRaises(CombatServiceError):
+                await CombatService.cast_spell(MagicMock(), "s1", req, "u1", False)
+
+        self.assertEqual(attacker_state.state_json["spellcasting"]["slots"]["3"]["used"], 0)
+        self.assertEqual(state.participants[1].get("active_effects") or [], [])
+        self.assertEqual(state.participants[2].get("active_effects") or [], [])
+        success_logs = [
+            c for c in emit_log.await_args_list
+            if "conjurou Charm Person" in ((c.args[4] or {}).get("message", "") if len(c.args) > 4 else "")
+        ]
+        self.assertEqual(success_logs, [])
+
+    async def test_break_on_damage_is_isolated_per_target(self):
+        state = _make_state([
+            _make_player(),
+            _make_target("ally", "ally-1", team="players"),
+            _make_target("a", "enemy-a"),
+            _make_target("b", "enemy-b"),
+            _make_target("c", "enemy-c", team="neutral"),
+        ])
+
+        for target in (state.participants[2], state.participants[3]):
+            target["active_effects"] = [{
+                "id": f"charm-{target['id']}",
+                "kind": "condition",
+                "condition_type": "charmed",
+                "source_participant_id": "p1",
+                "metadata": {
+                    "source_spell_key": "charm_person",
+                    "caster_participant_id": "p1",
+                    "charmer_participant_id": "p1",
+                    "target_knows_charmed_by_caster": True,
+                    "termination_conditions": [{"type": "target_takes_damage_from_caster_or_allies"}],
+                },
+            }]
+
+        removed_from_a = remove_damage_terminated_effects_from_participant(
+            state,
+            state.participants[2],
+            attacker_participant_id="ally",
+        )
+        self.assertTrue(removed_from_a)
+        self.assertEqual(state.participants[2].get("active_effects") or [], [])
+        self.assertEqual(len(state.participants[3].get("active_effects") or []), 1)
+        self.assertTrue((state.participants[3]["active_effects"][0].get("metadata") or {}).get("target_knows_charmed_by_caster"))
+
+        removed_from_b_by_neutral = remove_damage_terminated_effects_from_participant(
+            state,
+            state.participants[3],
+            attacker_participant_id="c",
+        )
+        self.assertFalse(removed_from_b_by_neutral)
+        self.assertEqual(len(state.participants[3].get("active_effects") or []), 1)
+
+    async def test_upcast_multi_target_then_damage_removes_only_damaged_target_effect(self):
+        state = _make_state([
+            _make_player(),
+            _make_target("ally", "ally-1", team="players"),
+            _make_target("a", "enemy-a"),
+            _make_target("b", "enemy-b"),
+        ])
+        attacker_state = MagicMock()
+        attacker_state.state_json = {
+            "spellcasting": {
+                "slots": {"2": {"used": 0, "max": 2}},
+                "spells": [{"canonicalKey": "charm_person", "name": "Charm Person", "prepared": True, "level": 1}],
+            }
+        }
+        req = CombatCastSpellRequest(
+            actor_participant_id="p1",
+            spell_canonical_key="charm_person",
+            target_ref_ids=["enemy-a", "enemy-b"],
+            slot_level=2,
+        )
+        spell_context = {
+            "spell_name": "Charm Person",
+            "spell_canonical_key": "charm_person",
+            "spell_mode": "saving_throw",
+            "selection_type": "creature",
+            "slot_level": 2,
+            "action_cost": "action",
+            "source_kind": "spell",
+            "effect_kind": "damage",
+            "effect_dice": None,
+            "effect_bonus": 0,
+            "save_ability": "wisdom",
+            "save_dc": 14,
+            "save_success_outcome": "none",
+            "target_type": "ranged",
+            "range_kind": "distance",
+            "attack_type": "none",
+            "requires_target_sight": True,
+            "requires_target_effect": True,
+            "concentration": False,
+            "max_targets": 2,
+        }
+        targeting_result = MagicMock(
+            is_valid=True,
+            validated_primary_target_ref_id="enemy-a",
+            spatial_metadata=MagicMock(cover=None),
+        )
+        roll_fail_a = RollResult(
+            event_id="r1",
+            roll_type="save",
+            actor_kind="session_entity",
+            actor_ref_id="enemy-a",
+            actor_display_name="Target a",
+            rolls=[5, 11],
+            selected_roll=11,
+            advantage_mode="advantage",
+            modifier_used=0,
+            override_used=False,
+            formula="2d20kh1",
+            total=11,
+            ability="wisdom",
+            dc=14,
+            success=False,
+            timestamp=datetime.now(timezone.utc),
+        )
+        roll_fail_b = RollResult(
+            event_id="r2",
+            roll_type="save",
+            actor_kind="session_entity",
+            actor_ref_id="enemy-b",
+            actor_display_name="Target b",
+            rolls=[3, 7],
+            selected_roll=7,
+            advantage_mode="advantage",
+            modifier_used=0,
+            override_used=False,
+            formula="2d20kh1",
+            total=7,
+            ability="wisdom",
+            dc=14,
+            success=False,
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=state),
+            patch("app.services.combat.CombatService._get_stats", return_value=(attacker_state, 10, 10, 10, 2, 3)),
+            patch("app.services.combat.CombatService._resolve_player_spell_context", return_value=spell_context),
+            patch("app.services.combat.CombatService.resolve_effective_creature_type", side_effect=["humanoid", "humanoid"]),
+            patch(
+                "app.services.combat_service.spells.cast_target.get_combat_targeting_service",
+                return_value=MagicMock(validate=MagicMock(return_value=targeting_result)),
+            ),
+            patch("app.services.combat_service.spell_automation.resolve_saving_throw", side_effect=[roll_fail_a, roll_fail_b]),
+            patch.object(CombatService, "_emit_state", new_callable=AsyncMock),
+            patch.object(CombatService, "_emit_and_persist_log", new_callable=AsyncMock),
+        ):
+            result = await CombatService.cast_spell(MagicMock(), "s1", req, "u1", False)
+
+        self.assertEqual(attacker_state.state_json["spellcasting"]["slots"]["2"]["used"], 1)
+        self.assertEqual(len(state.participants[2].get("active_effects") or []), 1)
+        self.assertEqual(len(state.participants[3].get("active_effects") or []), 1)
+        self.assertEqual(result.get("target_count"), 2)
+
+        removed_from_a = remove_damage_terminated_effects_from_participant(
+            state,
+            state.participants[2],
+            attacker_participant_id="ally",
+        )
+        self.assertTrue(removed_from_a)
+        self.assertEqual(state.participants[2].get("active_effects") or [], [])
+        self.assertEqual(len(state.participants[3].get("active_effects") or []), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PR: feat(spells) Charm Person automation and hostile context logic (#359)

## Description

Este PR implementa a automação da magia *Charm Person*. A implementação foca na conformidade com as regras de contexto de combate, aplicando vantagem na salvaguarda de alvos hostis, e introduz a condição de término dinâmico por dano. O sistema também suporta escalonamento para múltiplos alvos (Upcast) e mantém a política estrita de alvos humanoides estabelecida nas issues anteriores.

## Changes

### Engine de Automação e Contexto (`spell_automation.py`)
- **Hostile Context Advantage:** O sistema agora detecta se o conjurador e o alvo pertencem a times hostis. Em caso positivo, o alvo recebe automaticamente vantagem na salvaguarda inicial de Sabedoria (WIS).
- **Damage-Triggered Termination:** Implementada a condição de término `target_takes_damage_from_caster_or_allies`. Se o alvo enfeitiçado sofrer dano de qualquer membro do grupo do conjurador, o efeito de *Charmed* é removido instantaneamente.
- **Social Metadata:** O efeito carrega o metadado `target_knows_charmed_by_caster: true`, permitindo que o sistema (ou o mestre) gerencie a reação do NPC após o término da magia (1 hora).

### Validação e Upcast
- **Multi-target Atomic Scaling:** Configurado `maxTargets: 1` com progressão de $+1$ alvo por nível de slot superior. A validação de alvos (tipo de criatura e distância) é atômica; um único alvo inválido cancela o cast antes do consumo de slot.
- **Isolated Removal:** Em conjurações multi-alvo, causar dano ao Alvo A remove apenas o seu encanto, mantendo o Alvo B sob o efeito da magia original.

### Data & Content (`base_spells.seed.json`)
- **Charm Person Seed:** 1º nível, escola de Encantamento, alcance de 9m, duração de 1 hora (`timed`) e restrição para humanoides.

## Summary of Changes

| Component | Change |
| :--- | :--- |
| **`spell_automation`** | New handler with team-based advantage detection |
| **`Condition Logic`** | Support for reactive effect removal upon taking damage |
| **`Upcast Scaling`** | Multi-target support (Slot 1/2/3/4 → 1/2/3/4 targets) |
| **`Targeting`** | Strict humanoid validation with atomic failure guards |

## Validation

A implementação foi submetida a um hardening de contexto e integridade de efeito:

- **Focused Tests (`test_charm_person.py`)**: 9 testes passando, cobrindo:
    - **Advantage Guard:** Verificação de vantagem em saves contra times hostis vs. saves normais.
    - **Atomic Failure:** Garantia de que alvos inválidos em lista multi-target impedem o consumo de recursos.
    - **E2E Damage Break:** Confirmação de que o dano remove o efeito de forma isolada por alvo.
- **Regressão Ampla**: **109 testes passando**, incluindo *Hold Person*, *Animal Friendship*, *Bless/Bane* e magias de dano.

> [!WARNING]
> Cuidado com o fogo amigo! O sistema agora remove o encanto se **qualquer** aliado do conjurador causar dano ao alvo, protegendo a integridade mecânica da condição *Charmed* da 5e.