### PR TITLE
feat(combat) Full Heroism spell implementation with Condition Immunity and Recurring Temp HP (#366)

### DIFF
--- a/Base/base_spells.seed.json
+++ b/Base/base_spells.seed.json
@@ -2884,6 +2884,79 @@
           }
         }
       ]
+    },
+    {
+      "system": "DND5E",
+      "canonicalKey": "heroism",
+      "nameEn": "Heroism",
+      "namePt": "Heroísmo",
+      "descriptionEn": "A willing creature you touch is imbued with bravery. Until the spell ends, the creature is immune to being frightened and gains temporary hit points equal to your spellcasting ability modifier at the start of each of its turns. When the spell ends, the target loses any remaining temporary hit points from this spell.",
+      "descriptionPt": "Uma criatura voluntária que você toca é imbuída de bravura. Até o fim da magia, a criatura fica imune a amedrontado e ganha pontos de vida temporários iguais ao seu modificador de habilidade de conjuração no início de cada um de seus turnos. Quando a magia termina, o alvo perde quaisquer pontos de vida temporários restantes desta magia.",
+      "level": 1,
+      "school": "enchantment",
+      "classesJson": [
+        "Bard",
+        "Paladin"
+      ],
+      "castingTimeType": "action",
+      "castingTime": "1 action",
+      "rangeMeters": 1.5,
+      "rangeText": "Touch",
+      "duration": "Concentration, up to 1 minute",
+      "componentsJson": [
+        "V",
+        "S"
+      ],
+      "concentration": true,
+      "ritual": false,
+      "resolutionType": "buff",
+      "maxTargets": 1,
+      "upcast": {
+        "mode": "additional_targets",
+        "perLevel": 1
+      },
+      "source": "seed_json_bootstrap",
+      "isSrd": true,
+      "isActive": true,
+      "requiresTargetSight": true,
+      "requiresTargetEffect": true,
+      "requiresPointSight": false,
+      "requiresPointEffect": false,
+      "targetType": "ranged",
+      "selectionType": "creature",
+      "originType": "caster",
+      "targetAnchor": "selected_target",
+      "attackType": "none",
+      "rangeKind": "touch",
+      "effectTiming": "persistent",
+      "effects": [
+        {
+          "type": "condition_immunity",
+          "target": "selected_target",
+          "duration": {
+            "type": "manual"
+          },
+          "params": {
+            "conditions": [
+              "frightened"
+            ]
+          },
+          "stacking": "replace"
+        },
+        {
+          "type": "recurring_temp_hp",
+          "target": "selected_target",
+          "duration": {
+            "type": "manual"
+          },
+          "params": {
+            "amount_source": "caster_spellcasting_modifier",
+            "timing": "start_of_target_turn",
+            "remove_granted_temp_hp_on_end": true
+          },
+          "stacking": "replace"
+        }
+      ]
     }
   ]
 }

--- a/apps/control-server/app/schemas/base_spell_effects.py
+++ b/apps/control-server/app/schemas/base_spell_effects.py
@@ -9,6 +9,7 @@ from app.schemas.campaign_entity_shared import AbilityName
 
 SpellDeclarativeEffectType = Literal[
     "apply_condition",
+    "condition_immunity",
     "modify_stat",
     "modify_weapon_damage",
     "armor_class_formula",
@@ -28,6 +29,7 @@ SpellDeclarativeEffectType = Literal[
     "roll_bonus_dice",
     "roll_dice_modifier",
     "attack_advantage_against_target",
+    "recurring_temp_hp",
 ]
 
 SpellDeclarativeEffectTarget = Literal["selected_target", "caster"]
@@ -106,6 +108,20 @@ class SpellOutOfCombatTimedDuration(BaseModel):
 
 class ApplyConditionParams(BaseModel):
     condition: SpellDeclarativeConditionType
+
+
+class ConditionImmunityParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    conditions: list[SpellDeclarativeConditionType]
+
+
+class RecurringTempHpParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    amount_source: Literal["caster_spellcasting_modifier"]
+    timing: Literal["start_of_target_turn"]
+    remove_granted_temp_hp_on_end: bool = True
 
 
 class ModifyStatParams(BaseModel):
@@ -230,6 +246,7 @@ class SpellDeclarativeEffect(BaseModel):
     repeat_save: SpellDeclarativeRepeatSave | None = None
     params: (
         ApplyConditionParams
+        | ConditionImmunityParams
         | ModifyStatParams
         | GrantTempHpParams
         | ModifyWeaponDamageParams
@@ -247,6 +264,7 @@ class SpellDeclarativeEffect(BaseModel):
         | RollBonusDiceParams
         | RollDiceModifierParams
         | AttackAdvantageAgainstTargetParams
+        | RecurringTempHpParams
     )
     stacking: SpellDeclarativeEffectStacking | None = None
 
@@ -254,6 +272,8 @@ class SpellDeclarativeEffect(BaseModel):
     def validate_params_shape(self):
         if self.type == "apply_condition" and not isinstance(self.params, ApplyConditionParams):
             raise ValueError("apply_condition effects require ApplyConditionParams")
+        if self.type == "condition_immunity" and not isinstance(self.params, ConditionImmunityParams):
+            raise ValueError("condition_immunity effects require ConditionImmunityParams")
         if self.type == "modify_stat" and not isinstance(self.params, ModifyStatParams):
             raise ValueError("modify_stat effects require ModifyStatParams")
         if self.type == "modify_weapon_damage" and not isinstance(self.params, ModifyWeaponDamageParams):
@@ -296,4 +316,6 @@ class SpellDeclarativeEffect(BaseModel):
             raise ValueError(
                 "attack_advantage_against_target effects require AttackAdvantageAgainstTargetParams"
             )
+        if self.type == "recurring_temp_hp" and not isinstance(self.params, RecurringTempHpParams):
+            raise ValueError("recurring_temp_hp effects require RecurringTempHpParams")
         return self

--- a/apps/control-server/app/services/combat_service/concentration.py
+++ b/apps/control-server/app/services/combat_service/concentration.py
@@ -156,6 +156,7 @@ class CombatConcentrationMixin:
         state: CombatState,
         *,
         source_participant_id: str,
+        db=None,
     ) -> dict:
         groups: set[str] = set()
         for participant in state.participants:
@@ -179,6 +180,8 @@ class CombatConcentrationMixin:
                 state=state,
                 removed_effects=all_removed,
             )
