### PR TITLE
 feat(spells) Detect Magic automation and Narrative Concentration pipeline (#361)

### DIFF
--- a/apps/control-server/app/services/combat_service/persistent_effects.py
+++ b/apps/control-server/app/services/combat_service/persistent_effects.py
@@ -268,8 +268,6 @@ def derive_active_concentration(state_json: dict | None) -> dict | None:
     first_group: str | None = None
     first_metadata: dict | None = None
     for effect in persisted:
-        if not is_mechanical_effect(effect):
-            continue
         metadata = effect.get("metadata")
         if not isinstance(metadata, dict):
             continue

--- a/apps/control-server/app/services/combat_service/spell_automation.py
+++ b/apps/control-server/app/services/combat_service/spell_automation.py
@@ -135,6 +135,12 @@ class CombatSpellAutomationMixin:
             requires_effect_payload=False,
             handler_name="_cast_light_automation",
         ),
+        "detect_magic": SpellAutomationSpec(
+            canonical_key="detect_magic",
+            default_mode="utility",
+            requires_effect_payload=False,
+            handler_name="_cast_detect_magic_automation",
+        ),
     }
 
     @classmethod
@@ -1115,6 +1121,85 @@ class CombatSpellAutomationMixin:
             },
         )
 
+
+    @classmethod
+    async def _cast_detect_magic_automation(
+        cls,
+        db: Session,
+        session_id: str,
+        *,
+        attacker: dict,
+        attacker_model,
+        actor_user_id: str,
+        is_gm: bool,
+        req,
+        state: CombatState,
+        spell_context: dict,
+        target_participant: dict | None,
+    ) -> dict:
+        result = cls._clear_concentration_for_source(
+            state,
+            source_participant_id=attacker["id"],
+        )
+        cls._sync_area_effects_if_changed(
+            session_id, state, result["removed_area_effects"],
+        )
+        concentration_group = str(uuid4())
+        spell_name = spell_context["spell_name"]
+        game_time = get_game_time_seconds(session_id, db)
+
+        cls._append_effect_to_participant(
+            attacker,
+            cls._build_active_effect(
+                kind="spell_effect",
+                source_participant_id=attacker["id"],
+                duration_type="timed",
+                expires_at_participant_id=None,
+                created_at_game_time_seconds=game_time,
+                expires_at_game_time_seconds=game_time + 600,
+                metadata={
+                    "concentration": True,
+                    "concentration_group": concentration_group,
+                    "source_spell_key": "detect_magic",
+                    "source_spell_name": spell_name,
+                    "owner_participant_id": attacker["id"],
+                    "created_by_participant_id": attacker["id"],
+                    "mechanical": False,
+                    "narrative": True,
+                    "visible_to_all": True,
+                    "utility": "detect_magic",
+                    "radius_meters": 9,
+                    "can_reveal_aura_with_action": True,
+                    "reveals_magic_school": True,
+                    "blocked_by": {
+                        "stone_cm": 30,
+                        "common_metal_cm": 2.5,
+                        "lead_sheet": True,
+                        "wood_or_earth_meters": 1,
+                    },
+                },
+                display_label=spell_name,
+            ),
+        )
+        flag_modified(state, "participants")
+
+        summary_text = f"{spell_name} ativa: presença de magia em até 9m por até 10 minutos."
+        if result["removed_effects"] or result["removed_area_effects"]:
+            summary_text += " A concentração anterior terminou."
+
+        return cls._base_spell_result(
+            spell_name=spell_name,
+            spell_context=spell_context,
+            target_display_name=attacker["display_name"],
+            target_kind=attacker["kind"],
+            summary_text=summary_text,
+            log_message=(
+                f"{attacker['display_name']} conjurou {spell_name} e abriu sentidos arcanos em 9m."
+            ),
+            extra={
+                "concentration_group": concentration_group,
+            },
+        )
 
     @classmethod
     async def use_spiritual_weapon_action(

--- a/apps/control-server/app/services/out_of_combat_cast.py
+++ b/apps/control-server/app/services/out_of_combat_cast.py
@@ -13,6 +13,8 @@ from datetime import datetime, timezone
 from math import floor
 from uuid import uuid4
 
+_SPECIAL_OOC_UTILITY_SPELLS = {"detect_magic"}
+
 
 # ---------------------------------------------------------------------------
 # Eligibility
@@ -91,7 +93,52 @@ def build_persisted_effects(
     without modification.
     """
     raw_effects = _resolve_effects(spell, variant_key)
+    canonical_key = str(getattr(spell, "canonical_key", "") or "").strip().lower()
     if not raw_effects:
+        if canonical_key == "detect_magic":
+            spell_name = spell.name_pt or spell.name_en
+            group_id = str(uuid4()) if spell.concentration else None
+            return [{
+                "id": str(uuid4()),
+                "source_participant_id": None,
+                "kind": "spell_effect",
+                "condition_type": None,
+                "numeric_value": None,
+                "duration_type": "timed",
+                "remaining_rounds": None,
+                "expires_on": None,
+                "expires_at_participant_id": None,
+                "created_at_game_time_seconds": game_time_seconds,
+                "expires_at_game_time_seconds": game_time_seconds + 600,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "metadata": {
+                    "source_spell_key": "detect_magic",
+                    "source_spell_name": spell_name,
+                    "selected_variant_key": None,
+                    "selected_variant_label": None,
+                    "context_origin": "out_of_combat_cast",
+                    "concentration": bool(spell.concentration),
+                    "concentration_group": group_id,
+                    "caster_player_user_id": caster_user_id,
+                    "target_player_user_id": target_user_id,
+                    "owner_participant_id": caster_user_id,
+                    "created_by_participant_id": caster_user_id,
+                    "mechanical": False,
+                    "narrative": True,
+                    "visible_to_all": True,
+                    "utility": "detect_magic",
+                    "radius_meters": 9,
+                    "can_reveal_aura_with_action": True,
+                    "reveals_magic_school": True,
+                    "blocked_by": {
+                        "stone_cm": 30,
+                        "common_metal_cm": 2.5,
+                        "lead_sheet": True,
+                        "wood_or_earth_meters": 1,
+                    },
+                },
+                "display_label": spell_name,
+            }]
         return []
 
     group_id = str(uuid4())
@@ -266,6 +313,9 @@ def _resolve_effects(spell, variant_key: str | None) -> list[dict]:
 
 
 def _has_resolvable_effects(spell, variant_key: str | None) -> bool:
+    canonical_key = str(getattr(spell, "canonical_key", "") or "").strip().lower()
+    if canonical_key in _SPECIAL_OOC_UTILITY_SPELLS:
+        return True
     return bool(_resolve_effects(spell, variant_key))
 
 
@@ -275,6 +325,9 @@ def has_castable_effects(spell) -> bool:
     Used by the eligible-list endpoint to exclude spells that would always be
     rejected at cast time due to having no persistable effects.
     """
+    canonical_key = str(getattr(spell, "canonical_key", "") or "").strip().lower()
+    if canonical_key in _SPECIAL_OOC_UTILITY_SPELLS:
+        return True
     if spell.effects_json:
         return True
     variants = spell.variants_json or []

--- a/apps/control-server/tests/test_detect_magic.py
+++ b/apps/control-server/tests/test_detect_magic.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.models.combat import CombatPhase, CombatState
+from app.models.session_state import SessionState
+from app.schemas.combat import CombatCastSpellRequest
+from app.services.combat import CombatService
+from app.services.combat_service.persistent_effects import derive_active_concentration, restore_persisted_effects
+from app.services.out_of_combat_cast import (
+    build_persisted_effects,
+    check_out_of_combat_cast_eligibility,
+    has_castable_effects,
+)
+from app.services.persistent_effect_expiry import prune_expired_persisted_effects_from_state
+
+
+class DetectMagicSeedTests(unittest.TestCase):
+    def test_detect_magic_seed_contract(self):
+        payload = json.loads(open("Base/base_spells.seed.json", encoding="utf-8").read())
+        raw = next(entry for entry in payload["spells"] if entry["canonicalKey"] == "detect_magic")
+
+        self.assertEqual(raw["level"], 1)
+        self.assertEqual(raw["school"], "divination")
+        self.assertEqual(raw["castingTimeType"], "action")
+        self.assertEqual(raw["rangeKind"], "self")
+        self.assertEqual(raw["rangeMeters"], 0)
+        self.assertTrue(raw["concentration"])
+        self.assertTrue(raw["ritual"])
+        self.assertEqual(raw["selectionType"], "self")
+        self.assertEqual(raw["targetAnchor"], "caster")
+        self.assertEqual(raw["attackType"], "none")
+        self.assertEqual(raw.get("savingThrow"), None)
+        self.assertEqual(raw.get("damageDice"), None)
+        self.assertEqual(raw.get("upcast"), None)
+
+
+class DetectMagicRegistryTests(unittest.TestCase):
+    def test_detect_magic_is_registered_as_special_handler(self):
+        registry = CombatService._SPELL_AUTOMATION_REGISTRY
+        self.assertIn("detect_magic", registry)
+        self.assertEqual(registry["detect_magic"].handler_name, "_cast_detect_magic_automation")
+
+
+class DetectMagicCombatCastTests(unittest.IsolatedAsyncioTestCase):
+    def _state(self) -> CombatState:
+        return CombatState(
+            id="c1",
+            session_id="s1",
+            phase=CombatPhase.active,
+            round=1,
+            current_turn_index=0,
+            participants=[
+                {
+                    "id": "p1",
+                    "ref_id": "caster",
+                    "kind": "player",
+                    "display_name": "Lia",
+                    "status": "active",
+                    "team": "players",
+                    "actor_user_id": "u1",
+                    "turn_resources": {"action_used": False, "bonus_action_used": False, "reaction_used": False},
+                    "active_effects": [],
+                }
+            ],
+            use_map=False,
+        )
+
+    async def test_cast_consumes_slot_and_applies_narrative_spell_effect_with_concentration(self):
+        state = self._state()
+        attacker_state = MagicMock()
+        attacker_state.state_json = {
+            "spellcasting": {
+                "slots": {"1": {"used": 0, "max": 2}},
+                "spells": [{"canonicalKey": "detect_magic", "name": "Detect Magic", "prepared": True, "level": 1}],
+            }
+        }
+        req = CombatCastSpellRequest(actor_participant_id="p1", spell_canonical_key="detect_magic", slot_level=1)
+        spell_context = {
+            "spell_name": "Detect Magic",
+            "spell_canonical_key": "detect_magic",
+            "spell_mode": "utility",
+            "selection_type": "self",
+            "slot_level": 1,
+            "action_cost": "action",
+            "source_kind": "spell",
+            "effect_kind": None,
+            "effect_dice": None,
+            "effect_bonus": 0,
+            "save_ability": None,
+            "save_dc": None,
+            "save_success_outcome": None,
+            "target_type": "self",
+            "range_kind": "self",
+            "attack_type": "none",
+            "requires_target_sight": False,
+            "requires_target_effect": False,
+            "concentration": True,
+            "effect_timing": "persistent",
+        }
+
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=state),
+            patch("app.services.combat.CombatService._get_stats", return_value=(attacker_state, 10, 10, 10, 2, 3)),
+            patch("app.services.combat.CombatService._resolve_player_spell_context", return_value=spell_context),
+            patch("app.services.combat_service.spell_automation.get_game_time_seconds", return_value=1000),
+            patch.object(CombatService, "_emit_state", new_callable=AsyncMock),
+            patch.object(CombatService, "_emit_and_persist_log", new_callable=AsyncMock),
+        ):
+            result = await CombatService.cast_spell(MagicMock(), "s1", req, "u1", False)
+
+        self.assertEqual(attacker_state.state_json["spellcasting"]["slots"]["1"]["used"], 1)
+        effects = state.participants[0].get("active_effects") or []
+        self.assertEqual(len(effects), 1)
+        effect = effects[0]
+        metadata = effect.get("metadata") or {}
+        self.assertEqual(effect.get("kind"), "spell_effect")
+        self.assertEqual(effect.get("duration_type"), "timed")
+        self.assertEqual(effect.get("created_at_game_time_seconds"), 1000)
+        self.assertEqual(effect.get("expires_at_game_time_seconds"), 1600)
+        self.assertEqual(metadata.get("source_spell_key"), "detect_magic")
+        self.assertFalse(metadata.get("mechanical"))
+        self.assertTrue(metadata.get("narrative"))
+        self.assertTrue(metadata.get("visible_to_all"))
+        self.assertEqual(metadata.get("utility"), "detect_magic")
+        self.assertEqual(metadata.get("radius_meters"), 9)
+        self.assertTrue(metadata.get("can_reveal_aura_with_action"))
+        self.assertTrue(metadata.get("reveals_magic_school"))
+        self.assertEqual((metadata.get("blocked_by") or {}).get("stone_cm"), 30)
+        self.assertTrue(metadata.get("concentration"))
+        self.assertIsInstance(metadata.get("concentration_group"), str)
+        self.assertIsInstance(result.get("concentration_group"), str)
+        self.assertEqual(result.get("pending_spell_id"), None)
+        self.assertEqual(result.get("pending_save_id"), None)
+
+    async def test_replaces_existing_concentration_group_from_same_caster(self):
+        state = self._state()
+        state.participants[0]["active_effects"] = [
+            {
+                "id": "old-1",
+                "kind": "spell_effect",
+                "duration_type": "manual",
+                "source_participant_id": "p1",
+                "metadata": {
+                    "concentration": True,
+                    "concentration_group": "grp-old",
+                    "source_spell_key": "shield_of_faith",
+                },
+            }
+        ]
+
+        with (
+            patch("app.services.combat_service.spell_automation.get_game_time_seconds", return_value=200),
+        ):
+            result = await CombatService._cast_detect_magic_automation(
+                MagicMock(),
+                "s1",
+                attacker=state.participants[0],
+                attacker_model=MagicMock(),
+                actor_user_id="u1",
+                is_gm=False,
+                req=MagicMock(),
+                state=state,
+                spell_context={"spell_name": "Detect Magic", "spell_canonical_key": "detect_magic", "concentration": True},
+                target_participant=state.participants[0],
+            )
+
+        effects = state.participants[0].get("active_effects") or []
+        self.assertEqual(len(effects), 1)
+        self.assertEqual((effects[0].get("metadata") or {}).get("source_spell_key"), "detect_magic")
+        self.assertNotEqual((effects[0].get("metadata") or {}).get("concentration_group"), "grp-old")
+        self.assertIsInstance(result.get("concentration_group"), str)
+
+
+class DetectMagicOutOfCombatTests(unittest.TestCase):
+    def _spell(self):
+        return SimpleNamespace(
+            canonical_key="detect_magic",
+            name_en="Detect Magic",
+            name_pt="Detectar Magia",
+            concentration=True,
+            out_of_combat_castable=True,
+            out_of_combat_target="self",
+            effects_json=None,
+            variants_json=[],
+            level=1,
+            ritual=True,
+        )
+
+    def test_ooc_special_spell_is_castable_without_declarative_effects(self):
+        spell = self._spell()
+        self.assertTrue(has_castable_effects(spell))
+        ok, rejection = check_out_of_combat_cast_eligibility(
+            spell=spell,
+            state_json={"spellcasting": {"slots": {"1": {"used": 0, "max": 1}}}},
+            slot_level=1,
+            variant_key=None,
+            out_of_combat_target="self",
+            target_user_id="u1",
+            caster_user_id="u1",
+            target_state_json={},
+        )
+        self.assertTrue(ok)
+        self.assertIsNone(rejection)
+
+    def test_ritual_runtime_not_supported_yet_slot_still_required(self):
+        spell = self._spell()
+        ok, rejection = check_out_of_combat_cast_eligibility(
+            spell=spell,
+            state_json={"spellcasting": {"slots": {"1": {"used": 0, "max": 1}}}},
+            slot_level=None,
+            variant_key=None,
+            out_of_combat_target="self",
+            target_user_id="u1",
+            caster_user_id="u1",
+            target_state_json={},
+        )
+        self.assertFalse(ok)
+        self.assertIn("slotLevel must be >= 1", str(rejection))
+
+    def test_builds_timed_narrative_effect_and_active_concentration(self):
+        spell = self._spell()
+        effects = build_persisted_effects(
+            spell=spell,
+            caster_user_id="u1",
+            target_user_id="u1",
+            variant_key=None,
+            game_time_seconds=500,
+        )
+        self.assertEqual(len(effects), 1)
+        effect = effects[0]
+        meta = effect.get("metadata") or {}
+        self.assertEqual(effect.get("duration_type"), "timed")
+        self.assertEqual(effect.get("expires_at_game_time_seconds"), 1100)
+        self.assertEqual(meta.get("source_spell_key"), "detect_magic")
+        self.assertFalse(meta.get("mechanical"))
+        self.assertEqual(meta.get("utility"), "detect_magic")
+        self.assertEqual(meta.get("radius_meters"), 9)
+        self.assertIsInstance(meta.get("concentration_group"), str)
+
+        state_json = {"active_spell_effects": effects}
+        active = derive_active_concentration(state_json)
+        self.assertIsNotNone(active)
+        self.assertEqual(active.get("spellKey"), "detect_magic")
+
+    def test_expired_effect_is_pruned_and_concentration_disappears(self):
+        spell = self._spell()
+        effects = build_persisted_effects(
+            spell=spell,
+            caster_user_id="u1",
+            target_user_id="u1",
+            variant_key=None,
+            game_time_seconds=100,
+        )
+        state_json = {"active_spell_effects": effects}
+        pruned = prune_expired_persisted_effects_from_state(state_json, game_time_seconds=1000)
+        self.assertNotIn("active_spell_effects", pruned)
+        self.assertIsNone(derive_active_concentration(pruned))
+
+    def test_restore_to_combat_does_not_duplicate_effect(self):
+        spell = self._spell()
+        effects = build_persisted_effects(
+            spell=spell,
+            caster_user_id="u1",
+            target_user_id="u1",
+            variant_key=None,
+            game_time_seconds=200,
+        )
+        session_state = SessionState(
+            id="ss1",
+            session_id="s1",
+            player_user_id="caster",
+            state_json={"active_spell_effects": effects},
+        )
+        db = MagicMock()
+        first = MagicMock()
+        first.first.return_value = session_state
+        db.exec.return_value = first
+
+        participant = {
+            "id": "p1",
+            "ref_id": "caster",
+            "kind": "player",
+            "display_name": "Lia",
+            "active_effects": [],
+        }
+
+        with patch("app.services.combat_service.persistent_effects.get_game_time_seconds", return_value=200):
+            restore_persisted_effects(db, "s1", participant)
+            restore_persisted_effects(db, "s1", participant)
+
+        active_effects = participant.get("active_effects") or []
+        self.assertEqual(len(active_effects), 1)
+        self.assertEqual((active_effects[0].get("metadata") or {}).get("source_spell_key"), "detect_magic")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PR: feat(spells) Detect Magic automation and Narrative Concentration pipeline (#361)

## Description

Este PR implementa a automação da magia *Detect Magic*. A implementação introduz a "dupla trilha" de persistência, onde um efeito marcado como narrativo (`mechanical=false`) ainda assim exige e ocupa o slot de concentração do conjurador. O sistema foi expandido para suportar essa lógica tanto em combate quanto em fluxos fora de combate (OOC), garantindo que a expiração de um remova automaticamente o outro.

## Changes

### Engine de Concentração Narrativa (`persistent_effects.py`)
- **Dual-Track Concentration:** Atualizada a função `derive_active_concentration` para monitorar efeitos de concentração independentemente de serem mecânicos ou narrativos. Isso impede que um conjurador mantenha *Detect Magic* e *Hold Person* simultaneamente.
- **Self-Replacement:** O handler agora garante a limpeza de qualquer concentração anterior antes de aplicar o novo efeito, evitando estados órfãos de concentração "vazia".

### Automação de Utilitários (`spell_automation.py` & `out_of_combat_cast.py`)
- **Detailed Metadata:** O efeito gerado carrega as restrições canônicas da magia (raio de 9m, bloqueios por materiais como chumbo ou pedra espessa) e a flag `can_reveal_aura_with_action`, preparando o terreno para interações manuais de detecção.
- **OOC Persistência:** Implementado o suporte no `out_of_combat_cast` para que o *Detect Magic* possa ser conjurado durante a exploração, persistindo corretamente ao entrar em iniciativa.

### Data & Content (`base_spells.seed.json`)
- **Detect Magic Seed:** Nível 1, Ritual (metadata), alcance de 9m (Self), concentração de 10 minutos.

## Summary of Changes

| Component | Change |
| :--- | :--- |
| **`persistent_effects`** | Enabled concentration tracking for narrative/utility effects |
| **`Detect Magic`** | Full automation: 600s duration, concentration, and sensor metadata |
| **`OOC Pipeline`** | Support for casting and persisting detect sensors outside combat |
| **`Automation Registry`** | New handler for self-centered utility detection fields |

## Validation

A implementação foi validada com foco na integridade da concentração e transições de cena:

- **Focused Tests (`test_detect_magic.py`)**: 9 testes passando, cobrindo:
    - **Slot Consumption:** Confirmação de que o cast consome recurso (ritual runtime pendente).
    - **Concentration Swap:** Garantia de que lançar outra magia de concentração remove o sensor.
    - **Expiry & Prune:** Verificação de que o fim dos 600s remove tanto o efeito quanto a concentração do conjurador.
- **Regressão Ampla**: **188 testes passando**, validando a coexistência com *Hold Person*, *Bless*, *Bane* e os sistemas de OOC.

> [!IMPORTANT]
> **Boundary Note:** O suporte a rituais sem gasto de slot permanece fora do escopo desta issue. No momento, o cast de *Detect Magic* exige o consumo de um slot de nível 1, embora a flag `ritual=true` já esteja presente no catálogo para consulta.