### PR TITLE
feat(armor): add target_wearing_metal_armor function and correspondin…

### DIFF
--- a/apps/control-server/app/services/combat_service/condition_effects_predicates.py
+++ b/apps/control-server/app/services/combat_service/condition_effects_predicates.py
@@ -94,6 +94,20 @@ def has_condition(participant: dict, condition_type: str) -> bool:
     return False
 
 
+def target_wearing_metal_armor(participant: dict | None) -> bool:
+    if not isinstance(participant, dict):
+        return False
+
+    equipped_armor = participant.get("equippedArmor")
+    if isinstance(equipped_armor, dict):
+        armor_type = equipped_armor.get("armorType")
+        armor_material = equipped_armor.get("armorMaterial")
+        if isinstance(armor_type, str) and armor_type != "none" and armor_material == "metal":
+            return True
+
+    return participant.get("wearingMetalArmor") is True
+
+
 def has_condition_immunity(participant: dict, condition_type: str) -> bool:
     for effect in participant.get("active_effects") or []:
         if effect.get("kind") != "spell_effect":

--- a/apps/control-server/tests/test_target_wearing_metal_armor.py
+++ b/apps/control-server/tests/test_target_wearing_metal_armor.py
@@ -1,0 +1,83 @@
+from app.services.combat_service.condition_effects_predicates import target_wearing_metal_armor
+
+
+def test_equipped_metal_armor_returns_true():
+    participant = {"equippedArmor": {"armorType": "heavy", "armorMaterial": "metal"}}
+    assert target_wearing_metal_armor(participant) is True
+
+
+def test_equipped_non_metal_armor_returns_false():
+    assert target_wearing_metal_armor({"equippedArmor": {"armorType": "light", "armorMaterial": "leather"}}) is False
+    assert target_wearing_metal_armor({"equippedArmor": {"armorType": "medium", "armorMaterial": "hide"}}) is False
+
+
+def test_equipped_armor_unknown_or_missing_returns_false():
+    assert target_wearing_metal_armor({"equippedArmor": {"armorType": "heavy", "armorMaterial": None}}) is False
+    assert target_wearing_metal_armor({"equippedArmor": {"armorType": "heavy"}}) is False
+    assert target_wearing_metal_armor({}) is False
+
+
+def test_armor_type_none_blocks_metal_material():
+    participant = {"equippedArmor": {"armorType": "none", "armorMaterial": "metal"}}
+    assert target_wearing_metal_armor(participant) is False
+
+
+def test_metal_requires_explicit_armor_type_string():
+    participant = {"equippedArmor": {"armorMaterial": "metal"}}
+    assert target_wearing_metal_armor(participant) is False
+
+
+def test_shield_metal_alone_does_not_count():
+    participant = {"equippedShield": {"armorMaterial": "metal"}}
+    assert target_wearing_metal_armor(participant) is False
+
+
+def test_shield_metal_plus_non_metal_armor_still_false():
+    participant = {
+        "equippedArmor": {"armorType": "light", "armorMaterial": "leather"},
+        "equippedShield": {"armorMaterial": "metal"},
+    }
+    assert target_wearing_metal_armor(participant) is False
+
+
+def test_shield_metal_plus_metal_armor_true_due_to_armor():
+    participant = {
+        "equippedArmor": {"armorType": "heavy", "armorMaterial": "metal"},
+        "equippedShield": {"armorMaterial": "metal"},
+    }
+    assert target_wearing_metal_armor(participant) is True
+
+
+def test_npc_wearing_metal_armor_policy():
+    assert target_wearing_metal_armor({"wearingMetalArmor": True}) is True
+    assert target_wearing_metal_armor({"wearingMetalArmor": False}) is False
+    assert target_wearing_metal_armor({"wearingMetalArmor": None}) is False
+    assert target_wearing_metal_armor({"name": "No Metadata NPC"}) is False
+
+
+def test_no_heuristics_used():
+    assert target_wearing_metal_armor({"armorClass": 18}) is False
+    assert target_wearing_metal_armor({"name": "Armored Knight"}) is False
+    assert target_wearing_metal_armor({"description": "wears plate armor"}) is False
+    assert target_wearing_metal_armor({"equippedArmor": {"armorType": "heavy"}}) is False
+
+
+def test_malformed_participants_return_false():
+    assert target_wearing_metal_armor(None) is False
+    assert target_wearing_metal_armor({"equippedArmor": "not-a-dict"}) is False
+    assert target_wearing_metal_armor({"equippedShield": "not-a-dict"}) is False
+
+
+def test_hybrid_explicit_positive_sources():
+    assert (
+        target_wearing_metal_armor(
+            {"equippedArmor": {"armorType": "heavy", "armorMaterial": "metal"}, "wearingMetalArmor": False}
+        )
+        is True
+    )
+    assert (
+        target_wearing_metal_armor(
+            {"equippedArmor": {"armorType": "light", "armorMaterial": "leather"}, "wearingMetalArmor": True}
+        )
+        is True
+    )