+        if db is not None and all_removed:
+            cls._cleanup_recurring_temp_hp_effects(db, state, all_removed)
         return {
             "removed_effects": all_removed,
             "removed_area_effects": all_area_removed,
@@ -331,6 +334,7 @@ class CombatConcentrationMixin:
             result = cls._clear_concentration_for_source(
                 state,
                 source_participant_id=target_participant.get("id", ""),
+                db=db,
             )
             removed = result["removed_effects"]
             area_removed = result["removed_area_effects"]

--- a/apps/control-server/app/services/combat_service/condition_effects_predicates.py
+++ b/apps/control-server/app/services/combat_service/condition_effects_predicates.py
@@ -94,6 +94,16 @@ def has_condition(participant: dict, condition_type: str) -> bool:
     return False
 
 
+def has_condition_immunity(participant: dict, condition_type: str) -> bool:
+    for effect in participant.get("active_effects") or []:
+        if effect.get("kind") != "spell_effect":
+            continue
+        metadata = effect.get("metadata") or {}
+        if metadata.get("condition_immunity") and condition_type in (metadata.get("immune_conditions") or []):
+            return True
+    return False
+
+
 def is_incapacitated(participant: dict) -> bool:
     return any(has_condition(participant, c) for c in _INCAPACITATING_CONDITIONS)
 

--- a/apps/control-server/app/services/combat_service/effects_actions.py
+++ b/apps/control-server/app/services/combat_service/effects_actions.py
@@ -15,6 +15,7 @@ from app.schemas.combat import (
     CombatRemoveEffectRequest,
 )
 
+from .condition_effects_predicates import has_condition_immunity
 from .effects_core import CombatEffectsCoreMixin
 from .exceptions import CombatServiceError
 
@@ -48,6 +49,8 @@ class CombatEffectsActionsMixin(CombatEffectsCoreMixin):
             raise CombatServiceError("Target participant not found in combat", 404)
         if req.kind == "condition" and not req.condition_type:
             raise CombatServiceError("condition_type is required when kind is 'condition'")
+        if req.kind == "condition" and req.condition_type and has_condition_immunity(target, req.condition_type):
+            raise CombatServiceError(f"Target is immune to {req.condition_type}", 409)
         if req.kind in ("temp_ac_bonus", "attack_bonus", "damage_bonus", "size_modifier") and req.numeric_value is None:
             raise CombatServiceError(f"numeric_value is required for kind '{req.kind}'")
         if req.kind == "size_modifier" and req.numeric_value not in (-1, 1):

--- a/apps/control-server/app/services/combat_service/lifecycle_turns.py
+++ b/apps/control-server/app/services/combat_service/lifecycle_turns.py
@@ -124,6 +124,56 @@ class CombatLifecycleTurnsMixin:
                 )
 
     @classmethod
