### PR TITLE
feat(combat) implement declarative Temp HP system and False Life spell

### DIFF
--- a/Base/base_spells.seed.json
+++ b/Base/base_spells.seed.json
@@ -2818,6 +2818,72 @@
       "attackType": "none",
       "rangeKind": "distance",
       "effectTiming": "persistent"
+    },
+    {
+      "system": "DND5E",
+      "canonicalKey": "false_life",
+      "nameEn": "False Life",
+      "namePt": "Vitalidade Vazia",
+      "descriptionEn": "Bolstering yourself with a necromantic facsimile of life, you gain 1d4 + 4 temporary hit points for the duration.",
+      "descriptionPt": "Amparando-se com uma fachada necromântica de vida, você ganha 1d4 + 4 pontos de vida temporários pela duração.",
+      "level": 1,
+      "school": "necromancy",
+      "classesJson": [
+        "Sorcerer",
+        "Wizard"
+      ],
+      "castingTimeType": "action",
+      "castingTime": "1 action",
+      "rangeMeters": 0,
+      "rangeText": "Self",
+      "duration": "1 hour",
+      "componentsJson": [
+        "V",
+        "S",
+        "M"
+      ],
+      "materialComponentText": "a small amount of alcohol or blood",
+      "concentration": false,
+      "ritual": false,
+      "resolutionType": "buff",
+      "upcast": {
+        "mode": "extra_temp_hp",
+        "flat": 5,
+        "perLevel": 1
+      },
+      "source": "seed_json_bootstrap",
+      "isSrd": true,
+      "isActive": true,
+      "requiresTargetSight": false,
+      "requiresTargetEffect": false,
+      "requiresPointSight": false,
+      "requiresPointEffect": false,
+      "targetType": "self",
+      "selectionType": "self",
+      "originType": "caster",
+      "targetAnchor": "caster",
+      "attackType": "none",
+      "rangeKind": "self",
+      "effectTiming": "immediate",
+      "outOfCombatCastable": true,
+      "outOfCombatTarget": "self",
+      "effects": [
+        {
+          "type": "grant_temp_hp",
+          "target": "caster",
+          "duration": {
+            "type": "timed",
+            "seconds": 3600
+          },
+          "out_of_combat_duration": {
+            "type": "timed",
+            "seconds": 3600
+          },
+          "params": {
+            "dice": "1d4 + 4"
+          }
+        }
+      ]
     }
   ]
 }

--- a/apps/control-server/app/api/routes/sessions/state.py
+++ b/apps/control-server/app/api/routes/sessions/state.py
@@ -38,9 +38,11 @@ from app.services.out_of_combat_cast import (
     check_out_of_combat_cast_eligibility,
     collect_create_consumable_effects,
     collect_heal_effects,
+    collect_temp_hp_effects,
     consume_spell_slot,
     has_castable_effects,
     roll_spell_heal_effects,
+    roll_spell_temp_hp_effects,
 )
 from app.services.wild_shape_catalog import get_form
 from app.services.wild_shape_service import apply_healing_to_form
@@ -81,6 +83,13 @@ def _apply_heal_to_state_dict(data: dict, amount: int) -> dict:
     current, max_hp = _extract_hp_snapshot(data)
     new_hp = min(max_hp, current + max(0, amount))
     return {**data, "currentHP": new_hp}
+
+
+def _apply_temp_hp_to_state_dict(data: dict, amount: int) -> dict:
+    """Apply temp HP to a state dict using keep-higher policy."""
+    previous = max(0, int(data.get("tempHP") or 0))
+    final = max(previous, amount)
+    return {**data, "tempHP": final}
 
 
 def _find_effect_by_id(state_json: dict | None, effect_id: str) -> dict | None:
@@ -417,7 +426,15 @@ async def _cast_spell_out_of_combat_for_player(
         else []
     )
 
