### PR TITLE
feat(npc) add wearingMetalArmor metadata to campaign entities and combat snapshot (#379)

### DIFF
--- a/apps/control-server/alembic/versions/0082_campaign_entity_wearing_metal_armor.py
+++ b/apps/control-server/alembic/versions/0082_campaign_entity_wearing_metal_armor.py
@@ -1,0 +1,25 @@
+"""add wearing_metal_armor to campaign entity
+
+Revision ID: 0082_campaign_entity_wearing_metal_armor
+Revises: 0081_armor_material_model
+Create Date: 2026-05-22 16:20:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0082_campaign_entity_wearing_metal_armor"
+down_revision = "0081_armor_material_model"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("campaign_entity", sa.Column("wearing_metal_armor", sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("campaign_entity", "wearing_metal_armor")

--- a/apps/control-server/app/api/routes/campaign_entities.py
+++ b/apps/control-server/app/api/routes/campaign_entities.py
@@ -116,6 +116,7 @@ def to_campaign_entity_read(entry: CampaignEntity) -> CampaignEntityRead:
         description=entry.description,
         imageUrl=entry.image_url,
         armorClass=entry.armor_class,
+        wearingMetalArmor=entry.wearing_metal_armor,
         maxHp=entry.max_hp,
         speedMeters=entry.speed_meters,
         initiativeBonus=entry.initiative_bonus,
@@ -149,6 +150,7 @@ def to_campaign_entity_public_read(entry: CampaignEntity) -> CampaignEntityPubli
         description=entry.description,
         imageUrl=entry.image_url,
         armorClass=entry.armor_class,
+        wearingMetalArmor=entry.wearing_metal_armor,
         maxHp=entry.max_hp,
         speedMeters=entry.speed_meters,
         initiativeBonus=entry.initiative_bonus,
@@ -212,6 +214,7 @@ def create_campaign_entity(
         description=payload.description,
         image_url=None,
         armor_class=payload.armorClass,
+        wearing_metal_armor=payload.wearingMetalArmor,
         max_hp=payload.maxHp,
         speed_meters=payload.speedMeters,
         initiative_bonus=payload.initiativeBonus,
@@ -293,6 +296,7 @@ def update_campaign_entity(
     else:
         entry.image_url = source_image_ref.url
     entry.armor_class = payload.armorClass
+    entry.wearing_metal_armor = payload.wearingMetalArmor
     entry.max_hp = payload.maxHp
     entry.speed_meters = payload.speedMeters
     entry.initiative_bonus = payload.initiativeBonus

--- a/apps/control-server/app/models/campaign_entity.py
+++ b/apps/control-server/app/models/campaign_entity.py
@@ -20,6 +20,7 @@ class CampaignEntity(SQLModel, table=True):
     description: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
     image_url: str | None = None
     armor_class: int | None = Field(default=None, sa_column=Column(Integer, nullable=True))
+    wearing_metal_armor: bool | None = Field(default=None, nullable=True)
     max_hp: int | None = Field(default=None, sa_column=Column(Integer, nullable=True))
     speed_meters: int | None = Field(default=None, sa_column=Column(Integer, nullable=True))
     initiative_bonus: int | None = Field(default=None, sa_column=Column(Integer, nullable=True))

--- a/apps/control-server/app/schemas/campaign_entity_models.py
+++ b/apps/control-server/app/schemas/campaign_entity_models.py
@@ -30,6 +30,7 @@ class CampaignEntityBase(BaseModel):
     description: str | None = None
     imageUrl: str | None = None
     armorClass: int | None = Field(default=None, ge=0)
+    wearingMetalArmor: bool | None = None
     maxHp: int | None = Field(default=None, ge=0)
     speedMeters: int | None = Field(default=None, ge=0)
     initiativeBonus: int | None = None

--- a/apps/control-server/app/services/combat_service/lifecycle_initiative.py
+++ b/apps/control-server/app/services/combat_service/lifecycle_initiative.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from pydantic import ValidationError
 from sqlmodel import select
 
+from app.models.campaign_entity import CampaignEntity
 from app.models.campaign_tactical_map import CampaignTacticalMap
 from app.models.combat import CombatPhase
+from app.models.session_entity import SessionEntity
 from app.models.session import Session as CampaignSession
 from app.schemas.campaign import decode_blocked_cells, decode_edge_obstacles, decode_obstacles
 from app.schemas.combat import CombatMapSelection
@@ -167,6 +169,7 @@ class CombatLifecycleInitiativeMixin:
         from app.models.combat import CombatState
 
         built_participants = []
+        entity_metal_armor_cache: dict[str, bool | None] = {}
         for p in req.participants:
             entry = {
                 **p.model_dump(),
@@ -202,6 +205,30 @@ class CombatLifecycleInitiativeMixin:
                     active_effects=entry.get("active_effects"),
                     effective_size=size_payload["effective_size"],
                 )
+            elif p.kind == "session_entity":
+                wearing_metal_armor = entity_metal_armor_cache.get(p.ref_id)
+                if p.ref_id not in entity_metal_armor_cache:
+                    try:
+                        session_entity = db.exec(
+                            select(SessionEntity).where(
+                                SessionEntity.id == p.ref_id,
+                                SessionEntity.session_id == session_id,
+                            )
+                        ).first()
+                        if session_entity and isinstance(session_entity.campaign_entity_id, str):
+                            campaign_entity = db.exec(
+                                select(CampaignEntity).where(
+                                    CampaignEntity.id == session_entity.campaign_entity_id
+                                )
+                            ).first()
+                            raw_flag = campaign_entity.wearing_metal_armor if campaign_entity else None
+                            wearing_metal_armor = raw_flag if isinstance(raw_flag, bool) else None
+                        else:
+                            wearing_metal_armor = None
+                    except Exception:
+                        wearing_metal_armor = None
+                    entity_metal_armor_cache[p.ref_id] = wearing_metal_armor
+                entry["wearingMetalArmor"] = wearing_metal_armor
             built_participants.append(entry)
 
         new_state = CombatState(

--- a/apps/control-server/tests/test_campaign_entity_statblock.py
+++ b/apps/control-server/tests/test_campaign_entity_statblock.py
@@ -38,6 +38,7 @@ class TestCampaignEntityStatblock(unittest.TestCase):
             skills={"stealth": 6, "perception": 3},
             senses={"darkvisionMeters": 18, "passivePerception": 13},
             spellcasting={"ability": "wisdom", "saveDc": 12, "attackBonus": 4},
+            wearingMetalArmor=True,
             damageResistances=["fire"],
             conditionImmunities=["poisoned"],
             combatActions=[
@@ -58,6 +59,7 @@ class TestCampaignEntityStatblock(unittest.TestCase):
         self.assertEqual(payload.skills["stealth"], 6)
         self.assertEqual(payload.senses.darkvisionMeters, 18)
         self.assertEqual(payload.spellcasting.saveDc, 12)
+        self.assertIs(payload.wearingMetalArmor, True)
 
     def test_campaign_entity_create_prunes_redundant_derived_overrides(self):
         payload = CampaignEntityCreate(
@@ -104,6 +106,7 @@ class TestCampaignEntityStatblock(unittest.TestCase):
             size="medium",
             creature_type="undead",
             armor_class=12,
+            wearing_metal_armor=False,
             max_hp=22,
             speed_meters=9,
             initiative_bonus=2,
@@ -148,6 +151,7 @@ class TestCampaignEntityStatblock(unittest.TestCase):
         self.assertEqual(serialized.spellcasting.saveDc, 11)
         self.assertEqual(serialized.damageImmunities, ["poison"])
         self.assertEqual(serialized.combatActions[0].name, "Claws")
+        self.assertIs(serialized.wearingMetalArmor, False)
 
     def test_serialization_normalizes_redundant_overrides(self):
         entity = CampaignEntity(

--- a/apps/control-server/tests/test_npc_metal_armor_policy.py
+++ b/apps/control-server/tests/test_npc_metal_armor_policy.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.models.campaign_entity import CampaignEntity
+from app.models.session_entity import SessionEntity
+from app.schemas.campaign_entity import CampaignEntityCreate
+from app.schemas.combat import CombatParticipant, CombatStartRequest
+from app.services.combat import CombatService
+
+
+class NpcMetalArmorSchemaTests(unittest.TestCase):
+    def test_campaign_entity_accepts_true_false_and_null(self):
+        with_true = CampaignEntityCreate(name="Knight", wearingMetalArmor=True)
+        with_false = CampaignEntityCreate(name="Scout", wearingMetalArmor=False)
+        without_value = CampaignEntityCreate(name="Mystery")
+
+        self.assertIs(with_true.wearingMetalArmor, True)
+        self.assertIs(with_false.wearingMetalArmor, False)
+        self.assertIsNone(without_value.wearingMetalArmor)
+
+
+class NpcMetalArmorCombatSnapshotTests(unittest.IsolatedAsyncioTestCase):
+    @patch("app.services.combat.CombatService._emit_state", new_callable=AsyncMock)
+    @patch("app.services.combat.CombatService._emit_log", new_callable=AsyncMock)
+    @patch("app.services.combat.CombatService._sync_all_participant_statuses")
+    @patch("app.services.combat.CombatService._resolve_map_selection", return_value=None)
+    @patch("app.services.combat.CombatService.get_state", return_value=None)
+    async def test_start_combat_propagates_true_false_and_null_without_inference(
+        self,
+        _mock_get_state,
+        _mock_resolve_map_selection,
+        _mock_sync_status,
+        _mock_emit_log,
+        _mock_emit_state,
+    ):
+        db = MagicMock()
+        db.exec.side_effect = [
+            MagicMock(first=MagicMock(return_value=SessionEntity(id="se-true", session_id="session-1", campaign_entity_id="ce-true"))),
+            MagicMock(first=MagicMock(return_value=CampaignEntity(id="ce-true", campaign_id="camp-1", name="Knight", armor_class=18, wearing_metal_armor=True))),
+            MagicMock(first=MagicMock(return_value=SessionEntity(id="se-false", session_id="session-1", campaign_entity_id="ce-false"))),
+            MagicMock(first=MagicMock(return_value=CampaignEntity(id="ce-false", campaign_id="camp-1", name="Scout", armor_class=12, wearing_metal_armor=False))),
+            MagicMock(first=MagicMock(return_value=SessionEntity(id="se-null", session_id="session-1", campaign_entity_id="ce-null"))),
+            MagicMock(first=MagicMock(return_value=CampaignEntity(id="ce-null", campaign_id="camp-1", name="Mystery Armor 18", armor_class=18, description="Wears plate armor", wearing_metal_armor=None))),
+        ]
+
+        req = CombatStartRequest(
+            participants=[
+                CombatParticipant(id="p1", kind="session_entity", ref_id="se-true", display_name="Knight", team="enemies"),
+                CombatParticipant(id="p2", kind="session_entity", ref_id="se-false", display_name="Scout", team="enemies"),
+                CombatParticipant(id="p3", kind="session_entity", ref_id="se-null", display_name="Mystery Armor 18", team="enemies"),
+            ],
+            useMap=False,
+        )
+
+        state = await CombatService.start_combat(db, "session-1", req)
+        by_ref = {p["ref_id"]: p for p in state.participants}
+
+        self.assertIs(by_ref["se-true"].get("wearingMetalArmor"), True)
+        self.assertIs(by_ref["se-false"].get("wearingMetalArmor"), False)
+        self.assertIsNone(by_ref["se-null"].get("wearingMetalArmor"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Este PR implementa o suporte de ponta a ponta para a flag de metadados `wearingMetalArmor` em entidades de campanha (NPCs/Monstros), conforme planejado na Issue #379. A propriedade foi estendida para os schemas de API, persistência em banco de dados e propagação automática no snapshot de participantes ao iniciar um combate (`start_combat`). Isso isola a lógica de NPCs da esteira de inventário de jogadores (PCs) e blinda o motor contra inferências ambíguas baseadas em texto ou CA.

## Changes

### Database & Models
- **`campaign_entity.py`**: Inclusão da coluna bônus `wearing_metal_armor` (Boolean, anulável) para rastrear o uso de armaduras metálicas diretamente no modelo da criatura.
- **Alembic Migration (`0082_campaign_entity_wearing_metal_armor.py`)**: Migração criada e testada para adicionar a nova coluna sem quebrar registros legados.

### API, Schemas & Serialization
- **`campaign_entity_models.py`**: Adaptação dos schemas Pydantic para suportar a propriedade `wearingMetalArmor` aceitando os estados estritos de `true | false | null`.
- **`routes/campaign_entities.py`**: Atualização dos mapeamentos e serializadores de leitura para garantir o tráfego correto do metadado entre o cliente e o servidor.

### Combat Integration
- **`lifecycle_initiative.py`**: Ajustada a rotina de inicialização de combate (`start_combat`). Quando um participante do tipo `kind="session_entity"` é instanciado, o snapshot do combate captura e propaga o valor de `CampaignEntity.wearing_metal_armor` diretamente em seu estado ativo.

---

## Summary of Metadata Policy

| Field | Type | Supported States | Policy / Logic |
| :--- | :--- | :--- | :--- |
| **`wearingMetalArmor`** | `Boolean | null` | `true`, `false`, `null` | **Zero Inference:** Não há adivinhação por nome, descrição ou valor de CA. O dado deve ser explícito. |

> [!NOTE]
> Esta alteração não afeta o cálculo de CA de nenhuma criatura, não altera o fluxo de magias como *Mage Armor* ou *Shield of Faith*, e não interfere na esteira de `equippedArmor` de Personagens Jogadores.

---

## Validation & Test Suite

A suíte de testes foi expandida para garantir a estabilidade do contrato de metadados e impedir regressões nas stacks de combate:
- **`test_npc_metal_armor_policy.py`**: Nova suíte focada em validar o ciclo de vida do metadado da entidade até o snapshot de iniciativa.
- **`test_campaign_entity_statblock.py`**: Extensão dos testes de bloco de estatísticas para cobrir a leitura/escrita do novo campo.

### Comandos Úteis (Dev Checklist)

#### 1. Executar os novos testes de política de NPC e Statblock
```bash
pytest apps/control-server/tests/test_npc_metal_armor_policy.py apps/control-server/tests/test_campaign_entity_statblock.py -v

```

#### 2. Executar testes de regressão de CA e Snapshots de Jogadores (#376)

```bash
pytest apps/control-server/tests/test_equipped_armor_material_snapshot.py apps/control-server/tests/test_session_state_finalize.py -v

```

## Test Results

Os testes rodados no ambiente virtual local retornaram conformidade total:

* **NPC & Combat Suite**: **24 passed** (Incluindo validação de distâncias locais).
* **Player Armor & Spell Stack**: **73 passed** (Garantindo integridade absoluta de *Mage Armor*, *Shield of Faith* e finalização de estado).