+    async def _process_recurring_temp_hp(
+        cls,
+        db,
+        session_id: str,
+        state,
+        participant: dict,
+    ) -> None:
+        from app.services.session_state_finalize import finalize_session_state_data
+        from sqlalchemy.orm.attributes import flag_modified as _flag_modified
+
+        effects = cls._get_participant_effects(participant)
+        for effect in effects:
+            metadata = cls._get_effect_metadata(effect)
+            if not metadata.get("recurring_temp_hp"):
+                continue
+            temp_hp_per_turn = cls._safe_int(metadata.get("temp_hp_per_turn"), 0)
+            if temp_hp_per_turn <= 0:
+                continue
+            target_ref_id = metadata.get("effect_target_ref_id")
+            target_kind = None
+            for p in state.participants:
+                if p.get("ref_id") == target_ref_id or p.get("id") == metadata.get("effect_target_participant_id"):
+                    target_kind = p.get("kind")
+                    target_ref_id = p.get("ref_id")
+                    break
+            if target_kind == "player" and target_ref_id:
+                try:
+                    target_model, *_ = cls._get_stats(db, target_ref_id, "player", session_id)
+                    data = cls._as_dict(target_model.state_json)
+                    previous = max(0, cls._safe_int(data.get("tempHP"), 0))
+                    final = max(previous, temp_hp_per_turn)
+                    metadata["last_granted_temp_hp"] = temp_hp_per_turn
+                    if final > previous:
+                        data["tempHP"] = final
+                        target_model.state_json = finalize_session_state_data(data)
+                        _flag_modified(target_model, "state_json")
+                        if db is not None:
+                            db.add(target_model)
+                    spell_name = metadata.get("source_spell_name") or "Spell"
+                    await cls._emit_log(
+                        session_id,
+                        {
+                            "message": f"{participant['display_name']} ganhou {temp_hp_per_turn} PV temporários de {spell_name}.",
+                            "source": "recurring_temp_hp",
+                        },
+                    )
+                except Exception:
+                    pass
+
+    @classmethod
     async def next_turn(
         cls,
         db,
@@ -211,6 +261,7 @@ class CombatLifecycleTurnsMixin:
             label = anchor.get("source_spell_name") or anchor.get("source_spell_key") or "Spell anchor"
             await cls._emit_log(session_id, {"message": f"Spell anchor '{label}' expired (start of {incoming['display_name']}'s turn).", "source": "effect_expired"})
         cls._reset_turn_resources(incoming)
+        await cls._process_recurring_temp_hp(db, session_id, state, incoming)
         db.add(state)
         db.commit()
         db.refresh(state)
@@ -261,7 +312,7 @@ class CombatLifecycleTurnsMixin:
 
         all_removed: list[dict] = []
         for source_id in concentration_source_ids:
-            result = cls._clear_concentration_for_source(state, source_participant_id=source_id)
+            result = cls._clear_concentration_for_source(state, source_participant_id=source_id, db=db)
             all_removed.extend(result["removed_effects"])
 
         persist_surviving_spell_effects(db, state)

--- a/apps/control-server/app/services/combat_service/spell_automation.py
+++ b/apps/control-server/app/services/combat_service/spell_automation.py
@@ -276,6 +276,7 @@ class CombatSpellAutomationMixin:
         result = cls._clear_concentration_for_source(
             state,
             source_participant_id=attacker["id"],
+            db=db,
         )
         cls._sync_area_effects_if_changed(
             session_id, state, result["removed_area_effects"],
@@ -1140,6 +1141,7 @@ class CombatSpellAutomationMixin:
         result = cls._clear_concentration_for_source(
             state,
             source_participant_id=attacker["id"],
+            db=db,
         )
         cls._sync_area_effects_if_changed(
             session_id, state, result["removed_area_effects"],

--- a/apps/control-server/app/services/combat_service/spell_declarative_effects.py
+++ b/apps/control-server/app/services/combat_service/spell_declarative_effects.py
@@ -17,6 +17,7 @@ from app.schemas.campaign_entity_shared import AbilityName, SKILL_ABILITY_MAP, S
 from .condition_effects_predicates import (
     explain_check_modifier_sources,
     get_roll_bonus_dice_sources,
+    has_condition_immunity,
     resolve_actor_participant,
     resolve_check_advantage_mode,
 )
@@ -451,16 +452,41 @@ class CombatSpellDeclarativeEffectsMixin:
 
         created: list[dict] = []
         if effect.type == "apply_condition":
+            condition_type = params["condition"]
+            if has_condition_immunity(resolved_target, condition_type):
+                return []
             active_effect = cls._build_active_effect(
                 kind="condition",
                 source_participant_id=attacker.get("id"),
-                condition_type=params["condition"],
+                condition_type=condition_type,
                 metadata=metadata,
                 display_label=spell_context.get("spell_name"),
                 **duration_kwargs,
             )
             cls._append_effect_to_participant(resolved_target, active_effect)
             created.append(active_effect)
+        elif effect.type == "condition_immunity":
+            immune_conditions: list[str] = params.get("conditions") or []
+            active_effect = cls._build_active_effect(
+                kind="spell_effect",
+                source_participant_id=attacker.get("id"),
+                metadata={
+                    **metadata,
+                    "condition_immunity": True,
+                    "immune_conditions": immune_conditions,
+                },
+                display_label=spell_context.get("spell_name"),
+                **duration_kwargs,
+            )
+            cls._append_effect_to_participant(resolved_target, active_effect)
+            created.append(active_effect)
+            # Suppress any matching conditions already present on the target
+            existing_effects = cls._get_participant_effects(resolved_target)
+            kept = [
+                e for e in existing_effects
+                if not (e.get("kind") == "condition" and e.get("condition_type") in immune_conditions)
+            ]
+            cls._set_participant_effects(resolved_target, kept)
         elif effect.type == "modify_stat":
             active_effect = cls._build_active_effect(
                 kind=params["stat"],
@@ -498,6 +524,27 @@ class CombatSpellDeclarativeEffectsMixin:
                 source_participant_id=attacker.get("id"),
                 numeric_value=params["value"],
                 metadata=metadata,
+                display_label=spell_context.get("spell_name"),
+                **duration_kwargs,
+            )
+            cls._append_effect_to_participant(resolved_target, active_effect)
+            created.append(active_effect)
+        elif effect.type == "recurring_temp_hp":
+            amount_source = params.get("amount_source")
+            if amount_source == "caster_spellcasting_modifier":
+                temp_hp_per_turn = max(0, int(spell_context.get("caster_spell_mod") or 0))
+            else:
+                temp_hp_per_turn = 0
+            active_effect = cls._build_active_effect(
+                kind="spell_effect",
+                source_participant_id=attacker.get("id"),
+                metadata={
+                    **metadata,
+                    "recurring_temp_hp": True,
+                    "temp_hp_per_turn": temp_hp_per_turn,
+                    "last_granted_temp_hp": 0,
+                    "remove_granted_temp_hp_on_end": params.get("remove_granted_temp_hp_on_end", True),
+                },
                 display_label=spell_context.get("spell_name"),
                 **duration_kwargs,
             )
@@ -653,6 +700,47 @@ class CombatSpellDeclarativeEffectsMixin:
             metadata["applied_temp_hp"] = True
             metadata["previous_temp_hp"] = previous_temp_hp
             metadata["final_temp_hp"] = final_temp_hp
+
+    @classmethod
+    def _cleanup_recurring_temp_hp_effects(
+        cls,
+        db,
+        state,
+        removed_effects: list[dict],
+    ) -> None:
+        from app.services.session_state_finalize import finalize_session_state_data
+        from sqlalchemy.orm.attributes import flag_modified as _flag_modified
+
+        for effect in removed_effects:
+            metadata = cls._get_effect_metadata(effect)
+            if not metadata.get("recurring_temp_hp"):
+                continue
+            if not metadata.get("remove_granted_temp_hp_on_end"):
+                continue
+            last_granted = cls._safe_int(metadata.get("last_granted_temp_hp"), 0)
+            if last_granted <= 0:
+                continue
+            target_ref_id = metadata.get("effect_target_ref_id")
+            target_kind = None
+            for p in (state.participants if state else []):
+                if p.get("ref_id") == target_ref_id or p.get("id") == metadata.get("effect_target_participant_id"):
+                    target_kind = p.get("kind")
+                    target_ref_id = p.get("ref_id")
+                    break
+            if target_kind != "player" or not target_ref_id:
+                continue
+            try:
+                session_id = state.session_id if state else ""
+                target_model, *_ = cls._get_stats(db, target_ref_id, "player", session_id)
+                data = cls._as_dict(target_model.state_json)
+                current_temp_hp = max(0, cls._safe_int(data.get("tempHP"), 0))
+                if current_temp_hp <= last_granted:
+                    data["tempHP"] = 0
+                    target_model.state_json = finalize_session_state_data(data)
+                    _flag_modified(target_model, "state_json")
+                    db.add(target_model)
+            except Exception:
+                pass
 
     @classmethod
     async def _cast_spell_via_declarative_effects(

--- a/apps/control-server/app/services/combat_service/spells/cast_area.py
+++ b/apps/control-server/app/services/combat_service/spells/cast_area.py
@@ -509,7 +509,7 @@ class CastAreaMixin:
         if spell_context.get("effect_timing") == "persistent":
             if spell_context.get("concentration"):
                 prev = cls._clear_concentration_for_source(
-                    state, source_participant_id=attacker["id"],
+                    state, source_participant_id=attacker["id"], db=db,
                 )
                 if prev["removed_effects"]:
                     flag_modified(state, "participants")

--- a/apps/control-server/app/services/combat_service/spells/spell_context_resolve.py
+++ b/apps/control-server/app/services/combat_service/spells/spell_context_resolve.py
@@ -390,6 +390,7 @@ class SpellContextResolveMixin:
         resolved_math: dict,
         resolved_upcast: dict,
         spell_level: int,
+        caster_spell_mod: int = 0,
     ) -> dict:
         upcast_result = resolved_upcast["upcast_result"]
         base_max_targets = getattr(catalog_spell, "max_targets", None)
@@ -487,6 +488,7 @@ class SpellContextResolveMixin:
             "ignore_components": source_context["ignore_components"],
             "no_free_hand_required": source_context["no_free_hand_required"],
             "source_item": source_context["source_item"],
+            "caster_spell_mod": caster_spell_mod,
         }
 
     @classmethod
@@ -546,4 +548,5 @@ class SpellContextResolveMixin:
             resolved_math=resolved_math,
             resolved_upcast=resolved_upcast,
             spell_level=catalog_context["spell_level"],
+            caster_spell_mod=spell_mod,
         )

--- a/apps/control-server/tests/test_heroism.py
+++ b/apps/control-server/tests/test_heroism.py
@@ -1,0 +1,990 @@
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.models.combat import CombatPhase, CombatState
+from app.models.session_state import SessionState
+from app.schemas.base_spell_effects import ConditionImmunityParams, RecurringTempHpParams, SpellDeclarativeEffect
+from app.schemas.combat_spells import CombatResolveSpellContextRequest
+from app.services.combat import CombatService
+from app.services.combat_service.condition_effects_predicates import has_condition_immunity
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_player(pid: str = "p1", user_id: str = "u1") -> dict:
+    return {
+        "id": pid,
+        "ref_id": pid,
+        "kind": "player",
+        "display_name": "Hero",
+        "status": "active",
+        "team": "players",
+        "visible": True,
+        "actor_user_id": user_id,
+        "active_effects": [],
+        "turn_resources": {"action_used": False, "bonus_action_used": False, "reaction_used": False},
+    }
+
+
+def _make_target(pid: str = "t1", ref_id: str = "target-1") -> dict:
+    return {
+        "id": pid,
+        "ref_id": ref_id,
+        "kind": "session_entity",
+        "display_name": f"Target {pid}",
+        "status": "active",
+        "team": "players",
+        "visible": True,
+        "actor_user_id": None,
+        "active_effects": [],
+        "turn_resources": {"action_used": False, "bonus_action_used": False, "reaction_used": False},
+    }
+
+
+def _make_state(participants: list[dict]) -> CombatState:
+    return CombatState(
+        id="c1",
+        session_id="s1",
+        phase=CombatPhase.active,
+        round=1,
+        current_turn_index=0,
+        participants=participants,
+        use_map=False,
+    )
+
+
+def _make_heroism_catalog_spell(max_targets: int = 1):
+    return SimpleNamespace(
+        canonical_key="heroism",
+        name_en="Heroism",
+        name_pt="Heroísmo",
+        level=1,
+        resolution_type="buff",
+        damage_dice=None,
+        heal_dice=None,
+        damage_type=None,
+        saving_throw=None,
+        save_success_outcome=None,
+        upcast_json={"mode": "additional_targets", "perLevel": 1},
+        cantrip_scaling_json=None,
+        casting_time_type="action",
+        target_type="ranged",
+        selection_type="creature",
+        origin_type="caster",
+        target_anchor="selected_target",
+        attack_type="none",
+        range_kind="touch",
+        effect_timing="persistent",
+        area_shape=None,
+        range_meters=1.5,
+        duration="Concentration, up to 1 minute",
+        concentration=True,
+        max_targets=max_targets,
+        requires_target_sight=True,
+        requires_target_effect=True,
+        requires_point_sight=False,
+        requires_point_effect=False,
+        effects_json=[
+            {
+                "type": "condition_immunity",
+                "target": "selected_target",
+                "duration": {"type": "manual"},
+                "params": {"conditions": ["frightened"]},
+                "stacking": "replace",
+            }
+        ],
+    )
+
+
+def _condition_immunity_effect(concentration_group: str = "grp-1") -> SpellDeclarativeEffect:
+    return SpellDeclarativeEffect.model_validate(
+        {
+            "type": "condition_immunity",
+            "target": "selected_target",
+            "duration": {"type": "manual"},
+            "params": {"conditions": ["frightened"]},
+            "stacking": "replace",
+        }
+    )
+
+
+def _spell_context(concentration: bool = True) -> dict:
+    return {
+        "spell_name": "Heroísmo",
+        "spell_canonical_key": "heroism",
+        "spell_mode": "utility",
+        "concentration": concentration,
+        "slot_level": 1,
+        "action_cost": "action",
+        "source_kind": "spell",
+        "effect_kind": "none",
+        "effect_dice": None,
+        "effect_bonus": 0,
+        "target_type": "ranged",
+        "range_kind": "touch",
+        "attack_type": "none",
+        "requires_target_sight": True,
+        "requires_target_effect": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Seed tests
+# ---------------------------------------------------------------------------
+
+class HeroismSeedTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = os.path.join(
+            os.path.dirname(__file__), "..", "..", "..", "Base", "base_spells.seed.json"
+        )
+        with open(os.path.abspath(path), encoding="utf-8") as f:
+            data = json.load(f)
+        cls.spells = {s["canonicalKey"]: s for s in data.get("spells", [])}
+
+    def test_heroism_present(self):
+        self.assertIn("heroism", self.spells)
+
+    def test_heroism_basic_fields(self):
+        s = self.spells["heroism"]
+        self.assertEqual(s["level"], 1)
+        self.assertEqual(s["school"], "enchantment")
+        self.assertTrue(s["concentration"])
+        self.assertEqual(s["maxTargets"], 1)
+
+    def test_heroism_upcast(self):
+        upcast = self.spells["heroism"].get("upcast") or {}
+        self.assertEqual(upcast.get("mode"), "additional_targets")
+        self.assertEqual(upcast.get("perLevel"), 1)
+
+    def test_heroism_has_condition_immunity_effect(self):
+        effects = self.spells["heroism"].get("effects", [])
+        types = [e.get("type") for e in effects]
+        self.assertIn("condition_immunity", types)
+
+    def test_heroism_condition_immunity_targets_frightened(self):
+        effects = self.spells["heroism"].get("effects", [])
+        immunity = next(e for e in effects if e.get("type") == "condition_immunity")
+        self.assertIn("frightened", immunity["params"]["conditions"])
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+class ConditionImmunitySchemaTests(unittest.TestCase):
+    def test_valid_condition_immunity_effect(self):
+        effect = SpellDeclarativeEffect.model_validate(
+            {
+                "type": "condition_immunity",
+                "target": "selected_target",
+                "duration": {"type": "manual"},
+                "params": {"conditions": ["frightened", "charmed"]},
+            }
+        )
+        self.assertIsInstance(effect.params, ConditionImmunityParams)
+        self.assertEqual(effect.params.conditions, ["frightened", "charmed"])
+
+    def test_invalid_condition_immunity_effect_rejects_unknown_condition(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            SpellDeclarativeEffect.model_validate(
+                {
+                    "type": "condition_immunity",
+                    "target": "selected_target",
+                    "duration": {"type": "manual"},
+                    "params": {"conditions": ["nonexistent_condition"]},
+                }
+            )
+
+
+# ---------------------------------------------------------------------------
+# Predicate tests
+# ---------------------------------------------------------------------------
+
+class HasConditionImmunityTests(unittest.TestCase):
+    def _participant_with_immunity(self, immune_conditions: list[str]) -> dict:
+        return {
+            "active_effects": [
+                {
+                    "id": "eff-1",
+                    "kind": "spell_effect",
+                    "metadata": {
+                        "condition_immunity": True,
+                        "immune_conditions": immune_conditions,
+                    },
+                }
+            ]
+        }
+
+    def test_immune_to_listed_condition(self):
+        p = self._participant_with_immunity(["frightened"])
+        self.assertTrue(has_condition_immunity(p, "frightened"))
+
+    def test_not_immune_to_unlisted_condition(self):
+        p = self._participant_with_immunity(["frightened"])
+        self.assertFalse(has_condition_immunity(p, "charmed"))
+
+    def test_no_effects_returns_false(self):
+        self.assertFalse(has_condition_immunity({"active_effects": []}, "frightened"))
+
+    def test_non_spell_effect_does_not_count(self):
+        p = {
+            "active_effects": [
+                {
+                    "id": "eff-1",
+                    "kind": "condition",
+                    "metadata": {
+                        "condition_immunity": True,
+                        "immune_conditions": ["frightened"],
+                    },
+                }
+            ]
+        }
+        self.assertFalse(has_condition_immunity(p, "frightened"))
+
+    def test_multiple_conditions(self):
+        p = self._participant_with_immunity(["frightened", "charmed", "poisoned"])
+        self.assertTrue(has_condition_immunity(p, "charmed"))
+        self.assertTrue(has_condition_immunity(p, "poisoned"))
+        self.assertFalse(has_condition_immunity(p, "blinded"))
+
+
+# ---------------------------------------------------------------------------
+# _apply_single_declarative_effect: condition_immunity
+# ---------------------------------------------------------------------------
+
+class ApplyConditionImmunityEffectTests(unittest.TestCase):
+    def _apply(self, attacker: dict, target: dict, state: CombatState, effect: SpellDeclarativeEffect | None = None):
+        if effect is None:
+            effect = _condition_immunity_effect()
+        return CombatService._apply_single_declarative_effect(
+            state=state,
+            attacker=attacker,
+            target_participant=target,
+            spell_context=_spell_context(concentration=True),
+            effect=effect,
+            effect_group_id="grp-heroism",
+            on_end_effects=[],
+        )
+
+    def test_applies_condition_immunity_effect_to_target(self):
+        attacker = _make_player()
+        target = _make_target()
+        state = _make_state([attacker, target])
+        created = self._apply(attacker, target, state)
+        self.assertEqual(len(created), 1)
+        effect = created[0]
+        self.assertEqual(effect["kind"], "spell_effect")
+        self.assertTrue(effect["metadata"]["condition_immunity"])
+        self.assertIn("frightened", effect["metadata"]["immune_conditions"])
+
+    def test_concentration_group_set_when_concentration(self):
+        attacker = _make_player()
+        target = _make_target()
+        state = _make_state([attacker, target])
+        created = self._apply(attacker, target, state)
+        meta = created[0]["metadata"]
+        self.assertEqual(meta["concentration_group"], "grp-heroism")
+
+    def test_target_has_one_active_effect_after_apply(self):
+        attacker = _make_player()
+        target = _make_target()
+        state = _make_state([attacker, target])
+        self._apply(attacker, target, state)
+        effects = target.get("active_effects") or []
+        self.assertEqual(len(effects), 1)
+
+    def test_suppresses_existing_frightened_on_cast(self):
+        attacker = _make_player()
+        target = _make_target()
+        target["active_effects"] = [
+            {
+                "id": "pre-existing",
+                "kind": "condition",
+                "condition_type": "frightened",
+                "metadata": {},
+            }
+        ]
+        state = _make_state([attacker, target])
+        self._apply(attacker, target, state)
+        effects = target.get("active_effects") or []
+        condition_kinds = [e.get("kind") for e in effects]
+        self.assertNotIn("condition", condition_kinds)
+
+    def test_does_not_suppress_unrelated_conditions(self):
+        attacker = _make_player()
+        target = _make_target()
+        target["active_effects"] = [
+            {
+                "id": "charmed-eff",
+                "kind": "condition",
+                "condition_type": "charmed",
+                "metadata": {},
+            }
+        ]
+        state = _make_state([attacker, target])
+        self._apply(attacker, target, state)
+        effects = target.get("active_effects") or []
+        condition_types = [e.get("condition_type") for e in effects if e.get("kind") == "condition"]
+        self.assertIn("charmed", condition_types)
+
+
+# ---------------------------------------------------------------------------
+# Immunity gate: apply_condition blocked when immune
+# ---------------------------------------------------------------------------
+
+class ConditionImmunityGateTests(unittest.TestCase):
+    def _immunity_effect_dict(self, conditions: list[str]) -> dict:
+        return {
+            "id": "immunity-eff",
+            "kind": "spell_effect",
+            "metadata": {
+                "condition_immunity": True,
+                "immune_conditions": conditions,
+            },
+        }
+
+    def _apply_condition(self, target: dict, state: CombatState, condition: str = "frightened") -> list[dict]:
+        attacker = next(p for p in state.participants if p["id"] == "p1")
+        effect = SpellDeclarativeEffect.model_validate(
+            {
+                "type": "apply_condition",
+                "target": "selected_target",
+                "duration": {"type": "manual"},
+                "params": {"condition": condition},
+            }
+        )
+        return CombatService._apply_single_declarative_effect(
+            state=state,
+            attacker=attacker,
+            target_participant=target,
+            spell_context={"spell_name": "Fear", "spell_canonical_key": "fear", "concentration": False},
+            effect=effect,
+            effect_group_id="grp-fear",
+            on_end_effects=[],
+        )
+
+    def test_frightened_blocked_by_heroism_immunity(self):
+        attacker = _make_player()
+        target = _make_target()
+        target["active_effects"] = [self._immunity_effect_dict(["frightened"])]
+        state = _make_state([attacker, target])
+
+        pre_count = len(target["active_effects"])
+        created = self._apply_condition(target, state, "frightened")
+        self.assertEqual(created, [])
+        self.assertEqual(len(target["active_effects"]), pre_count)
+
+    def test_non_immune_condition_not_blocked(self):
+        attacker = _make_player()
+        target = _make_target()
+        target["active_effects"] = [self._immunity_effect_dict(["frightened"])]
+        state = _make_state([attacker, target])
+
+        created = self._apply_condition(target, state, "charmed")
+        self.assertEqual(len(created), 1)
+        self.assertEqual(created[0]["kind"], "condition")
+
+
+# ---------------------------------------------------------------------------
+# Upcast max_targets via resolve_spell_context
+# ---------------------------------------------------------------------------
+
+class HeroismUpcastContextTests(unittest.TestCase):
+    def _resolve_context(self, slot_level: int) -> dict:
+        state = _make_state([_make_player()])
+        attacker_state = SessionState(
+            id="ss-1",
+            session_id="s1",
+            player_user_id="u1",
+            state_json={
+                "spellcasting": {
+                    "spells": [{"canonicalKey": "heroism", "level": 1, "prepared": True}],
+                    "slots": {str(slot_level): {"used": 0, "max": 3}},
+                }
+            },
+        )
+        with (
+            patch("app.services.combat.CombatService.get_state", return_value=state),
+            patch("app.services.combat.CombatService._get_spell_catalog_entry_for_session", return_value=_make_heroism_catalog_spell(1)),
+            patch("app.services.combat.CombatService._get_stats", return_value=(attacker_state, 12, 10, 10, 3, 4)),
+        ):
+            return CombatService.resolve_spell_context(
+                None,
+                "s1",
+                CombatResolveSpellContextRequest(
+                    actor_participant_id="p1",
+                    spell_canonical_key="heroism",
+                    spell_mode="utility",
+                    slot_level=slot_level,
+                ),
+                "u1",
+                False,
+            )
+
+    def test_upcast_max_targets_progression(self):
+        self.assertEqual(self._resolve_context(1)["max_targets"], 1)
+        self.assertEqual(self._resolve_context(2)["max_targets"], 2)
+        self.assertEqual(self._resolve_context(3)["max_targets"], 3)
+
+
+# ---------------------------------------------------------------------------
+# Concentration cleanup removes condition_immunity
+# ---------------------------------------------------------------------------
+
+class HeroismConcentrationCleanupTests(unittest.TestCase):
+    def test_clearing_concentration_removes_immunity_effect(self):
+        attacker = _make_player()
+        target = _make_target()
+        target["active_effects"] = [
+            {
+                "id": "heroism-immunity",
+                "kind": "spell_effect",
+                "source_participant_id": "p1",
+                "metadata": {
+                    "condition_immunity": True,
+                    "immune_conditions": ["frightened"],
+                    "concentration": True,
+                    "concentration_group": "grp-heroism-1",
+                },
+            }
+        ]
+        attacker["active_effects"] = [
+            {
+                "id": "heroism-concentration-marker",
+                "kind": "spell_effect",
+                "source_participant_id": "p1",
+                "metadata": {
+                    "concentration": True,
+                    "concentration_group": "grp-heroism-1",
+                },
+            }
+        ]
+        state = _make_state([attacker, target])
+
+        CombatService._clear_concentration_for_source(state, source_participant_id="p1")
+
+        remaining = target.get("active_effects") or []
+        immunity_effects = [
+            e for e in remaining
+            if (e.get("metadata") or {}).get("condition_immunity")
+        ]
+        self.assertEqual(immunity_effects, [])
+
+    def test_clearing_one_concentration_does_not_affect_other_groups(self):
+        attacker = _make_player()
+        target = _make_target()
+        target["active_effects"] = [
+            {
+                "id": "heroism-immunity",
+                "kind": "spell_effect",
+                "source_participant_id": "p1",
+                "metadata": {
+                    "condition_immunity": True,
+                    "immune_conditions": ["frightened"],
+                    "concentration": True,
+                    "concentration_group": "grp-heroism-1",
+                },
+            },
+            {
+                "id": "other-effect",
+                "kind": "spell_effect",
+                "source_participant_id": "p2",
+                "metadata": {
+                    "concentration": True,
+                    "concentration_group": "grp-other",
+                },
+            },
+        ]
+        attacker["active_effects"] = [
+            {
+                "id": "heroism-marker",
+                "kind": "spell_effect",
+                "source_participant_id": "p1",
+                "metadata": {
+                    "concentration": True,
+                    "concentration_group": "grp-heroism-1",
+                },
+            }
+        ]
+        state = _make_state([attacker, target])
+
+        CombatService._clear_concentration_for_source(state, source_participant_id="p1")
+
+        remaining = target.get("active_effects") or []
+        remaining_ids = [e["id"] for e in remaining]
+        self.assertNotIn("heroism-immunity", remaining_ids)
+        self.assertIn("other-effect", remaining_ids)
+
+
+# ---------------------------------------------------------------------------
+# RecurringTempHp schema tests
+# ---------------------------------------------------------------------------
+
+class RecurringTempHpSchemaTests(unittest.TestCase):
+    def test_valid_recurring_temp_hp_effect(self):
+        effect = SpellDeclarativeEffect.model_validate(
+            {
+                "type": "recurring_temp_hp",
+                "target": "selected_target",
+                "duration": {"type": "manual"},
+                "params": {
+                    "amount_source": "caster_spellcasting_modifier",
+                    "timing": "start_of_target_turn",
+                    "remove_granted_temp_hp_on_end": True,
+                },
+            }
+        )
+        self.assertIsInstance(effect.params, RecurringTempHpParams)
+        self.assertEqual(effect.params.amount_source, "caster_spellcasting_modifier")
+        self.assertTrue(effect.params.remove_granted_temp_hp_on_end)
+
+    def test_invalid_amount_source_rejected(self):
+        from pydantic import ValidationError
+        with self.assertRaises(ValidationError):
+            SpellDeclarativeEffect.model_validate(
+                {
+                    "type": "recurring_temp_hp",
+                    "target": "selected_target",
+                    "duration": {"type": "manual"},
+                    "params": {
+                        "amount_source": "fixed_value",
+                        "timing": "start_of_target_turn",
+                    },
+                }
+            )
+
+    def test_heroism_seed_has_recurring_temp_hp_effect(self):
+        path = os.path.join(
+            os.path.dirname(__file__), "..", "..", "..", "Base", "base_spells.seed.json"
+        )
+        with open(os.path.abspath(path), encoding="utf-8") as f:
+            data = json.load(f)
+        spells = {s["canonicalKey"]: s for s in data.get("spells", [])}
+        effects = spells["heroism"].get("effects", [])
+        types = [e.get("type") for e in effects]
+        self.assertIn("recurring_temp_hp", types)
+
+    def test_heroism_recurring_temp_hp_params(self):
+        path = os.path.join(
+            os.path.dirname(__file__), "..", "..", "..", "Base", "base_spells.seed.json"
+        )
+        with open(os.path.abspath(path), encoding="utf-8") as f:
+            data = json.load(f)
+        spells = {s["canonicalKey"]: s for s in data.get("spells", [])}
+        effects = spells["heroism"].get("effects", [])
+        recur = next(e for e in effects if e.get("type") == "recurring_temp_hp")
+        self.assertEqual(recur["params"]["amount_source"], "caster_spellcasting_modifier")
+        self.assertEqual(recur["params"]["timing"], "start_of_target_turn")
+        self.assertTrue(recur["params"]["remove_granted_temp_hp_on_end"])
+
+
+# ---------------------------------------------------------------------------
+# Apply recurring_temp_hp effect via _apply_single_declarative_effect
+# ---------------------------------------------------------------------------
+
+class ApplyRecurringTempHpEffectTests(unittest.TestCase):
+    def _apply(self, attacker: dict, target: dict, state: CombatState, caster_spell_mod: int = 3):
+        effect = SpellDeclarativeEffect.model_validate(
+            {
+                "type": "recurring_temp_hp",
+                "target": "selected_target",
+                "duration": {"type": "manual"},
+                "params": {
+                    "amount_source": "caster_spellcasting_modifier",
+                    "timing": "start_of_target_turn",
+                    "remove_granted_temp_hp_on_end": True,
+                },
+                "stacking": "replace",
+            }
+        )
+        ctx = _spell_context(concentration=True)
+        ctx["caster_spell_mod"] = caster_spell_mod
+        return CombatService._apply_single_declarative_effect(
+            state=state,
+            attacker=attacker,
+            target_participant=target,
+            spell_context=ctx,
+            effect=effect,
+            effect_group_id="grp-heroism",
+            on_end_effects=[],
+        )
+
+    def test_creates_spell_effect_with_recurring_temp_hp_metadata(self):
+        attacker = _make_player()
+        target = _make_target()
+        state = _make_state([attacker, target])
+        created = self._apply(attacker, target, state, caster_spell_mod=3)
+        self.assertEqual(len(created), 1)
+        meta = created[0]["metadata"]
+        self.assertTrue(meta["recurring_temp_hp"])
+        self.assertEqual(meta["temp_hp_per_turn"], 3)
+        self.assertEqual(meta["last_granted_temp_hp"], 0)
+        self.assertTrue(meta["remove_granted_temp_hp_on_end"])
+
+    def test_temp_hp_per_turn_reflects_caster_spell_mod(self):
+        attacker = _make_player()
+        target = _make_target()
+        state = _make_state([attacker, target])
+        created = self._apply(attacker, target, state, caster_spell_mod=5)
+        self.assertEqual(created[0]["metadata"]["temp_hp_per_turn"], 5)
+
+    def test_zero_spell_mod_yields_zero_temp_hp_per_turn(self):
+        attacker = _make_player()
+        target = _make_target()
+        state = _make_state([attacker, target])
+        created = self._apply(attacker, target, state, caster_spell_mod=0)
+        self.assertEqual(created[0]["metadata"]["temp_hp_per_turn"], 0)
+
+    def test_concentration_group_set_on_recurring_effect(self):
+        attacker = _make_player()
+        target = _make_target()
+        state = _make_state([attacker, target])
+        created = self._apply(attacker, target, state)
+        self.assertEqual(created[0]["metadata"]["concentration_group"], "grp-heroism")
+
+
+# ---------------------------------------------------------------------------
+# _process_recurring_temp_hp: applies temp HP at turn start
+# ---------------------------------------------------------------------------
+
+class ProcessRecurringTempHpTests(unittest.IsolatedAsyncioTestCase):
+    def _participant_with_recurring_effect(
+        self,
+        ref_id: str = "p1",
+        temp_hp_per_turn: int = 3,
+        last_granted: int = 0,
+    ) -> dict:
+        return {
+            "id": "pid-1",
+            "ref_id": ref_id,
+            "kind": "player",
+            "display_name": "Hero",
+            "status": "active",
+            "team": "players",
+            "actor_user_id": "u1",
+            "active_effects": [
+                {
+                    "id": "recurring-eff",
+                    "kind": "spell_effect",
+                    "metadata": {
+                        "recurring_temp_hp": True,
+                        "temp_hp_per_turn": temp_hp_per_turn,
+                        "last_granted_temp_hp": last_granted,
+                        "remove_granted_temp_hp_on_end": True,
+                        "effect_target_participant_id": "pid-1",
+                        "effect_target_ref_id": ref_id,
+                        "source_spell_name": "Heroísmo",
+                    },
+                }
+            ],
+        }
+
+    def _mock_player_model(self, current_temp_hp: int = 0):
+        model = SimpleNamespace()
+        model.state_json = {"tempHP": current_temp_hp, "level": 5}
+        return model
+
+    async def test_applies_temp_hp_when_zero_current(self):
+        participant = self._participant_with_recurring_effect(temp_hp_per_turn=3)
+        state = _make_state([participant])
+        player_model = self._mock_player_model(current_temp_hp=0)
+
+        with (
+            patch.object(CombatService, "_get_stats", return_value=(player_model, 20, 20, 15, 3, 3)),
+            patch.object(CombatService, "_emit_log"),
+            patch("app.services.session_state_finalize.finalize_session_state_data", side_effect=lambda d: d),
+        ):
+            await CombatService._process_recurring_temp_hp(None, "s1", state, participant)
+
+        self.assertEqual(player_model.state_json["tempHP"], 3)
+
+    async def test_keep_higher_does_not_overwrite_existing_higher_temp_hp(self):
+        participant = self._participant_with_recurring_effect(temp_hp_per_turn=3)
+        state = _make_state([participant])
+        player_model = self._mock_player_model(current_temp_hp=10)
+
+        with (
+            patch.object(CombatService, "_get_stats", return_value=(player_model, 20, 20, 15, 3, 3)),
+            patch.object(CombatService, "_emit_log"),
+            patch("app.services.session_state_finalize.finalize_session_state_data", side_effect=lambda d: d),
+        ):
+            await CombatService._process_recurring_temp_hp(None, "s1", state, participant)
+
+        self.assertEqual(player_model.state_json["tempHP"], 10)
+
+    async def test_last_granted_temp_hp_updated_in_metadata(self):
+        participant = self._participant_with_recurring_effect(temp_hp_per_turn=3)
+        state = _make_state([participant])
+        player_model = self._mock_player_model(current_temp_hp=0)
+
+        with (
+            patch.object(CombatService, "_get_stats", return_value=(player_model, 20, 20, 15, 3, 3)),
+            patch.object(CombatService, "_emit_log"),
+            patch("app.services.session_state_finalize.finalize_session_state_data", side_effect=lambda d: d),
+        ):
+            await CombatService._process_recurring_temp_hp(None, "s1", state, participant)
+
+        meta = participant["active_effects"][0]["metadata"]
+        self.assertEqual(meta["last_granted_temp_hp"], 3)
+
+    async def test_zero_temp_hp_per_turn_skipped(self):
+        participant = self._participant_with_recurring_effect(temp_hp_per_turn=0)
+        state = _make_state([participant])
+        player_model = self._mock_player_model(current_temp_hp=0)
+
+        with (
+            patch.object(CombatService, "_get_stats", return_value=(player_model, 20, 20, 15, 3, 3)),
+            patch.object(CombatService, "_emit_log"),
+            patch("app.services.session_state_finalize.finalize_session_state_data", side_effect=lambda d: d),
+        ):
+            await CombatService._process_recurring_temp_hp(None, "s1", state, participant)
+
+        # tempHP unchanged because temp_hp_per_turn is 0
+        self.assertEqual(player_model.state_json["tempHP"], 0)
+
+    async def test_non_player_participant_skipped(self):
+        participant = {
+            "id": "npc-1",
+            "ref_id": "npc-ref",
+            "kind": "session_entity",
+            "display_name": "NPC",
+            "status": "active",
+            "team": "enemies",
+            "actor_user_id": None,
+            "active_effects": [
+                {
+                    "id": "recurring-eff",
+                    "kind": "spell_effect",
+                    "metadata": {
+                        "recurring_temp_hp": True,
+                        "temp_hp_per_turn": 3,
+                        "last_granted_temp_hp": 0,
+                        "effect_target_participant_id": "npc-1",
+                        "effect_target_ref_id": "npc-ref",
+                        "source_spell_name": "Heroísmo",
+                    },
+                }
+            ],
+        }
+        state = _make_state([participant])
+        get_stats_mock = patch.object(CombatService, "_get_stats")
+        with get_stats_mock as mock_stats:
+            await CombatService._process_recurring_temp_hp(None, "s1", state, participant)
+            mock_stats.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_recurring_temp_hp_effects: zeros temp HP on concentration end
+# ---------------------------------------------------------------------------
+
+class CleanupRecurringTempHpTests(unittest.TestCase):
+    def _removed_effect(
+        self,
+        ref_id: str = "p1",
+        last_granted: int = 3,
+        remove_on_end: bool = True,
+    ) -> dict:
+        return {
+            "id": "recurring-eff",
+            "kind": "spell_effect",
+            "metadata": {
+                "recurring_temp_hp": True,
+                "temp_hp_per_turn": 3,
+                "last_granted_temp_hp": last_granted,
+                "remove_granted_temp_hp_on_end": remove_on_end,
+                "effect_target_participant_id": "pid-1",
+                "effect_target_ref_id": ref_id,
+            },
+        }
+
+    def _mock_player_model(self, current_temp_hp: int):
+        m = SimpleNamespace()
+        m.state_json = {"tempHP": current_temp_hp}
+        return m
+
+    def _state_with_player(self, ref_id: str = "p1") -> CombatState:
+        p = {"id": "pid-1", "ref_id": ref_id, "kind": "player", "display_name": "Hero", "active_effects": []}
+        return _make_state([p])
+
+    def test_zeros_temp_hp_when_at_or_below_last_granted(self):
+        state = self._state_with_player()
+        player_model = self._mock_player_model(current_temp_hp=3)
+        removed = [self._removed_effect(last_granted=3)]
+
+        with (
+            patch.object(CombatService, "_get_stats", return_value=(player_model, 20, 20, 15, 3, 3)),
+            patch("app.services.session_state_finalize.finalize_session_state_data", side_effect=lambda d: d),
+        ):
+            db_mock = SimpleNamespace(add=lambda x: None)
+            CombatService._cleanup_recurring_temp_hp_effects(db_mock, state, removed)
+
+        self.assertEqual(player_model.state_json["tempHP"], 0)
+
+    def test_does_not_zero_when_higher_source_replaced_it(self):
+        state = self._state_with_player()
+        player_model = self._mock_player_model(current_temp_hp=10)
+        removed = [self._removed_effect(last_granted=3)]
+
+        with (
+            patch.object(CombatService, "_get_stats", return_value=(player_model, 20, 20, 15, 3, 3)),
+            patch("app.services.session_state_finalize.finalize_session_state_data", side_effect=lambda d: d),
+        ):
+            db_mock = SimpleNamespace(add=lambda x: None)
+            CombatService._cleanup_recurring_temp_hp_effects(db_mock, state, removed)
+
+        self.assertEqual(player_model.state_json["tempHP"], 10)
+
+    def test_skipped_when_remove_on_end_false(self):
+        state = self._state_with_player()
+        player_model = self._mock_player_model(current_temp_hp=3)
+        removed = [self._removed_effect(last_granted=3, remove_on_end=False)]
+
+        with patch.object(CombatService, "_get_stats", return_value=(player_model, 20, 20, 15, 3, 3)) as mock_stats:
+            db_mock = SimpleNamespace(add=lambda x: None)
+            CombatService._cleanup_recurring_temp_hp_effects(db_mock, state, removed)
+            mock_stats.assert_not_called()
+
+        self.assertEqual(player_model.state_json["tempHP"], 3)
+
+    def test_skipped_when_last_granted_is_zero(self):
+        state = self._state_with_player()
+        player_model = self._mock_player_model(current_temp_hp=0)
+        removed = [self._removed_effect(last_granted=0)]
+
+        with patch.object(CombatService, "_get_stats", return_value=(player_model, 20, 20, 15, 3, 3)) as mock_stats:
+            db_mock = SimpleNamespace(add=lambda x: None)
+            CombatService._cleanup_recurring_temp_hp_effects(db_mock, state, removed)
+            mock_stats.assert_not_called()
+
+    def test_skipped_for_non_recurring_effects(self):
+        state = self._state_with_player()
+        player_model = self._mock_player_model(current_temp_hp=5)
+        removed = [
+            {
+                "id": "other-eff",
+                "kind": "spell_effect",
+                "metadata": {"condition_immunity": True, "immune_conditions": ["frightened"]},
+            }
+        ]
+
+        with patch.object(CombatService, "_get_stats", return_value=(player_model, 20, 20, 15, 3, 3)) as mock_stats:
+            db_mock = SimpleNamespace(add=lambda x: None)
+            CombatService._cleanup_recurring_temp_hp_effects(db_mock, state, removed)
+            mock_stats.assert_not_called()
+
+        self.assertEqual(player_model.state_json["tempHP"], 5)
+
+
+# ---------------------------------------------------------------------------
+# _clear_concentration_for_source triggers cleanup when db is passed
+# ---------------------------------------------------------------------------
+
+class ConcentrationEndCleanupIntegrationTests(unittest.TestCase):
+    def _participant_with_heroism_effects(self, caster_id: str = "p1", target_id: str = "t1") -> tuple[dict, dict]:
+        caster = _make_player(caster_id, "u1")
+        target = _make_player(target_id, "u2")
+        conc_group = "grp-heroism-test"
+        shared_meta = {
+            "concentration": True,
+            "concentration_group": conc_group,
+            "source_spell_key": "heroism",
+        }
+        caster["active_effects"] = [
+            {
+                "id": "immunity-eff",
+                "kind": "spell_effect",
+                "source_participant_id": caster_id,
+                "metadata": {
+                    **shared_meta,
+                    "condition_immunity": True,
+                    "immune_conditions": ["frightened"],
+                    "effect_target_participant_id": target_id,
+                    "effect_target_ref_id": target_id,
+                },
+            }
+        ]
+        target["active_effects"] = [
+            {
+                "id": "recurring-eff",
+                "kind": "spell_effect",
+                "source_participant_id": caster_id,
+                "metadata": {
+                    **shared_meta,
+                    "recurring_temp_hp": True,
+                    "temp_hp_per_turn": 3,
+                    "last_granted_temp_hp": 3,
+                    "remove_granted_temp_hp_on_end": True,
+                    "effect_target_participant_id": target_id,
+                    "effect_target_ref_id": target_id,
+                },
+            }
+        ]
+        return caster, target
+
+    def test_cleanup_runs_when_db_passed(self):
+        caster, target = self._participant_with_heroism_effects()
+        state = _make_state([caster, target])
+        player_model = SimpleNamespace()
+        player_model.state_json = {"tempHP": 3}
+
+        with (
+            patch.object(CombatService, "_get_stats", return_value=(player_model, 20, 20, 15, 3, 3)),
+            patch.object(CombatService, "_execute_on_end_effects_for_removed"),
+            patch("app.services.session_state_finalize.finalize_session_state_data", side_effect=lambda d: d),
+        ):
+            db_mock = SimpleNamespace(add=lambda x: None)
+            CombatService._clear_concentration_for_source(
+                state,
+                source_participant_id="p1",
+                db=db_mock,
+            )
+
+        self.assertEqual(player_model.state_json["tempHP"], 0)
+
+    def test_cleanup_skipped_when_no_db(self):
+        caster, target = self._participant_with_heroism_effects()
+        state = _make_state([caster, target])
+        player_model = SimpleNamespace()
+        player_model.state_json = {"tempHP": 3}
+
+        with (
+            patch.object(CombatService, "_get_stats", return_value=(player_model, 20, 20, 15, 3, 3)) as mock_stats,
+            patch.object(CombatService, "_execute_on_end_effects_for_removed"),
+        ):
+            CombatService._clear_concentration_for_source(
+                state,
+                source_participant_id="p1",
+            )
+            mock_stats.assert_not_called()
+
+        self.assertEqual(player_model.state_json["tempHP"], 3)
+
+    def test_all_effects_removed_from_participants_on_concentration_end(self):
+        caster, target = self._participant_with_heroism_effects()
+        state = _make_state([caster, target])
+
+        with (
+            patch.object(CombatService, "_execute_on_end_effects_for_removed"),
+            patch.object(CombatService, "_cleanup_recurring_temp_hp_effects"),
+        ):
+            CombatService._clear_concentration_for_source(
+                state,
+                source_participant_id="p1",
+                db=SimpleNamespace(add=lambda x: None),
+            )
+
+        self.assertEqual(caster.get("active_effects") or [], [])
+        self.assertEqual(target.get("active_effects") or [], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PR: feat(combat) Full Heroism spell implementation with Condition Immunity and Recurring Temp HP (#366)

## Description

Este PR consolida a implementação completa e em três fases da magia *Heroism* (Heroísmo - Issue #366). O motor declarativo foi expandido para suportar imunidade dinâmica a condições (supressão e bloqueio de *Frightened*), gatilhos recorrentes no início do turno baseados no modificador de conjuração do suserano, e um pipeline de *cleanup* inteligente para remoção de PVTs ao encerrar a concentração.

## Changes

### Phase 1: Condition Immunity & Suppression
- **`base_spells.seed.json`**: Adicionada a semente de *Heroism* (Encantamento de 1º nível, concentração, 1 alvo base, upcast de +1 alvo por nível de slot).
- **`base_spell_effects.py`**: Criação do schema, validador e união de tipos para `ConditionImmunityParams`.
- **`spell_declarative_effects.py`**: 
  - Adicionado o branch `condition_immunity` para aplicar o efeito e suprimir retroativamente a condição *Frightened* (Atemorizado).
  - Injetado um *immunity gate* no `apply_condition` para bloquear novas instâncias da condição.
- **`effects_actions.py`**: O menu manual do mestre (GM) agora valida imunidades, retornando HTTP `409 Conflict` se tentar forçar a condição em um alvo imune.

### Phase 2: Recurring Temp HP & Turn Lifecycle
- **`base_spell_effects.py`**: Introdução do `RecurringTempHpParams` (`amount_source`, `timing`, `remove_granted_temp_hp_on_end`).
- **`spell_context_resolve.py`**: Injeção do parâmetro `caster_spell_mod` no dicionário de contexto resolvido da magia.
- **`lifecycle_turns.py` (`_process_recurring_temp_hp`)**: Nova rotina disparada no início de cada turno (após o reset de recursos). Ela localiza efeitos recorrentes ativos no participante, calcula os PVTs baseados no modificador do conjurador e aplica-os utilizando a política de *keep-higher*.

### Phase 3: Concentration Cleanup & Dependency Injection
- **`spell_declarative_effects.py` (`_cleanup_recurring_temp_hp_effects`)**: Classmethod encarregado de varrer os alvos após a queda de concentração. Se `remove_granted_temp_hp_on_end` for verdadeiro, o PVT do alvo é zerado **apenas se** for menor ou igual ao `last_granted_temp_hp` registrado (preservando fontes externas maiores).
- **`concentration.py` & Subsystems**: Refatorada a assinatura de `_clear_concentration_for_source` para aceitar a instância do banco de dados (`db`). Todos os orquestradores de quebra de concentração (dano, novo cast de concentração, fim de combate e áreas sobrepostas) foram atualizados para passar o `db` e disparar o cleanup de forma atômica.

## Architectural Architecture

| Layer | Component | Impact |
| :--- | :--- | :--- |
| **Data** | `base_spells.seed.json` | Registration of Heroism targets, upcast logic, and duration |
| **Validation** | `base_spell_effects.py` | Typed strict schemas for recurring triggers and immunities |
| **Turn Engine** | `lifecycle_turns.py` | Turn-start hook integration to evaluate active metadata snapshots |
| **State Machine**| `concentration.py` | Cascading database cleanup when concentration is broken/dropped |

## Test Suite (`test_heroism.py`)

A suíte de testes foi expandida e conta agora com **109 testes verdes (101/101 $\rightarrow$ 109/109)** na raiz do projeto, cobrindo:
- **Validation**: Contrato da semente e integridade do schema Pydantic.
- **Upcast Scaling**: Alvos escalando de forma linear ($1 \rightarrow 1$, $2 \rightarrow 2$, $3 \rightarrow 3$).
- **Suppression Mechanics**: Garantia de que uma criatura já *Frightened* deixa de sofrer os efeitos da condição ao receber a magia.
- **Turn Progression**: Verificação de que os PVTs reatribulados a cada início de turno herdam corretamente o bônus do modificador de atributo do caster.
- **Cleanup Sanity**: Teste da regra de preservação de PVT maior vindo de outras fontes (*keep-higher policy*) ao cair a concentração.

### Results:
- **Total**: 109 tests passed, 0 failures.
- **Pyright**: Nenhuma nova violação adicionada ao projeto (alertas remanescentes limitados ao padrão estrutural de mixins).

> [!SUCCESS]
> Com a conclusão de todas as três fases da Issue #366, o sistema de turnos do Limiar Control agora é capaz de orquestrar efeitos complexos de início de turno e limpezas reativas com total segurança transacional.