### PR DESCRIPTION
## Description

Este PR implementa o helper canônico `target_wearing_metal_armor(participant)` dentro do ecossistema de predicados de combate (`condition_effects_predicates.py`), consolidando as entregas de taxonomia de jogadores (#376) e metadados de NPCs (#379). O predicado opera sob uma política estrita de não-inferência e comportamento defensivo para servir de base para a resolução de magias e efeitos dinâmicos (como *Heat Metal*).

## Changes

### Combat Core Mechanics & Predicates
- **`condition_effects_predicates.py`**: Criação da função `target_wearing_metal_armor`. A lógica resolve a presença de armadura metálica sob a seguinte ordem de precedência:
  1. **Personagens Jogadores (PCs)**: Se o snapshot `equippedArmor` possuir um tipo válido diferente de `"none"` e o `armorMaterial` for estritamente `"metal"`, retorna `True`.
  2. **Entidades de Campanha / NPCs**: Se as propriedades de inventário não se aplicarem, avalia se o metadado `wearingMetalArmor` é estritamente `True`.
  3. **Escudos**: Conforme regra de design, o estado de `equippedShield` é ignorado e **não** participa da tomada de decisão.
  4. **Fail-Safe**: Qualquer dado ausente, nulo, malformado ou desconhecido falha graciosamente, retornando `False`.

### Test Suite & Hybrid Matrix
- **`test_target_wearing_metal_armor.py`**: Nova suíte de testes unitários focada na cobertura de todos os cenários e matrizes de dados do participante, incluindo os casos híbridos de sobreposição:
  - PC com armadura de metal ativa + metadado geral setado como falso $\rightarrow$ Resolve como `True` (Inventário real prevalece).
  - PC com armadura de couro (*leather*) ativa + metadado geral setado como verdadeiro $\rightarrow$ Resolve como `True` (A flag explícita de metadado atua como override válido).

---

## Predicate Resolution Matrix

| Participant Context | `equippedArmor` Snapshot | `wearingMetalArmor` Flag | Result |
| :--- | :--- | :--- | :--- |
| **Player (Chain Mail)** | Type: `"heavy"`, Material: `"metal"` | `null` / `false` | **`True`** |
| **Player (Leather)** | Type: `"light"`, Material: `"leather"` | `true` (Override) | **`True`** |
| **NPC (Knight / Iron Golem)** | Type: `"none"` (No Inventory) | `true` | **`True`** |
| **NPC (Goblin / Mage)** | Type: `"none"` (No Inventory) | `false` / `null` | **`False`** |
| **Malformed Payload** | `{}` (Missing Fields) | `undefined` | **`False`** (Fail-Safe) |

---

## Comandos Úteis (Dev Checklist)

### 1. Executar os testes dedicados do predicado canônico
```bash
pytest apps/control-server/tests/test_target_wearing_metal_armor.py -v

```

### 2. Rodar a esteira completa de validação da taxonomia de armaduras

```bash
pytest apps/control-server/tests/test_equipped_armor_material_snapshot.py apps/control-server/tests/test_npc_metal_armor_policy.py -v

```

## Validation Results

A integridade do predicado foi totalmente validada utilizando a suíte de testes local:

* **Execution**: `./apps/control-server/.venv/bin/pytest`
* **Output**: **87 passed** em 1.27 segundos (Cobrindo os fluxos isolados de jogadores, NPCs, isolamento de escudos e resiliência contra payloads quebrados).

> [!SUCCESS]
> Com este predicado homologado e blindado contra regressões, o Limiar Control possui agora o contrato lógico necessário para avaliar interações ambientais e de magias elementais de forma 100% automatizada.