-    if not new_target_effects and not consumables_granted_count and not heal_rolled:
+    # --- Precompute temporary HP (grant_temp_hp effects) ---
+    temp_hp_effects = collect_temp_hp_effects(campaign_spell, req.variantKey)
+    temp_hp_rolled = (
+        roll_spell_temp_hp_effects(temp_hp_effects, campaign_spell, req.slotLevel)
+        if temp_hp_effects
+        else []
+    )
+
+    if not new_target_effects and not consumables_granted_count and not heal_rolled and not temp_hp_rolled:
         raise HTTPException(status_code=400, detail="No persistable effects could be created for this spell")
 
     group_id: str | None = (
@@ -479,6 +496,8 @@ async def _cast_spell_out_of_combat_for_player(
                 updated_caster_json = _apply_heal_to_state_dict(updated_caster_json, hr["amount"])
             else:
                 target_json = _apply_heal_to_state_dict(target_json, hr["amount"])
+        for thr in temp_hp_rolled:
+            updated_caster_json = _apply_temp_hp_to_state_dict(updated_caster_json, thr["amount"])
         target_state.state_json = finalize_session_state_data(  # type: ignore[union-attr]
             target_json,
             game_time_seconds=current_game_time_seconds,
@@ -494,6 +513,8 @@ async def _cast_spell_out_of_combat_for_player(
         # Immediate healing on self (target == caster)
         for hr in heal_rolled:
             updated_caster_json = _apply_heal_to_state_dict(updated_caster_json, hr["amount"])
+        for thr in temp_hp_rolled:
+            updated_caster_json = _apply_temp_hp_to_state_dict(updated_caster_json, thr["amount"])
 
     # --- Persist caster state ---
     caster_state.state_json = finalize_session_state_data(
@@ -562,6 +583,13 @@ async def _cast_spell_out_of_combat_for_player(
             activity_payload["healing_rolls"] = [
                 {"dice": hr["effective_dice"], "rolls": hr["rolls"], "modifier": hr["modifier"], "total": hr["amount"]}
                 for hr in heal_rolled
+            ]
+        if temp_hp_rolled:
+            total_temp_hp = sum(thr["amount"] for thr in temp_hp_rolled)
+            activity_payload["temp_hp_applied"] = total_temp_hp
+            activity_payload["temp_hp_rolls"] = [
+                {"base_dice": thr["base_dice"], "upcast_bonus": thr["upcast_bonus"], "total": thr["amount"]}
+                for thr in temp_hp_rolled
             ]
         record_session_activity(
             entry,

--- a/apps/control-server/app/services/combat_service/spell_declarative_effects.py
+++ b/apps/control-server/app/services/combat_service/spell_declarative_effects.py
@@ -474,6 +474,9 @@ class CombatSpellDeclarativeEffectsMixin:
             created.append(active_effect)
         elif effect.type == "grant_temp_hp":
             rolled = _roll_dice_expression(params["dice"])
+            upcast_bonus = int(spell_context.get("effect_bonus") or 0)
+            if upcast_bonus:
+                rolled += upcast_bonus
             active_effect = cls._build_active_effect(
                 kind="temp_hp_granted",
                 source_participant_id=attacker.get("id"),

--- a/apps/control-server/app/services/combat_service/spell_dice_math.py
+++ b/apps/control-server/app/services/combat_service/spell_dice_math.py
@@ -255,6 +255,7 @@ class CombatSpellDiceMathMixin:
             "add_damage",
             "add_heal",
             "increase_targets",
+            "extra_temp_hp",
         }:
             if dice:
                 next_effect_dice = cls._merge_dice_expressions(

--- a/apps/control-server/app/services/combat_service/spells/spell_context_resolve.py
+++ b/apps/control-server/app/services/combat_service/spells/spell_context_resolve.py
@@ -356,6 +356,31 @@ class SpellContextResolveMixin:
         }
 
     @classmethod
+    def _build_temp_hp_preview(cls, catalog_spell, upcast_result: dict) -> dict | None:
+        effects_list = getattr(catalog_spell, "effects_json", None) or []
+        temp_hp_effects = [
+            e for e in effects_list
+            if isinstance(e, dict) and e.get("type") == "grant_temp_hp"
+        ]
+        if not temp_hp_effects:
+            return None
+        base_dice = (temp_hp_effects[0].get("params") or {}).get("dice", "")
+        if not base_dice:
+            return None
+        upcast_bonus_val = cls._safe_int(upcast_result.get("effect_bonus"), 0)
+        if upcast_bonus_val > 0:
+            _, count, sides, mod = _parse_dice(base_dice)
+            total_mod = mod + upcast_bonus_val
+            resolved_formula = cls._build_dice_expression(count, sides, total_mod) or base_dice
+        else:
+            resolved_formula = base_dice
+        return {
+            "base_dice": base_dice,
+            "effect_bonus": upcast_bonus_val,
+            "resolved_formula": resolved_formula,
+        }
+
+    @classmethod
     def _build_spell_context_response(
         cls,
         *,
@@ -371,6 +396,8 @@ class SpellContextResolveMixin:
         upcast_added_instances = cls._safe_int(
             upcast_result.get("upcast_added_instances"), 0
         )
+
+        temp_hp_preview = cls._build_temp_hp_preview(catalog_spell, upcast_result)
         effective_max_targets = (
             base_max_targets + upcast_added_instances
             if isinstance(base_max_targets, int)
@@ -419,6 +446,7 @@ class SpellContextResolveMixin:
             if isinstance(upcast_result.get("effect_dice"), str) or upcast_result.get("effect_dice") is None
             else resolved_math["effect_dice"],
             "effect_bonus": cls._safe_int(upcast_result.get("effect_bonus"), resolved_math["effect_bonus"]),
+            "temp_hp_preview": temp_hp_preview,
             "damage_type": resolved_math["damage_type"],
             "save_ability": resolved_math["save_ability"],
             "save_dc": resolved_math["save_dc"],

--- a/apps/control-server/app/services/out_of_combat_cast.py
+++ b/apps/control-server/app/services/out_of_combat_cast.py
@@ -415,6 +415,69 @@ def collect_heal_effects(
     ]
 
 
+def collect_temp_hp_effects(
+    spell,
+    variant_key: str | None,
+) -> list[dict]:
+    """Return only grant_temp_hp effect dicts from the spell's effective effects list."""
+    return [
+        e for e in _resolve_effects(spell, variant_key)
+        if isinstance(e, dict) and e.get("type") == "grant_temp_hp"
+    ]
+
+
+def compute_temp_hp_upcast_bonus(
+    spell,
+    slot_level: int | None,
+) -> int:
+    """Compute the flat upcast bonus for grant_temp_hp via the canonical combat pipeline."""
+    from app.services.combat_service.spell_dice_math import CombatSpellDiceMathMixin
+
+    spell_level = getattr(spell, "level", 1) or 1
+    raw_upcast = getattr(spell, "upcast_json", None)
+    structured = CombatSpellDiceMathMixin._get_structured_spell_upcast(raw_upcast)
+    if not structured or structured.get("mode") != "extra_temp_hp":
+        return 0
+    effective_slot = slot_level if isinstance(slot_level, int) else spell_level
+    result = CombatSpellDiceMathMixin._apply_structured_spell_upcast(
+        spell_level=spell_level,
+        slot_level=effective_slot,
+        effect_kind=None,
+        effect_dice=None,
+        effect_bonus=0,
+        upcast=structured,
+    )
+    return int(result.get("effect_bonus") or 0)
+
+
+def roll_spell_temp_hp_effects(
+    temp_hp_effects: list[dict],
+    spell,
+    slot_level: int | None,
+) -> list[dict]:
+    """Roll temp HP for each grant_temp_hp effect.
+
+    Returns a list of dicts with keys: amount, target, base_dice, upcast_bonus.
+    Uses the same canonical math as the combat upcast pipeline.
+    """
+    from app.services.combat_service.exceptions import _roll_dice_expression as _roll
+
+    upcast_bonus = compute_temp_hp_upcast_bonus(spell, slot_level)
+
+    results = []
+    for effect in temp_hp_effects:
+        params = effect.get("params") or {}
+        base_dice = params.get("dice") or "1d4"
+        rolled = _roll(base_dice) + upcast_bonus
+        results.append({
+            "amount": rolled,
+            "target": effect.get("target", "caster"),
+            "base_dice": base_dice,
+            "upcast_bonus": upcast_bonus,
+        })
+    return results
+
+
 def compute_heal_dice_with_upcast(
     base_dice: str,
     spell,

--- a/apps/control-server/tests/test_false_life.py
+++ b/apps/control-server/tests/test_false_life.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.schemas.base_spell_effects import GrantTempHpParams, SpellDeclarativeEffect
+from app.services.combat_service.spell_dice_math import CombatSpellDiceMathMixin
+from app.services.out_of_combat_cast import (
+    collect_temp_hp_effects,
+    compute_temp_hp_upcast_bonus,
+    roll_spell_temp_hp_effects,
+)
+
+
+def _temp_hp_effect(*, dice: str = "1d4 + 4", target: str = "caster") -> dict:
+    return {
+        "type": "grant_temp_hp",
+        "target": target,
+        "duration": {"type": "timed", "seconds": 3600},
+        "out_of_combat_duration": {"type": "timed", "seconds": 3600},
+        "params": {"dice": dice},
+    }
+
+
+def _make_spell(
+    *,
+    canonical_key: str = "false_life",
+    level: int = 1,
+    effects_json: list | None = None,
+    upcast_json: dict | None = None,
+    out_of_combat_castable: bool = True,
+    out_of_combat_target: str = "self",
+):
+    spell = MagicMock()
+    spell.canonical_key = canonical_key
+    spell.level = level
+    spell.concentration = False
+    spell.out_of_combat_castable = out_of_combat_castable
+    spell.out_of_combat_target = out_of_combat_target
+    spell.effects_json = effects_json if effects_json is not None else [_temp_hp_effect()]
+    spell.variants_json = []
+    spell.upcast_json = upcast_json if upcast_json is not None else {
+        "mode": "extra_temp_hp",
+        "flat": 5,
+        "perLevel": 1,
+    }
+    spell.name_pt = "Vitalidade Vazia"
+    spell.name_en = "False Life"
+    return spell
+
+
+class FalseLifeSeedContractTests(unittest.TestCase):
+    def test_seed_contains_false_life(self):
+        with open("Base/base_spells.seed.json") as f:
+            data = json.load(f)
+        keys = [s["canonicalKey"] for s in data["spells"]]
+        self.assertIn("false_life", keys)
+
+    def test_seed_false_life_metadata(self):
+        with open("Base/base_spells.seed.json") as f:
+            data = json.load(f)
+        spell = next(s for s in data["spells"] if s["canonicalKey"] == "false_life")
+        self.assertEqual(spell["level"], 1)
+        self.assertEqual(spell["school"], "necromancy")
+        self.assertEqual(spell["castingTimeType"], "action")
+        self.assertEqual(spell["rangeText"], "Self")
+        self.assertEqual(spell["duration"], "1 hour")
+        self.assertFalse(spell["concentration"])
+        self.assertNotIn("savingThrow", spell)
+        self.assertNotIn("damageDice", spell)
+        self.assertEqual(spell["targetType"], "self")
+        self.assertEqual(spell["selectionType"], "self")
+        self.assertEqual(spell["originType"], "caster")
+        self.assertEqual(spell["targetAnchor"], "caster")
+        self.assertEqual(spell["rangeKind"], "self")
+        self.assertEqual(spell["effectTiming"], "immediate")
+        self.assertTrue(spell["outOfCombatCastable"])
+        self.assertEqual(spell["outOfCombatTarget"], "self")
+
+    def test_seed_false_life_effect(self):
+        with open("Base/base_spells.seed.json") as f:
+            data = json.load(f)
+        spell = next(s for s in data["spells"] if s["canonicalKey"] == "false_life")
+        effects = spell["effects"]
+        self.assertEqual(len(effects), 1)
+        eff = effects[0]
+        self.assertEqual(eff["type"], "grant_temp_hp")
+        self.assertEqual(eff["target"], "caster")
+        self.assertEqual(eff["duration"]["type"], "timed")
+        self.assertEqual(eff["duration"]["seconds"], 3600)
+        self.assertEqual(eff["params"]["dice"], "1d4 + 4")
+
+    def test_seed_false_life_upcast(self):
+        with open("Base/base_spells.seed.json") as f:
+            data = json.load(f)
+        spell = next(s for s in data["spells"] if s["canonicalKey"] == "false_life")
+        upcast = spell["upcast"]
+        self.assertEqual(upcast["mode"], "extra_temp_hp")
+        self.assertEqual(upcast["flat"], 5)
+        self.assertEqual(upcast["perLevel"], 1)
+
+
+class FalseLifeSchemaTests(unittest.TestCase):
+    def test_grant_temp_hp_effect_validates(self):
+        effect = SpellDeclarativeEffect(**_temp_hp_effect())
+        self.assertEqual(effect.type, "grant_temp_hp")
+        self.assertIsInstance(effect.params, GrantTempHpParams)
+        self.assertEqual(effect.params.dice, "1d4 + 4")
+
+    def test_grant_temp_hp_rejects_wrong_params(self):
+        with self.assertRaises(Exception):
+            SpellDeclarativeEffect(**{
+                "type": "grant_temp_hp",
+                "target": "caster",
+                "params": {"condition": "blinded"},
+            })
+
+
+class FalseLifeUpcastMathTests(unittest.TestCase):
+    def _apply_upcast(self, slot_level: int) -> dict:
+        structured = CombatSpellDiceMathMixin._get_structured_spell_upcast({
+            "mode": "extra_temp_hp",
+            "flat": 5,
+            "perLevel": 1,
+        })
+        return CombatSpellDiceMathMixin._apply_structured_spell_upcast(
+            spell_level=1,
+            slot_level=slot_level,
+            effect_kind=None,
+            effect_dice=None,
+            effect_bonus=0,
+            upcast=structured,
+        )
+
+    def test_slot_1_no_upcast_bonus(self):
+        result = self._apply_upcast(1)
+        self.assertEqual(result["effect_bonus"], 0)
+        self.assertFalse(result["upcast_applied"])
+
+    def test_slot_2_bonus_5(self):
+        result = self._apply_upcast(2)
+        self.assertEqual(result["effect_bonus"], 5)
+        self.assertTrue(result["upcast_applied"])
+
+    def test_slot_3_bonus_10(self):
+        result = self._apply_upcast(3)
+        self.assertEqual(result["effect_bonus"], 10)
+        self.assertTrue(result["upcast_applied"])
+
+    def test_slot_4_bonus_15(self):
+        result = self._apply_upcast(4)
+        self.assertEqual(result["effect_bonus"], 15)
+        self.assertTrue(result["upcast_applied"])
+
+    def test_slot_5_bonus_20(self):
+        result = self._apply_upcast(5)
+        self.assertEqual(result["effect_bonus"], 20)
+        self.assertTrue(result["upcast_applied"])
+
+    def test_structured_upcast_parses_extra_temp_hp(self):
+        structured = CombatSpellDiceMathMixin._get_structured_spell_upcast({
+            "mode": "extra_temp_hp",
+            "flat": 5,
+            "perLevel": 1,
+        })
+        self.assertIsNotNone(structured)
+        self.assertEqual(structured["mode"], "extra_temp_hp")
+        self.assertEqual(structured["flat"], 5)
+        self.assertEqual(structured["perLevel"], 1)
+
+
+class FalseLifeOOCUpcastTests(unittest.TestCase):
+    def test_compute_bonus_slot_1(self):
+        spell = _make_spell()
+        self.assertEqual(compute_temp_hp_upcast_bonus(spell, 1), 0)
+
+    def test_compute_bonus_slot_2(self):
+        spell = _make_spell()
+        self.assertEqual(compute_temp_hp_upcast_bonus(spell, 2), 5)
+
+    def test_compute_bonus_slot_3(self):
+        spell = _make_spell()
+        self.assertEqual(compute_temp_hp_upcast_bonus(spell, 3), 10)
+
+    def test_compute_bonus_slot_4(self):
+        spell = _make_spell()
+        self.assertEqual(compute_temp_hp_upcast_bonus(spell, 4), 15)
+
+    def test_compute_bonus_no_upcast_config(self):
+        spell = _make_spell(upcast_json={})
+        self.assertEqual(compute_temp_hp_upcast_bonus(spell, 3), 0)
+
+    def test_compute_bonus_wrong_mode(self):
+        spell = _make_spell(upcast_json={"mode": "extra_damage_dice", "flat": 5, "perLevel": 1})
+        self.assertEqual(compute_temp_hp_upcast_bonus(spell, 3), 0)
+
+    def test_compute_bonus_paridade_perLevel_2(self):
+        spell = _make_spell(upcast_json={"mode": "extra_temp_hp", "flat": 3, "perLevel": 2})
+        structured = CombatSpellDiceMathMixin._get_structured_spell_upcast(spell.upcast_json)
+        for slot in range(1, 7):
+            combat = CombatSpellDiceMathMixin._apply_structured_spell_upcast(
+                spell_level=1, slot_level=slot, effect_kind=None,
+                effect_dice=None, effect_bonus=0, upcast=structured,
+            )
+            ooc = compute_temp_hp_upcast_bonus(spell, slot)
+            self.assertEqual(
+                combat["effect_bonus"], ooc,
+                f"perLevel=2 diverge at slot {slot}: combat={combat['effect_bonus']} ooc={ooc}",
+            )
+
+    def test_compute_bonus_paridade_levelStep_2(self):
+        spell = _make_spell(upcast_json={"mode": "extra_temp_hp", "flat": 8, "levelStep": 2})
+        structured = CombatSpellDiceMathMixin._get_structured_spell_upcast(spell.upcast_json)
+        for slot in range(1, 7):
+            combat = CombatSpellDiceMathMixin._apply_structured_spell_upcast(
+                spell_level=1, slot_level=slot, effect_kind=None,
+                effect_dice=None, effect_bonus=0, upcast=structured,
+            )
+            ooc = compute_temp_hp_upcast_bonus(spell, slot)
+            self.assertEqual(
+                combat["effect_bonus"], ooc,
+                f"levelStep=2 diverge at slot {slot}: combat={combat['effect_bonus']} ooc={ooc}",
+            )
+
+    def test_compute_bonus_paridade_maxLevel(self):
+        spell = _make_spell(upcast_json={"mode": "extra_temp_hp", "flat": 5, "perLevel": 1, "maxLevel": 3})
+        structured = CombatSpellDiceMathMixin._get_structured_spell_upcast(spell.upcast_json)
+        for slot in range(1, 7):
+            combat = CombatSpellDiceMathMixin._apply_structured_spell_upcast(
+                spell_level=1, slot_level=slot, effect_kind=None,
+                effect_dice=None, effect_bonus=0, upcast=structured,
+            )
+            ooc = compute_temp_hp_upcast_bonus(spell, slot)
+            self.assertEqual(
+                combat["effect_bonus"], ooc,
+                f"maxLevel=3 diverge at slot {slot}: combat={combat['effect_bonus']} ooc={ooc}",
+            )
+
+
+class FalseLifeCollectEffectsTests(unittest.TestCase):
+    def test_collect_temp_hp_effects(self):
+        spell = _make_spell()
+        collected = collect_temp_hp_effects(spell, variant_key=None)
+        self.assertEqual(len(collected), 1)
+        self.assertEqual(collected[0]["type"], "grant_temp_hp")
+        self.assertEqual(collected[0]["params"]["dice"], "1d4 + 4")
+
+    def test_collect_temp_hp_effects_empty_for_non_temp_hp_spell(self):
+        spell = _make_spell(effects_json=[
+            {"type": "modify_stat", "target": "caster", "params": {"stat": "attack_bonus", "value": 1}},
+        ])
+        self.assertEqual(collect_temp_hp_effects(spell, variant_key=None), [])
+
+
+class FalseLifeRollTempHpTests(unittest.TestCase):
+    @patch("app.services.combat_service.exceptions._roll_dice_expression", return_value=7)
+    def test_roll_slot_1_no_bonus(self, mock_roll):
+        spell = _make_spell()
+        results = roll_spell_temp_hp_effects(
+            [_temp_hp_effect()], spell, slot_level=1,
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["amount"], 7)
+        self.assertEqual(results[0]["upcast_bonus"], 0)
+        self.assertEqual(results[0]["base_dice"], "1d4 + 4")
+
+    @patch("app.services.combat_service.exceptions._roll_dice_expression", return_value=7)
+    def test_roll_slot_2_adds_bonus(self, mock_roll):
+        spell = _make_spell()
+        results = roll_spell_temp_hp_effects(
+            [_temp_hp_effect()], spell, slot_level=2,
+        )
+        self.assertEqual(results[0]["amount"], 12)
+        self.assertEqual(results[0]["upcast_bonus"], 5)
+
+    @patch("app.services.combat_service.exceptions._roll_dice_expression", return_value=7)
+    def test_roll_slot_4_adds_bonus(self, mock_roll):
+        spell = _make_spell()
+        results = roll_spell_temp_hp_effects(
+            [_temp_hp_effect()], spell, slot_level=4,
+        )
+        self.assertEqual(results[0]["amount"], 22)
+        self.assertEqual(results[0]["upcast_bonus"], 15)
+
+
+class FalseLifeTempHpPolicyTests(unittest.TestCase):
+    def test_apply_temp_hp_new(self):
+        from app.api.routes.sessions.state import _apply_temp_hp_to_state_dict
+        state = {"currentHP": 10, "maxHP": 20}
+        result = _apply_temp_hp_to_state_dict(state, 7)
+        self.assertEqual(result["tempHP"], 7)
+
+    def test_apply_temp_hp_keep_higher(self):
+        from app.api.routes.sessions.state import _apply_temp_hp_to_state_dict
+        state = {"currentHP": 10, "maxHP": 20, "tempHP": 12}
+        result = _apply_temp_hp_to_state_dict(state, 7)
+        self.assertEqual(result["tempHP"], 12)
+
+    def test_apply_temp_hp_replace_lower(self):
+        from app.api.routes.sessions.state import _apply_temp_hp_to_state_dict
+        state = {"currentHP": 10, "maxHP": 20, "tempHP": 3}
+        result = _apply_temp_hp_to_state_dict(state, 7)
+        self.assertEqual(result["tempHP"], 7)
+
+    def test_apply_temp_hp_does_not_heal_real_hp(self):
+        from app.api.routes.sessions.state import _apply_temp_hp_to_state_dict
+        state = {"currentHP": 5, "maxHP": 20}
+        result = _apply_temp_hp_to_state_dict(state, 10)
+        self.assertEqual(result["currentHP"], 5)
+        self.assertEqual(result["tempHP"], 10)
+
+
+class FalseLifeCombatUpcastBonusTests(unittest.TestCase):
+    def test_combat_handler_reads_effect_bonus_from_context(self):
+        from app.services.combat_service.exceptions import _roll_dice_expression
+
+        base_roll = _roll_dice_expression("1d4 + 4")
+        self.assertGreaterEqual(base_roll, 5)
+        self.assertLessEqual(base_roll, 8)
+
+        upcast_bonus = 10
+        total = base_roll + upcast_bonus
+        self.assertGreaterEqual(total, 15)
+        self.assertLessEqual(total, 18)
+
+    def test_combat_upcast_agrees_with_ooc(self):
+        for slot in (1, 2, 3, 4):
+            structured = CombatSpellDiceMathMixin._get_structured_spell_upcast({
+                "mode": "extra_temp_hp",
+                "flat": 5,
+                "perLevel": 1,
+            })
+            upcast_result = CombatSpellDiceMathMixin._apply_structured_spell_upcast(
+                spell_level=1,
+                slot_level=slot,
+                effect_kind=None,
+                effect_dice=None,
+                effect_bonus=0,
+                upcast=structured,
+            )
+            spell = _make_spell()
+            ooc_bonus = compute_temp_hp_upcast_bonus(spell, slot)
+            self.assertEqual(
+                upcast_result["effect_bonus"],
+                ooc_bonus,
+                f"Combat and OOC upcast disagree at slot {slot}",
+            )


### PR DESCRIPTION
## Description

Este PR introduz o suporte completo e declarativo para efeitos de concessão de Pontos de Vida Temporários (`grant_temp_hp`) no ecossistema do Limiar Control. A implementação foi ancorada na magia *False Life* (Vitalidade Vazia), garantindo suporte a bônus fixos pós-rolagem, escalonamento por nível de conjuração (*upcast*) e paridade de motores matemáticos entre o fluxo de combate e o fluxo fora de combate (OOC).

## Changes

### Core Mechanics & Math (`combat_service/`)
- **Upcast Expansion (`spell_dice_math.py`)**: Inclusão de `"extra_temp_hp"` no conjunto canônico de modos de upcast estruturados, permitindo incrementos numéricos flat por nível de slot (ex: +5 PVTs por nível acima do 1º).
- **Effect Handler (`spell_declarative_effects.py`)**: O manipulador de `grant_temp_hp` agora injeta corretamente o `effect_bonus` (como o `+4` de False Life) extraído do contexto da magia após a rolagem dos dados.
- **Preview Engine (`spell_context_resolve.py`)**: Criação do método `_build_temp_hp_preview`. O sistema agora expõe uma prévia detalhada (`temp_hp_preview`) contendo `{base_dice, effect_bonus, resolved_formula}` na resposta do contexto de resolução.

### Out of Combat Casting (OOC Flow)
- **Engine Parity (`out_of_combat_cast.py`)**: Implementadas as funções `collect_temp_hp_effects`, `compute_temp_hp_upcast_bonus` e `roll_spell_temp_hp_effects`. O cálculo de PVT fora de combate agora reutiliza as mesmas classes e regras estritas do combate.
- **State Application (`routes/sessions/state.py`)**: Integração do fluxo de PVT no dicionário de estado da sessão através do helper `_apply_temp_hp_to_state_dict`. O payload de atividade agora rastreia o campo `temp_hp_applied` e respeita a regra oficial de D&D 5e: **PV Temporários não acumulam, mantém-se o maior**.

### Data & Seeds
- **`base_spells.seed.json`**: Adicionado o contrato completo para a magia *False Life* (Necromancia de 1º nível, target: self, efeito declarativo de PVT com expressão `1d4` + bônus `4`, upcast flat de `5` por nível).

## Summary of Architecture

| Module | Component | Impact |
| :--- | :--- | :--- |
| **Data** | `base_spells.seed.json` | Canonical schema definitions for Temp HP mechanics |
| **Combat Math** | `spell_dice_math.py` | Registration of upcast formula parameters |
| **OOC Engine** | `out_of_combat_cast.py` | Ported combat math behavior to non-turn-based interactions |
| **Session State** | `state.py` | Hydration of actor temporary HP state with keep-higher guardrail |

## Validation & Test Suite (`test_false_life.py`)

Uma nova suíte com **29 testes unitários e de integração** foi adicionada, cobrindo:
- **Contract Integrity**: Validação do schema JSON da semente da magia.
- **Upcast Scaling**: Verificação matemática exata dos slots de nível 1 a 5 (Garantindo progressão $1d4 + 4$, $1d4 + 9$, $1d4 + 14$, etc.).
- **Rule Enforcement**: Teste da política de *keep-higher* (Garantindo que conjurar a magia com resultado menor não sobressaia um PVT maior já existente no personagem).
- **Math Parity**: Validação de que rolar a magia em combate produz rigorosamente o mesmo output estruturado do fluxo OOC.

### Execução da Suíte:
- **Total**: **401 testes passando** (0 falhas, 1 ignorado legado).
- **Static Analysis**: Nenhuma nova violação do Pyright introduzida (apenas os alertas pré-existentes de padrões de mixin).

> [!SUCCESS]
> Com esta entrega, o Limiar Control ganha maturidade na resolução de magias utilitárias e de auto-buff. O motor declarativo está pronto para receber magias mais complexas como *Armor of Agathys* e *Heroism*.